### PR TITLE
fix(subagent): 补全 resume 会话 agentOptions 模型路由——子代理继承获得 provider/model

### DIFF
--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -517,9 +517,18 @@ async function resolveAgent(
 ): Promise<{ agent: Agent; handle?: AgentHandle; agentPreset?: string; route?: ModelRoute }> {
   // Resume override (issue #67): cordis.yml overrides the target session's
   // recorded route only when it pins BOTH halves; undefined halves let the
-  // session's own request/header records win (issue #30).
+  // session's own request/header records win (issue #30). The agent options
+  // are the request default AND what spawned/forked subagents inherit via
+  // resolveChildAgentOptions — they must never be empty, or every subagent
+  // created from a resumed session fails with "has no provider/model".
+  // Fall back to the startup route (cordis.yml > /model pref > harness
+  // default, always complete); the status-line route below still prefers the
+  // session's own recorded route for display.
   const resumeRoute = explicitModelRoute(configuredRoute)
-  const resumeOptions = { provider: resumeRoute?.provider, model: resumeRoute?.model }
+  const resumeOptions = {
+    provider: resumeRoute?.provider ?? startupRoute.provider,
+    model: resumeRoute?.model ?? startupRoute.model,
+  }
   if (requestedSessionId !== undefined) {
     const resumeId = SessionId(requestedSessionId)
     const existing = ctx.agents.get(resumeId)


### PR DESCRIPTION
## 动机

Resume 会话（`dsh-tui --resume` / 启动恢复）创建的子代理（spawn/fork）全部失败：

```
agent ... has no provider/model: set AgentOptions.provider and AgentOptions.model or supply both via the agent/request waterfall
```

**Web UI 下同样委托正常**。完整诊断见 [#191](https://github.com/ccch1mneyyy/dsh-TUI/issues/191)。

## 根因

- 新会话路径（`agents.create`）已写入 `agentOptions: route`（完整模型路由）；
- **resume 路径（`agents.resume`）的 `resumeOptions` 只在 cordis.yml 双 pin 时有值**——未双 pin 时 `provider`/`model` 均为 undefined，主 agent 的 `AgentOptions` 为空；
- 官方 `resolveChildAgentOptions` 让子代理**继承 `parent.options`**——父 options 为空 → 子代理无模型 → 失败。

## 改动

`src/dsh-adapter/plugin.ts`：resume 的 agentOptions 补全为「双 pin 优先，否则 `startupRoute`（cordis.yml > /model 偏好 > harness 默认，恒完整）兜底」——与新会话路径的解析链一致；状态栏显示路由（双 pin > 会话日志 > startup）逻辑不变。

```ts
const resumeOptions = {
  provider: resumeRoute?.provider ?? startupRoute.provider,
  model: resumeRoute?.model ?? startupRoute.model,
}
```

## 验证

- `pnpm build` 全绿（tsc + verify:boundary / contract / patch-surface / packaged-presets / minimal-preset-tools / liangshen-bootstrap）
- 本地实测：resume 会话 + agent/request 兜底插件，子代理获得 `currentSelection()` 模型（链路日志确认）；本修复使主 agent options 恒有完整路由，子代理经继承自动获得模型（无需兜底插件）