### PR TITLE
fix: working-activity 行改经自有子路径导出挂载，pnpm 严格布局下不再秒退（#60）

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -202,12 +202,15 @@
         sessionId: !!js process.env.DSH_CC_RESUME_SESSION ?? undefined
 
     # Live working-line data source (thinking copy / running tool / turn
-    # summary). dsh-working-activity ships as a plain npm dependency of
-    # dsh-cc-tui — transitive deps never enter dsh.profile.bundles — so this
-    # layer inserts the row itself instead of relying on a separate bundle.
+    # summary). Mounted through dsh-cc-tui's own `./working-activity`
+    # re-export, NOT the bare `dsh-working-activity` name: the dsh Loader
+    # resolves row names from the profile directory, and pnpm's isolated
+    # node_modules layout never links a transitive dependency into the
+    # profile root (npm's flat layout hid this), so the bare name died with
+    # ERR_MODULE_NOT_FOUND and disposed the whole app at boot (#60).
     # publishIntervalMs 500 keeps the status-line timers ticking smoothly
     # (default 2000ms).
     - id: working-activity
-      name: 'dsh-working-activity'
+      name: 'dsh-cc-tui/working-activity'
       config:
         publishIntervalMs: 500

--- a/cordis.yml
+++ b/cordis.yml
@@ -142,10 +142,14 @@
 # Live working line for the status bar: thinking copy / running tool / turn
 # summary. dsh-cc consumes its log-only activity/status events; the
 # plugin's own TUI prompt slot is skipped without an official dsh-tui.
+# Mounted through dsh-cc-tui's `./working-activity` re-export (not the bare
+# `dsh-working-activity` name) so the row resolves from install layouts that
+# never link transitive dependencies into the boot anchor's node_modules —
+# pnpm's isolated profile layout, issue #60.
 # publishIntervalMs 500: live-phase snapshots republish every 500ms so the
 # cc-tui status-line elapsed timers tick smoothly (default 2000ms).
 - id: working-activity
-  name: 'dsh-working-activity'
+  name: 'dsh-cc-tui/working-activity'
   config:
     publishIntervalMs: 500
 

--- a/lib/types/working-activity.d.ts
+++ b/lib/types/working-activity.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Re-export of the `dsh-working-activity` plugin under this package's own
+ * name, so the bundle patch layer can mount the working-activity row as
+ * `dsh-cc-tui/working-activity` instead of the bare package name.
+ *
+ * The dsh Loader resolves row names from the *profile* directory
+ * (`~/.dsh/profiles/<name>/`): only the profile's direct dependencies are
+ * linked into its node_modules. npm's flat layout also hoists transitive
+ * dependencies there, but pnpm's isolated layout never does — so the bare
+ * `dsh-working-activity` name (a transitive dependency of dsh-cc-tui) fails
+ * with ERR_MODULE_NOT_FOUND at boot and the loader disposes the whole app,
+ * exiting the TUI before any UI appears (issue #60). Mounting through this
+ * subpath keeps resolution anchored at dsh-cc-tui itself — always a direct
+ * profile dependency — and from its real location `dsh-working-activity`
+ * resolves under every package-manager layout.
+ * @module dsh-cc-tui/working-activity
+ */
+export * from 'dsh-working-activity';
+//# sourceMappingURL=working-activity.d.ts.map

--- a/lib/types/working-activity.d.ts.map
+++ b/lib/types/working-activity.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"working-activity.d.ts","sourceRoot":"","sources":["../../src/working-activity.ts"],"names":[],"mappings":"AAAA;;;;;;;;;;;;;;;;GAgBG;AACH,cAAc,sBAAsB,CAAA"}

--- a/lib/types/working-activity.js
+++ b/lib/types/working-activity.js
@@ -1,0 +1,18 @@
+/**
+ * Re-export of the `dsh-working-activity` plugin under this package's own
+ * name, so the bundle patch layer can mount the working-activity row as
+ * `dsh-cc-tui/working-activity` instead of the bare package name.
+ *
+ * The dsh Loader resolves row names from the *profile* directory
+ * (`~/.dsh/profiles/<name>/`): only the profile's direct dependencies are
+ * linked into its node_modules. npm's flat layout also hoists transitive
+ * dependencies there, but pnpm's isolated layout never does — so the bare
+ * `dsh-working-activity` name (a transitive dependency of dsh-cc-tui) fails
+ * with ERR_MODULE_NOT_FOUND at boot and the loader disposes the whole app,
+ * exiting the TUI before any UI appears (issue #60). Mounting through this
+ * subpath keeps resolution anchored at dsh-cc-tui itself — always a direct
+ * profile dependency — and from its real location `dsh-working-activity`
+ * resolves under every package-manager layout.
+ * @module dsh-cc-tui/working-activity
+ */
+export * from 'dsh-working-activity';

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "types": "./lib/types/index.d.ts",
       "import": "./lib/types/index.js"
     },
