### PR TITLE
fix(resume): 防止重复回车并发执行会话操作

### DIFF
--- a/scripts/verify-session-browser.mjs
+++ b/scripts/verify-session-browser.mjs
@@ -14,7 +14,8 @@
  *      session, and the cursor FOLLOWS that session when the rename bumps it
  *      to the top of the list — the cursor tracks identity, not position;
  *   6. delete: the confirmation names the focused session, Ctrl+Enter must
- *      NOT confirm an irreversible action, Esc cancels, plain Enter commits.
+ *      NOT confirm an irreversible action, Esc cancels, and repeated Enter
+ *      commits the action only once.
  *
  * Assertion discipline: ink repaints only changed lines, so each step opens a
  * FRESH output window and asserts on what that window painted; checks that
@@ -332,9 +333,9 @@ check('Ctrl+Enter does not confirm an irreversible delete', channel.calls.delete
 await windowed(() => stdin.write('\x1b'), 350) // Esc cancels
 check('Esc cancels the confirmation', !/Delete "/.test(flat(screen())) && channel.calls.delete.length === 0)
 await windowed(() => stdin.write('\x04'), 400)
-await windowed(() => stdin.write('\r'), 700)
+await windowed(() => stdin.write('\x1b[13u\x1b[13u'), 700)
 check(
-  'plain Enter commits the delete, on the session the confirmation named',
+  'repeated Enter commits one delete, on the session the confirmation named',
   channel.calls.delete.length === 1 && channel.calls.delete[0] === 's-mid',
   JSON.stringify(channel.calls.delete),
 )

--- a/src/screens/SessionBrowser.tsx
+++ b/src/screens/SessionBrowser.tsx
@@ -143,6 +143,10 @@ export function SessionBrowser({
   const [previewOpen, setPreviewOpen] = React.useState(false)
   const [preview, setPreview] = React.useState<readonly PreviewEntry[]>([])
   const [previewLoading, setPreviewLoading] = React.useState(false)
+  // React batches every parsed key from one stdin chunk. Lock actions in a
+  // ref so a repeated Enter cannot start the same async operation twice
+  // before the mode change is rendered.
+  const actionPendingRef = React.useRef(false)
 
   // One clock per render pass: every relative time on screen must agree, and
   // re-reading it per row would let two rows a millisecond apart round to
@@ -283,13 +287,21 @@ export function SessionBrowser({
     topRef.current = 0
   }
 
+  const runAction = (action: () => Promise<void>): void => {
+    if (actionPendingRef.current) return
+    actionPendingRef.current = true
+    void action().finally(() => {
+      actionPendingRef.current = false
+    })
+  }
+
   /** Run one mutation, report it, and re-list — reporting a failure either way. */
   const mutate = (
     action: () => Promise<boolean>,
     done: string,
     failed: string,
   ): void => {
-    void (async () => {
+    runAction(async () => {
       let ok = false
       let reason: string | undefined
       try {
@@ -299,7 +311,7 @@ export function SessionBrowser({
       }
       report(ok ? done : reason === undefined ? failed : `${failed} · ${reason}`, ok ? 'info' : 'error')
       await reload()
-    })()
+    })
   }
 
   const runDelete = (target: SessionSummary): void =>
@@ -321,7 +333,7 @@ export function SessionBrowser({
     // below, and deleting from a list that moved under us would be a
     // destructive action aimed at whatever happens to be there now.
     const ids = [...view.emptyIds]
-    void (async () => {
+    runAction(async () => {
       let removed = 0
       for (const id of ids) {
         try {
@@ -332,10 +344,11 @@ export function SessionBrowser({
       }
       report(t('session-cleaned', { n: removed }), 'info')
       await reload()
-    })()
+    })
   }
 
   useInput((input, key) => {
+    if (actionPendingRef.current) return
     // A notice describes what the LAST action did; the next keystroke makes it
     // stale, so it goes as soon as the user acts again.
     if (notice !== undefined) setNotice(undefined)
@@ -388,19 +401,19 @@ export function SessionBrowser({
       // that explanation to the conversation the user is not looking at, and
       // leave them staring at an unchanged transcript wondering what Enter
       // did. `resumeTo` reports its own reasons; this only has to stay put.
-      void channel
-        .resumeTo(target.id)
-        .then((ok) => {
+      runAction(async () => {
+        try {
+          const ok = await channel.resumeTo(target.id)
           if (ok) {
             channel.notify(t('resume-resumed'))
             onClose()
           } else {
             setNotice({ text: t('session-resume-refused'), tone: 'error' })
           }
-        })
-        .catch((error: unknown) => {
+        } catch (error) {
           setNotice({ text: t('session-resume-failed', { err: message(error) }), tone: 'error' })
-        })
+        }
+      })
     } else if (key.escape) {
       // Esc backs out one layer at a time: a live query first, the screen
       // second. Closing on the first Esc would discard a search the user is


### PR DESCRIPTION
## 动机

`/resume` 会话浏览器会在一个 stdin 输入块内批量处理多个按键，但确认框和列表动作依赖 React 下一次渲染才更新模式。用户快速按两次 Enter，或终端在同一批次上报重复 Return 时，两次处理都会读取旧状态并启动同一个异步动作。

删除操作的稳定复现记录为：

```text
修复前：["s-mid","s-mid"]
```

第一次删除成功后，第二次调用还会失败，并把界面上的成功提示覆盖成失败提示。恢复、重命名和清理空会话也存在同类重入风险。

## 根因与修改

- 根因：同一输入批次中的按键处理发生在 React 重渲染之前，`setMode('list')` 不能同步阻止后续 Return；
- 增加组件内同步 action guard，在异步动作开始前立即上锁，并在完成或失败后释放；
- 删除、重命名、清理和恢复共用同一保护，动作进行中忽略后续输入；
- 扩展真实 `SessionBrowser` + fake stdin 回归：在一个输入块中发送两个独立 Return 事件，断言只调用一次删除并保留成功提示。

修复后的调用记录为：

```text
修复后：["s-mid"]
```

## 验证

使用 pnpm 11.7.0，以下均实际通过：

- `pnpm build`
- `node scripts/verify-session-browser.mjs`
- `node scripts/verify-session-browser-layout.mjs`
- `node scripts/verify-session-kinds.mjs`（99 checks）
- `node scripts/verify-session-index.mjs`（50 checks）
- `pnpm verify:package`
- `git diff --check`

该缺陷位于本地输入批处理和 UI 动作状态，不涉及模型请求或凭证路径，因此无需 API key。静态截图无法证明底层动作只执行一次；这里使用真实组件输入回归同时核验调用记录、成功提示和删除后的列表状态。