### PR TITLE
feat(commands): 添加 /skills 技能列表命令

### DIFF
--- a/scripts/verify-i18n-command-descriptions.tsx
+++ b/scripts/verify-i18n-command-descriptions.tsx
@@ -64,7 +64,7 @@ function screenText(term: InstanceType<typeof XTerm>, rows: number): string {
 
 // 混合清单：内置命令 + 已收录外部命令（plan）+ 未收录外部命令。
 const commands = [
-  ...LOCAL_COMMANDS.filter(c => ['new', 'compact', 'rewind'].includes(c.name)),
+  ...LOCAL_COMMANDS.filter(c => ['new', 'compact', 'rewind', 'skills'].includes(c.name)),
   { name: 'plan', description: 'Toggle plan mode', external: true },
   { name: 'unlisted-ext', description: 'Registry fallback text', external: true },
 ]
@@ -89,7 +89,14 @@ console.log('CommandSuggestions 随 /lang 切换:')
   let text = screenText(term, ROWS)
   assert(text.includes('新开会话'), 'zh：内置命令显示中文描述（新开会话）')
   assert(text.includes('压缩会话历史'), 'zh：compact 显示中文描述')
+  assert(text.includes('查看可用技能'), 'zh：/skills 在补全菜单显示中文描述')
   assert(text.includes('切换计划模式'), 'zh：外部命令 plan 走 cmd-desc 中文映射')
+
+  // The sixth command is outside the five-row suggestion window until it is
+  // selected; keep the external fallback assertion precise as well.
+  app.rerender(React.createElement(CommandSuggestions, { commands, selectedIndex: 5, columns: COLS }))
+  await sleep(200)
+  text = screenText(term, ROWS)
   assert(text.includes('Registry fallback text'), 'zh：未收录外部命令回退注册表原文')
   assert(!text.includes('Toggle plan mode'), 'zh：已收录外部命令不再显示英文原文')
 
@@ -98,6 +105,7 @@ console.log('CommandSuggestions 随 /lang 切换:')
   await sleep(200)
   text = screenText(term, ROWS)
   assert(text.includes('Start a new conversation'), 'en：内置命令回退 LOCAL_COMMANDS 英文原文')
+  assert(text.includes('List available skills'), 'en：/skills 在补全菜单回退 LOCAL_COMMANDS 英文描述')
   assert(text.includes('Toggle plan mode'), 'en：外部命令 plan 回退注册表英文原文')
   assert(!text.includes('新开会话'), 'en：不再残留中文描述')
 
@@ -126,12 +134,14 @@ console.log('HelpMenu 随 /lang 切换:')
   let text = screenText(term, ROWS)
   assert(text.includes('/new — 新开会话'), 'zh：帮助菜单显示 /new — 新开会话')
   assert(text.includes('/rewind — 回退会话到历史消息'), 'zh：帮助菜单显示 rewind 中文描述')
+  assert(text.includes('/skills — 查看可用技能'), 'zh：帮助菜单显示 /skills 中文描述')
 
   setLang('en')
   app.rerender(React.createElement(HelpMenu, { commands }))
   await sleep(200)
   text = screenText(term, ROWS)
   assert(text.includes('/new — Start a new conversation'), 'en：帮助菜单显示英文原文')
+  assert(text.includes('/skills — List available skills'), 'en：/skills 回退 LOCAL_COMMANDS 英文描述')
 
   setLang('zh')
   app.unmount()

--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -26,6 +26,7 @@ const tick = () => new Promise(resolve => setTimeout(resolve, 20))
 const handlers = new Map()
 const fire = event => { for (const handler of handlers.get(event) ?? []) handler() }
 // Mutable catalog: the skills/change phase re-reads this.
+const skillSnapshots = []
 const catalog = [
   { name: 'i-h', description: 'Interactive help skill', invocation: { modelInvocable: true, userInvocable: true }, content: 'HELP BODY', resourceBase: { kind: 'directory', path: '/home/u/.agents/skills/i-h' } },
   { name: 'helper', description: 'A helper skill', invocation: { modelInvocable: true, userInvocable: true } },
@@ -61,7 +62,10 @@ const ctx = {
     }
     if (name === 'skills') {
       return {
-        snapshot: async () => ({ skills: catalog, complete: true }),
+        snapshot: async options => {
+          skillSnapshots.push(options)
+          return { skills: catalog, complete: true }
+        },
         // A `get` miss models a SKILL.md deleted between listing and Enter.
         get: async skillName => catalog.find(skill => skill.name === skillName),
       }
@@ -125,6 +129,90 @@ check(
 check(
   'locals all kept',
   LOCAL_COMMANDS.every(local => names.includes(local.name)),
+)
+
+// ---- immediate skill directory query: authoritative user-facing catalog
+const snapshotsBeforeList = skillSnapshots.length
+const listedSkills = await channel.listSkills()
+const listSnapshot = skillSnapshots[snapshotsBeforeList]
+check(
+  'listSkills returns user-invocable skill',
+  Array.isArray(listedSkills) && listedSkills.some(skill => skill.name === 'i-h'),
+)
+check(
+  'listSkills preserves description',
+  Array.isArray(listedSkills) && listedSkills.some(skill =>
+    skill.name === 'i-h' && skill.description === 'Interactive help skill'),
+)
+check(
+  'listSkills excludes model-only skill',
+  Array.isArray(listedSkills) && !listedSkills.some(skill => skill.name === 'secret'),
+)
+check(
+  'listSkills keeps a skill shadowed by a registry command',
+  Array.isArray(listedSkills) && listedSkills.some(skill => skill.name === 'plan'),
+)
+check(
+  'listSkills keeps a skill shadowed by a local command',
+  Array.isArray(listedSkills) && listedSkills.some(skill => skill.name === 'review'),
+)
+check(
+  'listSkills reads through live-agent scope',
+  skillSnapshots.length === snapshotsBeforeList + 1 &&
+    listSnapshot?.scope === agent &&
+    listSnapshot?.cwd === '/tmp',
+)
+
+const originalGet = ctx.get
+ctx.get = name => {
+  if (name === 'skills') {
+    return { snapshot: async options => {
+      skillSnapshots.push(options)
+      return { skills: [], complete: true }
+    } }
+  }
+  return originalGet(name)
+}
+const emptySkills = await channel.listSkills()
+ctx.get = originalGet
+check(
+  'complete empty catalog returns an empty list',
+  Array.isArray(emptySkills) && emptySkills.length === 0,
+)
+
+ctx.get = name => {
+  if (name === 'skills') {
+    return { snapshot: async options => {
+      skillSnapshots.push(options)
+      return {
+        skills: [{ name: 'partial', description: 'Partial skill', invocation: { modelInvocable: true, userInvocable: true } }],
+        complete: false,
+      }
+    } }
+  }
+  return originalGet(name)
+}
+const incompleteSkills = await channel.listSkills()
+ctx.get = originalGet
+check(
+  'incomplete skill catalog is not exposed as authoritative',
+  incompleteSkills === undefined,
+)
+
+let listWarned = 0
+const originalLogger = ctx.logger
+ctx.logger = { warn() { listWarned += 1 } }
+ctx.get = name => {
+  if (name === 'skills') return { snapshot: async () => { throw new Error('scan failed') } }
+  return originalGet(name)
+}
+const failedSkills = await channel.listSkills()
+ctx.get = originalGet
+ctx.logger = originalLogger
+check(
+  'failed skill catalog read reports unavailable instead of throwing',
+  failedSkills === undefined && listWarned >= 1,
+  `warned=${listWarned}`,
 )
 
 // ---- live refresh: skills/change re-reads the catalog

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -78,6 +78,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
   { name: 'doctor', description: 'Run environment checks' },
   { name: 'init', description: 'Create AGENTS.md in the working directory' },
   { name: 'agents', description: 'Show subagents of this session' },
+  { name: 'skills', description: 'List available skills' },
   // Model / display
   { name: 'activity', description: 'Switch the working-activity indicator preset' },
   { name: 'preset', description: 'Switch the agent preset (standard/code/minimal/cordis)' },

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -242,6 +242,12 @@ export interface LoadedContextSkill {
   readonly description: string
 }
 
+/** One user-invocable skill visible to the live agent. */
+export interface AvailableSkill {
+  readonly name: string
+  readonly description: string
+}
+
 /** One model-visible tool from the prompt assembly. */
 export interface LoadedContextTool {
   readonly name: string
@@ -514,6 +520,12 @@ export interface Channel {
    *  the service is absent). */
   listSubagents(): Promise<string[]>
   /**
+   * User-invocable skills visible to the live agent.
+   * `[]` means the registry is unavailable or authoritatively empty.
+   * `undefined` means a mounted registry could not provide an authoritative snapshot.
+   */
+  listSkills(): Promise<readonly AvailableSkill[] | undefined>
+  /**
    * Dispose the host-registry entries this channel registered (skill slash
    * commands).
    *
@@ -713,6 +725,8 @@ export interface ChannelState {
   doctorInfo(): string[]
   /** Subagent rows (CC's /agents). */
   listSubagents(): Promise<string[]>
+  /** See {@link Channel.listSkills}. */
+  listSkills(): Promise<readonly AvailableSkill[] | undefined>
   /** See {@link Channel.releaseContributions}. */
   releaseContributions(): void
   /** Live session event log (see the public Channel type, `/trace`). */
@@ -2776,6 +2790,24 @@ export function createChannel(
         })
       } catch (error) {
         return [t('subagent-query-failed', { err: error instanceof Error ? error.message : String(error) })]
+      }
+    },
+    async listSkills() {
+      const target = agent
+      try {
+        const registry = skillRegistryFor(target)
+        if (registry === undefined) return []
+        const observation = await registry.snapshot(skillViewOptions(target))
+        if (target !== agent || !observation.complete) return undefined
+        return observation.skills
+          .filter(skill => isUserInvocable(skill))
+          .map(skill => ({
+            name: skill.name,
+            description: skill.description,
+          }))
+      } catch (error) {
+        ctx.logger.warn('skills list: catalog read failed: %o', error)
+        return undefined
       }
     },
     releaseContributions() {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -572,6 +572,7 @@ const dict = {
   'cmd-desc-doctor': { zh: '运行环境检查' },
   'cmd-desc-init': { zh: '在工作目录创建 AGENTS.md' },
   'cmd-desc-agents': { zh: '查看本会话的子代理' },
+  'cmd-desc-skills': { zh: '查看可用技能' },
   // Model / display
   'cmd-desc-activity': { zh: '切换工作状态指示器预设' },
   'cmd-desc-preset': { zh: '切换 Agent 预设（standard/code/minimal/cordis）' },
@@ -614,6 +615,9 @@ const dict = {
   'cmd-desc-plan': { zh: '切换计划模式（/plan off 退出）' },
   'cmd-desc-goal': { zh: '设置或查看会话目标' },
   'cmd-desc-feedback': { zh: '提交使用反馈' },
+
+  'skills-none': { zh: '当前没有可调用的技能', en: 'No user-invocable skills are currently available' },
+  'skills-list-unavailable': { zh: '暂时无法读取完整的技能列表，请稍后重试', en: 'The complete skill list is temporarily unavailable; try again later' },
 
   // ── /lang command ───────────────────────────────────────────────────
   'lang-current': { zh: '当前语言  {{lang}}', en: 'Current language  {{lang}}' },

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -902,6 +902,21 @@ export function Chat({
           channel.pushLocal('/agents', lines)
         })
         return true
+      case 'skills':
+        setHelpOpen(false)
+        void channel.listSkills().then((skills) => {
+          if (skills === undefined) {
+            channel.notify(t('skills-list-unavailable'), { color: 'warning' })
+            return
+          }
+          channel.pushLocal(
+            '/skills',
+            skills.length === 0
+              ? [t('skills-none')]
+              : skills.map(skill => `${skill.name} — ${skill.description}`),
+          )
+        })
+        return true
       case 'login': {
         const key = process.env.DEEPSEEK_API_KEY
         const lines = [


### PR DESCRIPTION
实现 #204，新增 `/skills` 命令，用于查看当前 live agent 可用的 user-invocable skills 及其描述。

## 修改

- 新增 `/skills` 本地命令
- 通过 live-agent scoped SkillRegistry 读取技能目录
- 仅展示 user-invocable skills
- 保留与本地命令或 registry command 重名的 skill 条目
- 增加中英文命令描述和空状态提示
- 补充 skill catalog、scope、collision 和 i18n 回归测试

## 验证

- `pnpm build`
- `node scripts/verify-skill-commands.mjs`
- `node scripts/verify-i18n-command-descriptions.tsx`
- `git diff --check`

Fixes #204