### PR TITLE
ci: 自动取消过期的重复运行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 动机

同一 PR 连续 push 时，旧 commit 的 CI 已经没有合并价值，但仍会继续占用 runner。`main` 短时间连续更新时也存在同样问题。

## 改动

在 CI workflow 顶层增加并发控制：

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

- PR 按 PR number 分组，新 commit 自动取消该 PR 的旧运行。
- `main` push 按 ref 分组，只保留最新一次运行。
- workflow 名包含在分组中，不会误取消其他 workflow。

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm build`
- workflow YAML 结构解析
- `scripts/repro-askpanel.tsx` 通过
- `scripts/verify-askpanel-layout.tsx` 通过
- `scripts/repro-toolcards.tsx` 内容/布局断言通过；本地非 TTY 下两条 ANSI 色彩断言为既有环境差异，由 GitHub CI 最终验证
