### PR TITLE
fix(render): thinking spinner 残影——text-default emoji 量宽 2 实画 1（issue #72）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,7 @@ jobs:
       # CJK 显示宽度截断回归（issue #41）：4 处描述按终端显示宽度处理，
       # CJK 不劈字、窄终端布局不破。
       - run: node --import tsx/esm scripts/verify-cjk-truncate.tsx
+
+      # thinking spinner 残影回归（issue #72）：text-default emoji（✳）
+      # 量宽 2 实画 1 致 spinner 行每帧错位，thinking 残影堆积不消失。
+      - run: node --import tsx/esm scripts/repro-thinking.tsx

--- a/lib/types/ink/stringWidth.d.ts.map
+++ b/lib/types/ink/stringWidth.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"stringWidth.d.ts","sourceRoot":"","sources":["../../../src/ink/stringWidth.ts"],"names":[],"mappings":"AA2NA;;;;;;;;GAQG;AACH,eAAO,MAAM,WAAW,EAAE,CAAC,GAAG,EAAE,MAAM,KAAK,MAElB,CAAA"}
+{"version":3,"file":"stringWidth.d.ts","sourceRoot":"","sources":["../../../src/ink/stringWidth.ts"],"names":[],"mappings":"AAuRA;;;;;;;;GAQG;AACH,eAAO,MAAM,WAAW,EAAE,CAAC,GAAG,EAAE,MAAM,KAAK,MAElB,CAAA"}

--- a/lib/types/ink/stringWidth.js
+++ b/lib/types/ink/stringWidth.js
@@ -114,7 +114,68 @@ function getEmojiWidth(grapheme) {
             return 1;
         }
     }
+    // Single codepoint without VS16: only Emoji_Presentation=Yes characters
+    // actually render as wide emoji. Text-default emoji (✳ U+2733, ⚠ U+26A0,
+    // ❤ U+2764, ❄ U+2744, ✂ U+2702 …) render width 1 in terminals
+    // (ghostty/kitty/iTerm2/xterm.js all agree) unless VS16 forces emoji
+    // presentation. emoji-regex matches BOTH categories, so counting every
+    // match as 2 desyncs the layout from the terminal: the spinner glyph ✳
+    // measured 2 but painted 1, shifting the whole spinner row 1 column every
+    // time the animation cycle hit it — leaving stray cells ("tthinking",
+    // orphan "t" residue). VS16 sequences fall through to width 2 below.
+    if (!grapheme.includes('\ufe0f')) {
+        let codepoints = 0;
+        for (const _ of grapheme)
+            codepoints++;
+        if (codepoints === 1 && !hasEmojiPresentation(first)) {
+            return 1;
+        }
+    }
     return 2;
