### PR TITLE
fix(scripts): 回归读屏取视口而非整个缓冲区，并补一条收缩重绘守卫

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,11 @@ jobs:
       # 旧宽度的测量结果，靠 flex 仲裁的行因此由两套布局拼成。
       - run: node --import tsx/esm scripts/verify-resize-reflow.tsx
 
+      # 收缩重绘回归：一个高于视口的帧在一帧内收起，屏幕必须等于同一短状态的
+      # 全新渲染——不留旧帧、表头不出现两次。shrink-frame 家族（#38/#39/#19/
+      # #10）里步长最大的一档，不经 Chat，直接对渲染器。
+      - run: node --import tsx/esm scripts/repro-collapse-shrink.tsx
+
       # /provider 向导回归：catalog/custom 两分支的 profile 形状、凭据回滚
       # （覆盖时恢复旧 key 而非误删）、env shadow 跳过、rc.6 兼容守卫、
       # hideCustomInput 逐题标记。

--- a/scripts/repro-collapse-shrink.tsx
+++ b/scripts/repro-collapse-shrink.tsx
@@ -1,0 +1,161 @@
+/**
+ * Collapsing a frame that is taller than the viewport must not leave a copy of
+ * it on screen.
+ *
+ * This is the shrink-frame family (#38/#39/#19/#10) at its largest step. The
+ * everyday cases — a thinking fold, the spinner row unmounting, markdown
+ * reflow — shrink the frame by a row or two, and `repaintViewportInPlace`
+ * handles them. The step this pins is the big one: an expanded panel that made
+ * the frame much TALLER than the viewport collapses back in a single frame.
+ *
+ * Reported from the loaded-context panel (expand with Ctrl+T, collapse again)
+ * and reproduced here without Chat, so the check describes the renderer rather
+ * than one screen's layout.
+ *
+ * The oracle is final-state equivalence, the same one verify-resize-reflow
+ * uses and for the same reason: it needs no theory of the bug. Drive the
+ * shrink, then build the same short state fresh, and demand the two screens
+ * match. Whatever the shrink path forgot to erase shows up as a diff.
+ *
+ * Run: node --import tsx/esm scripts/repro-collapse-shrink.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+  ])
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const COLS = 80
+const ROWS = 24
+
+function makeHarness() {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true })
+  const writes: string[] = []
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      writes.push(String(chunk))
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  /** Visible viewport rows, blanks dropped — placement is not what is at
+   *  stake here, leftover content is. */
+  const screen = (): string[] => {
+    // getLine() indexes the WHOLE buffer, scrollback included. The viewport
+    // starts at baseY — reading from 0 returns scrollback rows, which after a
+    // frame taller than the terminal is the previous, larger frame.
+    const buffer = term.buffer.active
+    return Array.from({ length: ROWS }, (_, y) =>
+      (buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+      .filter(line => line !== '')
+  }
+  return { term, stdout: new FakeStdout(), stdin: new FakeStdin(), screen, writes }
+}
+
+/**
+ * A header that never changes plus a body that can be much taller than the
+ * viewport — the shape of any expandable panel.
+ */
+function Panel({ open, bodyRows }: { open: boolean; bodyRows: number }): React.ReactNode {
+  return (
+    <Box flexDirection="column">
+      <Text>{open ? '▼' : '▶'} panel header</Text>
+      {open && (
+        <Box flexDirection="column">
+          {Array.from({ length: bodyRows }, (_, i) => (
+            <Text key={i}>{`  body line ${i + 1}`}</Text>
+          ))}
+        </Box>
+      )}
+      <Text>tail marker</Text>
+    </Box>
+  )
+}
+
+/** Body rows chosen so the OPEN frame is comfortably taller than the viewport. */
+const BODY_ROWS = ROWS + 12
+
+async function run(): Promise<void> {
+  // ── drive the shrink: render open, then collapse in place ────────────────
+  const live = makeHarness()
+  let setOpen: ((value: boolean) => void) | undefined
+  function Host(): React.ReactNode {
+    const [open, set] = React.useState(true)
+    setOpen = set
+    return <Panel open={open} bodyRows={BODY_ROWS} />
+  }
+  const liveInstance = await render(<Host />, {
+    stdout: live.stdout as never,
+    stdin: live.stdin as never,
+    stderr: live.stdout as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  await sleep(400)
+  check('the expanded frame is taller than the viewport', live.screen().length >= ROWS - 1,
+    `${live.screen().length} rows visible of ${ROWS}`)
+
+  const mark = live.writes.length
+  setOpen?.(false)
+  await sleep(600)
+  if (process.env.DBG_SHRINK === '1') {
+    live.writes.slice(mark).forEach((w, i) => {
+      console.log(`[w${i}] ${JSON.stringify(w.slice(0, 160))}`)
+    })
+  }
+  const collapsed = live.screen()
+  liveInstance.unmount()
+  live.term.dispose()
+  await sleep(40)
+
+  // ── the same short state, built fresh ────────────────────────────────────
+  const cold = makeHarness()
+  const coldInstance = await render(<Panel open={false} bodyRows={BODY_ROWS} />, {
+    stdout: cold.stdout as never,
+    stdin: cold.stdin as never,
+    stderr: cold.stdout as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  await sleep(400)
+  const fresh = cold.screen()
+  coldInstance.unmount()
+  cold.term.dispose()
+
+  check('the collapsed screen has no leftover body lines',
+    !collapsed.some(line => line.includes('body line')),
+    collapsed.filter(line => line.includes('body line')).length + ' leftover')
+  check('the header appears exactly once',
+    collapsed.filter(line => line.includes('panel header')).length === 1,
+    `${collapsed.filter(line => line.includes('panel header')).length} copies`)
+  check('the collapsed screen matches a fresh render',
+    collapsed.join('\n') === fresh.join('\n'),
+    collapsed.join('\n') === fresh.join('\n')
+      ? ''
+      : `after=${JSON.stringify(collapsed.slice(0, 4))} fresh=${JSON.stringify(fresh.slice(0, 4))}`)
+}
+
+await run()
+
+console.log(failed === 0 ? '\nAll collapse-shrink checks passed.' : `\n${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-resize-reflow.tsx
+++ b/scripts/verify-resize-reflow.tsx
@@ -198,9 +198,13 @@ function makeHarness(cols: number, rows: number) {
    * agree with each other about how wide the terminal is.
    */
   const screen = (): string => {
+    // getLine() indexes the WHOLE buffer, scrollback included; the viewport
+    // starts at baseY. Reading from 0 after a frame taller than the terminal
+    // returns the PREVIOUS, larger frame's rows — which reads exactly like a
+    // repaint bug and is not one.
     const buffer = term.buffer.active
     const lines = Array.from({ length: term.rows }, (_, y) =>
-      (buffer.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+      (buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
     const divider = lines.findLastIndex(line => /^─{8,}$/.test(line.trim()))
     return lines.slice(divider === -1 ? 0 : divider)
       .filter(line => line !== '')

--- a/scripts/verify-trace-scene.tsx
+++ b/scripts/verify-trace-scene.tsx
@@ -72,11 +72,26 @@ function makeHarness(cols: number, rows: number, scrollback = 200) {
   }
   const stdin = new FakeStdin()
   const screen = (): string => {
+    // getLine() indexes the WHOLE buffer, scrollback included; the viewport
+    // starts at baseY. Reading from 0 after a frame taller than the terminal
+    // returns the PREVIOUS, larger frame's rows — which reads exactly like a
+    // repaint bug and is not one.
     const buffer = term.buffer.active
-    return Array.from({ length: rows }, (_, y) => buffer.getLine(y)?.translateToString(true) ?? '')
+    return Array.from({ length: rows }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '')
       .join('\n')
   }
-  return { term, stdout: new FakeStdout(), stdin, screen, writes }
+  /**
+   * The same rows counted from the top of the buffer.
+   *
+   * Part A mounts the scene BARE, without the `<AlternateScreen>` the product
+   * wraps it in, so the park newline scrolls its first row out of the window
+   * here and nowhere else. The alternate screen has no scrollback, so reading
+   * from 0 is what that part is actually about.
+   */
+  const screenFromTop = (): string =>
+    Array.from({ length: rows }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '')
+      .join('\n')
+  return { term, stdout: new FakeStdout(), stdin, screen, screenFromTop, writes }
 }
 
 const T0 = 1_700_000_000_000
@@ -186,7 +201,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
 // ───────────────────────── part A: the scene ────────────────────────────────
 
 {
-  const { stdout, stdin, screen, term } = makeHarness(120, 30)
+  const { stdout, stdin, screenFromTop: screen, term } = makeHarness(120, 30)
   const instance = await render(
     React.createElement(TrajectoryScene, {
       channel: makeChannel() as never,


### PR DESCRIPTION
## 问题

回归脚本读屏用的是 `term.buffer.active.getLine(y)`，而它索引的是**整个缓冲区、
含 scrollback**——视口从 `baseY` 起。帧一旦高于终端就有行被推进 scrollback，
从 0 读回来的是**上一个更大的帧**，看起来和"收起后残留旧内容"的重绘 bug 一模
一样。

我先在这上面栽了一跤：用这个读法观察"展开的上下文面板收起"，屏幕上出现两份
logo 加展开态表头，据此判定存在一个 shrink-frame 重绘缺陷。抓写流才发现渲染器
发出的字节本来就是对的：

```
CR + ESC[23A + ESC[J  然后画新帧的两行
```

换成从 `baseY` 读之后，同一交互完全正常。**那个缺陷不存在**，是判据错了。

## 改动

- `verify-resize-reflow` / `verify-trace-scene`：读屏改为 `baseY + y`。两者改
  前改后都通过，但此前在"帧高于视口"的用例里读的是 scrollback 行，比对的东西
  并不是它们声称在比对的东西。
- `verify-trace-scene` 的 **Part A 例外**，单独用 `screenFromTop`：那一部分把
  场景**裸挂**渲染，没有套产品里的 `<AlternateScreen>`，停泊换行因此把首行推出
  了窗口；而备用屏没有 scrollback，从 0 读才是那部分真正要断言的东西。理由写在
  函数注释里，不是随手留的例外。
- 新增 `repro-collapse-shrink.tsx` 并挂 CI：一个高于视口的帧在一帧内收起，用
  终局等价判据（收起后的屏幕 === 同一短状态的全新渲染）。不经 Chat，直接对
  渲染器。

`repro-collapse-shrink` 目前是**通过**的，所以它是守卫不是修复。加它的理由是这
条路径（#38/#39/#19/#10）在这个渲染器里历史最差，而"收起一个展开的大面板"是步
长最大的一档，此前没有任何断言覆盖到。

## 验证

改动前后逐一对照，全部通过：verify-resize-reflow、verify-trace-scene（35 条）、
repro-collapse-shrink、verify-trace-projection、verify-shrink、repro-pill、
repro-model-switch-scrollback。

另外复核了 `markTreeDirty`（#171 的缩放修复）在正确读法下依然被判据支持——临时
移除该修复，verify-resize-reflow 六项全失败；恢复后全过。判据本身可靠，之前那
个结论没有受读法影响。
