### PR TITLE
fix(test): 子进程 stderr 重复计数断言兼容英文环境

### DIFF
--- a/scripts/verify-child-stderr.tsx
+++ b/scripts/verify-child-stderr.tsx
@@ -90,7 +90,7 @@ async function runDriver(): Promise<void> {
   reporter.push(failing)
   await sleep(150)
   check('去重：同一行连发 3 次只出一条通知', notices.length === 1)
-  check('去重：通知带重复计数（重复 3 次）', notices[0]?.includes('重复 3 次') ?? false)
+  check('去重：通知带重复计数（重复 3 次）', /(?:重复 3 次|repeated 3×)/u.test(notices[0] ?? ''))
 
   reporter.push(failing)
   await sleep(150)


### PR DESCRIPTION
## Summary
- make the child stderr reporter repeat-count assertion locale-neutral
- keep the regression meaningful under both zh and en UI language defaults

## Verification
- corepack pnpm build
- corepack pnpm verify:package
- corepack pnpm exec tsx scripts/verify-child-stderr.tsx
- corepack pnpm exec tsx scripts/verify-shutdown-stderr.tsx

Refs #93