### PR TITLE
fix(deps): dsh-working-activity ^0.2.4——类型注册根治未知事件连环炸

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-harness-tui/dsh-tui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "repository": {
@@ -83,7 +83,7 @@
     "cli-boxes": "^3.0.0 || ^4.0.0",
     "cli-highlight": "^2.1.11",
     "code-excerpt": "^3.0.0 || ^4.0.0",
-    "dsh-working-activity": "^0.2.2",
+    "dsh-working-activity": "^0.2.4",
     "emoji-regex": "^10.0.0",
     "figures": "^6.1.0",
     "get-east-asian-width": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.0
       dsh-working-activity:
-        specifier: ^0.2.2
-        version: 0.2.2(39a36c574a0198ee03b30434badbe59d)
+        specifier: ^0.2.4
+        version: 0.2.4(39a36c574a0198ee03b30434badbe59d)
       emoji-regex:
         specifier: ^10.0.0
         version: 10.6.0
@@ -908,8 +908,8 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  dsh-working-activity@0.2.2:
-    resolution: {integrity: sha512-9gjEP2AYQpUccUvogyHZnPL+HxMqQz4vDCODgLXaY8tGVbSwOY1HC874pMsL3e8Mcl3KtqjZx1xyDiZvJHqzuw==}
+  dsh-working-activity@0.2.4:
+    resolution: {integrity: sha512-UwTFlL6XDwUuahGx57HB72uKAXpyEuPGA1sXFKlG1A8ggQVfZkrjpt4N4oq8UcA8a944oQUuY2aTcngErNzgGg==}
     engines: {node: ^22.19 || >=24}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
@@ -1678,7 +1678,7 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  dsh-working-activity@0.2.2(39a36c574a0198ee03b30434badbe59d):
+  dsh-working-activity@0.2.4(39a36c574a0198ee03b30434badbe59d):
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,5 +42,5 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-user-approval@0.1.0-rc.6'
   - '@deepseek-ai/dsh-user-questions@0.1.0-rc.6'
   - '@deepseek-ai/schemastery@3.18.1'
-  - dsh-working-activity@0.2.2
+  - dsh-working-activity@0.2.2 || 0.2.4
   - '@deepseek-ai/dsh-session-persistence-jsonl@0.1.0-rc.6'


### PR DESCRIPTION
dsh-working-activity 0.2.4 在加载时把 `activity/status` 注册进所有可达的 `KNOWN_SESSION_EVENT_TYPES` 副本（import.meta.url + process.argv[1] 双锚点——CLI 树与 profile 树在升级窗口期会加载不同物理副本，严格校验器只查自己那份）。

至此同一颗雷的三层防御齐备：
1. **写入侧注册**（本次）：挂载插件的进程里，新旧日志的 activity 事件对所有严格校验放行；
2. **读取侧 resume 修复**（0.5.1）：未挂载插件的消费方仍能把旧日志补标 ignorable；
3. **选择器标题宽容读取**（0.6.0）：任何未知类型都不再影响标题。