### PR TITLE
fix(resume): 所有项目视图保持会话分组

### DIFF
--- a/scripts/verify-session-kinds.mjs
+++ b/scripts/verify-session-kinds.mjs
@@ -176,6 +176,21 @@ check(
   ['#/proj', 'conv', 'fork', '#/elsewhere', 'other-project'],
 )
 
+const interleavedProjects = buildView(
+  [
+    summary({ id: 'a-new', cwd: '/a', updatedAt: 30 }),
+    summary({ id: 'b-mid', cwd: '/b', updatedAt: 20 }),
+    summary({ id: 'a-old', cwd: '/a', updatedAt: 10 }),
+  ],
+  { ...DEFAULT_FILTERS, allProjects: true },
+  context,
+)
+check(
+  'all projects: interleaved MRU entries stay in one group per project',
+  interleavedProjects.rows.map(r => (r.kind === 'project' ? `#${r.project}:${r.count}` : r.session.id)),
+  ['#/a:2', 'a-new', 'a-old', '#/b:1', 'b-mid'],
+)
+
 const runs = buildView(population, { ...DEFAULT_FILTERS, showSubagents: true }, context)
 check(
   'sub-agent runs appear indented under their parent',

--- a/src/sessions/view.ts
+++ b/src/sessions/view.ts
@@ -144,7 +144,19 @@ export function buildView(
   const rows: BrowserRow[] = []
   let shown = 0
   let lastProject: string | undefined
-  for (const session of visible.sort((left, right) => right.updatedAt - left.updatedAt)) {
+  const ordered = visible.sort((left, right) => right.updatedAt - left.updatedAt)
+  if (filters.allProjects) {
+    // Order project groups by their newest visible session, then keep every
+    // session from that project together in MRU order. A global MRU sort alone
+    // can interleave A/B/A and emit the same project header more than once.
+    const projectOrder = new Map<string, number>()
+    for (const session of ordered) {
+      if (!projectOrder.has(session.cwd)) projectOrder.set(session.cwd, projectOrder.size)
+    }
+    ordered.sort((left, right) =>
+      projectOrder.get(left.cwd)! - projectOrder.get(right.cwd)! || right.updatedAt - left.updatedAt)
+  }
+  for (const session of ordered) {
     // Group headers only earn their line when more than one project is in
     // play; inside a single project they would repeat the same path forever.
     if (filters.allProjects && session.cwd !== lastProject) {


### PR DESCRIPTION
## 动机

v0.7.2 的 `/resume` 会话浏览器在“所有项目”视图中先按全局 MRU 排序，再仅凭相邻 cwd 变化插入项目标题。不同项目的更新时间交错时，同一项目会被拆成多段并重复显示标题和计数。

最小复现：项目 A 的会话更新时间为 30、10，项目 B 为 20。修复前行序列为：

```text
A(2) → a-new → B(1) → b-mid → A(2) → a-old
```

## 根因与修改

- 根因：全局 `updatedAt` 排序不能保证同一 cwd 的条目相邻，但项目标题算法隐含依赖相邻性；
- 先按 MRU 得出项目组顺序（各项目最新可见会话决定组位置）；
- 再聚拢同一项目的会话，组内仍按 `updatedAt` 降序；
- 默认单项目视图、搜索、branch 筛选和 subagent 折叠逻辑保持不变；
- 新增 A/B/A 时间交错 fixture，同时断言项目标题只出现一次、组计数正确、组内 MRU 不变。

修复后行序列为：

```text
A(2) → a-new → a-old → B(1) → b-mid
```

## 验证

使用 pnpm 11.7.0：

- `pnpm build`
- `node scripts/verify-session-kinds.mjs`（100 checks）
- `node scripts/verify-session-browser.mjs`
- `node scripts/verify-session-browser-layout.mjs`
- `node scripts/verify-session-index.mjs`（50 checks）
- `pnpm verify:package`
- `git diff --check`

以上均通过。该缺陷位于纯视图派生层，不涉及模型或凭证路径。

## 截图验证

使用真实 `SessionBrowser` 组件在 100×24 xterm-headless 终端中渲染 A(30)、B(20)、A(10) 交错 fixture，切换到“所有项目”后将最终终端缓冲区栅格化为 PNG 并人工检查：

- `D:/Projects/alpha` 标题只出现一次，计数为 2；
- `Alpha newest session` 与 `Alpha older session` 连续显示，组内保持 MRU 顺序；
- `D:/Projects/beta` 独立成组，计数为 1；
- 当前焦点、搜索栏、分隔线和底部快捷键提示均完整，无重叠或换行溢出。

该截图检查补充了自动化布局断言；它是 xterm-headless 组件渲染截图，不宣称覆盖 Windows Terminal/tmux 等真实终端协议差异。