### PR TITLE
fix(render): 切断 MessageList 测量嵌套更新链

### DIFF
--- a/scripts/verify-message-measure-depth.tsx
+++ b/scripts/verify-message-measure-depth.tsx
@@ -28,7 +28,7 @@ const rows = [{
   id: 1,
   kind: 'assistant' as const,
   get text(): string {
-    textRevision = Math.min(60, textRevision + 1)
+    textRevision = Math.min(200, textRevision + 1)
     return Array.from({ length: textRevision }, (_, line) => `measured line ${line}`).join('\n')
   },
   streaming: false,
@@ -54,8 +54,11 @@ const instance = await render(<MessageList
   patchConsole: false,
 })
 
-const deadline = Date.now() + 2000
-while (textRevision < 60 && Date.now() < deadline) await sleep(25)
+let timerTurns = 0
+const turnCounter = setInterval(() => { timerTurns += 1 }, 0)
+const deadline = Date.now() + 5000
+while (textRevision < 200 && Date.now() < deadline) await sleep(25)
+clearInterval(turnCounter)
 
 await instance.unmount()
 const output = stdout.text + stderr.text
@@ -63,8 +66,12 @@ if (/Maximum update depth|Minified React error #185/.test(output)) {
   console.error('FAIL: MessageList entered a nested measurement update loop')
   process.exit(1)
 }
-if (textRevision !== 60) {
+if (textRevision !== 200) {
   console.error(`FAIL: MessageList measurement stopped at revision ${textRevision}`)
   process.exit(1)
 }
-console.log('PASS: MessageList measurements settle without nested update overflow')
+if (timerTurns < 10) {
+  console.error(`FAIL: MessageList measurement stayed in one microtask chain (${timerTurns} timer turns)`)
+  process.exit(1)
+}
+console.log(`PASS: MessageList measurements settle across ${timerTurns} timer turns without nested update overflow`)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -131,7 +131,7 @@ export function MessageList({
   const localRefs = React.useRef(new Map<number, DOMElement>())
   /** Content-space offset of visibleRows[0] (header + dividers), measured. */
   const baseRef = React.useRef<number | null>(null)
-  const measureQueuedRef = React.useRef(false)
+  const measureTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const [, setMeasureTick] = React.useState(0)
   const [, setScrollTick] = React.useState(0)
 
@@ -150,6 +150,12 @@ export function MessageList({
     const tick = (): void =>{  setScrollTick(t => t + 1) }
     return scrollHandle.subscribe(tick)
   }, [scrollHandle])
+
+  React.useLayoutEffect(() => () => {
+    if (measureTimerRef.current === null) return
+    clearTimeout(measureTimerRef.current)
+    measureTimerRef.current = null
+  }, [])
 
   const heightOf = (row: ChatRow): number =>
     heightsRef.current.get(row.id) ?? DEFAULT_ROW_HEIGHT
@@ -253,14 +259,15 @@ export function MessageList({
         scrollHandle.setClampBounds(min, Math.max(min, base + mountedBottom - viewport))
       }
     }
-    if (changed && !measureQueuedRef.current) {
-      // Layout corrections can cascade for many rows. Yield between commits
-      // so React does not count the valid convergence as nested updates.
-      measureQueuedRef.current = true
-      queueMicrotask(() => {
-        measureQueuedRef.current = false
+    if (changed && measureTimerRef.current === null) {
+      // A microtask still belongs to React's current synchronous work turn and
+      // can exhaust the reconciler's 50-update guard during sustained streams.
+      // A timer starts a fresh task while still coalescing all corrections from
+      // this commit. The cleanup above prevents a late update after unmount.
+      measureTimerRef.current = setTimeout(() => {
+        measureTimerRef.current = null
         setMeasureTick(t => t + 1)
-      })
+      }, 0)
     }
   })
 


### PR DESCRIPTION
## 问题

长时间流式输出期间，`MessageList` 的布局测量会在 `useLayoutEffect` 后通过 `queueMicrotask` 触发 `setMeasureTick`。流式外部 store 更新与测量更新持续交错时，微任务仍可能处于 React 19 的同一同步工作链，最终超过 reconciler 的 50 次嵌套更新限制并以 React error #185 退出。

安装产物中的崩溃点为 `lib/types/components/MessageList.js:207`，对应源码的测量 tick。

## 修复

- 将测量校正从 `queueMicrotask` 改为单例 `setTimeout(0)`，进入新的事件循环 task，切断 React 的同步嵌套更新链
- 保留原有合并语义：每个 `MessageList` 同时最多一个待处理测量任务
- 在 layout cleanup 中取消待处理 timer，避免卸载后的迟到状态更新
- 将测量压力回归从 60 次提高到 200 次，并断言校正过程真实跨越多个 timer turn，防止退回连续微任务链

## 验证

- `pnpm install --frozen-lockfile`
- `pnpm compile`
- `NODE_ENV=production node --import tsx/esm scripts/verify-message-measure-depth.tsx`
- `node scripts/verify-scroll.mjs`
- `node scripts/verify-shrink.mjs`
- `node --import tsx/esm scripts/repro-inline-scrollback.tsx`
- `pnpm verify:build`
- `pnpm verify:package`

本 PR 仅包含 `MessageList` 调度修复及对应回归，不依赖其他功能分支。