### PR TITLE
fix:  install.sh 无法在 mac 下正常安装

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
   esbuild: false
-  koffi: false
+  koffi: true
 minimumReleaseAgeExclude:
   - '@deepseek-ai/cordis-plugin-include@1.0.6'
   - '@deepseek-ai/cordis-plugin-loader@1.0.2'


### PR DESCRIPTION
```
da dsh-TUI % sh install.sh
[WARN] Issues with peer dependencies found. Run "pnpm peers check" to list them.
dependencies:
+ dsh-cc-tui ^0.4.1
Packages: +91
++++++++++++++++++++++++++++++++++++++++++++++++++++
Packages are cloned from the content-addressable store to the virtual store.
  Content-addressable store is at: /Users/da/Library/pnpm/store/v11
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 104, reused 0, downloaded 90, added 91, done
Added 20 entries to minimumReleaseAgeExclude in pnpm-workspace.yaml (set minimumReleaseAgeStrict to true to gate these updates with a prompt):
  @deepseek-ai/dsh-agent-instructions@0.1.0-rc.6
  @deepseek-ai/dsh-agent-presets@0.1.0-rc.6
  @deepseek-ai/dsh-agent-tool-presentation@0.1.0-rc.6
  @deepseek-ai/dsh-agent@0.1.0-rc.6
  @deepseek-ai/dsh-commands@0.1.0-rc.6
  @deepseek-ai/dsh-cordis-host-runner@0.1.0-rc.6
  @deepseek-ai/dsh-llm@0.1.0-rc.6
  @deepseek-ai/dsh-persona@0.1.0-rc.6
  @deepseek-ai/dsh-session-persistence-jsonl@0.1.0-rc.6
  @deepseek-ai/dsh-session@0.1.0-rc.6
  @deepseek-ai/dsh-skill@0.1.0-rc.6
  @deepseek-ai/dsh-system-prompt@0.1.0-rc.6
  @deepseek-ai/dsh-terminal-bash@0.1.0-rc.6
  @deepseek-ai/dsh-terminal@0.1.0-rc.6
  @deepseek-ai/dsh-tool-ask-user@0.1.0-rc.6
  @deepseek-ai/dsh-tool-bash-persistent@0.1.0-rc.6
  @deepseek-ai/dsh-tool-cordis@0.1.0-rc.6
  @deepseek-ai/dsh-user-questions@0.1.0-rc.6
  dsh-cc-tui@0.4.1
  dsh-working-activity@0.2.2
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: koffi@3.1.4

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
dsh: pnpm failed in profile directory /Users/da/.dsh/profiles/cc-tui
```

mac 在 运行时有当前的报错。需要修改下 install.sh 的 `koffi `

