### PR TITLE
fix(update): 使用预检解析的明确版本更新

### DIFF
--- a/scripts/verify-update.mjs
+++ b/scripts/verify-update.mjs
@@ -8,8 +8,8 @@
  * - resolveRegistryBase() honors NPM_CONFIG_REGISTRY (both spellings), the
  *   user ~/.npmrc `registry=` line, and falls back to npmjs.org
  * - isVersionNewer() requires a strictly greater valid semver
- * - updateTuiAndRestart's pnpm args include --latest (cross-minor updates);
- *   asserted via the compiled source text since spawning dsh is out of scope
+ * - update command args pin the preflight target version, with --latest as the
+ *   fallback when preflight could not resolve one
  *
  * Run: node scripts/verify-update.mjs
  */
@@ -24,9 +24,14 @@ function check(name, ok, extra = '') {
   if (!ok) failed += 1
 }
 
-const { installedTuiVersion, resolveRegistryBase, isVersionNewer, resolveDshProfileName, shellQuote } = await import(
-  '../lib/types/update.js'
-)
+const {
+  installedTuiVersion,
+  resolveRegistryBase,
+  isVersionNewer,
+  resolveDshProfileName,
+  shellQuote,
+  tuiUpdatePluginArgs,
+} = await import('../lib/types/update.js')
 const compiledModulePath = fileURLToPath(new URL('../lib/types/update.js', import.meta.url))
 const compiledShellQuotePath = fileURLToPath(new URL('../lib/types/utils/shellQuote.js', import.meta.url))
 const repoRoot = fileURLToPath(new URL('..', import.meta.url))
@@ -189,16 +194,25 @@ check(
   shellQuote(['a"b c']).join(' ') === '"a""b c"',
 )
 
-// ---- pnpm args include --latest (must-fix: cross-minor update capability)
+// ---- pnpm args reuse the preflight result instead of resolving latest twice
+const exactUpdateArgs = tuiUpdatePluginArgs('dsh-tui', '0.7.2')
+check(
+  'update command pins the preflight target version',
+  JSON.stringify(exactUpdateArgs) === JSON.stringify([
+    'plugin', '--profile', 'dsh-tui', 'update', '@deepseek-harness-tui/dsh-tui@0.7.2',
+  ]),
+  `got ${JSON.stringify(exactUpdateArgs)}`,
+)
+const fallbackUpdateArgs = tuiUpdatePluginArgs('custom-profile')
+check(
+  'update command falls back to --latest when preflight failed',
+  JSON.stringify(fallbackUpdateArgs) === JSON.stringify([
+    'plugin', '--profile', 'custom-profile', 'update', '--latest', '@deepseek-harness-tui/dsh-tui',
+  ]),
+  `got ${JSON.stringify(fallbackUpdateArgs)}`,
+)
+
 const compiledSource = readFileSync(compiledModulePath, 'utf8')
-check(
-  'update command passes --latest to pnpm',
-  /['"]update['"],\s*\n\s*['"]--latest['"],/.test(compiledSource),
-)
-check(
-  'update command keeps the scoped package name',
-  compiledSource.includes('@deepseek-harness-tui/dsh-tui'),
-)
 // P1: the node restart must NOT go through a shell — assert the compiled
 // restart spawn call has no shell option while the dsh call does.
 const dshSpawn = compiledSource.indexOf("runProcess(dsh")

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -338,6 +338,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   let instance: Awaited<ReturnType<typeof render>> | undefined
   let exited = false
   let updateRequested = false
+  let updateTargetVersion: string | undefined
   // The profile this process was booted with (`dsh --profile <name>`); dsh
   // exposes it nowhere else, and /update must update the installation the
   // user is actually running, not a hard-coded one.
@@ -377,7 +378,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
           config.fullscreen === true,
           'Updating @deepseek-harness-tui/dsh-tui and restarting…',
           undefined,
-          () => runUpdate(ctx, profile, channel.agentId),
+          () => runUpdate(ctx, profile, channel.agentId, updateTargetVersion),
         )
         return
       }
@@ -437,6 +438,8 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
         }
         if (target.kind === 'unknown') {
           channel.notify(t('update-check-failed'))
+        } else {
+          updateTargetVersion = target.latest
         }
         channel.notify(t('update-starting'))
         updateRequested = true
