### PR TITLE
fix(launcher): profile 非零退出时显示诊断（#93）

### DIFF
--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -69,6 +69,10 @@ const MSG = {
     en: err => `[dsh-tui] Failed to launch: ${err.message}`,
     zh: err => `[dsh-tui] 启动失败：${err.message}`,
   },
+  profileExited: {
+    en: code => `[dsh-tui] dsh profile exited with code ${code}. Run it directly for diagnostics:\n  dsh --profile ${PROFILE}`,
+    zh: code => `[dsh-tui] dsh profile 已退出（退出码 ${code}）。可直接运行以下命令查看诊断：\n  dsh --profile ${PROFILE}`,
+  },
   legacyEnv: {
     en: (oldName, newName) => `[dsh-tui] note: env ${oldName} was renamed to ${newName}; the old name no longer takes effect.`,
     zh: (oldName, newName) => `[dsh-tui] 提示：环境变量 ${oldName} 已更名为 ${newName}，旧名不再生效。`,
@@ -197,6 +201,7 @@ child.on('exit', (code, signal) => {
   if (signal) {
     process.kill(process.pid, signal)
   } else {
+    if (code !== null && code !== 0) console.error(MSG.profileExited[lang](code))
     process.exit(code ?? 0)
   }
 })

--- a/scripts/verify-launcher.mjs
+++ b/scripts/verify-launcher.mjs
@@ -7,6 +7,7 @@
  *   - 残骸 profile（目录在、package.json 不可读）触发重新自举，且版本号
  *     与本包对齐
  *   - profile 已装版本与启动器不一致时打印提示，但不阻塞启动
+ *   - profile 子进程非零退出时保留退出码与直跑诊断命令
  *   - 面向用户的消息双语：DSH_TUI_LANG=zh 输出中文，否则默认英文
  *   - shellQuote 单元（win32 的 shell:true 路径 CI 跑不到 Windows，只能靠
  *     单测覆盖转义规则本身）
@@ -38,8 +39,9 @@ const stubDir = join(tmp, 'stub-bin')
 const stubLog = join(tmp, 'stub.log')
 const isWin = process.platform === 'win32'
 mkdirSync(stubDir, { recursive: true })
-// argv 逐参数 <angle> 编码，参数被拆分时一目了然；退出码恒 0。
-writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\nfor a in "$@"; do printf \'<%s>\' "$a"; done >> "$DSH_STUB_LOG"\nprintf \'\\n\' >> "$DSH_STUB_LOG"\nexit 0\n')
+// argv 逐参数 <angle> 编码，参数被拆分时一目了然；DSH_STUB_EXIT 只让真正
+// 的 profile 子进程失败，`dsh --version` 预检始终成功。
+writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\nfor a in "$@"; do printf \'<%s>\' "$a"; done >> "$DSH_STUB_LOG"\nprintf \'\\n\' >> "$DSH_STUB_LOG"\nif [ "$1" = "--profile" ]; then exit "${DSH_STUB_EXIT:-0}"; fi\nexit 0\n')
 writeFileSync(join(stubDir, 'pnpm'), '#!/bin/sh\nexit 0\n')
 chmodSync(join(stubDir, 'dsh'), 0o755)
 chmodSync(join(stubDir, 'pnpm'), 0o755)
