### PR TITLE
fix(todo): Agent 空闲后隐藏已完成任务（#72）

### DIFF
--- a/scripts/verify-goal-todo.mjs
+++ b/scripts/verify-goal-todo.mjs
@@ -114,6 +114,7 @@ async function run() {
     const { stdout, stderr, stdin } = makeStreams()
     const channel = {
       ...baseChannel,
+      working: true,
       goal: {
         id: 'g1',
         revision: 3,
@@ -145,7 +146,48 @@ async function run() {
     instance.unmount()
   }
 
-  // 3. Blocked goal with reason.
+  // 3. Idle channels drop a snapshot containing only completed work.
+  {
+    const { stdout, stderr, stdin } = makeStreams()
+    const channel = {
+      ...baseChannel,
+      todos: [
+        { content: 'Reproduce the crash', status: 'completed' },
+        { content: 'Fix the null deref in auth', status: 'completed' },
+      ],
+    }
+    const instance = await render(
+      React.createElement(GoalTodoPanel, { channel }),
+      { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
+    )
+    await sleep(500)
+    const frame = toPlain(stdout.frames.join(''))
+    check('idle channel hides an all-completed todo snapshot', frame.trim() === '', JSON.stringify(frame))
+    instance.unmount()
+  }
+
+  // 4. Idle channels retain unfinished work but drop completed rows.
+  {
+    const { stdout, stderr, stdin } = makeStreams()
+    const channel = {
+      ...baseChannel,
+      todos: [
+        { content: 'Reproduce the crash', status: 'completed' },
+        { content: 'Add a regression test', status: 'pending' },
+      ],
+    }
+    const instance = await render(
+      React.createElement(GoalTodoPanel, { channel }),
+      { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
+    )
+    await sleep(500)
+    const frame = toPlain(stdout.frames.join(''))
+    check('idle channel hides completed todo rows', !frame.includes('Reproduce the crash'))
+    check('idle channel keeps unfinished todo rows', frame.includes('Add a regression test'))
+    instance.unmount()
+  }
+
+  // 5. Blocked goal with reason.
   {
     const { stdout, stderr, stdin } = makeStreams()
     const channel = {
@@ -171,7 +213,7 @@ async function run() {
     instance.unmount()
   }
 
-  // 4. Live update: data arrives after mount (simulates a channel.emit from
+  // 6. Live update: data arrives after mount (simulates a channel.emit from
   //    a goal/change or todo/write event re-rendering the Chat screen).
   {
     const { stdout, stderr, stdin } = makeStreams()

--- a/src/components/GoalTodoPanel.tsx
+++ b/src/components/GoalTodoPanel.tsx
@@ -65,7 +65,12 @@ function BranchPrefix({ last }: { last: boolean }): React.ReactNode {
  */
 export function GoalTodoPanel({ channel }: { channel: Channel }): React.ReactNode {
   const goal = channel.goal
-  const todos = channel.todos ?? []
+  const allTodos = channel.todos ?? []
+  // Completed rows are useful progress while a turn is running, but become
+  // stale footer noise once the agent is idle. Keep unfinished work visible.
+  const todos = channel.working
+    ? allTodos
+    : allTodos.filter(todo => todo.status !== 'completed')
   if (goal === undefined && todos.length === 0) return null
   const visible = todos.slice(0, MAX_TODOS)
   const hidden = todos.length - visible.length


### PR DESCRIPTION
## 动机

`#72` 的子问题 2 报告：多个任务完成后，已完成任务列表仍持续显示在输入框上方。

聚焦回归用 fresh render 复现了该现象，排除了旧像素或 scrollback 残留：当 channel 已空闲且最后一次 `todo/write` 快照全部为 `completed` 时，`GoalTodoPanel` 仍稳定输出所有完成行。

## 根因

Channel 保留最后一次 `todo/write` 快照是正确的会话投影行为，但 `GoalTodoPanel` 不区分工作态与空闲态，无条件展示整个快照。于是 Agent 回合结束后，已经完成的进度信息继续占据底部工作区。

## 修改

- Agent 工作中继续展示完整 todo 快照，保留完成进度反馈；
- Agent 空闲后只展示 `pending` / `in_progress` 项；
- 空闲且全部完成、同时没有 goal 时，整个面板退出；
- 过滤仅发生在视图派生层，不清空或改写 session/channel 的 todo 真源，resume 与 replay 仍保留完整事实；
- 扩展既有 `verify-goal-todo.mjs`，覆盖工作态、空闲全完成和空闲混合状态。

## 回归闭环

修复前新增断言稳定失败：

```text
FAIL: idle channel hides an all-completed todo snapshot
```

修复后该场景为空输出；同时确认工作中仍显示 completed 行，空闲时未完成行不会被误隐藏。

## 验证

使用 pnpm 11.7.0：

- `pnpm build`
- `pnpm verify:package`
- `node scripts/verify-goal-todo.mjs`
- `node scripts/verify-channel-goal-todo.mjs`
- `pnpm smoke`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/repro-askpanel.tsx`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/verify-askpanel-layout.tsx`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/repro-toolcards.tsx`

以上命令均以 exit code 0 完成。真实模型/真机 TTY 验证见下节。

Refs #72

### 真实 DeepSeek E2E

使用隔离的临时 profile 将 `@deepseek-harness-tui/dsh-tui` 链接到本 PR 工作区，并通过 `--dump-config` 确认加载的是当前本地版本。随后在真实 TTY 中使用 DeepSeek 官方 `deepseek-v4-flash` 完成一次 todo 生命周期验证：

- 模型实际调用第一次 `todo_write`：`FIRST_E2E` 为 `completed`，`SECOND_E2E` 为 `in_progress`；工作态面板同时显示两项；
- 模型实际调用第二次 `todo_write`：两项均为 `completed`；
- Agent 回到空闲输入状态后，已完成 todo 面板不再显示；
- 模型最终返回 `TODO_E2E_OK`，会话正常退出并生成 session 记录。

该验证确认修复不仅通过 headless 组件测试，也覆盖了真实模型、真实工具调用和 TTY 状态切换。API key 仅注入到单次测试进程环境，未写入仓库、profile 或 PR。