+}
+/**
+ * Emoji_Presentation=Yes codepoints (Unicode emoji-data.txt, merged
+ * ranges). These render as wide emoji without VS16; everything else
+ * emoji-regex matches is text-default and renders narrow.
+ */
+const EMOJI_PRESENTATION_RANGES = [
+    [0x231a, 0x231b], [0x23e9, 0x23ec], 0x23f0, 0x23f3, [0x25fd, 0x25fe],
+    [0x2614, 0x2615], [0x2648, 0x2653], 0x267f, 0x2693, 0x26a1,
+    [0x26aa, 0x26ab], [0x26bd, 0x26be], [0x26c4, 0x26c5], 0x26ce, 0x26d4,
+    0x26ea, [0x26f2, 0x26f3], 0x26f5, 0x26fa, 0x26fd, 0x2705,
+    [0x270a, 0x270b], 0x2728, 0x274c, 0x274e, [0x2753, 0x2755], 0x2757,
+    [0x2795, 0x2797], 0x27b0, 0x27bf, [0x2b1b, 0x2b1c], 0x2b50, 0x2b55,
+    0x1f004, 0x1f0cf, 0x1f18e, [0x1f191, 0x1f19a], [0x1f1e6, 0x1f1ff],
+    0x1f201, 0x1f21a, 0x1f22f, [0x1f232, 0x1f236], [0x1f238, 0x1f23a],
+    [0x1f250, 0x1f251], [0x1f300, 0x1f320], [0x1f32d, 0x1f335],
+    [0x1f337, 0x1f37c], [0x1f37e, 0x1f393], [0x1f3a0, 0x1f3ca],
+    [0x1f3cf, 0x1f3d3], [0x1f3e0, 0x1f3f0], 0x1f3f4, [0x1f3f8, 0x1f43e],
+    0x1f440, [0x1f442, 0x1f4fc], [0x1f4ff, 0x1f53d], [0x1f54b, 0x1f54e],
+    [0x1f550, 0x1f567], 0x1f57a, [0x1f595, 0x1f596], 0x1f5a4,
+    [0x1f5fb, 0x1f64f], [0x1f680, 0x1f6c5], 0x1f6cc, [0x1f6d0, 0x1f6d2],
+    [0x1f6d5, 0x1f6d8], [0x1f6dc, 0x1f6df], [0x1f6eb, 0x1f6ec],
+    [0x1f6f4, 0x1f6fc], [0x1f7e0, 0x1f7eb], 0x1f7f0, [0x1f90c, 0x1f93a],
+    [0x1f93c, 0x1f945], [0x1f947, 0x1f9ff], [0x1fa70, 0x1fa7c],
+    [0x1fa80, 0x1fa8a], [0x1fa8e, 0x1fac6], 0x1fac8, [0x1facd, 0x1fadc],
+    [0x1fadf, 0x1faea], [0x1faef, 0x1faf8],
+];
+/** Binary search over the merged, sorted Emoji_Presentation ranges. */
+function hasEmojiPresentation(cp) {
+    let lo = 0;
+    let hi = EMOJI_PRESENTATION_RANGES.length - 1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const entry = EMOJI_PRESENTATION_RANGES[mid];
+        const start = typeof entry === 'number' ? entry : entry[0];
+        const end = typeof entry === 'number' ? entry : entry[1];
+        if (cp < start)
+            hi = mid - 1;
+        else if (cp > end)
+            lo = mid + 1;
+        else
+            return true;
+    }
+    return false;
 }
 function isZeroWidth(codePoint) {
     // Fast path for common printable range

--- a/scripts/repro-thinking.tsx
+++ b/scripts/repro-thinking.tsx
@@ -1,0 +1,181 @@
+/**
+ * thinking spinner 残影回归（issue #72 症状之一）。
+ *
+ * 背景：spinner 动画字符 ✳（U+2733）是 text-default emoji，终端画 1 格，
+ * 但 stringWidth 的 JS 回退实现曾把 emoji-regex 匹配到的字符一律量 2 格。
+ * 于是 spinner 行每次动画切到 ✳ 就整体错位 1 列，thinking 文字的残影
+ * （"tthinking"、孤立 t）在屏幕上堆积不消失。
+ *
+ * 本脚本 headless 渲染 Chat 全屏：working=true、spinnerMode='thinking'、
+ * 助手文本持续流式增长（强制内容增长 + stickyScroll），捕获全部帧字节，
+ * 用 xterm-headless 回放后断言可见区干净：
+ *
+ * - 恰有 1 行含 'thinking'（spinner 行本身；灌入文本刻意不含该词）
+ * - 无 'tthinking' 叠字
+ * - 无孤立残影 't'（任意列，两侧为空白或行尾）
+ *
+ * 运行：node --import tsx/esm scripts/repro-thinking.tsx
+ * 可选：COLS/ROWS 环境变量控制终端尺寸。失败以非零退出。
+ */
+process.env.FORCE_COLOR = '3'
+
+const [{ PassThrough, Writable }, React, { render }, { Chat }, { QuestionStore }, { Terminal: XTerm }, fs] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/questions.js'),
+    import('@xterm/headless'),
+    import('node:fs'),
+  ])
+
+const COLS = Number(process.env.COLS ?? 100)
+const ROWS = Number(process.env.ROWS ?? 28)
+
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  frames: string[] = []
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void) {
+    this.frames.push(String(chunk))
+    callback()
+  }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+
+// ── 可变 channel：模拟一轮 thinking + 流式输出 ──
+const rows: any[] = [
+  { id: 0, kind: 'user', text: '帮我分析一下这个渲染问题的可能原因' },
+]
+let version = 0
+const listeners = new Set<() => void>()
+const channel = {
+  get version() { return version },
+  rows,
+  status: 'working',
+  sessionTitle: 'repro',
+  agentId: 'repro',
+  model: 'deepseek-v4-flash',
+  tokens: { input: 120, output: 45 },
+  cwd: '/tmp/repro',
+  gitBranch: 'main',
+  working: true,
+  spinnerMode: 'thinking',
+  get responseChars() { return currentText.length },
+  activeToolCount: 0,
+  turnStart: Date.now(),
+  lastUserText: '帮我分析一下这个渲染问题的可能原因',
+  pending: [],
+  commandList: [],
+  notifications: [],
+  activityEnabled: false, // 强制走 WorkingSpinner（而非 ActivityLine）
+  contextBarEnabled: false,
+  subscribe: (fn: () => void) => { listeners.add(fn); return () => listeners.delete(fn) },
+  submit: () => {},
+  cancel: () => {},
+  clear: () => {},
+  notify: () => {},
+  listModels: () => Promise.resolve([]),
+  listSessions: () => [],
+  setResumeTarget: () => {},
+} as never
+
+let currentText = ''
+let nextId = 1
+function pushChunk(chunk: string) {
+  currentText += chunk
+  // 更新流式中的 assistant 行
+  const last = rows[rows.length - 1]
+  if (last && last.kind === 'assistant' && last.streaming) {
+    last.text = currentText
+  } else {
+    rows.push({ id: nextId++, kind: 'assistant', text: currentText, streaming: true })
+  }
+  version++
+  for (const fn of listeners) fn()
+}
+
+const stdout = new FakeStdout()
+const instance = await render(
+  React.createElement(Chat, { channel, questionStore: new QuestionStore(), onExit: () => {} }),
+  {
+    stdout,
+    stdin: new FakeStdin(),
+    stderr: new FakeStderr(),
+    exitOnCtrlC: false,
+    patchConsole: false,
+  },
+)
+
+// 启动稳定
+await new Promise(r => setTimeout(r, 500))
+
+// 流式灌文本 ~6 秒（thinking 状态保持）。内容刻意全为中文、不含 'thinking'
+// 与孤立 ASCII 't'，让残影断言无歧义。
+const CHUNKS = [
+  '好的，', '让我来分析', '这个问题。', '首先，', '渲染器', '使用相对', '光标移动',
+  '来重绘', '变化的单元格。', '如果虚拟', '光标与真实', '终端光标', '失步，',
+  '写入就会', '落在错误的', '位置。', '具体来说，', '动画行', '每 50ms',
+  '重绘一次，', '微光颜色', '每帧都在变化。', '这就导致', '该行所有单元格',
+  '每帧都被重写。', '如果光标模型', '偏差了一行，', '重写就会', '落在下一行，',
+  '留下残影。', '这就是', '多个字符', '堆积的原因。', '分析完毕。',
+]
+for (const chunk of CHUNKS) {
+  pushChunk(chunk)
+  await new Promise(r => setTimeout(r, 120))
+}
+
+// 再让 spinner 空转几帧
+await new Promise(r => setTimeout(r, 800))
+
+const byteStream = stdout.frames.join('')
+try { instance.unmount() } catch {}
+
+// ── xterm-headless 回放 ──
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 500, allowProposedApi: true })
+term.write(byteStream)
+await new Promise(r => setTimeout(r, 1200))
+
+const buf = term.buffer.active
+const lines: string[] = []
+for (let y = 0; y < ROWS; y++) {
+  lines.push(buf.getLine(y)?.translateToString(true) ?? '')
+}
+
+// ── 残影检测 ──
+const problems: string[] = []
+let thinkingRows = 0
+lines.forEach((line, y) => {
+  if (line.includes('thinking')) thinkingRows++
+  if (/tthinking/.test(line)) problems.push(`row ${y}: 叠字残影 "tthinking" → ${JSON.stringify(line)}`)
+  // 孤立 't'：两侧为空白/行首行尾（灌入文本不含 ASCII 't'，出现即残影）
+  const m = line.match(/(?:^|\s)t(?=\s|$)/)
+  if (m) problems.push(`row ${y}: 孤立残影 't' → ${JSON.stringify(line)}`)
+})
+if (thinkingRows !== 1) {
+  problems.push(`含 'thinking' 的行数为 ${thinkingRows}（期望 1，即 spinner 行本身）`)
+}
+
+if (problems.length > 0) {
+  const dump = '/tmp/repro-thinking-frames.bin'
+  fs.writeFileSync(dump, byteStream)
+  console.error(`FAIL: thinking spinner 残影回归（帧字节已存 ${dump}）`)
+  console.error(`=== xterm-headless replay: ${COLS}x${ROWS} (viewport baseY=${buf.baseY}) ===`)
+  lines.forEach((line, y) => console.error(`${String(y).padStart(3)}|${line}`))
+  for (const p of problems) console.error(`- ${p}`)
+  process.exit(1)
+}
+
+console.log(`PASS: thinking spinner 无残影（${COLS}x${ROWS}，spinner 行恰 1 处 'thinking'）`)
+process.exit(0)