@@ -755,13 +758,18 @@ function writeStream(stream: NodeJS.WriteStream, data: string): Promise<void> {
   })
 }
 
-function runUpdate(ctx: Context, profile: string | undefined, sessionId: string): void {
+function runUpdate(
+  ctx: Context,
+  profile: string | undefined,
+  sessionId: string,
+  targetVersion: string | undefined,
+): void {
   disposeRootAndThen(ctx, () => {
     if (profile === undefined) {
       process.stderr.write(`\n${t('update-aborted-no-profile')}\n`)
       process.exit(1)
     }
-    void updateTuiAndRestart(sessionId, profile).then(
+    void updateTuiAndRestart(sessionId, profile, targetVersion).then(
       ({ updateCode, restartCode }) => {
         if (updateCode !== 0) {
           process.stderr.write(

--- a/src/update.ts
+++ b/src/update.ts
@@ -203,33 +203,38 @@ function runProcess(
   })
 }
 
+/** Build the profile-manager command, preferring a preflight-pinned version. */
+export function tuiUpdatePluginArgs(profile: string, targetVersion?: string): string[] {
+  return targetVersion === undefined
+    ? ['plugin', '--profile', profile, 'update', '--latest', PACKAGE_NAME]
+    : ['plugin', '--profile', profile, 'update', `${PACKAGE_NAME}@${targetVersion}`]
+}
+
 /**
  * Update the installed dsh-tui package and restart the same launcher while
  * preserving the active session. The TUI must already be unmounted before
  * this is called so pnpm output cannot corrupt the rendered terminal frame.
  *
- * `--latest` is required: `pnpm add` writes a caret range into the profile
- * manifest, and a plain `pnpm update` stays inside that range — with this
- * project's minor-per-release cadence the TUI would restart unchanged while
- * reporting success. The restart carries `DSH_TUI_UPDATED_FROM` so the new
- * process can warn when the version did not actually move (e.g. a mirror
- * registry still serving the old `latest`).
+ * When the preflight registry check resolved an exact target, pass that
+ * version to pnpm instead of resolving `latest` a second time. This avoids a
+ * stale mirror/dist-tag response between the check and install. If preflight
+ * failed, retain the `--latest` fallback: a plain `pnpm update` stays inside
+ * the manifest range and can restart unchanged across minor releases.
  *
  * @param sessionId - Session to resume in the replacement process.
  * @param profile - The dsh profile this TUI was launched with; updating any
  *   other profile would leave the running install untouched.
+ * @param targetVersion - Exact version returned by the preflight registry
+ *   check, or undefined when that check failed and pnpm should resolve latest.
  * @returns Exit codes for the update run and the replacement process.
  */
-export async function updateTuiAndRestart(sessionId: string, profile: string): Promise<TuiUpdateResult> {
+export async function updateTuiAndRestart(
+  sessionId: string,
+  profile: string,
+  targetVersion?: string,
+): Promise<TuiUpdateResult> {
   const dsh = process.platform === 'win32' ? 'dsh.cmd' : 'dsh'
-  const updateCode = await runProcess(dsh, [
-    'plugin',
-    '--profile',
-    profile,
-    'update',
-    '--latest',
-    PACKAGE_NAME,
-  ], { shell: true })
+  const updateCode = await runProcess(dsh, tuiUpdatePluginArgs(profile, targetVersion), { shell: true })
   if (updateCode !== 0) return { updateCode, restartCode: updateCode }
 
   const restartCode = await runProcess(process.execPath, [...process.execArgv, ...process.argv.slice(1)], {


### PR DESCRIPTION
动机：/update 预检已经从当前 registry 解析出明确的新版本，但安装阶段再次使用 latest，镜像或 dist-tag 短暂滞后时可能成功重启却仍停留在旧版本。修改：把预检得到的目标版本传到退出/更新流程，执行 pnpm update package@明确版本；预检失败时继续保留 --latest 回退；新增更新参数专项验证。验证：隔离 profile 真实执行 0.6.1 → 0.7.2 升级；pnpm@11.7.0 build；node scripts/verify-update.mjs；pnpm@11.7.0 verify:package；git diff --check。未提交生成的 lib。

Fixes #209