### PR TITLE
fix(chat): Ctrl+T 在启动上下文面板在屏时归面板，之后才归轨迹场景

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,11 @@ jobs:
       # 旧宽度的测量结果，靠 flex 仲裁的行因此由两套布局拼成。
       - run: node --import tsx/esm scripts/verify-resize-reflow.tsx
 
+      # Ctrl+T 归属回归：启动上下文面板在屏时该键属于面板（它自己在屏幕上
+      # 印着「Ctrl+T 展开」），转录有行之后才归轨迹场景。两者永不同屏——
+      # 面板只在首条消息前出现，而那正是轨迹为空的窗口。
+      - run: node --import tsx/esm scripts/verify-ctrl-t-scope.tsx
+
       # /provider 向导回归：catalog/custom 两分支的 profile 形状、凭据回滚
       # （覆盖时恢复旧 key 而非误删）、env shadow 跳过、rc.6 兼容守卫、
       # hideCustomInput 逐题标记。

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -1,0 +1,265 @@
+/**
+ * Ctrl+T scope regression.
+ *
+ * Two things in this UI can be "expanded", and they never share the screen:
+ * the startup loaded-context panel renders only while the transcript is empty,
+ * which is exactly the window where the trajectory — folded from the session's
+ * own events — has nothing in it yet.
+ *
+ * The trajectory feature claimed Ctrl+T outright on the reasoning that the
+ * panel binding was dead. It was not: the panel prints its own
+ * `（Ctrl+T 展开）` hint, so the key carried a visible promise, and the scene
+ * it opened instead was necessarily empty at that moment. The panel was left
+ * reachable only by clicking its header — no keyboard path at all.
+ *
+ * These checks pin both halves, because fixing one half by hand is how the
+ * halves drift apart:
+ *
+ * - while the panel is up, Ctrl+T expands the panel and does NOT open a scene;
+ * - once the transcript has rows, Ctrl+T opens the scene;
+ * - the panel's own hint still names the key it actually triggers.
+ *
+ * Run: node --import tsx/esm scripts/verify-ctrl-t-scope.tsx
+ */
+process.env.FORCE_COLOR = '3'
+// Asserts Chinese UI copy, so it pins the language rather than inheriting the
+// ambient one — `activeLang` resolves at import from env → persisted pref → OS
+// locale, none of which a runner is obliged to agree with.
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/dsh-adapter/questions.js'),
+  ])
+const instances = (await import('../src/ink/instances.js')).default
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const T0 = 1_700_000_000_000
+let seq = 0
+const ev = (type: string, data: unknown): Record<string, unknown> =>
+  ({ type, seq: ++seq, time: T0 + ++seq * 250, data })
+
+/** A short session, so the scene has rows to show in the second case. */
+function events(): Record<string, unknown>[] {
+  seq = 0
+  const out: Record<string, unknown>[] = []
+  out.push(ev('turn/start', { turn: 1 }))
+  out.push(ev('step/start', { turn: 1, step: 1 }))
+  out.push(ev('tool/call', { turn: 1, step: 1, callId: 'c1', name: 'read_file', arguments: '{}' }))
+  out.push(ev('tool/result', { turn: 1, step: 1, message: { source: { callId: 'c1' }, content: [] } }))
+  out.push(ev('step/end', { turn: 1, step: 1 }))
+  out.push(ev('turn/end', { turn: 1, reason: { kind: 'completed' } }))
+  return out
+}
+const EVENTS = events()
+
+/** Shapes match the LoadedContext contract in dsh-adapter/channel.ts: the
+ *  collapsed header only counts array lengths, so a fixture of bare strings
+ *  renders fine until the panel is expanded and reads the fields. */
+const LOADED_CONTEXT = {
+  sections: [
+    { name: 'harness:identity', text: '你是 dsh。' },
+    { name: 'deployment:persona', text: '简洁作答。' },
+  ],
+  contexts: [{ name: 'runtime:cwd', text: 'C:/code/x' }],
+  files: [{ displayPath: './AGENTS.md' }],
+  skills: [{ name: 'audit', description: '代码审计' }],
+  tools: [
+    { name: 'read', description: '读文件' },
+    { name: 'bash', description: '执行命令' },
+  ],
+}
+
+function makeChannel(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    version: 0,
+    rows: [],
+    status: 'idle',
+    sessionTitle: 'ctrl-t probe',
+    agentId: 'probe',
+    provider: 'deepseek',
+    model: 'deepseek-v4-pro',
+    tokens: { input: 0, output: 0 },
+    cwd: 'C:/code/x',
+    displayCwd: 'C:/code/x',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    cycleMode(): void {},
+    turnStart: T0,
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: true,
+    activityFrames: [],
+    goal: undefined,
+    todos: [],
+    loadedContext: LOADED_CONTEXT,
+    traceEvents: () => EVENTS,
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => {},
+    clear: (): void => {},
+    notify: (): void => {},
+    listModels: () => Promise.resolve([]),
+    listSessions: () => [],
+    setResumeTarget: (): void => {},
+    stageImage: () => Promise.resolve(''),
+    lastUsage: { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 },
+    contextWindow: 1_000_000,
+    contextSegments: { system: 0, prompt: 0, assistant: 0, thinking: 0, tools: 0 },
+    tps: undefined,
+    tpsSamples: [],
+    reasoningEffort: 'high',
+    agentPreset: 'standard',
+    workspaceLabel: undefined,
+    ...overrides,
+  }
+}
+
+function makeHarness(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 200, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdin = new FakeStdin()
+  const screen = (): string => {
+    // getLine() indexes the WHOLE buffer, scrollback included; the viewport
+    // starts at baseY. Reading from 0 after a frame taller than the terminal
+    // returns the PREVIOUS, larger frame's rows — which reads exactly like a
+    // repaint bug and is not one.
+    const buffer = term.buffer.active
+    return Array.from({ length: rows }, (_, y) =>
+      (buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+      .filter(line => line !== '')
+      .join('\n')
+  }
+  return { term, stdout: new FakeStdout(), stdin, screen }
+}
+
+async function mount(harness: ReturnType<typeof makeHarness>, channel: Record<string, unknown>) {
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    {
+      stdout: harness.stdout as never,
+      stdin: harness.stdin as never,
+      stderr: harness.stdout as never,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  )
+  // AlternateScreen resolves its instance through `process.stdout`; alias the
+  // fake one so the scene behaves as it does on a real terminal.
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  return instance
+}
+
+const CTRL_T = '\x14'
+const isScene = (text: string): boolean => /✦\s*轨迹/.test(text)
+/** The panel's own header line, so the open/closed marker is read where it
+ *  belongs instead of searched for anywhere on screen. */
+const panelHeader = (text: string): string =>
+  text.split('\n').find(line => line.includes('已加载上下文')) ?? ''
+
+// ── the panel is up (empty transcript): Ctrl+T belongs to the panel ─────────
+{
+  // Tall enough that the EXPANDED panel is actually on screen. At an ordinary
+  // height the expanded frame exceeds the viewport, so the terminal shows its
+  // bottom (prompt + status line) and the panel's own rows sit above the
+  // window — nothing to assert on. This says nothing about correctness at
+  // smaller sizes; the collapse below is checked either way.
+  const harness = makeHarness(100, 60)
+  const instance = await mount(harness, makeChannel({ rows: [] }))
+  await sleep(500)
+
+  const collapsed = harness.screen()
+  check('the startup panel is on screen', /已加载上下文/.test(collapsed))
+  check(
+    'and it advertises Ctrl+T',
+    collapsed.includes('Ctrl+T'),
+    collapsed.split('\n').find(line => line.includes('Ctrl+T'))?.trim(),
+  )
+  check('collapsed to begin with', panelHeader(collapsed).includes('▶'), panelHeader(collapsed).trim())
+
+  harness.stdin.write(CTRL_T)
+  await sleep(700)
+  const expanded = harness.screen()
+  check('Ctrl+T expands the panel', /系统提示词 · 2 段/.test(expanded),
+    expanded.split('\n').find(line => line.includes('系统提示词'))?.trim())
+  check('and does NOT open the scene', !isScene(expanded))
+
+  harness.stdin.write(CTRL_T)
+  await sleep(700)
+  const recollapsed = harness.screen()
+  check('Ctrl+T collapses it again', panelHeader(recollapsed).includes('▶'),
+    panelHeader(recollapsed).trim())
+  check('and the expanded body is gone', !/系统提示词 · 2 段/.test(recollapsed))
+
+  instance.unmount()
+  instances.delete(process.stdout)
+  harness.term.dispose()
+  await sleep(40)
+}
+
+// ── the transcript has rows: the panel is gone, the key is the scene's ──────
+{
+  const harness = makeHarness(100, 30)
+  const instance = await mount(
+    harness,
+    makeChannel({ rows: [{ id: 1, kind: 'user', text: '第一条消息' }] }),
+  )
+  await sleep(500)
+
+  const before = harness.screen()
+  check('the startup panel is gone once a row exists', !/已加载上下文/.test(before))
+
+  harness.stdin.write(CTRL_T)
+  await sleep(500)
+  check('Ctrl+T opens the trajectory scene', isScene(harness.screen()), harness.screen().split('\n')[0]?.trim())
+
+  harness.stdin.write('q')
+  await sleep(400)
+  check('q returns to the conversation', !isScene(harness.screen()))
+
+  instance.unmount()
+  instances.delete(process.stdout)
+  harness.term.dispose()
+}
+
+console.log(failed === 0 ? '\nAll Ctrl+T scope checks passed.' : `\n${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -307,6 +307,14 @@ export function Chat({
   }, [])
   /** Startup context panel: expanded by header click or Ctrl+T. */
   const [loadedContextOpen, setLoadedContextOpen] = React.useState(false)
+  /**
+   * Whether the startup context panel is on screen. Derived once and read by
+   * BOTH the Ctrl+T handler and the render below: the key's meaning depends on
+   * the panel being visible, so a second copy of this condition is a place for
+   * the two to disagree — which is how the key came to advertise one thing and
+   * do another in the first place.
+   */
+  const loadedContextVisible = channel.rows.length === 0 && channel.loadedContext !== undefined
   /** `/` transcript search (less-style incsearch, ported from CC's REPL). */
   const [searchOpen, setSearchOpen] = React.useState(false)
   const [searchQuery, setSearchQuery] = React.useState('')
@@ -1619,11 +1627,25 @@ export function Chat({
       return
     }
     if (isMod(key) && input === 't') {
-      // Ctrl+T opens the trajectory scene (issue #80 evolution). It used to
-      // toggle the startup loaded-context panel — which only ever renders
-      // before the first message (see the render below), so the binding was
-      // dead for the whole rest of a session. The panel keeps its header
-      // click-to-toggle; the key now has a meaning that always applies.
+      // Ctrl+T means "expand what is in front of you", and the two things it
+      // can expand never share the screen.
+      //
+      // The startup loaded-context panel renders only while the transcript is
+      // empty (see the render below) — and that is exactly the window where
+      // the trajectory has nothing in it yet, since the trajectory is folded
+      // from the session's own events. So the panel wins while it is up, and
+      // the scene takes over for the rest of the session.
+      //
+      // Claiming the key outright for the scene was wrong even though the
+      // panel binding looked dead: the panel prints its own `（Ctrl+T 展开）`
+      // hint, so the key still had a visible promise attached to it, and the
+      // scene it opened instead was necessarily empty at that moment. That
+      // left the panel reachable only by clicking its header, which is not a
+      // keyboard path at all.
+      if (loadedContextVisible) {
+        setLoadedContextOpen(previous => !previous)
+        return
+      }
       openScene()
       return
     }
@@ -1777,7 +1799,7 @@ export function Chat({
             transcript is empty, so the collapsed summary of what this
             conversation will load (system prompt, workspace instructions,
             skills, tools) sits at the top; the first rows take over. */}
-        {channel.rows.length === 0 && channel.loadedContext !== undefined && (
+        {loadedContextVisible && (
           <LoadedContextPanel
             context={channel.loadedContext}
             open={loadedContextOpen}


### PR DESCRIPTION
## 我引入的回归

#171 把 `Ctrl+T` 收给轨迹场景，依据是「这个绑定在会话其余时间都是死的」——面板
只在首条消息之前渲染。前半句没错，但我漏了一件事：**面板自己在屏幕上印着
`（Ctrl+T 展开）`**。于是这个键带着一个可见的承诺被改了含义，而它转而打开的场景
在那个时刻**必然是空的**（轨迹由会话事件折叠而来，那时一条都没有）。

实测（v0.7.1）：

```
面板显示:  ▶ 已加载上下文 · 系统提示词 2 段 · … （Ctrl+T展开）
按 Ctrl+T → ✦ 轨迹  0 轮 · 0 步 · 0ms
面板纹丝不动
```

而且被我改掉的那段代码，注释写的是「keyboard only — the ported ink core handles
no mouse clicks」。所以拿走的不是"一个死绑定"，是那个面板**唯一**的键盘路径。

## 修法

让键的含义跟着屏幕上有什么走：**面板在屏时切面板，不在屏时开场景**。两者按构造
永不同屏——面板只在转录为空时渲染，而那正是轨迹为空的窗口——所以没有歧义，也不
必让用户记两个键。

面板可见性从此**只算一次**（`loadedContextVisible`），键处理与渲染共用同一个值。
此前它只存在于渲染条件里，键处理凭对它的记忆行事，两者就是这样走散的。

**只动 `src/screens/Chat.tsx`。** `LoadedContextPanel.tsx` 一行未改——#167 的窄
终端重叠改的是那个文件（#178 已合入 `a5649eb`，把两个并排 Text 合成了一个可截断
的嵌套 Text），本 PR 与它零文件重叠。两件事也不冲突：那边让这行提示不再错位，本
PR 让这行提示说的是真话。已在 `a5649eb` 上 rebase 并重跑，9 条断言全过——合并后
的表头会把提示截成 `（Ctrl+T展…`，断言用 `includes('Ctrl+T')` 仍然稳。

## 验证

新增 `verify-ctrl-t-scope.tsx` 并挂 CI，9 条断言：面板在屏时该键展开/收起面板、
展开的正文出现又消失、且**不**开场景；转录有行后该键开场景、`q` 返回；面板确实
印着这个键。

面板那一组用 60 行视口，理由是展开后的面板在普通高度下会超出视口——终端显示的是
帧的底部（输入行与状态栏），面板自身的行在窗口上方，没有可断言的东西。这不代表
小尺寸下有问题，收起那条在任何高度都验。

脚本读屏用 `buffer.baseY + y`（理由见 #187）：`getLine()` 索引整个缓冲
区含 scrollback，帧高于终端时从 0 读会读回上一个更大的帧。

相关回归通过：verify-trace-scene、verify-resize-reflow、verify-trace-projection、
verify-shrink、repro-inline-scrollback、repro-pill、repro-model-switch-scrollback；
tsc 干净。


