### PR TITLE
fix(test): 修复 #153 回归在 Windows 上的权限误判

### DIFF
--- a/scripts/verify-resume-legacy-events.mjs
+++ b/scripts/verify-resume-legacy-events.mjs
@@ -102,7 +102,9 @@ assert.equal(loaded.events[0].type, 'activity/status')
 // 3. The shared store was never rewritten.
 assert.equal(Buffer.compare(readFileSync(legacyFile), bytesBefore), 0, 'log bytes untouched')
 assert.equal(statSync(legacyFile).mode & 0o777, modeBefore, 'log mode untouched')
-assert.equal(modeBefore, 0o600, 'fixture really exercised the 0600 contract')
+if (process.platform !== 'win32') {
+  assert.equal(modeBefore, 0o600, 'fixture really exercised the 0600 contract')
+}
 
 // 4. Fail-closed preserved: the non-whitelisted unknown still rejects.
 await assert.rejects(


### PR DESCRIPTION
## 修改

- Windows 上继续断言 #153 resume 兼容层不会改变日志权限位
- 仅在支持 POSIX mode 的平台要求测试夹具必须呈现为 `0600`
- 保留 Linux CI 对 `0600` 契约的原有覆盖

## 根因

Windows 的 Node `chmodSync(path, 0o600)` 在 NTFS 上通过 `statSync().mode & 0o777` 读取为 `0666`。原回归先成功证明兼容层前后 mode 完全一致，随后却无条件要求初始 mode 为 `0600`，导致 Windows 本地验证假失败。

最小探针在系统临时目录与仓库目录都稳定返回 `0666`，排除了路径 ACL 和被测代码改写。

## 验证

- `pnpm build`
- `pnpm verify:package`
- `node scripts/verify-resume-legacy-events.mjs`
- `node scripts/verify-session-titles.mjs`
- `node scripts/verify-session-cwd.mjs`

范围说明：这是 #153 回归脚本的 Windows 可移植性修复，不解决 issue 中尚无退出码证据的 macOS 静默崩溃。