### PR TITLE
feat(activity): TUI bundle 默认开启工作状态行（publish: true）

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -211,8 +211,12 @@
     # bare name died with ERR_MODULE_NOT_FOUND and disposed the whole app at
     # boot (#60).
     # publishIntervalMs 500 keeps the status-line timers ticking smoothly
-    # (default 2000ms).
+    # (default 2000ms). publish is enabled here (upstream default off since
+    # 0.2.2) because this profile's resume path repairs third-party event
+    # types via src/compat/sessionLog.ts — the TUI is the protected consumer;
+    # the bare plugin stays default-off for unprotected web/headless users.
     - id: working-activity
       name: '@deepseek-harness-tui/dsh-tui/working-activity'
       config:
+        publish: true
         publishIntervalMs: 500

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-harness-tui/dsh-tui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 变更

TUI bundle patch 挂载 working-activity 的行补 `publish: true`（上游 0.2.2 起默认关）。

## 为什么现在开是安全的

0.5.1 起本包的 resume 路径有 `src/compat/sessionLog.ts` 兼容层兜底：第三方事件类型（activity/status）在 resume 前自动补 ignorable 标记，不再触发整会话拒绝。TUI 是被保护的消费者。

裸 `dsh-working-activity` 包保持默认关：web/headless 场景没有兼容层保护。

## 验证

- [x] `dsh --patch cordis.patch.yml --dump-config` 组合验证：working-activity config = publish:true + publishIntervalMs:500
- [x] 本机 profile 已有同配置覆盖层在跑（0.5.1 期间手工开的），行为一致