### PR TITLE
fix: /resume 与 dsh web 共用 JSONL 会话库（0.3.7，issue #24）

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -140,10 +140,13 @@
   config:
     policy: !!js "process.platform === 'win32' ? 'never' : ((process.env.DSH_PERMISSION_MODE ?? 'workspace-write') === 'danger-full-access' ? 'never' : 'ask')"
 
-# Sessions are durable under the SQLite backend inserted below; the shared
-# JSONL backend is off so one write path owns every session.
+# Sessions live in the shared JSONL store (~/.dsh/sessions) — the same
+# backend dsh web writes — so /resume here and the web session list see each
+# other (#24). The row itself comes from the dsh-base layer; this override
+# only re-points the root when DSH_CC_SESSION_ROOT is set (test isolation).
 - id: session-persistence-jsonl
-  disabled: true
+  config:
+    root: !!js process.env.DSH_CC_SESSION_ROOT ?? dshHomePath('sessions')
 
 # ── cc-tui rows ─────────────────────────────────────────────────────────────
 
@@ -197,15 +200,6 @@
         # wins over the roster default (standard).
         preset: !!js process.env.CC_TUI_PRESET ?? undefined
         sessionId: !!js process.env.DSH_CC_RESUME_SESSION ?? undefined
-
-    # Durable session log (DSH's own persistence seam): /resume and rewind
-    # both rely on this backend writing every session/event. Root defaults
-    # under the user home so sessions survive across terminals (Windows:
-    # USERPROFILE); DSH_CC_SESSION_ROOT overrides the path.
-    - id: sessions
-      name: '@deepseek-ai/dsh-session-persistence-sqlite'
-      config:
-        path: !!js process.env.DSH_CC_SESSION_ROOT ?? (process.env.USERPROFILE ?? process.env.HOME) + '/.dsh-cc/sessions.sqlite'
 
     # Live working-line data source (thinking copy / running tool / turn
     # summary). dsh-working-activity ships as a plain npm dependency of

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-cc-tui",
-  "version": "0.2.1",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-cc-tui",
-      "version": "0.2.1",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-cc-tui",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "type": "module",
@@ -48,7 +48,7 @@
     "@deepseek-ai/dsh-llm": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-persona": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-session": "^0.1.0-rc.6",
-    "@deepseek-ai/dsh-session-persistence-sqlite": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-skill": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-system-prompt": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-terminal": "^0.1.0-rc.6",
@@ -86,6 +86,7 @@
   "devDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-session-persistence-sqlite": "^0.1.0-rc.6",
     "@types/lodash-es": "^4.17.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
       '@deepseek-ai/dsh-session':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
-      '@deepseek-ai/dsh-session-persistence-sqlite':
+      '@deepseek-ai/dsh-session-persistence-jsonl':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))
       '@deepseek-ai/dsh-skill':
@@ -147,6 +147,9 @@ importers:
       '@deepseek-ai/dsh-invariants':
         specifier: ^0.1.0-rc.6
         version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session-persistence-sqlite':
+        specifier: ^0.1.0-rc.6
+        version: 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))
       '@types/lodash-es':
         specifier: ^4.17.0
         version: 4.17.12
@@ -361,6 +364,14 @@ packages:
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+
+  '@deepseek-ai/dsh-session-persistence-jsonl@0.1.0-rc.6':
+    resolution: {integrity: sha512-US9Q4b5CZJPRRqa/M+WESL5VAOLjfYWjdzb3TQ/7zmpR4/+EQWCOFA9CtDSMh4t1oFOQBjz2+YJJcGu59MKHDA==}
+    peerDependencies:
+      '@deepseek-ai/cordis': ^4.0.1
+      '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session': ^0.1.0-rc.6
+      '@deepseek-ai/dsh-session-persistence': ^0.1.0-rc.6
 
   '@deepseek-ai/dsh-session-persistence-sqlite@0.1.0-rc.6':
     resolution: {integrity: sha512-0pHni+hKe+VkZiuEieCmetcZQJd7gaA6Iw1qp3yMH6T904r2AuzqjQDU4yAJfKErMTbstvcR2vIdMw89CScFdQ==}
