### PR TITLE
feat: 添加最终 Prompt 调试命令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 *.tsbuildinfo
 *.tgz
 AGENTS.md
+.dsh-prompt-debug.json

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "dev": "node scripts/dev-test.mjs",
     "dev:copy-config": "node scripts/dev-copy-config.mjs",
     "dev:test": "node scripts/verify-dev-command.mjs && node scripts/dev-test.mjs --no-launch",
+    "prompt:debug": "node scripts/read-prompt-debug.mjs",
     "tui": "node --import tsx/esm scripts/run.ts",
     "smoke": "node --import tsx/esm scripts/smoke.tsx",
     "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap",
@@ -74,6 +75,7 @@
     "verify:minimal-preset-tools": "node scripts/verify-minimal-preset-tools.mjs",
     "verify:liangshen-bootstrap": "node scripts/verify-liangshen-bootstrap.mjs",
     "verify:package": "npm pack --dry-run --json --ignore-scripts | node scripts/verify-package.mjs",
+    "verify:prompt-debug": "npm run build && node scripts/verify-prompt-debug.mjs",
     "verify:clipboard-image": "node --import tsx/esm scripts/verify-clipboard-image.ts"
   },
   "peerDependencies": {
@@ -81,6 +83,7 @@
     "@deepseek-ai/dsh-agent": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-agent-instructions": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-agent-presets": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-atomic-write": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-commands": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-cordis-host-runner": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-invariants": "^0.1.0-rc.6",

--- a/scripts/read-prompt-debug.mjs
+++ b/scripts/read-prompt-debug.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+/** Read the `/debug-prompt` snapshot as a prompt-oriented terminal report. */
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const input = resolve(process.argv[2] ?? '.dsh-prompt-debug.json')
+
+function section(title, body) {
+  return `${'-'.repeat(80)}\n${title}\n${'-'.repeat(80)}\n${body}`
+}
+
+function formatJson(value) {
+  return JSON.stringify(value, null, 2)
+}
+
+function formatMessages(messages) {
+  if (!Array.isArray(messages) || messages.length === 0) return '(none)'
+  return messages.map((message, index) => {
+    const role = typeof message?.role === 'string' ? message.role : 'unknown'
+    return `[${index + 1}] ${role}\n${formatJson(message)}`
+  }).join('\n\n')
+}
+
+function formatTools(tools) {
+  if (!Array.isArray(tools) || tools.length === 0) return '(none)'
+  return tools.map((tool, index) => {
+    const name = typeof tool?.name === 'string' ? tool.name : 'unknown'
+    const description = typeof tool?.description === 'string' ? tool.description : '(none)'
+    return [
+      `[${index + 1}] ${name}`,
+      `Description:\n${description}`,
+      `Parameters:\n${formatJson(tool?.parameters ?? {})}`,
+    ].join('\n')
+  }).join('\n\n')
+}
+
+function formatRequest(request, index, total) {
+  const context = request?.finalLlmContext
+  if (context === null || typeof context !== 'object' || Array.isArray(context)) {
+    throw new Error(`request ${index + 1} has no finalLlmContext object`)
+  }
+
+  const metadata = [
+    `REQUEST ${index + 1}/${total}`,
+    `Captured: ${request.capturedAt ?? 'unknown'}`,
+    `Turn: ${request.turn ?? 'unknown'}`,
+    `Step: ${request.step ?? 'unknown'}`,
+    `Attempt: ${request.attempt ?? 'unknown'}`,
+    `Request header: ${request.requestHeaderReason ?? '(unchanged)'}`,
+    `Provider: ${context.provider ?? 'unknown'}`,
+    `Model: ${context.model ?? 'unknown'}`,
+    `Reasoning effort: ${context.reasoningEffort ?? '(default)'}`,
+    `Max tokens: ${context.maxTokens ?? '(default)'}`,
+    `Temperature: ${context.temperature ?? '(default)'}`,
+    `Stop: ${context.stop === undefined ? '(none)' : formatJson(context.stop)}`,
+  ].join('\n')
+
+  return [
+    '='.repeat(80),
+    metadata,
+    section('SYSTEM PROMPT', context.system ?? '(none)'),
+    section(`TOOLS - TOP-LEVEL SCHEMAS (${Array.isArray(context.tools) ? context.tools.length : 0})`, formatTools(context.tools)),
+    section(`MESSAGES - ORDERED CONVERSATION (${Array.isArray(context.messages) ? context.messages.length : 0})`, formatMessages(context.messages)),
+  ].join('\n')
+}
+
+async function main() {
+  let document
+  try {
+    document = JSON.parse(await readFile(input, 'utf8'))
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined
+    if (code === 'ENOENT') {
+      throw new Error(`prompt debug file not found: ${input}\nRun /debug-prompt in dsh-tui first.`)
+    }
+    throw new Error(`cannot read prompt debug file ${input}: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  const turns = Array.isArray(document?.turns)
+    ? document.turns
+    : Array.isArray(document?.requests)
+      ? [{ turn: document.turn, requests: document.requests }]
+      : undefined
+  if (turns === undefined || turns.some(turn => !Array.isArray(turn?.requests))) {
+    throw new Error(`invalid prompt debug file: "turns[].requests" must be arrays (${input})`)
+  }
+  const requests = turns.flatMap(turn => turn.requests.map(request => ({
+    ...request,
+    ...(request.turn === undefined ? { turn: turn.turn } : {}),
+  })))
+
+  const header = [
+    'DSH FINAL LLM CONTEXT',
+    `File: ${input}`,
+    `Session: ${document.sessionId ?? 'unknown'}`,
+    `Turns: ${turns.length}`,
+    `Requests: ${requests.length}`,
+    `Capture started: ${document.captureStartedAt ?? '(legacy snapshot)'}`,
+    `Generated: ${document.generatedAt ?? 'unknown'}`,
+    'Sensitive: this output may contain conversation, workspace, and tool-result data.',
+  ].join('\n')
+
+  const report = requests.length === 0
+    ? '(no requests)'
+    : requests
+      .map((request, index) => formatRequest(request, index, requests.length))
+      .join('\n')
+  process.stdout.write(`${header}\n\n${report}\n`)
+}
+
+main().catch(error => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exitCode = 1
+})

--- a/scripts/verify-prompt-debug.mjs
+++ b/scripts/verify-prompt-debug.mjs
@@ -1,0 +1,199 @@
+/**
+ * Regression for `/debug-prompt`: final AgentLoop requests across turns and
+ * retry attempts must land in one private workspace file, while auxiliary
+ * calls and transport-only fields stay out.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { markAgentLoopRequest } from '@deepseek-ai/dsh-llm'
+import { PROMPT_DEBUG_FILENAME, registerPromptDebug } from '../lib/types/dsh-adapter/promptDebug.js'
+
+const workspace = mkdtempSync(join(tmpdir(), 'dsh-tui-prompt-debug-'))
+const sessionId = 'prompt-debug-session'
+const events = [
+  { type: 'turn/start', seq: 0, time: Date.now(), data: { turn: 1 } },
+  { type: 'step/start', seq: 1, time: Date.now(), data: { turn: 1, step: 0 } },
+]
+const agent = {
+  id: sessionId,
+  session: {
+    id: sessionId,
+    header: { id: sessionId, cwd: workspace },
+    events,
+  },
+}
+
+let definition
+let streamHandler
+let disposedHandler
+let nextCalls = 0
+const ctx = {
+  get(name) {
+    if (name === 'commands') {
+      return {
+        register(value) {
+          definition = value
+          return () => {}
+        },
+      }
+    }
+    if (name === 'agents') return { get: id => String(id) === sessionId ? agent : undefined }
+    if (name === 'llm') return {}
+    return undefined
+  },
+  on(name, handler) {
+    if (name === 'llm/stream') streamHandler = handler
+    if (name === 'agent/disposed') disposedHandler = handler
+    return () => {}
+  },
+  effect(factory) {
+    return factory()
+  },
+}
+
+async function dispatch(request) {
+  const stream = streamHandler(request, () => {
+    nextCalls += 1
+    return (async function* () {
+      yield { type: 'finish', reason: { kind: 'stop' } }
+    })()
+  })
+  for await (const _chunk of stream) {
+    // Consume the waterfall result so this exercises the same delegation
+    // contract as LlmRuntime.stream().
+  }
+}
+
+try {
+  registerPromptDebug(ctx)
+  assert.equal(definition?.name, 'debug-prompt')
+  assert.equal(typeof streamHandler, 'function')
+  assert.equal(typeof disposedHandler, 'function')
+
+  await dispatch({
+    provider: 'auxiliary',
+    model: 'title-model',
+    purpose: 'session-title',
+    sessionId,
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'make a title' }] }],
+  })
+
+  events.push({
+    type: 'request/header',
+    seq: 2,
+    time: Date.now(),
+    data: { reason: 'initial', header: {} },
+  })
+  await dispatch(markAgentLoopRequest({
+    provider: 'deepseek-official',
+    model: 'deepseek-v4-pro',
+    sessionId,
+    system: 'final force-smart bootstrap prompt',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'inspect the repository' }] }],
+    tools: [{
+      name: 'bash',
+      description: 'Run a shell command',
+      parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+    }],
+    maxTokens: 1024,
+    signal: new AbortController().signal,
+    apiKey: 'must-not-be-written',
+  }))
+
+  events.push({
+    type: 'request/header',
+    seq: 3,
+    time: Date.now(),
+    data: { reason: 'change', header: {} },
+  })
+  await dispatch(markAgentLoopRequest({
+    provider: 'deepseek-official',
+    model: 'deepseek-v4-pro',
+    sessionId,
+    system: 'final promoted prompt',
+    messages: [
+      { role: 'user', content: [{ type: 'text', text: 'inspect the repository' }] },
+      { role: 'assistant', content: [{ type: 'tool-call', id: 'call-1', name: 'bash', arguments: '{"command":"pwd"}' }] },
+      { role: 'tool', content: [{ type: 'tool-result', callId: 'call-1', content: [{ type: 'text', text: workspace }] }] },
+    ],
+    tools: [{
+      name: 'bash',
+      description: 'Run a shell command',
+      parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+    }],
+    maxTokens: 256000,
+  }))
+  events.push({ type: 'turn/end', seq: 4, time: Date.now(), data: { turn: 1, reason: { kind: 'completed' } } })
+
+  const result = await definition.handler({ agent, rawInput: '', signal: new AbortController().signal })
+  assert.equal(result.kind, 'success')
+  assert.match(result.text, /Wrote 2 final LLM requests/)
+  assert.equal(nextCalls, 3, 'the capture hook must always delegate to the next waterfall listener')
+
+  const output = join(workspace, PROMPT_DEBUG_FILENAME)
+  const document = JSON.parse(readFileSync(output, 'utf8'))
+  assert.equal(document.schemaVersion, 2)
+  assert.equal(document.sessionId, sessionId)
+  assert.equal(document.turnCount, 1)
+  assert.equal(document.requestCount, 2)
+  assert.equal(document.turns[0].turn, 1)
+  assert.equal(document.turns[0].requestCount, 2)
+  assert.deepEqual(document.turns[0].requests.map(request => request.attempt), [1, 2])
+  assert.deepEqual(document.turns[0].requests.map(request => request.step), [0, 0])
+  assert.deepEqual(document.turns[0].requests.map(request => request.requestHeaderReason), ['initial', 'change'])
+  assert.equal(document.turns[0].requests[0].finalLlmContext.system, 'final force-smart bootstrap prompt')
+  assert.equal(document.turns[0].requests[0].finalLlmContext.tools[0].parameters.type, 'object')
+  assert.equal(document.turns[0].requests[1].finalLlmContext.system, 'final promoted prompt')
+  assert.equal(document.turns[0].requests[1].finalLlmContext.messages[2].content[0].content[0].text, workspace)
+  assert.equal(JSON.stringify(document).includes('must-not-be-written'), false)
+  assert.equal(JSON.stringify(document).includes('session-title'), false)
+  assert.equal('signal' in document.turns[0].requests[0].finalLlmContext, false)
+  if (process.platform !== 'win32') {
+    assert.equal(statSync(output).mode & 0o777, 0o600)
+  }
+
+  const readable = spawnSync(process.execPath, [join(process.cwd(), 'scripts', 'read-prompt-debug.mjs'), output], {
+    encoding: 'utf8',
+  })
+  assert.equal(readable.status, 0, readable.stderr)
+  assert.match(readable.stdout, /DSH FINAL LLM CONTEXT/)
+  assert.match(readable.stdout, /REQUEST 1\/2/)
+  assert.match(readable.stdout, /Turn: 1\nStep: 0\nAttempt: 1/)
+  assert.match(readable.stdout, /SYSTEM PROMPT\n-{80}\nfinal force-smart bootstrap prompt/)
+  assert.match(readable.stdout, /TOOLS - TOP-LEVEL SCHEMAS \(1\)/)
+  assert.match(readable.stdout, /MESSAGES - ORDERED CONVERSATION \(3\)/)
+  assert.ok(
+    readable.stdout.indexOf('TOOLS - TOP-LEVEL SCHEMAS')
+      < readable.stdout.indexOf('MESSAGES - ORDERED CONVERSATION'),
+  )
+  assert.match(readable.stdout, /"type": "object"/)
+
+  events.push({ type: 'turn/start', seq: 5, time: Date.now(), data: { turn: 2 } })
+  events.push({ type: 'step/start', seq: 6, time: Date.now(), data: { turn: 2, step: 0 } })
+  await dispatch(markAgentLoopRequest({
+    provider: 'deepseek-official',
+    model: 'deepseek-v4-flash',
+    sessionId,
+    system: 'latest smart prompt',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'second turn' }] }],
+  }))
+  events.push({ type: 'turn/end', seq: 7, time: Date.now(), data: { turn: 2, reason: { kind: 'completed' } } })
+  await definition.handler({ agent, rawInput: '', signal: new AbortController().signal })
+  const latest = JSON.parse(readFileSync(output, 'utf8'))
+  assert.equal(latest.turnCount, 2)
+  assert.equal(latest.requestCount, 3, 'all observed turns are retained')
+  assert.deepEqual(latest.turns.map(turn => turn.turn), [1, 2])
+  assert.equal(latest.turns[1].requestCount, 1)
+  assert.equal(latest.turns[1].requests[0].attempt, 1)
+  assert.equal(latest.turns[1].requests[0].finalLlmContext.system, 'latest smart prompt')
+
+  const usage = await definition.handler({ agent, rawInput: ' on', signal: new AbortController().signal })
+  assert.deepEqual(usage, { kind: 'error', text: 'Usage: /debug-prompt' })
+
+  console.log('prompt debug OK (final context, turn/step/retry retention, filtering, permissions)')
+} finally {
+  rmSync(workspace, { recursive: true, force: true })
+}

--- a/src/dsh-adapter/contract.ts
+++ b/src/dsh-adapter/contract.ts
@@ -31,6 +31,7 @@ export const UPSTREAM_BLESSED_PACKAGES = [
   '@deepseek-ai/dsh-agent',
   '@deepseek-ai/dsh-agent-instructions',
   '@deepseek-ai/dsh-agent-presets',
+  '@deepseek-ai/dsh-atomic-write',
   '@deepseek-ai/dsh-commands',
   '@deepseek-ai/dsh-cordis-host-runner',
   '@deepseek-ai/dsh-llm',

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -12,6 +12,7 @@ import { logForDebugging } from '../utils/debug.js'
 import { QuestionStore } from './questions.js'
 import { ApprovalStore } from './approvals.js'
 import { registerPackagedSkills } from './packaged-skills.js'
+import { registerPromptDebug } from './promptDebug.js'
 import { readActivityFrames } from '../activityPrefs.js'
 import { readModelPref } from '../modelPrefs.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
@@ -146,6 +147,9 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   // Packaged skills (/audit, /bug, …): contribute them through the host's
   // skill registry so they resolve with zero manual copying.
   registerPackagedSkills(ctx)
+  // `/debug-prompt` snapshots the final provider-neutral request at the
+  // llm/stream boundary, after every prompt and tool contributor has run.
+  registerPromptDebug(ctx)
   // Yield to an incumbent provider instead of crashing the whole plugin tree
   // (issue #98): the harness allows exactly ONE user-questions provider per
   // context, and stacking this TUI onto a profile that already carries

--- a/src/dsh-adapter/promptDebug.ts
+++ b/src/dsh-adapter/promptDebug.ts
@@ -1,0 +1,198 @@
+/**
+ * On-demand capture of every final AgentLoop request context observed for a
+ * live session.
+ *
+ * The LLM waterfall is the last provider-neutral boundary before adapter
+ * dispatch. Capturing there records the fully assembled system prompt,
+ * messages, and tool schemas after prompt/tool plugins have contributed.
+ * @module @deepseek-harness-tui/dsh-tui/prompt-debug
+ */
+import { join, resolve } from 'node:path'
+import type { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import type { CommandRuntime } from '@deepseek-ai/dsh-commands'
+import { writeFileAtomic } from '@deepseek-ai/dsh-atomic-write'
+import { isAgentLoopRequest, type GenerateOptions } from '@deepseek-ai/dsh-llm'
+
+export const PROMPT_DEBUG_FILENAME = '.dsh-prompt-debug.json'
+
+interface CapturedRequest {
+  capturedAt: string
+  requestIndex: number
+  turn: number
+  step: number
+  attempt: number
+  requestHeaderReason?: string
+  finalLlmContext: {
+    provider: string
+    model: string
+    reasoningEffort?: GenerateOptions['reasoningEffort']
+    system?: string
+    messages: GenerateOptions['messages']
+    tools?: GenerateOptions['tools']
+    temperature?: number
+    maxTokens?: number
+    stop?: string[]
+  }
+}
+
+interface TurnCapture {
+  turn: number
+  requests: CapturedRequest[]
+}
+
+interface SessionCapture {
+  requests: CapturedRequest[]
+}
+
+interface AgentRegistryLike {
+  get(id: NonNullable<GenerateOptions['sessionId']>): Agent | undefined
+}
+
+function latestPosition(agent: Agent): { turn: number; step: number } | undefined {
+  for (let index = agent.session.events.length - 1; index >= 0; index -= 1) {
+    const event = agent.session.events[index]
+    if (event?.type === 'step/start') return event.data
+  }
+  return undefined
+}
+
+function latestRequestHeaderReason(agent: Agent): string | undefined {
+  for (let index = agent.session.events.length - 1; index >= 0; index -= 1) {
+    const event = agent.session.events[index]
+    if (event?.type === 'request/header') return event.data.reason
+  }
+  return undefined
+}
+
+function turnCompleted(agent: Agent, turn: number): boolean {
+  return agent.session.events.some(event => event.type === 'turn/end' && event.data.turn === turn)
+}
+
+function captureRequest(
+  agent: Agent,
+  options: GenerateOptions,
+  requestIndex: number,
+  position: { turn: number; step: number },
+  attempt: number,
+): CapturedRequest {
+  const requestHeaderReason = latestRequestHeaderReason(agent)
+  return {
+    capturedAt: new Date().toISOString(),
+    requestIndex,
+    ...position,
+    attempt,
+    ...(requestHeaderReason === undefined ? {} : { requestHeaderReason }),
+    finalLlmContext: {
+      provider: options.provider,
+      model: options.model,
+      ...(options.reasoningEffort === undefined ? {} : { reasoningEffort: options.reasoningEffort }),
+      ...(options.system === undefined ? {} : { system: options.system }),
+      messages: options.messages,
+      ...(options.tools === undefined ? {} : { tools: options.tools }),
+      ...(options.temperature === undefined ? {} : { temperature: options.temperature }),
+      ...(options.maxTokens === undefined ? {} : { maxTokens: options.maxTokens }),
+      ...(options.stop === undefined ? {} : { stop: options.stop }),
+    },
+  }
+}
+
+/**
+ * Register `/debug-prompt` and retain every final request observed for each
+ * live session. The command writes one private, atomic snapshot into the
+ * receiving session's workspace; it never records credentials, transport
+ * headers, or AbortSignals.
+ */
+export function registerPromptDebug(ctx: Context): void {
+  const commands = ctx.get('commands') as CommandRuntime | undefined
+  const agents = ctx.get('agents') as AgentRegistryLike | undefined
+  if (commands === undefined || agents === undefined || ctx.get('llm') === undefined) return
+
+  const captureStartedAt = new Date().toISOString()
+  const captures = new Map<string, SessionCapture>()
+
+  ctx.on('llm/stream', (options, next) => {
+    if (!isAgentLoopRequest(options) || options.sessionId === undefined) return next()
+
+    const agent = agents.get(options.sessionId)
+    if (agent === undefined) return next()
+    const position = latestPosition(agent)
+    if (position === undefined) return next()
+
+    const sessionId = String(options.sessionId)
+    const capture = captures.get(sessionId) ?? { requests: [] }
+    if (!captures.has(sessionId)) captures.set(sessionId, capture)
+    const previous = capture.requests.findLast(request =>
+      request.turn === position.turn && request.step === position.step)
+    const attempt = (previous?.attempt ?? 0) + 1
+    capture.requests.push(captureRequest(agent, options, capture.requests.length + 1, position, attempt))
+    return next()
+  })
+
+  // Replaced agents are no longer addressable by `/debug-prompt`; release
+  // their potentially large message/tool snapshots with the agent lifecycle.
+  ctx.on('agent/disposed', ({ agent }) => {
+    captures.delete(String(agent.session.id))
+  })
+
+  ctx.effect(() => commands.register({
+    name: 'debug-prompt',
+    description: 'Write every observed final LLM request context for this session to the workspace root',
+    recordInput: false,
+    handler: async ({ agent, rawInput }) => {
+      if (rawInput.trim().length > 0) {
+        return { kind: 'error', text: 'Usage: /debug-prompt' }
+      }
+
+      const sessionId = String(agent.session.id)
+      const capture = captures.get(sessionId)
+      if (capture === undefined || capture.requests.length === 0) {
+        return {
+          kind: 'error',
+          text: 'No final LLM request is available for this session. Send one prompt, wait for it to finish, then run /debug-prompt.',
+        }
+      }
+      const latest = capture.requests.at(-1)!
+      if (!turnCompleted(agent, latest.turn)) {
+        return { kind: 'error', text: 'The latest model turn is still running. Wait for it to finish, then run /debug-prompt.' }
+      }
+
+      const root = resolve(agent.session.header.cwd ?? process.cwd())
+      const output = join(root, PROMPT_DEBUG_FILENAME)
+      const turns = new Map<number, TurnCapture>()
+      for (const request of capture.requests) {
+        const turn = turns.get(request.turn) ?? { turn: request.turn, requests: [] }
+        if (!turns.has(request.turn)) turns.set(request.turn, turn)
+        turn.requests.push(request)
+      }
+      const document = {
+        schemaVersion: 2,
+        generatedAt: new Date().toISOString(),
+        captureStartedAt,
+        captureScope: 'Requests observed by this dsh-tui process; requests from before a session resume cannot be reconstructed.',
+        warning: 'Sensitive debug data: contains system prompts, conversation messages, tool schemas, and tool results. It intentionally excludes credentials and transport headers.',
+        sessionId,
+        turnCount: turns.size,
+        requestCount: capture.requests.length,
+        turns: [...turns.values()].map(turn => ({
+          ...turn,
+          requestCount: turn.requests.length,
+        })),
+      }
+
+      try {
+        await writeFileAtomic(output, `${JSON.stringify(document, null, 2)}\n`, { mode: 0o600 })
+      } catch (error) {
+        return {
+          kind: 'error',
+          text: `Could not write prompt debug file: ${error instanceof Error ? error.message : String(error)}`,
+        }
+      }
+
+      return {
+        kind: 'success',
+        text: `Wrote ${capture.requests.length} final LLM request${capture.requests.length === 1 ? '' : 's'} to ${output}. The file contains sensitive conversation and prompt data.`,
+      }
+    },
+  }))
+}


### PR DESCRIPTION
新增 `/debug-prompt` 命令，用于导出当前会话实际发送给模型的最终请求上下文，包括 system prompt、messages、tools 和模型参数。

同时新增：

- `.dsh-prompt-debug.json` 格式化查看脚本
- Prompt 调试专项测试
- 敏感字段过滤和私有文件权限
- 调试文件的 `.gitignore` 规则