### PR TITLE
feat(cli): 新增 dsh-tui 直达命令——全局安装后免 --profile 启动

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,22 @@
 `DEEPSEEK_API_KEY`。
 
 ```sh
-# 1. 安装 DeepSeek Harness CLI（已装可跳过）
-npm install -g @deepseek-ai/dsh
+# 1. 全局安装 CLI + 本插件（本插件自带 dsh-tui 直达命令）
+npm install -g @deepseek-ai/dsh dsh-cc-tui
 
-# 2. 装入本插件（仓库根目录 install.sh 已封装这条命令，含 pnpm 预检）
-sh install.sh
-# 或手工执行：
-dsh plugin --profile cc-tui add dsh-cc-tui
-
-# 3. 启动
-dsh --profile cc-tui
+# 2. 启动（首次运行会自动初始化 cc-tui profile，需 pnpm）
+dsh-tui
 ```
 
-Windows 也可用仓库里的 `dsh-cc.cmd`（等价，且 `--resume` 恢复上次会话）。
+备选——手工安装 profile（仓库根目录 `install.sh` 已封装，含 pnpm 预检）：
+
+```sh
+sh install.sh
+# 或：dsh plugin --profile cc-tui add dsh-cc-tui
+# 之后 dsh-tui 与 dsh --profile cc-tui 等价
+```
+
+`dsh-tui --resume` 恢复上次会话；Windows 也可用仓库里的 `dsh-cc.cmd`（等价）。
 
 TUI 启动后会在后台检查 npm 是否有新版本；发现更新时会提示，输入 `/update`
 即可自动更新并重启恢复当前会话。

--- a/README_EN.md
+++ b/README_EN.md
@@ -63,19 +63,19 @@ Prerequisites: an interactive terminal TTY, the official `dsh` CLI, and
 `pnpm` 10+. Model requests also require `DEEPSEEK_API_KEY`.
 
 ```sh
-# 1. Install the DeepSeek Harness CLI
-npm install -g @deepseek-ai/dsh
+# 1. Install the CLI and this plugin globally (ships the dsh-tui command)
+npm install -g @deepseek-ai/dsh dsh-cc-tui
 
-# 2. Add the dsh-TUI profile plugin
-dsh plugin --profile cc-tui add dsh-cc-tui
-
-# 3. Start it
-dsh --profile cc-tui
+# 2. Start it (first run auto-initializes the cc-tui profile; needs pnpm)
+dsh-tui
 ```
 
-The repository's `sh install.sh` wraps step 2 and checks the required commands.
-Windows users can also launch with `dsh-cc.cmd`; passing `--resume` restores the
-most recently selected session.
+Manual alternative: `dsh plugin --profile cc-tui add dsh-cc-tui` (the
+repository's `sh install.sh` wraps this step and checks the required
+commands), then `dsh-tui` and `dsh --profile cc-tui` are equivalent.
+
+`dsh-tui --resume` restores the most recently selected session; on Windows
+the repository's `dsh-cc.cmd` works the same way.
 
 See [Getting started](docs/getting-started.en.md) for profile composition,
 source builds, and troubleshooting.