+    "./working-activity": {
+      "types": "./lib/types/working-activity.d.ts",
+      "import": "./lib/types/working-activity.js"
+    },
     "./invariant": {
       "types": "./lib/types/invariant.d.ts",
       "default": "./lib/invariant.js"

--- a/src/working-activity.ts
+++ b/src/working-activity.ts
@@ -1,0 +1,18 @@
+/**
+ * Re-export of the `dsh-working-activity` plugin under this package's own
+ * name, so the bundle patch layer can mount the working-activity row as
+ * `dsh-cc-tui/working-activity` instead of the bare package name.
+ *
+ * The dsh Loader resolves row names from the *profile* directory
+ * (`~/.dsh/profiles/<name>/`): only the profile's direct dependencies are
+ * linked into its node_modules. npm's flat layout also hoists transitive
+ * dependencies there, but pnpm's isolated layout never does — so the bare
+ * `dsh-working-activity` name (a transitive dependency of dsh-cc-tui) fails
+ * with ERR_MODULE_NOT_FOUND at boot and the loader disposes the whole app,
+ * exiting the TUI before any UI appears (issue #60). Mounting through this
+ * subpath keeps resolution anchored at dsh-cc-tui itself — always a direct
+ * profile dependency — and from its real location `dsh-working-activity`
+ * resolves under every package-manager layout.
+ * @module dsh-cc-tui/working-activity
+ */
+export * from 'dsh-working-activity'


### PR DESCRIPTION
## 问题

`dsh --profile cc-tui` 在 pnpm（v9.15.9 等隔离布局）安装的 profile 下启动即退出：loader 解析不到 `dsh-working-activity`，报 `ERR_MODULE_NOT_FOUND` 后整个应用被 dispose，TUI 秒退且无任何报错（#60）。

## 根因（与 issue 里 dsh-dsv4f 的结论不同的一点）

`dsh-working-activity` **并非缺失依赖声明**——它从 0.4.0 起就是 `dsh-cc-tui` 的 direct dependency（`package.json` 里 `"dsh-working-activity": "^0.2.2"`）。真正的问题在**解析锚点**：

- dsh Loader 以 **profile 目录**（`~/.dsh/profiles/cc-tui/`）为锚点解析组合行的 `name`（见 `dsh-app-boot`：`baseUrl` = profile 目录；`cordis-plugin-loader` 的 `internal.import(name, baseUrl)`）。
- 只有 profile 的**直接依赖**会被 pnpm 链接进 profile 根的 `node_modules`；npm 的扁平提升会把传递依赖也放进去，恰好掩盖了这一点，所以 npm 下没事、pnpm 的隔离布局下必炸。
- `@deepseek-ai/*` 行之所以没事，是因为 dsh 会维护 `~/.dsh/profiles/node_modules` 的扁平 symlink 兜底目录（`healProfilesModuleFallback`，BFS 遍历 dsh 安装自身的依赖闭包），父目录查找能命中；`dsh-working-activity` 是第三方包、不在该闭包里，兜底目录没有它。

即：这不是"哪个包没声明"，而是"任何被 patch 行以 bare 名挂载、却又不是 profile 直接依赖的第三方包，在 pnpm 下都解析不到"。

## 修复

把 `working-activity` 行的挂载名从 bare 包名改为 **dsh-cc-tui 自己的子路径导出**：

- 新增 `src/working-activity.ts`：`export * from 'dsh-working-activity'`，原样重导出（`name`/`Config`/`apply` 形态不变，loader 的 `unwrapExports` 行为与之前完全一致）。
- `package.json` 新增 `"./working-activity"` 导出（指向入库的 `lib/types/working-activity.js`）。
- `cordis.patch.yml`（profile 安装链路）与 `cordis.yml`（裸 `dsh --config` 链路）的 `working-activity` 行改为 `name: 'dsh-cc-tui/working-activity'`，行 id 不变，用户在 profile 层按 id 覆盖 config 的写法不受影响。

`dsh-cc-tui` 必然是 profile 的直接依赖，子路径解析锚定本包的真实位置，其 `node_modules` 下必有 `dsh-working-activity`——npm / pnpm v9 / v10 / v11 各布局均可解析。README 的安装命令本身没错，此修复后原命令在 pnpm 下同样一条就绪，无需增加安装步骤。

已按 issue 报告者的验证在 pnpm 9.15.9 下确认：其建议的"profile 里 `pnpm add dsh-working-activity`"权宜之计在本修复后不再需要（已加过的 profile 也兼容，遗留的直接依赖只是不再被引用）。

## 验证

- 模拟 issue 环境（pnpm v9.15.9，全新目录按 profile 方式 `pnpm add` 本包 tarball）：
  - `import('dsh-working-activity')` → `ERR_MODULE_NOT_FOUND`（复现 issue）；
  - `import('dsh-cc-tui/working-activity')` → 解析成功，导出为 `Config, apply, name`，与原包一致。
- `pnpm@11.21.0 install`（lockfile 无变化，未新增依赖）+ `pnpm build` 通过，`lib/types/working-activity.*` 产物已入库。
- CI 五件套中的三个回归脚本本地全过：`repro-askpanel.tsx`、`verify-askpanel-layout.tsx`、`repro-toolcards.tsx` 均 ALL PASS。

## 遗留建议（不在本 PR 范围）

- issue 报告者提的"入口组合失败时把错误打到 stderr 而非静默 dispose、退出码非 0"属于 dsh CLI 侧（`dsh-app-boot`/`cordis-plugin-loader`），建议向上游反馈。
- `dsh-working-activity@0.2.x` 的 peer 声明 `react@^18.2.0` 与本仓 react 19 有 WARN，不影响运行，可在其仓库对齐。

Closes #60