@@ -675,6 +686,81 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@koromix/koffi-darwin-arm64@3.1.4':
+    resolution: {integrity: sha512-/9o0uahf25sNXz7CczfMAsgdHrrrkDK3/d1W5ygJUC7QnpWo80103yTYpYahWP3vTABK5yjzKtURgssv1paskA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@koromix/koffi-darwin-x64@3.1.4':
+    resolution: {integrity: sha512-6IOhfAHbrySr6lYRU720Hg+IMQvtMpN08k9Ppf9WF8NxYRdHLnW1FJm7zCbClfrwudtjhS/piwDYwgAkO5u8cg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@koromix/koffi-freebsd-arm64@3.1.4':
+    resolution: {integrity: sha512-JKCWC0awdVvq7Nd/etn4PXFTa7uvyHn7IzqtaOZ3r4dJRdwQVby7Ai/wsQo8UUrJfAYlALkLYgFgU8wgsnAE/A==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.4':
+    resolution: {integrity: sha512-gU9pShDRLMZzftdGW+mTzyL8Cpa/7nzHPHe5vFakjGgtIzVFzdFBqwli4oB+tFsx44W1VqMMlvMMVlnz54ERiQ==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.4':
+    resolution: {integrity: sha512-2kppLX97xBM3WoQET6noN4W02zT2fkFRXHYluAwcCcmkEax8AVJ1CYs6hxcZ3kaNPc+5P7yMw3V/b1lg2v3aMw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.4':
+    resolution: {integrity: sha512-yYbypuGVGqrNchkAMY59kj+7TZ1c1u9lXRG1+74X9T8G4rOaushoVONNYLuu+ygpbwsKzz/NvEDtRioRU/dQlQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@koromix/koffi-linux-ia32@3.1.4':
+    resolution: {integrity: sha512-IoA/8Qfc6ZEmwMw2Nf4aSp9RfJnxh0UHhdqD4FsVXm0vC797kLMuzj744vv5tll+waVfjrU10jREqjtnMVFoQw==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.4':
+    resolution: {integrity: sha512-ZUTdea+9dg6CV9J9CIGbhTh0FtSBgvcGKqDrlp9BVQF71jEDKOri1by/TrDe8yQUyC5kzWN8vWnkzES5wT0xDg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.4':
+    resolution: {integrity: sha512-CINyyhNYV/8MX52MGhYcik2G6PXH+KEU2JEO7dOONlsGol4lSGyW40RvYA4RQgNYk8q8imGSEScL08X8eOXnaA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.4':
+    resolution: {integrity: sha512-x3XnAy/tUTTCX/gMpV7VJNpOQIVQvzNhNYDrpyIeS9Q8/f1qLsE0vp0tj7A/YEDIfMVLqoJtyamfRJc04+vk4w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@koromix/koffi-openbsd-ia32@3.1.4':
+    resolution: {integrity: sha512-r9p/fffvmBm7+iT5BZ+c17gZJ280jvmbinrPZqjG14rF9I4lk7xrlV79YfsexkeN4mcPjF2hSPtbMNFBoQU3Dw==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.4':
+    resolution: {integrity: sha512-SNp5AxOzheC2YaWPu3Y86wxRHHWf6V9NMl5Ot5nu9OpnP61Yinzug7JwsCeXtcZZTbKLsfsWoT7y4n17UYpOVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.4':
+    resolution: {integrity: sha512-oS8ETU35AelOD6DY7xmmz9qq26Xl38upXWiZbsdxbtH9UEIY0QpenQOuCK/0+q4CtfiLorRUlglGkO9YgPAIeA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@koromix/koffi-win32-ia32@3.1.4':
+    resolution: {integrity: sha512-zd7Qh8s4fzblD9zzuDf44XCbujYg3QrffhgcNJg79/YC6ABT2m0CUtX4yFic9EWm2ps8NPAM25kCTCXPpt3eaw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.4':
+    resolution: {integrity: sha512-BPeQXc1bRd0QBOklvsP+AjoRnUzKbPNE6rfx7VNxrebhh09MKld2ibstgKWn6ejQLEcfKEoUJ+WAWIhX4AOsIg==}
+    cpu: [x64]
+    os: [win32]
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -857,6 +943,9 @@ packages:
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
+
+  koffi@3.1.4:
+    resolution: {integrity: sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg==}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -1172,6 +1261,15 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
 
+  '@deepseek-ai/dsh-session-persistence-jsonl@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))':
+    dependencies:
+      '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
+      '@deepseek-ai/dsh-invariants': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)
+      '@deepseek-ai/dsh-session': 0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6)
+      '@deepseek-ai/dsh-session-persistence': 0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/schemastery': 3.18.1
+      koffi: 3.1.4
+
   '@deepseek-ai/dsh-session-persistence-sqlite@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-persistence@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))(@deepseek-ai/dsh-timeout@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.6(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.0-rc.6(6fd26f59436a18b115f326d6060415e6))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
@@ -1399,6 +1497,51 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
+  '@koromix/koffi-darwin-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-darwin-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-freebsd-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-freebsd-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-freebsd-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.4':
+    optional: true
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/lodash-es@4.17.12':
@@ -1559,6 +1702,24 @@ snapshots:
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  koffi@3.1.4:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.4
+      '@koromix/koffi-darwin-x64': 3.1.4
+      '@koromix/koffi-freebsd-arm64': 3.1.4
+      '@koromix/koffi-freebsd-ia32': 3.1.4
+      '@koromix/koffi-freebsd-x64': 3.1.4
+      '@koromix/koffi-linux-arm64': 3.1.4
+      '@koromix/koffi-linux-ia32': 3.1.4
+      '@koromix/koffi-linux-loong64': 3.1.4
+      '@koromix/koffi-linux-riscv64': 3.1.4
+      '@koromix/koffi-linux-x64': 3.1.4
+      '@koromix/koffi-openbsd-ia32': 3.1.4
+      '@koromix/koffi-openbsd-x64': 3.1.4
+      '@koromix/koffi-win32-arm64': 3.1.4
+      '@koromix/koffi-win32-ia32': 3.1.4
+      '@koromix/koffi-win32-x64': 3.1.4
 
   lodash-es@4.18.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   esbuild: false
+  koffi: false
 minimumReleaseAgeExclude:
   - '@deepseek-ai/cordis-plugin-include@1.0.6'
   - '@deepseek-ai/cordis-plugin-loader@1.0.2'
@@ -42,3 +43,4 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-user-questions@0.1.0-rc.6'
   - '@deepseek-ai/schemastery@3.18.1'
   - dsh-working-activity@0.2.2
+  - '@deepseek-ai/dsh-session-persistence-jsonl@0.1.0-rc.6'

--- a/scripts/migrate-sessions-to-jsonl.mts
+++ b/scripts/migrate-sessions-to-jsonl.mts
@@ -1,0 +1,78 @@
+/**
+ * One-shot migration (#24): copy sessions out of the retired cc-tui SQLite
+ * store (`~/.dsh-cc/sessions.sqlite`) into the shared JSONL store
+ * (`$DSH_HOME/sessions`, i.e. what dsh web and post-#24 cc-tui both use).
+ *
+ * Both sides are written/read through the official persistence backends — the
+ * sqlite backend decodes its rows (torn-tail repair included), the jsonl
+ * backend owns the physical encoding (zstd, packed chunk runs, project/session
+ * layout). Sessions already present in the target are skipped, so the script
+ * is safe to re-run. The source file is never modified or deleted.
+ *
+ *   pnpm tsx scripts/migrate-sessions-to-jsonl.mts [--from <sqlite>] [--to <root>] [--dry-run]
+ *
+ * Defaults: --from $DSH_CC_SESSION_ROOT ?? ~/.dsh-cc/sessions.sqlite
+ *           --to   $DSH_HOME/sessions ?? ~/.dsh/sessions
+ */
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { Context } from '@deepseek-ai/cordis'
+import SessionStore from '@deepseek-ai/dsh-session'
+import SqliteSessionPersistence from '@deepseek-ai/dsh-session-persistence-sqlite'
+import JsonlSessionPersistence from '@deepseek-ai/dsh-session-persistence-jsonl'
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag)
+  return i !== -1 ? process.argv[i + 1] : undefined
+}
+
+const from = argValue('--from') ?? process.env.DSH_CC_SESSION_ROOT ?? join(homedir(), '.dsh-cc', 'sessions.sqlite')
+const to = argValue('--to') ?? join(process.env.DSH_HOME?.trim() ? process.env.DSH_HOME : join(homedir(), '.dsh'), 'sessions')
+const dryRun = process.argv.includes('--dry-run')
+
+if (!existsSync(from)) {
+  console.log(`nothing to migrate: ${from} does not exist`)
+  process.exit(0)
+}
+
+const src = new Context()
+src.plugin(SessionStore)
+src.plugin(SqliteSessionPersistence, { path: from })
+const dst = new Context()
+dst.plugin(SessionStore)
+dst.plugin(JsonlSessionPersistence, { root: to })
+// Cordis fibers start asynchronously; give both contexts a tick to come up.
+await new Promise(r => setTimeout(r, 500))
+
+const metas = await src.sessionPersistence.list()
+const existing = new Set((await dst.sessionPersistence.list()).map(m => m.id))
+console.log(`source: ${metas.length} session(s) in ${from}`)
+console.log(`target: ${existing.size} already present in ${to}${dryRun ? '  (dry run — no writes)' : ''}`)
+
+let migrated = 0
+let skipped = 0
+let failed = 0
+for (const meta of metas) {
+  if (existing.has(meta.id)) {
+    skipped++
+    continue
+  }
+  try {
+    const { meta: stored, events } = await src.sessionPersistence.load(meta.id)
+    if (!dryRun) {
+      await dst.sessionPersistence.create(stored)
+      await dst.sessionPersistence.append(stored.id, events)
+    }
+    migrated++
+    console.log(`  ✓ ${stored.id}  ${events.length} event(s)${stored.cwd ? `  (${stored.cwd})` : ''}`)
+  } catch (error) {
+    failed++
+    console.warn(`  ✗ ${meta.id}  ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+console.log(`done: ${migrated} migrated, ${skipped} skipped (already in target), ${failed} failed`)
+if (migrated > 0 && !dryRun) {
+  console.log(`source left untouched at ${from} — delete it yourself once /resume and dsh web both look right`)
+}
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
Closes #24
Closes #32

## 根因

cc-tui 的 bundle patch 层禁用了 dsh-base 的共享 JSONL 会话后端（`session-persistence-jsonl`，写 `$DSH_HOME/sessions/`），自插 SQLite 后端写 `~/.dsh-cc/sessions.sqlite`——两个互不可见的会话库。/resume 只读 SQLite，dsh web 的会话在选择器中完全不可见（#24：web 6 个、/resume 3 个）；反向亦然，TUI 会话在 web 工作区同样不可见（#32）。

sqlite 是 0.1.x OOM 修复期随 2f60c33 引入的，但该 commit 与 b1e06d8 证实的 OOM 根因都在渲染缓存与 React dev build，与会话后端无关。

## 修复

**写路径整体切到共享 JSONL 库，双向互通**——TUI 会话 dsh web 也能看到：

- `cordis.patch.yml`：删除 jsonl 禁用行 + sqlite 插入行，base 层的 `session-persistence-jsonl` 自然生效；保留 `DSH_CC_SESSION_ROOT` 覆盖口（测试隔离）
- 运行时依赖 `dsh-session-persistence-sqlite` → `-jsonl`；sqlite 降为 devDep 仅供迁移脚本
- `pnpm-workspace.yaml`：`allowBuilds: koffi: false`（jsonl 的 Windows-only FFI 依赖，否则 profile 安装被 pnpm 构建审批拦下；三个本机 profile 的同名文件已同步修）

**存量迁移**：`scripts/migrate-sessions-to-jsonl.mts` 把 `~/.dsh-cc/sessions.sqlite` 迁入共享库。两边都走官方后端的公开 API（sqlite `list`/`load` 读出，jsonl `create`/`append` 写入），物理编码（zstd 帧、chunk 打包、目录布局）由后端自己保证；已存在 id 跳过、幂等可重跑、源库只读不动。支持 `--from/--to/--dry-run`。

## 验证

- 迁移先副本后真库：132 迁移 / 0 跳过 / 1 失败。失败那条含历史 `publish: true` 时期写入的 `activity/status` 未知事件类型，harness load 校验拒绝（sqlite 时代同样不可恢复），脚本报错后继续
- 三 profile（cc/cc-tui/cordis）装 0.3.7 tarball，pty 实测：`/home/sisct` 下 /resume 列出 web 会话；项目目录下列出迁移会话；回车恢复后消息记录、token 数、标题完整渲染
- `tsc` 干净

迁移后 `~/.dsh-cc/sessions.sqlite` 保留不删，确认无误后手动清理即可。