### PR TITLE
docs: 添加 dsplugin.app 插件目录链接

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -8,6 +8,7 @@
 | --- | --- | --- |
 | **dsh-tui-ecosystem** | <https://github.com/dsh-tui-ecosystem> | dsh-TUI 插件生态组织：社区插件、模板与收录列表 |
 | **plugin-template** | <https://github.com/dsh-tui-ecosystem/plugin-template> | 插件开发模板仓库（配合[插件开发指南](plugins.md)使用） |
+| **dsplugin.app** | <https://dsplugin.app/plugins/dsh-cc-tui> | DeepSeek Harness 社区插件目录中的本插件页 |
 | **dshfind** | <https://dshfind.com> | DeepSeek Harness 的中文学习与分享社区 |
 | **dsh-tui-vscode** | <https://github.com/baobaolaodie/dsh-tui-vscode> | dsh-TUI 的 VS Code companion 扩展：真实集成终端承载，体验与 Claude Code 官方扩展几乎一致（已上架 VS Code Marketplace） |
 | **deepseek-harness-ux** | <https://github.com/ayuanwong/deepseek-harness-ux> | 让你的 DeepSeek Harness 工作过程一目了然！ |


### PR DESCRIPTION
## 动机

社区插件目录 dsplugin.app 已收录 dsh-TUI，并在 #169 请求加入现有友情链接页。

## 修改

- 在 `docs/links.md` 的生态链接表中加入 dsh-TUI 的 dsplugin.app 收录页；
- 保留页面使用的旧包名 slug，展示名称与当前项目名一致。

## 验证

- 目标链接 HEAD 请求返回 HTTP 200；
- `git diff --check` 通过。

Closes #169