--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * dsh-tui — cc-tui profile 的一键直达启动器。
+ *
+ * 全局安装 dsh-cc-tui 后获得 `dsh-tui` 命令，免去手工输入
+ * `dsh --profile cc-tui`：
+ *
+ *   1. 检测 dsh CLI（缺失时提示安装 @deepseek-ai/dsh）；
+ *   2. 检测 $DSH_HOME/profiles/cc-tui 是否已初始化，未初始化则自动
+ *      执行 `dsh plugin --profile cc-tui add dsh-cc-tui@<本包版本>` 自举
+ *      ——版本号与本包对齐，避免 pnpm store 缓存带来的旧版漂移；
+ *   3. 透传全部参数启动 `dsh --profile cc-tui`。
+ *
+ * `--resume` 由本启动器拦截：读取 TUI 硬编码的 ~/.dsh-cc/resume.txt，
+ * 以 DSH_CC_RESUME_SESSION 环境变量喂回（见 src/sessionHistory.ts 的
+ * 启动器契约），该 flag 本身不再传给 dsh。
+ */
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = fileURLToPath(new URL('.', import.meta.url))
+const ownVersion = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')).version
+
+// React 开发构建会把每次渲染的 performance.measure() 堆进无界缓冲区导致
+// 长会话 OOM——与仓库根 dsh-cc.cmd 保持一致，强制 production。
+process.env.NODE_ENV ??= 'production'
+
+const isWin = process.platform === 'win32'
+// Windows 上 .cmd  shim 必须经 shell 启动（Node ≥18.20.2 的安全限制）；
+// 其余平台直接 spawn 无后缀的 dsh。
+const shellOpt = isWin ? { shell: true } : {}
+
+function runSync(args, options = {}) {
+  return spawnSync('dsh', args, { stdio: 'inherit', ...shellOpt, ...options })
+}
+
+// --- 1. dsh CLI 预检 ---------------------------------------------------------
+const probe = spawnSync('dsh', ['--version'], { stdio: 'pipe', ...shellOpt })
+if (probe.error || probe.status !== 0) {
+  console.error('[dsh-tui] 未检测到 dsh CLI。请先安装官方客户端：')
+  console.error('  npm install -g @deepseek-ai/dsh')
+  process.exit(1)
+}
+
+// --- 2. profile 自举 ----------------------------------------------------------
+const dshHome = process.env.DSH_HOME || join(homedir(), '.dsh')
+const profileDir = join(dshHome, 'profiles', 'cc-tui')
+if (!existsSync(join(profileDir, 'node_modules', 'dsh-cc-tui'))) {
+  const pnpmProbe = spawnSync('pnpm', ['--version'], { stdio: 'pipe', ...shellOpt })
+  if (pnpmProbe.error || pnpmProbe.status !== 0) {
+    console.error('[dsh-tui] 首次安装需要 pnpm（dsh plugin 会把安装转发给它）：')
+    console.error('  npm install -g pnpm   （或启用 corepack：corepack enable pnpm）')
+    process.exit(1)
+  }
+  console.log(`[dsh-tui] 首次运行，正在初始化 cc-tui profile（dsh-cc-tui@${ownVersion}）…`)
+  const add = runSync(['plugin', '--profile', 'cc-tui', 'add', `dsh-cc-tui@${ownVersion}`])
+  if (add.status !== 0) {
+    console.error('[dsh-tui] 插件安装失败。可稍后手工重试：')
+    console.error(`  dsh plugin --profile cc-tui add dsh-cc-tui@${ownVersion}`)
+    process.exit(add.status ?? 1)
+  }
+}
+
+// --- 3. --resume 拦截 ---------------------------------------------------------
+const args = []
+for (const a of process.argv.slice(2)) {
+  if (a === '--resume') {
+    try {
+      process.env.DSH_CC_RESUME_SESSION = readFileSync(join(homedir(), '.dsh-cc', 'resume.txt'), 'utf8').trim()
+    } catch {
+      // 没有历史会话可恢复——静默忽略，正常冷启动。
+    }
+  } else {
+    args.push(a)
+  }
+}
+
+// --- 4. 启动 ------------------------------------------------------------------
+const child = spawn('dsh', ['--profile', 'cc-tui', ...args], {
+  stdio: 'inherit',
+  env: process.env,
+  ...shellOpt,
+})
+child.on('error', (err) => {
+  console.error(`[dsh-tui] 启动失败：${err.message}`)
+  process.exit(1)
+})
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+  } else {
+    process.exit(code ?? 0)
+  }
+})

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,16 +30,26 @@ $env:DEEPSEEK_API_KEY = 'your-key'
 
 ## 安装
 
-```sh
-# 安装官方 CLI
-npm install -g @deepseek-ai/dsh
+最快路径（全局安装后自带 `dsh-tui` 直达命令）：
 
-# pnpm 未安装时任选一种方式
+```sh
+# 官方 CLI + 本插件
+npm install -g @deepseek-ai/dsh dsh-cc-tui
+
+# pnpm 未安装时任选一种方式（首次启动自动初始化 profile 时需要）
 npm install -g pnpm
 # 或：corepack enable pnpm
 
-# 为 cc-tui profile 安装插件
+# 启动：首次运行自动执行 dsh plugin --profile cc-tui add dsh-cc-tui@<版本>
+dsh-tui
+```
+
+手工分步（等价）：
+
+```sh
+npm install -g @deepseek-ai/dsh
 dsh plugin --profile cc-tui add dsh-cc-tui
+dsh --profile cc-tui   # 或 dsh-tui
 ```
 
 从仓库检出运行时，也可以执行：

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "dsh-cc-tui",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "dsh-tui": "./bin/dsh-tui.js"
+  },
   "main": "lib/types/index.js",
   "types": "lib/types/index.d.ts",
   "exports": {
@@ -24,6 +27,7 @@
     "./src/*": "./src/*"
   },
   "files": [
+    "bin",
     "lib",
     "cordis.patch.yml",
     "cordis.yml",


### PR DESCRIPTION
## 变更

- **新增 `bin/dsh-tui.js`**：直达启动器。检测 dsh CLI → cc-tui profile 未初始化则自动 `dsh plugin --profile cc-tui add dsh-cc-tui@<本包版本>` 自举（版本自钉，规避 pnpm store 旧缓存）→ 透传全部参数启动。`--resume` 按 `src/sessionHistory.ts` 的启动器契约读取 `~/.dsh-cc/resume.txt` 喂 `DSH_CC_RESUME_SESSION`。Windows 下经 shell 启动 .cmd shim（Node ≥18.20.2 安全限制）
- **package.json**：`bin: {"dsh-tui": "./bin/dsh-tui.js"}`，`files` 收编 `bin/`，版本 0.4.1 → 0.4.2
- **文档**（README 中英 + getting-started）：安装流程简化为 `npm i -g @deepseek-ai/dsh dsh-cc-tui` → `dsh-tui`，手工 profile 流程保留为备选

## 用户价值

装完输 `dsh-tui` 直接进 TUI，无需记忆 `--profile cc-tui`。纯增量：包名、profile 名、插件 id 均不变，老用户零迁移。

## 验证

- [x] 本地 profile 已存在路径：链路直达（headless 下按预期停在 interactive-terminal 检查）
- [x] 全新 DSH_HOME 路径：正确触发自举（因 0.4.2 未发布而停在版本不存在，发布后即通）
- [x] `npm pack --dry-run` 确认 bin/ 进 tarball
- [x] Windows cmd / git bash 双通道实测

注：本 PR 为旧包名 `dsh-cc-tui` 的收官特性版；改名方案见 #87，两者互补不冲突。