### PR TITLE
fix(subagent): 子代理继承 TUI 模型路由

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,10 @@ jobs:
       # 请求配置，而不是只做状态栏启动显示（≤0.3.5 的 display-only 行为）。
       - run: node --import tsx/esm scripts/repro-effort.tsx
 
+      # 子代理模型路由回归（issue #191）：child scope 没有 AgentOptions 路由时，
+      # 首次请求继承 TUI 当前完整路由；显式 child 路由保持优先。
+      - run: node --import tsx/esm scripts/verify-subagent-model-route.tsx
+
       # 子进程 stderr 接管回归（issue #17）：inherit 的 MCP 子进程 stderr
       # 不再裸写终端破坏 alt-screen，输出去重聚合为受控通知。
       - run: node --import tsx/esm scripts/verify-child-stderr.tsx

--- a/scripts/verify-subagent-model-route.tsx
+++ b/scripts/verify-subagent-model-route.tsx
@@ -1,0 +1,94 @@
+/**
+ * Regression for issue #191: a subagent whose AgentOptions do not carry a
+ * route must still receive the TUI's active provider/model pair through the
+ * agent/request waterfall. Complete child-specific routes remain untouched.
+ *
+ * Run with: node --import tsx/esm scripts/verify-subagent-model-route.tsx
+ */
+import { Context } from '@deepseek-ai/cordis'
+import { agentEvents } from '@deepseek-ai/dsh-agent'
+import { createScope } from '@deepseek-ai/dsh-scope'
+import { createChannel } from '../src/dsh-adapter/channel.js'
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const root = new Context()
+let parentScope: ReturnType<typeof createScope>
+const parent = {
+  id: 'parent-agent',
+  status: 'idle',
+  options: {},
+  get ctx() { return parentScope.ctx },
+  session: { id: 'parent-session', seq: 0, events: [], header: {} },
+  followup() {},
+  steer() {},
+  inbox: { remove() {} },
+} as never
+parentScope = createScope(root, parent)
+
+createChannel(root as never, parent, {
+  provider: 'deepseek-official',
+  model: 'deepseek-v4-flash',
+  cwd: '/tmp',
+  activity: false,
+})
+
+// A real sibling Agent scope stands in for the child. Scoped dispatch excludes
+// the parent's installModelSelection listener while retaining unscoped root
+// listeners, matching the spawn/fork routing boundary.
+let childScope: ReturnType<typeof createScope>
+const child = {
+  id: 'child-agent',
+  status: 'idle',
+  options: {},
+  get ctx() { return childScope.ctx },
+  session: { id: 'child-session', seq: 0, events: [], header: {} },
+  followup() {},
+  steer() {},
+  inbox: { remove() {} },
+} as never
+childScope = createScope(root, child)
+const childEvents = agentEvents(root, child)
+const payload = { turn: 1, step: 1, signal: new AbortController().signal }
+const inherited = (await childEvents.waterfall(
+  'agent/request',
+  payload,
+  () => Promise.resolve({ maxTokens: 1024 }),
+)) as { provider?: string; model?: string; maxTokens?: number }
+
+check(
+  'route-less child inherits the active TUI route (issue #191)',
+  inherited.provider === 'deepseek-official' && inherited.model === 'deepseek-v4-flash',
+  `provider=${String(inherited.provider)}, model=${String(inherited.model)}`,
+)
+check('unrelated request options survive fallback routing', inherited.maxTokens === 1024)
+
+const explicit = (await childEvents.waterfall(
+  'agent/request',
+  payload,
+  () => Promise.resolve({ provider: 'custom-provider', model: 'custom-model' }),
+)) as { provider?: string; model?: string }
+
+check(
+  'complete child-specific routes are not overwritten',
+  explicit.provider === 'custom-provider' && explicit.model === 'custom-model',
+  `provider=${String(explicit.provider)}, model=${String(explicit.model)}`,
+)
+
+const partial = (await childEvents.waterfall(
+  'agent/request',
+  payload,
+  () => Promise.resolve({ provider: 'orphaned-provider' }),
+)) as { provider?: string; model?: string }
+
+check(
+  'partial routes are replaced atomically',
+  partial.provider === 'deepseek-official' && partial.model === 'deepseek-v4-flash',
+  `provider=${String(partial.provider)}, model=${String(partial.model)}`,
+)
+
+process.exit(failed === 0 ? 0 : 1)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -3884,6 +3884,25 @@ ${output}
       }),
     ]
   }
+  // Subagents inherit provider/model from AgentOptions, but resumed TUI
+  // agents can legitimately carry their route only in persisted request
+  // headers. Their child scopes do not share this channel's per-agent
+  // ModelSelectionRef, so fill an otherwise incomplete first request from
+  // the active route. Keep complete child-specific routes authoritative.
+  ctx.on('agent/request', async (_payload, next) => {
+    const resolved = await next()
+    if (
+      typeof resolved.provider === 'string' && resolved.provider.length > 0 &&
+      typeof resolved.model === 'string' && resolved.model.length > 0
+    ) {
+      return resolved
+    }
+    return {
+      ...resolved,
+      provider: state.provider,
+      model: state.model,
+    }
+  })
   bindAgent()
   // Cordis owns the Channel lifetime. Rebinding handles the common case;
   // this effect closes the final timer when the Channel's context unloads.


### PR DESCRIPTION
## 动机

TUI 主 Agent 的模型选择绑定在自己的 Agent scope；当子代理没有从 AgentOptions 继承到 provider/model 时，其首次请求无法解析路由并报 `has no provider/model`。

## 根因

`installModelSelection` 使用 Channel 私有的 ModelSelectionRef，只覆盖当前主 Agent。spawn/fork 创建的兄弟 child scope 不共享该 selection，而 Channel 没有为缺失路由的 child 请求提供全局 fallback。

## 改动

- 在 Channel 生命周期注册未标记的 `agent/request` fallback，仅当 provider/model 任一缺失时，从 TUI 当前路由整对补齐。
- 保留完整的 child-specific 路由，不覆盖子代理显式选择。
- 新增真实 `dsh-scope` + `agentEvents` 回归，并挂入 CI；覆盖缺失路由、其他配置保留、显式路由优先和半路由原子替换。

## 验证

- `npx --yes pnpm@11.7.0 build`
- `npx --yes pnpm@11.7.0 verify:package`
- `node --import tsx/esm scripts/verify-subagent-model-route.tsx`
- `node --import tsx/esm scripts/repro-effort.tsx`
- `node scripts/verify-model-route.mjs`
- `node --import tsx/esm scripts/verify-submit.mjs`

回归脚本在修复前稳定复现 provider/model 均为 undefined，应用修复后全部通过。

Closes #191

### 真实 DeepSeek E2E

使用隔离临时 DSH_HOME、当前分支本地 link 包和真实 deepseek-v4-flash 完成凭证化测试：父 Agent 实际调用 spawn subagent，child 返回 SUBAGENT_E2E_OK，父回合返回 PARENT_E2E_OK；产生 parent + child 两份持久化 session，未出现 has no provider/model。