--- a/src/ink/stringWidth.ts
+++ b/src/ink/stringWidth.ts
@@ -123,7 +123,67 @@ function getEmojiWidth(grapheme: string): number {
     }
   }
 
+  // Single codepoint without VS16: only Emoji_Presentation=Yes characters
+  // actually render as wide emoji. Text-default emoji (✳ U+2733, ⚠ U+26A0,
+  // ❤ U+2764, ❄ U+2744, ✂ U+2702 …) render width 1 in terminals
+  // (ghostty/kitty/iTerm2/xterm.js all agree) unless VS16 forces emoji
+  // presentation. emoji-regex matches BOTH categories, so counting every
+  // match as 2 desyncs the layout from the terminal: the spinner glyph ✳
+  // measured 2 but painted 1, shifting the whole spinner row 1 column every
+  // time the animation cycle hit it — leaving stray cells ("tthinking",
+  // orphan "t" residue). VS16 sequences fall through to width 2 below.
+  if (!grapheme.includes('\ufe0f')) {
+    let codepoints = 0
+    for (const _ of grapheme) codepoints++
+    if (codepoints === 1 && !hasEmojiPresentation(first)) {
+      return 1
+    }
+  }
+
   return 2
+}
+
+/**
+ * Emoji_Presentation=Yes codepoints (Unicode emoji-data.txt, merged
+ * ranges). These render as wide emoji without VS16; everything else
+ * emoji-regex matches is text-default and renders narrow.
+ */
+const EMOJI_PRESENTATION_RANGES: Array<number | [number, number]> = [
+  [0x231a, 0x231b], [0x23e9, 0x23ec], 0x23f0, 0x23f3, [0x25fd, 0x25fe],
+  [0x2614, 0x2615], [0x2648, 0x2653], 0x267f, 0x2693, 0x26a1,
+  [0x26aa, 0x26ab], [0x26bd, 0x26be], [0x26c4, 0x26c5], 0x26ce, 0x26d4,
+  0x26ea, [0x26f2, 0x26f3], 0x26f5, 0x26fa, 0x26fd, 0x2705,
+  [0x270a, 0x270b], 0x2728, 0x274c, 0x274e, [0x2753, 0x2755], 0x2757,
+  [0x2795, 0x2797], 0x27b0, 0x27bf, [0x2b1b, 0x2b1c], 0x2b50, 0x2b55,
+  0x1f004, 0x1f0cf, 0x1f18e, [0x1f191, 0x1f19a], [0x1f1e6, 0x1f1ff],
+  0x1f201, 0x1f21a, 0x1f22f, [0x1f232, 0x1f236], [0x1f238, 0x1f23a],
+  [0x1f250, 0x1f251], [0x1f300, 0x1f320], [0x1f32d, 0x1f335],
+  [0x1f337, 0x1f37c], [0x1f37e, 0x1f393], [0x1f3a0, 0x1f3ca],
+  [0x1f3cf, 0x1f3d3], [0x1f3e0, 0x1f3f0], 0x1f3f4, [0x1f3f8, 0x1f43e],
+  0x1f440, [0x1f442, 0x1f4fc], [0x1f4ff, 0x1f53d], [0x1f54b, 0x1f54e],
+  [0x1f550, 0x1f567], 0x1f57a, [0x1f595, 0x1f596], 0x1f5a4,
+  [0x1f5fb, 0x1f64f], [0x1f680, 0x1f6c5], 0x1f6cc, [0x1f6d0, 0x1f6d2],
+  [0x1f6d5, 0x1f6d8], [0x1f6dc, 0x1f6df], [0x1f6eb, 0x1f6ec],
+  [0x1f6f4, 0x1f6fc], [0x1f7e0, 0x1f7eb], 0x1f7f0, [0x1f90c, 0x1f93a],
+  [0x1f93c, 0x1f945], [0x1f947, 0x1f9ff], [0x1fa70, 0x1fa7c],
+  [0x1fa80, 0x1fa8a], [0x1fa8e, 0x1fac6], 0x1fac8, [0x1facd, 0x1fadc],
+  [0x1fadf, 0x1faea], [0x1faef, 0x1faf8],
+]
+
+/** Binary search over the merged, sorted Emoji_Presentation ranges. */
+function hasEmojiPresentation(cp: number): boolean {
+  let lo = 0
+  let hi = EMOJI_PRESENTATION_RANGES.length - 1
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    const entry = EMOJI_PRESENTATION_RANGES[mid]!
+    const start = typeof entry === 'number' ? entry : entry[0]
+    const end = typeof entry === 'number' ? entry : entry[1]
+    if (cp < start) hi = mid - 1
+    else if (cp > end) lo = mid + 1
+    else return true
+  }
+  return false
 }
 
 function isZeroWidth(codePoint: number): boolean {


### PR DESCRIPTION
## 动机

issue #72 症状之一：模型思考时 TUI 渲染飘、残影堆积。本 PR 定位并修复其中一个确定性根因——thinking spinner 行的 `t`/`thinking` 残影不消失。

**根因**：spinner 动画字符 ✳（U+2733）是 text-default emoji，主流终端（ghostty/kitty/iTerm2/xterm.js）都画 1 格；但 `src/ink/stringWidth.ts` 的 JS 回退实现把 emoji-regex 匹配到的字符一律量 2 格。于是 spinner 行每次动画切到 ✳ 就整体错位 1 列，thinking 文字的残影（`tthinking` 叠字、孤立 `t`）在屏幕上堆积。仅 node 路径受影响（`Bun.stringWidth("✳")` 实测为 1）。

**复现取证**：headless 渲染 Chat 全屏（working + spinnerMode='thinking' + 流式增长），帧字节经 xterm-headless 回放，未修复时可见：

```
24|                               t
25|✳ Pouncing… (5s · ↓ 44 tokens ·tthinking)
```

## 改动

- `src/ink/stringWidth.ts`：`getEmojiWidth` 对单码点无 VS16 的 grapheme，仅 Emoji_Presentation=Yes 量 2 格；text-default emoji 量 1 格（新增 Unicode emoji-data 的 Emoji_Presentation 区间表 + 二分查找）。VS16 序列仍量 2。
- `scripts/repro-thinking.tsx`：新增 headless 残影回归——xterm-headless 回放后断言 spinner 行恰 1 处 `thinking`、无 `tthinking` 叠字、无任意列孤立 `t`，失败非零退出并 dump 屏幕。
- `.github/workflows/ci.yml`：挂入该回归。
- `lib/types/`：`pnpm build` 对应产物。

## 验证

- `pnpm build` 通过，生成产物仅 stringWidth 相关，无漂移。
- `repro-thinking.tsx` 双向对照：**撤掉修复 → FAIL**（检出孤立 `t` 残影，exit 1）；**应用修复 → PASS**。
- CI 渲染相关回归全绿：`repro-askpanel`、`verify-askpanel-layout`、`repro-toolcards`、`verify-cjk-truncate`、`pnpm smoke`。
- 未验：Windows ConPTY、tmux 真机手动走查。

## 说明

- issue #72 还提到鲸鱼残影、任务列表残留、tmux Shift+Enter、流式空白等其他症状，成因各异，本 PR 只修 spinner 宽度错位这一项，保持单一逻辑改动。
- 同目录另有若干取证脚本（bisect-residue 等）属本地调试工具，未纳入本 PR。