@@ -49,7 +51,7 @@ chmodSync(join(stubDir, 'pnpm'), 0o755)
 if (isWin) {
   writeFileSync(
     join(stubDir, 'dsh.cmd'),
-    '@echo off\r\nnode -e "const fs=require(\'fs\');fs.appendFileSync(process.env.DSH_STUB_LOG,process.argv.slice(1).map(a=>\'<\'+a+\'>\').join(\'\')+\'\\n\')" -- %*\r\n@exit /b 0\r\n',
+    '@echo off\r\nnode -e "const fs=require(\'fs\');const a=process.argv.slice(1);fs.appendFileSync(process.env.DSH_STUB_LOG,a.map(v=>\'<\'+v+\'>\').join(\'\')+\'\\n\');process.exit(a[0]===\'--profile\'?Number(process.env.DSH_STUB_EXIT||0):0)" -- %*\r\n@exit /b %errorlevel%\r\n',
     'ascii',
   )
   writeFileSync(join(stubDir, 'pnpm.cmd'), '@echo off\r\n@exit /b 0\r\n', 'ascii')
@@ -109,14 +111,23 @@ r = runBin(['foo', 'a b'])
 check('passthrough: args forwarded after --profile', stubCalls().at(-1) === '<--profile><dsh-tui><foo><a b>')
 check('passthrough: silent when aligned', r.stderr.trim() === '')
 
-// --- 3. 版本不一致：打印提示但不阻塞启动 --------------------------------------
+// --- 3. profile 非零退出：保留退出码与可直接复现的命令 -------------------------
+resetStubLog()
+r = runBin([], { DSH_STUB_EXIT: '42', DSH_TUI_LANG: 'en' })
+check('nonzero exit: launcher preserves the child status', r.status === 42)
+check('nonzero exit: stderr names the status', r.stderr.includes('profile exited with code 42'))
+check('nonzero exit: stderr gives the direct command', r.stderr.includes('dsh --profile dsh-tui'))
+r = runBin([], { DSH_STUB_EXIT: '42', DSH_TUI_LANG: 'zh' })
+check('nonzero exit: Chinese message names the status', r.stderr.includes('退出码 42'))
+
+// --- 4. 版本不一致：打印提示但不阻塞启动 --------------------------------------
 setProfileVersion('0.0.0')
 resetStubLog()
 r = runBin([])
 check('mismatch: hint names both versions', r.stderr.includes('v0.0.0') && r.stderr.includes(`v${ownVersion}`))
 check('mismatch: still launches', stubCalls().at(-1) === '<--profile><dsh-tui>' && r.status === 0)
 
-// --- 4. 消息双语：缺 dsh 时的报错（契约同 TUI：DSH_TUI_LANG 指定才生效，否则默认中文）
+// --- 5. 消息双语：缺 dsh 时的报错（契约同 TUI：DSH_TUI_LANG 指定才生效，否则默认中文）
 const envNoDsh = { PATH: noDshPath }
 r = runBin([], { ...envNoDsh, DSH_TUI_LANG: 'en' })
 check('i18n: DSH_TUI_LANG=en prints English', r.stderr.includes('dsh CLI not found'))
@@ -125,7 +136,7 @@ check('i18n: DSH_TUI_LANG=zh prints Chinese', r.stderr.includes('未检测到 ds
 r = runBin([], envNoDsh)
 check('i18n: default (unset) prints Chinese', r.stderr.includes('未检测到 dsh CLI'))
 
-// --- 5. shellQuote 单元（win32 shell:true 路径的转义规则）---------------------
+// --- 6. shellQuote 单元（win32 shell:true 路径的转义规则）---------------------
 check('shellQuote: plain tokens pass through', shellQuote(['plugin', '--profile', 'dsh-tui']).join(' ') === 'plugin --profile dsh-tui')
 check('shellQuote: spaces get quoted', shellQuote(['a b']).join(' ') === '"a b"')
 check('shellQuote: embedded quotes are doubled', shellQuote(['a"b c']).join(' ') === '"a""b c"')


### PR DESCRIPTION
## 动机

`#93` 中终端应答乱码已经由 #139 修复，但仍保留“PowerShell 启动后直接退出、没有可见原因”的报告。

启动器当前只在 `spawn` 本身失败时输出“启动失败”。如果 `dsh --profile dsh-tui` 已成功创建、随后以非零状态退出，而子进程自己没有写 stderr，启动器会直接 `process.exit(code)`，用户只看到返回 shell。

本 PR 修复这条确定性的诊断缺口，不猜测或屏蔽第三方 profile 配置错误，也不宣称修复 #93 尚未取证的底层退出原因。

## 修改

- profile 子进程以非零状态退出时，stderr 显示退出码；
- 同时给出 `dsh --profile dsh-tui` 直跑命令，便于绕过启动器观察底层诊断；
- 提示接入启动器现有中英文 `MSG` 契约；
- 退出码继续原样透传；正常零退出保持静默；信号退出继续按原逻辑转发信号。

## 回归闭环

扩展既有 `verify-launcher.mjs` 的 Linux shell / Windows `.cmd` 双路径 stub：

- `dsh --version` 预检固定成功；
- 仅正式 `--profile dsh-tui` 子进程按 `DSH_STUB_EXIT=42` 失败；
- 修复前：状态码正确透传，但 stderr 的退出码与直跑命令两项断言失败；
- 修复后：英文/中文诊断、直跑命令和状态码断言全部通过。

## 验证

使用 pnpm 11.7.0：

- `pnpm build`
- `pnpm verify:package`
- `node scripts/verify-launcher.mjs`
- `git diff --check`

以上均通过。未复现 #93 原报告者的未知底层崩溃；该部分仍需要退出码、stderr 或系统日志继续定位。

Refs #93