### PR TITLE
feat: /market 命令 — TUI 内浏览/搜索/安装 GitHub dsh-plugin 插件市场

### DIFF
--- a/scripts/verify-market-picker.tsx
+++ b/scripts/verify-market-picker.tsx
@@ -1,0 +1,272 @@
+/**
+ * `/market` MarketPicker + 搜索冒烟（xterm-headless，mock fetch，不打 GitHub API）：
+ *   1. zh 下渲染列表：标题、搜索行、owner/repo、★ star 数、简介截断、焦点 ❯ 指针；
+ *   2. en 下标题/提示热切换；busy 态页脚换成安装提示；
+ *   3. 空结果显示「没有匹配的插件」；
+ *   4. 窄终端每行宽度不超限；Loading 态渲染不炸；
+ *   5. fetchMarketPlugins 的 query 拼接（空词纯 topic 榜，带词追加关键词）；
+ *   6. createMarketSearch 防抖（连续输入只发一次）与竞态丢弃（旧查询后返回不生效）。
+ * 运行：node --import tsx/esm scripts/verify-market-picker.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+const [
+  { Writable },
+  React,
+  { Terminal: XTerm },
+  { render },
+  { MarketPicker, MarketPickerLoading },
+  { fetchMarketPlugins, createMarketSearch },
+  { setLang },
+  { stringWidth },
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/MarketPicker.js'),
+  import('../src/market.js'),
+  import('../src/i18n.js'),
+  import('../src/ink/stringWidth.js'),
+])
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+let failures = 0
+function assert(cond: boolean, msg: string) {
+  if (cond) {
+    console.log(`  ✓ ${msg}`)
+  } else {
+    failures++
+    console.error(`  ✗ ${msg}`)
+  }
+}
+
+function makeTerm(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 0, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+  }
+  return { term, stdout: new FakeStdout() }
+}
+
+function screenText(term: InstanceType<typeof XTerm>, rows: number): string {
+  const buf = term.buffer.active
+  const lines: string[] = []
+  for (let y = 0; y < rows; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
+  return lines.join('\n')
+}
+
+const plugins = [
+  { fullName: 'alice/dsh-plugin-weather', stars: 128, description: '天气查询插件，支持多个城市与空气质量' },
+  { fullName: 'bob/dsh-plugin-translate', stars: 64, description: 'Translate between zh and en inline' },
+  { fullName: 'carol/dsh-plugin-nodesc', stars: 3 },
+]
+
+// --- 1. zh 列表渲染 -----------------------------------------------------------
+
+console.log('zh 列表渲染:')
+
+{
+  const COLS = 90
+  const ROWS = 24
+  const { term, stdout } = makeTerm(COLS, ROWS)
+  setLang('zh')
+  const app = await render(
+    React.createElement(MarketPicker, { plugins, focusIndex: 1, busy: false, query: '' }),
+    { stdout, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(300)
+
+  const text = screenText(term, ROWS)
+  assert(text.includes('插件市场'), '标题显示「插件市场」')
+  assert(text.includes('搜索'), '搜索行显示标签')
+  assert(text.includes('输入以搜索插件'), '空查询词显示占位提示')
+  assert(text.includes('alice/dsh-plugin-weather'), '渲染 owner/repo 名')
+  assert(text.includes('★ 128'), '渲染 star 数')
+  assert(text.includes('天气查询插件'), '渲染简介')
+  assert(text.includes('❯'), '渲染焦点指针')
+  assert(text.includes('Enter'), '页脚显示确认/退出提示')
+
+  // 查询词显示在搜索行上
+  app.rerender(React.createElement(MarketPicker, { plugins, focusIndex: 1, busy: false, query: 'trans' }))
+  await sleep(200)
+  const queried = screenText(term, ROWS)
+  assert(queried.includes('搜索: trans'), '查询词显示在搜索行')
+  assert(!queried.includes('输入以搜索插件'), '有查询词时占位提示消失')
+
+  // --- 2. en 热切换 + busy 态 ---------------------------------------------------
+  setLang('en')
+  app.rerender(React.createElement(MarketPicker, { plugins, focusIndex: 1, busy: false, query: '' }))
+  await sleep(200)
+  const en = screenText(term, ROWS)
+  assert(en.includes('Plugin market'), 'en：标题显示 Plugin market')
+  assert(en.includes('Type to search'), 'en：搜索行英文占位')
+  assert(en.includes('Esc to exit'), 'en：页脚英文提示')
+
+  app.rerender(React.createElement(MarketPicker, { plugins, focusIndex: 1, busy: true, query: '' }))
+  await sleep(200)
+  const busy = screenText(term, ROWS)
+  assert(busy.includes('Installing, please wait'), 'busy：页脚换成安装提示')
+  assert(!busy.includes('Esc to exit'), 'busy：不再显示确认/退出提示')
+
+  // --- 3. 空结果态 --------------------------------------------------------------
+  app.rerender(React.createElement(MarketPicker, { plugins: [], focusIndex: 0, busy: false, query: 'zzz' }))
+  await sleep(200)
+  const empty = screenText(term, ROWS)
+  assert(empty.includes('No matching plugins'), '空结果显示 No matching plugins')
+
+  setLang('zh')
+  app.unmount()
+  await sleep(100)
+}
+
+// --- 4. 窄终端宽度不超限 -------------------------------------------------------
+
+console.log('窄终端截断:')
+
+{
+  const COLS = 32
+  const ROWS = 24
+  const { term, stdout } = makeTerm(COLS, ROWS)
+  setLang('zh')
+  const app = await render(
+    React.createElement(MarketPicker, { plugins, focusIndex: 0, busy: false, query: '' }),
+    { stdout, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(300)
+  app.unmount()
+  await sleep(100)
+
+  const buf = term.buffer.active
+  for (let y = 0; y < ROWS; y++) {
+    const line = buf.getLine(y)?.translateToString(true) ?? ''
+    if (line.trim() === '') continue
+    const w = stringWidth(line)
+    assert(w <= COLS, `第 ${y} 行宽 ${w} ≤ 终端宽 ${COLS}：'${line.trimEnd()}'`)
+  }
+}
+
+// --- 5. Loading 态 -------------------------------------------------------------
+
+console.log('Loading 态:')
+
+{
+  const COLS = 60
+  const ROWS = 10
+  const { term, stdout } = makeTerm(COLS, ROWS)
+  setLang('zh')
+  const app = await render(React.createElement(MarketPickerLoading), {
+    stdout,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  await sleep(300)
+  const text = screenText(term, ROWS)
+  assert(text.includes('插件市场'), 'Loading：标题渲染')
+  assert(text.includes('正在加载插件市场') || text.includes('正在查询 GitHub'), 'Loading：加载文案渲染')
+  app.unmount()
+  await sleep(100)
+}
+
+// --- 6/7. fetch 拼接 + 防抖/竞态（mock globalThis.fetch）-------------------------
+
+const realFetch = globalThis.fetch
+const calls: string[] = []
+const pending: Array<() => void> = []
+function mockOk(items: unknown[]) {
+  return { ok: true, json: async () => ({ items }) }
+}
+
+console.log('fetchMarketPlugins query 拼接:')
+
+{
+  globalThis.fetch = ((url: unknown) => {
+    calls.push(String(url))
+    return Promise.resolve(mockOk([]))
+  }) as typeof fetch
+
+  await fetchMarketPlugins()
+  assert(
+    calls.length === 1 && calls[0]!.includes(`q=${encodeURIComponent('topic:dsh-plugin')}`),
+    `空查询词保持纯 topic 榜（${calls[0]}）`,
+  )
+  assert(calls[0]!.includes('sort=stars') && calls[0]!.includes('per_page=50'), '带 sort/per_page 参数')
+
+  calls.length = 0
+  await fetchMarketPlugins('天气 plugin')
+  assert(
+    calls.length === 1 && decodeURIComponent(calls[0]!).includes('q=topic:dsh-plugin 天气 plugin'),
+    `关键词追加到 topic 之后（${decodeURIComponent(calls[0]!)}）`,
+  )
+}
+
+console.log('createMarketSearch 防抖:')
+
+{
+  calls.length = 0
+  const applied: Array<{ n: number | undefined; query: string }> = []
+  const driver = createMarketSearch((result, query) => {
+    applied.push({ n: result?.length, query })
+  }, 60)
+
+  driver.search('a')
+  await sleep(20)
+  driver.search('ab')
+  await sleep(20)
+  driver.search('abc')
+  await sleep(120)
+  assert(calls.length === 1, `连续输入只发一次请求（实际 ${calls.length} 次）`)
+  assert(decodeURIComponent(calls[0]!).includes('abc'), '请求用的是最终查询词 abc')
+  await sleep(20)
+  assert(applied.length === 1 && applied[0]!.query === 'abc', '结果回调一次且对应 abc')
+
+  // 重复查询词去重：不再发请求
+  driver.search('abc')
+  await sleep(120)
+  assert(calls.length === 1, '重复查询词被去重（不再发请求）')
+  driver.dispose()
+}
+
+console.log('createMarketSearch 竞态丢弃:')
+
+{
+  calls.length = 0
+  // 挂起式 mock：fetch 不主动 resolve，由测试手动放行
+  globalThis.fetch = ((url: unknown) => {
+    calls.push(String(url))
+    return new Promise(resolve => {
+      pending.push(() => resolve(mockOk([{ full_name: 'o/r', stargazers_count: 1 }])))
+    })
+  }) as typeof fetch
+
+  const applied: string[] = []
+  const driver = createMarketSearch((_result, query) => {
+    applied.push(query)
+  }, 60)
+
+  driver.search('slow', true)
+  driver.search('fast', true)
+  assert(calls.length === 2, '两个 immediate 请求都已发出')
+  pending[1]!() // fast 先返回
+  await sleep(30)
+  pending[0]!() // slow 后返回——查询词已变，必须丢弃
+  await sleep(30)
+  assert(applied.length === 1 && applied[0] === 'fast', `旧查询 slow 的结果被丢弃（applied: ${applied.join(',')}）`)
+
+  driver.dispose()
+}
+
+globalThis.fetch = realFetch
+
+// --- 结果 -------------------------------------------------------------------
+
+if (failures > 0) {
+  console.error(`\n${failures} 项断言失败`)
+  process.exit(1)
+}
+console.log('\n全部断言通过')
+process.exit(0)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -97,6 +97,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
   { name: 'mcp', description: 'Show MCP status' },
   { name: 'memory', description: 'Show memory status' },
   { name: 'update', description: 'Update dsh-tui and restart' },
+  { name: 'market', description: 'Browse and install dsh plugins from GitHub' },
   // Built-in skills (CC's skill commands, driven through DSH skills)
   { name: 'audit', description: 'Run a comprehensive code audit on this project' },
   { name: 'bug', description: 'Capture a bug report' },

--- a/src/components/MarketPicker.tsx
+++ b/src/components/MarketPicker.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { t } from '../i18n.js'
+import { Box, Text, useTerminalSize } from '../ui.js'
+import type { MarketPlugin } from '../market.js'
+import { Pane } from './design-system/Pane.js'
+import { ListItem } from './design-system/ListItem.js'
+import { HintLine } from './design-system/HintLine.js'
+import { LoadingState } from './design-system/LoadingState.js'
+import { listWindow } from './listWindow.js'
+
+/**
+ * `/market` plugin picker in the ModelPicker style: a permission-colored
+ * Pane with the repo list as ListItem rows (❯ focus pointer, `★ stars ·
+ * description` second line), plus the Enter/Esc hint line. Keyboard
+ * navigation lives in Chat.tsx; while an install runs (`busy`) the hint
+ * swaps to the installing notice and Chat ignores arrows/Enter.
+ *
+ * 长列表按焦点窗口化（ModelPicker 同款）：picker 经 OverlayAbove 浮层挂载后
+ * 有 maxHeight 裁剪，全量渲染会让焦点行被裁掉（看不到焦点按 Enter）。
+ */
+export function MarketPicker({
+  plugins,
+  focusIndex,
+  busy,
+  query,
+}: {
+  plugins: readonly MarketPlugin[]
+  focusIndex: number
+  busy: boolean
+  /** 当前搜索词（fzf 手感：打字即搜索），空串显示占位提示。 */
+  query: string
+}): React.ReactNode {
+  const { rows: terminalRows } = useTerminalSize()
+  // 每行恒占 2 行（正文 + ★/简介描述行，均 truncate 成单行）。
+  // 框架行：浮层预留 8 + Pane 2 + 标题 2 + 搜索行 2 + 页脚 1 = 15。
+  const { start, end } = listWindow(
+    plugins.map(() => 2),
+    focusIndex,
+    Math.max(terminalRows - 15, 2),
+  )
+  return (
+    <Pane color="permission">
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text color="remember" bold>
+            {t('picker-title-market')}
+          </Text>
+        </Box>
+        <Box marginBottom={1}>
+          <Text>
+            {t('market-search-label')}
+            {': '}
+            {query}
+            {query === '' && <Text dimColor>{t('market-search-placeholder')}</Text>}
+          </Text>
+        </Box>
+        {plugins.length === 0 ? (
+          <Text dimColor>{t('market-no-results')}</Text>
+        ) : (
+          plugins.slice(start, end).map((plugin, index) => {
+            const absoluteIndex = start + index
+            return (
+              <ListItem
+                key={plugin.fullName}
+                isFocused={absoluteIndex === focusIndex}
+                description={`★ ${plugin.stars}${plugin.description === undefined ? '' : ` · ${plugin.description}`}`}
+                showScrollUp={absoluteIndex === start && start > 0}
+                showScrollDown={absoluteIndex === end - 1 && end < plugins.length}
+              >
+                {plugin.fullName}
+              </ListItem>
+            )
+          })
+        )}
+      </Box>
+      <Text dimColor italic>
+        <HintLine text={busy ? t('market-busy-hint') : t('hint-confirm-exit')} />
+      </Text>
+    </Pane>
+  )
+}
+
+/** `/market` while the GitHub search is still in flight (ModelPickerLoading 同款). */
+export function MarketPickerLoading(): React.ReactNode {
+  return (
+    <Pane color="permission">
+      <Box flexDirection="column" gap={1}>
+        <Text bold color="permission">
+          {t('picker-title-market')}
+        </Text>
+        <LoadingState
+          message={t('market-loading')}
+          bold
+          subtitle={t('market-loading-subtitle')}
+        />
+      </Box>
+    </Pane>
+  )
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -415,6 +415,20 @@ const dict = {
   'model-switching': { zh: '正在切换模型到 {{name}}…', en: 'Switching model to {{name}}…' },
   'model-switched': { zh: '模型已切换为 {{name}}', en: 'Model switched to {{name}}' },
 
+  // ── components/MarketPicker.tsx + screens/Chat.tsx（/market 插件市场）──
+  'picker-title-market': { zh: '插件市场', en: 'Plugin market' },
+  'market-loading': { zh: '正在加载插件市场', en: 'Loading the plugin market' },
+  'market-loading-subtitle': { zh: '正在查询 GitHub…', en: 'Querying GitHub…' },
+  'market-busy-hint': { zh: '正在安装，请稍候…', en: 'Installing, please wait…' },
+  'market-search-label': { zh: '搜索', en: 'Search' },
+  'market-search-placeholder': { zh: '输入以搜索插件…', en: 'Type to search…' },
+  'market-no-results': { zh: '没有匹配的插件', en: 'No matching plugins' },
+  'market-no-profile': { zh: '/market 仅在 `dsh --profile <名称>` 启动的实例中可用', en: '/market is only available in a `dsh --profile <name>` launch' },
+  'market-load-failed': { zh: '插件市场加载失败（网络错误或 GitHub API 限流）', en: 'Failed to load the plugin market (network error or GitHub API rate limit)' },
+  'market-install-ok': { zh: '插件已安装：{{name}}', en: 'Plugin installed: {{name}}' },
+  'market-restart-hint': { zh: '重启 dsh-tui 后插件生效。', en: 'Restart dsh-tui for the plugin to take effect.' },
+  'market-install-failed': { zh: '插件安装失败：{{name}}（退出码 {{code}}）', en: 'Plugin install failed: {{name}} (exit code {{code}})' },
+
   // ── components/RewindPicker.tsx ─────────────────────────────────────
   'rewind-title': { zh: '回退', en: 'Rewind' },
   'rewind-subtitle': { zh: '选择一条消息，将对话回退到该处', en: 'Pick a message to rewind the conversation to' },
@@ -590,6 +604,7 @@ const dict = {
   'cmd-desc-mcp': { zh: '查看 MCP 状态' },
   'cmd-desc-memory': { zh: '查看记忆状态' },
   'cmd-desc-update': { zh: '更新 dsh-tui 并重启' },
+  'cmd-desc-market': { zh: '浏览并安装 GitHub 上的 dsh 插件' },
   // Built-in skills
   'cmd-desc-audit': { zh: '对当前项目做全面代码审计' },
   'cmd-desc-bug': { zh: '记录一份 bug 报告' },

--- a/src/market.ts
+++ b/src/market.ts
@@ -1,0 +1,153 @@
+/**
+ * `/market` plugin market: list community plugins published on GitHub under
+ * the `dsh-plugin` topic and install one into the current dsh profile via
+ * `dsh plugin --profile <name> add github:owner/repo`. Mirrors update.ts —
+ * plain fetch with an AbortController timeout (any failure degrades to
+ * undefined, never throws) and a captured no-throw child process.
+ */
+
+import { execFileNoThrow, type ExecFileNoThrowResult } from './utils/execFileNoThrow.js'
+import { shellQuote } from './utils/shellQuote.js'
+
+const MARKET_SEARCH_URL = 'https://api.github.com/search/repositories'
+const MARKET_FETCH_TIMEOUT_MS = 8000
+/** `dsh plugin add` clones/downloads; give it more room than a fetch. */
+const MARKET_INSTALL_TIMEOUT_MS = 120_000
+
+/** One row of the `/market` picker: a GitHub repo advertising `dsh-plugin`. */
+export interface MarketPlugin {
+  /** `owner/repo` — display name and the body of the `github:` install spec. */
+  fullName: string
+  stars: number
+  /** Repo description; undefined when the repo has none. */
+  description?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Search GitHub for `topic:dsh-plugin` repos, sorted by stars; a non-empty
+ * `query` is appended as extra keywords (空查询词保持纯 topic 榜). Undefined
+ * on any failure (offline, rate limit, malformed payload) so the caller can
+ * show one error notice instead of handling rejection kinds.
+ */
+export async function fetchMarketPlugins(query = ''): Promise<readonly MarketPlugin[] | undefined> {
+  const keywords = query.trim()
+  const q = keywords === '' ? 'topic:dsh-plugin' : `topic:dsh-plugin ${keywords}`
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), MARKET_FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(
+      `${MARKET_SEARCH_URL}?q=${encodeURIComponent(q)}&sort=stars&per_page=50`,
+      {
+        headers: {
+          accept: 'application/json',
+          // GitHub rejects API calls without a User-Agent.
+          'user-agent': 'dsh-tui',
+        },
+        signal: controller.signal,
+      },
+    )
+    if (!response.ok) return undefined
+    const payload: unknown = await response.json()
+    if (!isRecord(payload) || !Array.isArray(payload.items)) return undefined
+    const plugins: MarketPlugin[] = []
+    for (const item of payload.items) {
+      if (!isRecord(item) || typeof item.full_name !== 'string') continue
+      plugins.push({
+        fullName: item.full_name,
+        stars: typeof item.stargazers_count === 'number' ? item.stargazers_count : 0,
+        ...(typeof item.description === 'string' && item.description !== ''
+          ? { description: item.description }
+          : {}),
+      })
+    }
+    return plugins
+  } catch {
+    return undefined
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/** A debounced, race-safe driver behind the `/market` picker's fzf-style search. */
+export interface MarketSearch {
+  /** Queue a fetch; debounced unless `immediate`. Repeat queries are skipped. */
+  search(query: string, immediate?: boolean): void
+  /** Drop the pending timer and invalidate any in-flight result. */
+  dispose(): void
+}
+
+/**
+ * Typing in the picker re-searches GitHub after a short debounce; a slow
+ * response for a stale query must never overwrite a newer one, so each run
+ * carries a ticket and only the latest applies. `apply` receives undefined
+ * on fetch failure, mirroring {@link fetchMarketPlugins}.
+ */
+export function createMarketSearch(
+  apply: (result: readonly MarketPlugin[] | undefined, query: string) => void,
+  debounceMs = 300,
+): MarketSearch {
+  let seq = 0
+  /** 已拉取或已排队的查询词——去重以它为准（只看已返回的 last 会放过
+   *  「打字→退格回原值」期间 pending 的旧词）。 */
+  let queued = ''
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const run = (query: string): void => {
+    const ticket = ++seq
+    void fetchMarketPlugins(query).then((result) => {
+      // 竞态丢弃：返回时查询词已变（或已 dispose），旧结果直接作废。
+      if (ticket !== seq) return
+      apply(result, query)
+    })
+  }
+  return {
+    search(query, immediate = false) {
+      // 去重先于清定时器：同样的查询词已在排队时不能把 pending 的 fetch 清掉。
+      if (!immediate && query === queued) return
+      queued = query
+      if (timer !== undefined) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+      if (immediate) {
+        run(query)
+        return
+      }
+      timer = setTimeout(() => {
+        timer = undefined
+        run(query)
+      }, debounceMs)
+    },
+    dispose() {
+      if (timer !== undefined) {
+        clearTimeout(timer)
+        timer = undefined
+      }
+      seq++
+    },
+  }
+}
+
+/**
+ * Install a market plugin into the given dsh profile. The `github:` spec
+ * keeps `dsh plugin add` off the npm-name lookup path. Windows resolves dsh
+ * as `dsh.cmd`, which cannot spawn directly — route it through cmd.exe with
+ * the args folded into one shell-quoted command line (update.ts runProcess
+ * does the same for its shell path; DEP0190 forbids shell:true with an args
+ * array on Node ≥22).
+ */
+export function installMarketPlugin(
+  profile: string,
+  fullName: string,
+): Promise<ExecFileNoThrowResult> {
+  const args = ['plugin', '--profile', profile, 'add', `github:${fullName}`]
+  if (process.platform === 'win32') {
+    return execFileNoThrow('cmd.exe', ['/d', '/s', '/c', `dsh ${shellQuote(args).join(' ')}`], {
+      timeout: MARKET_INSTALL_TIMEOUT_MS,
+    })
+  }
+  return execFileNoThrow('dsh', args, { timeout: MARKET_INSTALL_TIMEOUT_MS })
+}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -28,6 +28,9 @@ import { StatusLine } from './StatusLine.js'
 import { WorkingSpinner, useThinkingStatus } from '../components/WorkingSpinner.js'
 import { ActivityLine, contextPressurePct } from '../components/ActivityLine.js'
 import { ModelPicker } from '../components/ModelPicker.js'
+import { MarketPicker, MarketPickerLoading } from '../components/MarketPicker.js'
+import { installMarketPlugin, createMarketSearch, type MarketPlugin, type MarketSearch } from '../market.js'
+import { resolveDshProfileName } from '../update.js'
 import { SessionBrowser } from './SessionBrowser.js'
 import { WorkspacePicker } from '../components/WorkspacePicker.js'
 import { WorkspaceFlowPicker } from '../components/WorkspaceFlowPicker.js'
@@ -211,6 +214,15 @@ export function Chat({
   const [modelPickerOpen, setModelPickerOpen] = React.useState(false)
   const [models, setModels] = React.useState<readonly LlmModelInfo[]>([])
   const [modelIndex, setModelIndex] = React.useState(0)
+  /** `/market` plugin market: repo list loads async; busy while installing. */
+  const [marketPickerOpen, setMarketPickerOpen] = React.useState(false)
+  const [marketPlugins, setMarketPlugins] = React.useState<readonly MarketPlugin[]>([])
+  const [marketIndex, setMarketIndex] = React.useState(0)
+  const [marketBusy, setMarketBusy] = React.useState(false)
+  /** fzf 手感：picker 打开时打字即搜索，防抖后重新拉 GitHub。 */
+  const [marketQuery, setMarketQuery] = React.useState('')
+  const [marketLoading, setMarketLoading] = React.useState(false)
+  const marketSearchRef = React.useRef<MarketSearch | null>(null)
   /** `/resume` opens the session browser, a screen rather than a panel. It
    *  owns its own selection, filters and keyboard — Chat only opens it. */
   const [browserOpen, setBrowserOpen] = React.useState(false)
@@ -271,6 +283,23 @@ export function Chat({
     setBtw(null)
   }
   React.useEffect(() => () => btwAbortRef.current?.abort(), [])
+  /** `/market` 搜索驱动（防抖 + 竞态丢弃在 market.ts）；结果直接落 state。 */
+  const getMarketSearch = (): MarketSearch =>
+    (marketSearchRef.current ??= createMarketSearch((result) => {
+      setMarketLoading(false)
+      if (result === undefined) {
+        channel.notify(t('market-load-failed'), { color: 'error' })
+        return
+      }
+      setMarketPlugins(result)
+    }))
+  // 查询词变化 → 防抖重搜。打开时 case 'market' 已做 immediate 首拉，
+  // createMarketSearch 的去重会跳过这里重复的 ''。
+  React.useEffect(() => {
+    if (!marketPickerOpen) return
+    getMarketSearch().search(marketQuery)
+  }, [marketQuery, marketPickerOpen])
+  React.useEffect(() => () => marketSearchRef.current?.dispose(), [])
   /**
    * The trajectory scene (issue #80 evolution). Unlike every other overlay
    * here it is not a panel but a whole screen: while open, Chat renders the
@@ -714,6 +743,26 @@ export function Chat({
           setModelIndex(index >= 0 ? index : 0)
         })
         return true
+      case 'market': {
+        // Plugin market: GitHub topic search fills the picker; typing in the
+        // picker re-searches (debounced, see the marketQuery effect above);
+        // Enter installs into the current profile (`dsh plugin add
+        // github:o/r`). Non-profile launches have no profile installation to
+        // act on — same gate as /update.
+        setHelpOpen(false)
+        if (resolveDshProfileName() === undefined) {
+          channel.notify(t('market-no-profile'), { color: 'error' })
+          return true
+        }
+        setMarketPlugins([])
+        setMarketIndex(0)
+        setMarketBusy(false)
+        setMarketQuery('')
+        setMarketLoading(true)
+        setMarketPickerOpen(true)
+        getMarketSearch().search('', true)
+        return true
+      }
       case 'provider': {
         // Interactive add-provider wizard (/provider): drives the shared
         // question panel, persists profile + key via the channel's settings/
@@ -1543,6 +1592,61 @@ export function Chat({
       }
       return
     }
+    if (marketPickerOpen) {
+      // busy 期间锁住方向键、Enter 与搜索输入（防重复安装/查询词漂移），
+      // Esc 仍可关浮层——安装结果走 notify/pushLocal 报告，不依赖 picker 存活。
+      if (key.escape) {
+        setMarketPickerOpen(false)
+        marketSearchRef.current?.dispose()
+      } else if (!marketBusy && marketPlugins.length > 0 && key.upArrow) {
+        setMarketIndex(index => (index <= 0 ? marketPlugins.length - 1 : index - 1))
+      } else if (!marketBusy && marketPlugins.length > 0 && key.downArrow) {
+        setMarketIndex(index => (index >= marketPlugins.length - 1 ? 0 : index + 1))
+      } else if (!marketBusy && key.backspace) {
+        if (marketQuery.length > 0) {
+          setMarketQuery(marketQuery.slice(0, -1))
+          setMarketIndex(0)
+        }
+      } else if (!marketBusy && plainReturn) {
+        const plugin = marketPlugins[marketIndex]
+        const profile = resolveDshProfileName()
+        // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: out-of-range index on an empty list
+        if (plugin && profile !== undefined) {
+          setMarketBusy(true)
+          channel.notify(t('market-busy-hint'))
+          void installMarketPlugin(profile, plugin.fullName).then((result) => {
+            setMarketBusy(false)
+            setMarketPickerOpen(false)
+            if (result.code === 0) {
+              channel.notify(t('market-install-ok', { name: plugin.fullName }), { color: 'success' })
+              channel.pushLocal('/market', [
+                t('market-install-ok', { name: plugin.fullName }),
+                t('market-restart-hint'),
+              ])
+            } else {
+              channel.notify(
+                t('market-install-failed', { name: plugin.fullName, code: result.code ?? 1 }),
+                { color: 'error' },
+              )
+              const stderrTail = result.stderr.trim().split('\n').filter(Boolean).slice(-3)
+              channel.pushLocal('/market', [
+                t('market-install-failed', { name: plugin.fullName, code: result.code ?? 1 }),
+                ...stderrTail,
+              ])
+            }
+          })
+        }
+      } else if (!marketBusy && !key.ctrl && !key.meta && !key.super && input) {
+        // fzf 手感：picker 打开时打字即进搜索词（剥掉控制字符，如未经
+        // plainReturn 拦截的 \r），防抖重搜走上面的 marketQuery effect。
+        const typed = input.replace(/[\x00-\x1f]/g, '')
+        if (typed !== '') {
+          setMarketQuery(marketQuery + typed)
+          setMarketIndex(0)
+        }
+      }
+      return
+    }
     if (historyOpen) {
       if (key.escape) {
         setHistoryOpen(false)
@@ -1725,7 +1829,7 @@ export function Chat({
 
   /** Prompt input is inert while a modal dialog owns the keyboard. */
   const promptSelectionActive =
-    selectionActive || modelPickerOpen || workspacePickerOpen || workspaceFlow !== null || activityPickerOpen ||
+    selectionActive || modelPickerOpen || marketPickerOpen || workspacePickerOpen || workspaceFlow !== null || activityPickerOpen ||
     effortSliderOpen || presetPickerOpen || themePickerOpen || thinkingOpen || historyOpen || rewindOpen || searchOpen ||
     btw !== null
 
@@ -1749,7 +1853,7 @@ export function Chat({
   // blit-skip 后留空（Esc 关 picker 一片空白的根因）。
   const dialogOverlayOpen =
     thinkingOpen || (workspacePickerOpen && workspaceTargets.length > 0) || workspaceFlow !== null ||
-    modelPickerOpen ||
+    modelPickerOpen || marketPickerOpen ||
     activityPickerOpen || (effortSliderOpen && effortOptions.length > 1) ||
     (presetPickerOpen && presetOptions.length > 0) || themePickerOpen || historyOpen ||
     rewindOpen || searchOpen
@@ -1981,6 +2085,20 @@ export function Chat({
           {themePickerOpen && (
             <Box flexDirection="column" marginTop={1}>
               <ThemePicker focusIndex={themeIndex} currentTheme={themeName} />
+            </Box>
+          )}
+          {marketPickerOpen && (
+            <Box flexDirection="column" marginTop={1}>
+              {marketLoading && marketPlugins.length === 0 ? (
+                <MarketPickerLoading />
+              ) : (
+                <MarketPicker
+                  plugins={marketPlugins}
+                  focusIndex={marketIndex}
+                  busy={marketBusy}
+                  query={marketQuery}
+                />
+              )}
             </Box>
           )}
           {historyOpen && (


### PR DESCRIPTION
## 动机

社区插件越来越多（GitHub `dsh-plugin` topic 下已有 1800+ 仓库），Web GUI 侧已有市场插件，但 TUI 用户只能手动 `dsh plugin add`。本 PR 给 TUI 加 `/market` 命令：不离终端就能发现、搜索、安装插件。

## 功能

- `/market` 打开浮层，拉取 GitHub `topic:dsh-plugin` 仓库（按 star 排序，每页 50），显示 ★ 数和简介
- **打字即搜**：直接输入关键词在整个 topic 内搜索（走 GitHub search API 的 `q`），300ms 防抖，旧请求竞态丢弃；退格清空回到 star 榜
- ↑/↓ 环形导航、Enter 安装（底层 `dsh plugin --profile <当前 profile> add github:<owner/repo>`）、Esc 关闭
- 安装中 busy 态锁定输入；成功/失败 notify + 转录区报告，成功附「重启后生效」提示
- 降级：非 profile 启动 / 断网 / 无结果均有对应提示，不踢出浮层
- i18n zh/en 全量文案

## 实现

- 新增 `src/market.ts`（fetch + 防抖搜索驱动 + 安装子进程，Windows `dsh.cmd` 走 cmd /c）、`src/components/MarketPicker.tsx`（沿用 ModelPicker 模式：Pane + 焦点窗口化 + HintLine）
- `Chat.tsx` 参照既有 picker 模式接入（state / runCommand / useInput / OverlayAbove）
- 无新增依赖

## 验证

- `pnpm build` 全绿（tsc + 全部边界闸）
- 新增 `scripts/verify-market-picker.tsx`：30 项断言（渲染、i18n 热切换、busy、窄终端、query 拼接含中文、防抖、竞态丢弃）
- 全量回归：65 个 verify 脚本全部通过（verify-update.mjs 在干净 main 上因 Windows symlink 权限同样失败，与本 PR 无关）
- 真机实测：打包装进独立 profile，`/market` 浏览/搜索/安装全流程可用
