### PR TITLE
docs: 更新指南与 pnpm 版本要求——插件升级方法、pnpm 9 秒退排障（issue #31 #60）

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ## 快速开始
 
-前置条件：可用的终端 TTY、官方 `dsh` CLI，以及 `pnpm`。运行模型还需要
+前置条件：可用的终端 TTY、官方 `dsh` CLI，以及 `pnpm` 10+。运行模型还需要
 `DEEPSEEK_API_KEY`。
 
 ```sh

--- a/README_EN.md
+++ b/README_EN.md
@@ -60,7 +60,7 @@ Live activity, goal/todo state, and context metrics:
 ## Quick Start
 
 Prerequisites: an interactive terminal TTY, the official `dsh` CLI, and
-`pnpm`. Model requests also require `DEEPSEEK_API_KEY`.
+`pnpm` 10+. Model requests also require `DEEPSEEK_API_KEY`.
 
 ```sh
 # 1. Install the DeepSeek Harness CLI

--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -6,7 +6,11 @@
 
 - Node.js `^22.19 || >=24`; CI uses Node 24.
 - The official DeepSeek Harness CLI: `@deepseek-ai/dsh`.
-- `pnpm`; `dsh plugin` delegates profile installation to pnpm.
+- `pnpm` **10 or newer** (CI uses 11); `dsh plugin` delegates profile
+  installation to pnpm. pnpm 9 hoists transitive dependencies differently,
+  leaving `dsh-working-activity` unresolvable inside the profile — the TUI
+  then exits right after startup with almost no error output (issue #60,
+  see Troubleshooting below).
 - An interactive terminal TTY. `dsh-cc-tui` cannot start with stdout redirected.
 - `DEEPSEEK_API_KEY`. Set `DEEPSEEK_BASE_URL` as well when using a compatible
   custom endpoint.
@@ -93,6 +97,27 @@ dsh-cc.cmd --resume
 last selected by the TUI. Set `DSH_CC_WORKSPACE` to override the working
 directory used by the batch launcher.
 
+## Update to the latest version
+
+The project moves fast. Updating reuses the install command with an explicit
+`@latest`:
+
+```sh
+dsh plugin --profile cc-tui add dsh-cc-tui@latest
+```
+
+- Without `@latest`, pnpm resolves within the version range already recorded
+  in the profile's `package.json` (for example `^0.1.4`) and may stay on an
+  old line — the usual reason "re-running the install command" appears to
+  change nothing.
+- To confirm: the startup banner shows the running version
+  (`✦ dsh-cc vX.Y.Z`).
+- Your `cordis.patch.yml` override layer survives updates untouched. Session
+  storage may move between versions (since 0.3.7, `/resume` uses the JSONL
+  session store shared with dsh web), so older sessions missing from the
+  list after a major update is expected — the underlying data is not
+  deleted.
+
 ## Profile configuration
 
 The user override file is:
@@ -112,7 +137,7 @@ the profile.
 ## Develop from source
 
 ```sh
-git clone https://github.com/yuxiaoLeeMarks/dsh-TUI.git
+git clone https://github.com/ccch1mneyyy/dsh-TUI.git
 cd dsh-TUI
 pnpm install --frozen-lockfile
 pnpm build
@@ -150,6 +175,18 @@ redirecting its main output to another command or file.
 
 Make sure the global npm bin directory is on `PATH`, then open a new terminal.
 `install.sh` checks both commands before installation.
+
+### The TUI exits right back to the shell with almost no error (pnpm 9)
+
+In a profile installed by pnpm 9, the transitive dependency
+`dsh-working-activity` is not hoisted where the loader can resolve it; the
+failed module resolution tears down the whole plugin tree, and the TUI prints
+the resume hint and exits (issue #60). Upgrade pnpm to 10+ and reinstall:
+
+```sh
+npm install -g pnpm@latest
+dsh plugin --profile cc-tui add dsh-cc-tui@latest
+```
 
 ### The model reports missing credentials
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,10 @@
 
 - Node.js `^22.19 || >=24`。CI 使用 Node 24。
 - 官方 DeepSeek Harness CLI：`@deepseek-ai/dsh`。
-- `pnpm`。`dsh plugin` 会把 profile 内的包安装交给 pnpm。
+- `pnpm` **10 或更高**（CI 使用 11）。`dsh plugin` 会把 profile 内的包安装
+  交给 pnpm；pnpm 9 对传递依赖的提升行为不同，profile 里会解析不到
+  `dsh-working-activity`，表现为启动后立刻退出且几乎无报错（见 issue #60
+  与下方常见问题）。
 - 支持交互输入的终端 TTY。`dsh-cc-tui` 不支持把 stdout 重定向后启动。
 - `DEEPSEEK_API_KEY`。使用自定义兼容端点时还可设置
   `DEEPSEEK_BASE_URL`。
@@ -89,6 +92,22 @@ dsh-cc.cmd --resume
 `--resume` 会读取 `%USERPROFILE%\.dsh-cc\resume.txt`，恢复 TUI 最近选择的
 会话。设置 `DSH_CC_WORKSPACE` 可以覆盖批处理启动器采用的工作目录。
 
+## 更新到最新版本
+
+项目迭代很快，更新复用安装命令，显式指定 `@latest`：
+
+```sh
+dsh plugin --profile cc-tui add dsh-cc-tui@latest
+```
+
+- 不带 `@latest` 时 pnpm 会按 profile `package.json` 里已记录的版本范围
+  （如 `^0.1.4`）就地解析，可能停留在旧的主线上——这是"重复执行安装命令
+  但版本没变"的常见原因。
+- 确认生效：启动横幅右上角显示当前版本（`✦ dsh-cc vX.Y.Z`）。
+- 用户覆盖层 `cordis.patch.yml` 在更新中原样保留；会话数据的存放位置
+  可能随版本变化（如 0.3.7 起 `/resume` 改用与 dsh web 共享的 JSONL
+  会话库），跨大版本更新后旧会话不在列表属预期，原数据不会被删除。
+
 ## Profile 配置
 
 用户覆盖文件位于：
@@ -106,7 +125,7 @@ $DSH_HOME/profiles/cc-tui/cordis.patch.yml
 ## 从源码开发
 
 ```sh
-git clone https://github.com/yuxiaoLeeMarks/dsh-TUI.git
+git clone https://github.com/ccch1mneyyy/dsh-TUI.git
 cd dsh-TUI
 pnpm install --frozen-lockfile
 pnpm build
@@ -140,6 +159,17 @@ stdout 不是 TTY。请直接在终端中启动，不要把主进程输出管道
 
 确认全局 npm bin 目录在 `PATH` 中，并重新打开终端。`install.sh` 会在安装前检查
 这两个命令。
+
+### 启动后立刻退回 shell，几乎没有报错（pnpm 9）
+
+pnpm 9 安装的 profile 里，传递依赖 `dsh-working-activity` 不会被提升到
+loader 可解析的位置，模块解析失败导致整棵插件树被回收，TUI 打印 resume
+提示后直接退出（issue #60）。升级 pnpm 到 10+ 后重装即可：
+
+```sh
+npm install -g pnpm@latest
+dsh plugin --profile cc-tui add dsh-cc-tui@latest
+```
 
 ### 模型启动失败或提示没有凭证
 


### PR DESCRIPTION
## 背景

两个反复出现的用户困惑，文档里都没有答案：

- **#31（评论三轮无解）**：怎么把插件更新到最新版。核心坑：重复执行安装命令**不带 `@latest`** 时，pnpm 按 profile `package.json` 里已记录的版本范围（如 `^0.1.4`）就地解析，停在旧主线上——"我装了但版本没变"。
- **#60**：pnpm 9 安装的 profile 启动即秒退、几乎无报错。根因是 pnpm 9 对传递依赖的提升行为不同，`dsh-working-activity` 在 profile 里解析不到，模块解析失败把整棵插件树回收（与 #60 评论区"升级 pnpm 后无法复现"互证）。

## 改动

`docs/getting-started`（中英）+ 双 README 同步：

- 前置条件写明 **pnpm 10+**（CI 用 11），附 pnpm 9 失败机理；
- 新增「更新到最新版本」一节：`dsh plugin --profile cc-tui add dsh-cc-tui@latest`、版本确认方法（启动横幅 `✦ dsh-cc vX.Y.Z`）、用户覆盖层不受影响、跨版本会话库变化（0.3.7 起共享 JSONL）的预期说明；
- 常见问题补「启动即秒退（pnpm 9）」条目与恢复命令；
- 顺手修正「从源码开发」里的克隆地址（原指向某个 fork，改回上游）。

## 验证

- 更新命令与版本确认路径为本机实操（0.1.4 → 0.3.5 → tgz 本地版全流程走过）；
- pnpm 版本结论与 #60 报告者的诊断、评论区复现结果一致；
- 中英四个文件逐段对照同步。

Closes #31
Closes #60
