### PR TITLE
fix(tui): unseen 计数只在变化时上报——根治 #146 后残留的 #185 链 (#129)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,13 @@ jobs:
       - run: node scripts/verify-scroll.mjs
       - run: node scripts/verify-shrink.mjs
 
+      # unseen-count 上报契约回归：同值重复上报会在密集流式 commit 下把
+      # setState 派发进 commit 内，嵌套更新计数连涨越过 React #185 上限
+      # （#146 之后残留的活链）。只在计数变化时才允许上报。
+      - run: node --import tsx/esm scripts/verify-unseen-report-once.tsx
+        env:
+          NODE_ENV: production
+
       # /model 切换 scrollback 重复沉积回归：瞬态面板（补全/picker）必须
       # 走零高度浮层，帧高不随开关涨落——否则帧顶行滚进 scrollback 后被
       # 关闭重绘二次写入，每切一次 /model 多一份启动画。

--- a/scripts/repro-185.tsx
+++ b/scripts/repro-185.tsx
@@ -1,0 +1,272 @@
+/**
+ * #185 repro probe: 长会话 + 长流式 + 复杂内容, watching for the nested-update
+ * counter (React error #185) on the POST-#146 code (queueMicrotask measure).
+ *
+ * Run instrumented (dev reconciler logs [NESTED++] / [IN-COMMIT-SETSTATE]):
+ *   NODE_ENV=development ./node_modules/.bin/tsx scripts/repro-185.tsx
+ * Run for the real crash (minified #185):
+ *   NODE_ENV=production  ./node_modules/.bin/tsx scripts/repro-185.tsx
+ *
+ * VARIANT env: base | resize | remount | scroll
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+])
+
+const VARIANT = process.env.VARIANT ?? 'base'
+const CHUNK_MS = Number(process.env.CHUNK_MS ?? 25)
+const COLS = Number(process.env.COLS ?? 110)
+const ROWS = 32
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 1000, allowProposedApi: true })
+
+const rawChunks: string[] = []
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { rawChunks.push(String(chunk)); term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+// Initialized BEFORE the crash handlers so finish() can never hit a TDZ
+// ReferenceError that would mask the original crash (review P2).
+const startedAt = Date.now()
+/** Set when the streaming loop starts; 0 = never reached it. */
+let streamStartedAt = 0
+let crashed: unknown = null
+function onCrash(err: unknown): void {
+  crashed = err
+  console.error('\n!!!! PROCESS CRASH !!!!')
+  console.error(err)
+  finish(1)
+}
+process.on('uncaughtException', onCrash)
+process.on('unhandledRejection', onCrash)
+
+const listeners = new Set<() => void>()
+let subCount = 0
+let versionReads = 0
+let _version = 0
+const channel: any = {
+  get version() { versionReads++; return _version },
+  set version(v: number) { _version = v },
+  rows: [] as any[],
+  status: 'idle',
+  sessionTitle: 'repro-185',
+  agentId: 'repro-185',
+  model: 'deepseek-v4-flash',
+  reasoningEffort: 'max',
+  mode: { plan: false },
+  modeIndex: 0,
+  displayCwd: '/tmp/demo',
+  contextBarEnabled: false,
+  contextSegments: undefined,
+  contextWindow: undefined,
+  lastUsage: undefined,
+  tps: undefined,
+  tpsSamples: [],
+  workingActivity: undefined,
+  activityFrames: undefined,
+  commandCompletions: [],
+  tokens: { input: 120, output: 45 },
+  cwd: '/tmp/demo',
+  gitBranch: 'main',
+  working: true,
+  spinnerMode: 'requesting',
+  responseChars: 0,
+  activeToolCount: 1,
+  turnStart: Date.now(),
+  lastUserText: '长会话流式压测',
+  pending: [],
+  commandList: [],
+  notifications: [],
+  subscribe(cb: () => void) { subCount++; listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {},
+  cancel: () => {},
+  clear: () => {},
+  notify: () => {},
+  listModels: () => Promise.resolve([]),
+  listSessions: () => [],
+  setResumeTarget: () => {},
+  loadOlder: () => {},
+  mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) cb() }
+
+let id = 0
+const codeBlock = (n: number, lang: string) =>
+  '```' + lang + '\n' + Array.from({ length: n }, (_, i) =>
+    `const handleRequest${i} = async (req: Request, res: Response): Promise<void> => { // 第 ${i} 行，故意写得很长，让窄终端里一定折行，从而撑高测量高度`
+  ).join('\n') + '\n```'
+
+// --- long session: 10 turns, mixed tool cards + markdown --------------------
+for (let turn = 0; turn < 10; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `历史问题 ${turn}：分析一下模块 ${turn} 的实现` })
+  channel.rows.push({ id: id++, kind: 'reasoning', text: `用户在问模块 ${turn}。`.repeat(4), streaming: false, durationMs: 1500 })
+  for (let t = 0; t < 3; t++) {
+    channel.rows.push({
+      id: id++, kind: 'tool', text: '',
+      tool: {
+        callId: `h${turn}-${t}`, name: t % 2 ? 'Read' : 'Bash',
+        argsText: t % 2 ? `{"file_path": "/tmp/demo/src/mod${turn}/file${t}.ts"}` : `{"command": "rg -n 'export' src/mod${turn} | head -40", "description": "list exports"}`,
+        argsFull: '{}',
+        status: 'ok', startedAt: Date.now() - 600000, durationMs: 30,
+        resultText: Array.from({ length: 12 + ((turn + t) % 5) * 6 }, (_, i) => `export function helper_${turn}_${t}_${i}(input: unknown): Promise<Result<unknown>> { /* 历史结果行 ${i}，长度凑一凑 */ return null }`).join('\n'),
+      },
+    })
+  }
+  channel.rows.push({
+    id: id++, kind: 'assistant', streaming: false,
+    text: `模块 ${turn} 的结论：\n\n- 入口在 \`src/mod${turn}/index.ts\`\n- 关键逻辑如下：\n\n${codeBlock(18 + (turn % 4) * 8, 'ts')}\n\n| 项 | 值 |\n| --- | --- |\n| 行数 | ${300 + turn * 17} |\n| 复杂度 | 高 |\n`,
+  })
+}
+
+const stdin = new FakeStdin()
+const stdout = new FakeStdout()
+
+class Trap extends React.Component<{ children: React.ReactNode }, { err: unknown }> {
+  override state = { err: null as unknown }
+  static getDerivedStateFromError(err: unknown): { err: unknown } { return { err } }
+  override componentDidCatch(err: unknown, info: unknown): void {
+    // A boundary-caught error (e.g. #185 thrown inside a commit) never reaches
+    // uncaughtException — record it as a crash so the run cannot false-pass.
+    crashed = err
+    console.error('TRAPPED RENDER ERROR:', err)
+    console.error('component stack:', (info as { componentStack?: string })?.componentStack)
+    finish(1)
+  }
+  override render(): React.ReactNode { return this.state.err ? null : this.props.children }
+}
+
+const chatTree = (
+  <Trap>
+    <Chat channel={channel} questionStore={new QuestionStore()} onExit={() => {}} />
+  </Trap>
+)
+const instance = await render(
+  <AlternateScreen>
+    {chatTree}
+  </AlternateScreen>,
+  { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
+)
+
+// status metrics ticking ~10/s (channel bumps without row changes)
+const ticker = setInterval(() => { channel.responseChars += 7; bump() }, 100)
+// second independent bump source (spinner cadence) to crowd the event loop
+const ticker2 = setInterval(() => { bump() }, 47)
+
+await sleep(800)
+
+// --- live turn: long streamed markdown+code at ~25ms/chunk -------------------
+channel.rows.push({ id: id++, kind: 'user', text: '把 AAA 项目的核心模块完整讲一遍，带上代码' }); bump()
+await sleep(150)
+
+const think = { id: id++, kind: 'reasoning', text: '', streaming: true, durationMs: undefined as number | undefined }
+channel.rows.push(think); bump()
+for (const c of ['用户要完整讲解，', '需要覆盖架构、', '关键代码与数据流。']) { think.text += c; bump(); await sleep(120) }
+think.streaming = false; think.durationMs = 900; bump()
+
+const finalMsg = { id: id++, kind: 'assistant', text: '', streaming: true }
+channel.rows.push(finalMsg); bump()
+
+// Build a big streamed doc: prose + fenced code with long wrapping lines + tables.
+const docChunks: string[] = ['好，完整梳理一遍 AAA 项目的核心模块。\n\n']
+for (let s = 0; s < 8; s++) {
+  docChunks.push(`\n## ${s + 1}. 子系统 ${s + 1}：职责与入口\n\n`)
+  docChunks.push(`子系统 ${s + 1} 负责请求生命周期第 ${s + 1} 阶段的编排。`.repeat(2) + '\n\n')
+  for (const ln of codeBlock(10 + (s % 3) * 6, 'ts').split('\n')) docChunks.push(ln + '\n')
+  docChunks.push('\n| 指标 | 数值 | 说明 |\n| --- | --- | --- |\n')
+  for (let r = 0; r < 5; r++) docChunks.push(`| 指标${s}-${r} | ${(s + 1) * (r + 2) * 137} | 这是一行表格说明文字，用来占宽 |\n`)
+  docChunks.push('\n')
+}
+
+streamStartedAt = Date.now()
+let midFired = false
+for (let i = 0; i < docChunks.length; i++) {
+  finalMsg.text += docChunks[i]!
+  bump()
+
+  if (!midFired && i === Math.floor(docChunks.length / 2)) {
+    midFired = true
+    if (VARIANT === 'resize') {
+      stdout.columns = 78
+      stdout.emit('resize')
+      console.error('[variant] resized columns -> 78 mid-stream')
+    } else if (VARIANT === 'remount') {
+      console.error('[variant] remounting tree mid-stream (easter-egg style)')
+      instance.rerender(<AlternateScreen><></></AlternateScreen>)
+      await sleep(1200)
+      instance.rerender(<AlternateScreen>{chatTree}</AlternateScreen>)
+      console.error('[variant] tree restored')
+    } else if (VARIANT === 'scroll') {
+      console.error('[variant] wheel-up x6 mid-stream (break sticky)')
+      for (let w = 0; w < 6; w++) { stdin.write('\x1b[<65;60;10M'); await sleep(30) }
+    }
+  }
+  await sleep(CHUNK_MS)
+}
+finalMsg.streaming = false
+channel.working = false
+bump()
+await sleep(1500)
+clearInterval(ticker)
+clearInterval(ticker2)
+await sleep(300)
+
+finish(0)
+
+function finish(code: number): void {
+  const allRaw = rawChunks.join('')
+  const hit185 = /Maximum update depth|Minified React error #185/.test(allRaw)
+  const ics = (globalThis as any).__ics as Map<string, { count: number; stack: string; ctx: number }> | undefined
+  console.log('\n==== repro-185 summary ====')
+  console.log('variant:', VARIANT, ' chunks:', rawChunks.length, ' elapsed:', Date.now() - startedAt, 'ms stream:', streamStartedAt ? `${Date.now() - streamStartedAt}ms` : 'n/a')
+  console.log('crashed:', crashed ? String(crashed).slice(0, 200) : false)
+  console.log('error #185 text in output:', hit185)
+  console.log('max nested count seen:', (globalThis as any).__maxNested ?? 0)
+  console.log('reconciler patch loaded:', Boolean((globalThis as any).__recPatched))
+  // nested-count trajectory: longest strictly-increasing runs (consecutive
+  // dirty commits on the same root) — the sawtooth peaks that kill at 50.
+  const traj = ((globalThis as any).__traj ?? []) as number[]
+  let longestRun = 0
+  const runs: number[] = []
+  {
+    let cur = 1
+    for (let i = 1; i < traj.length; i++) {
+      if (traj[i] === traj[i - 1]! + 1) cur++
+      else { if (cur > 1) runs.push(cur); longestRun = Math.max(longestRun, cur); cur = 1 }
+    }
+    if (cur > 1) { runs.push(cur); longestRun = Math.max(longestRun, cur) }
+  }
+  runs.sort((a, b) => b - a)
+  console.log(`trajectory: ${traj.length} commits, dirty ${traj.filter(v => v > 0).length}, longest consecutive-nested runs: [${runs.slice(0, 8).join(', ')}]`)
+  console.log('channel subscribes:', subCount, ' version getter reads:', versionReads, ' version:', _version)
+  if (ics && ics.size > 0) {
+    console.log('in-render/in-commit setState sources:')
+    for (const [name, v] of ics) {
+      console.log(`  ${name} x${v.count} ctx=${v.ctx}`)
+      console.log('    ' + String(v.stack).split('\n').slice(1, 8).join('\n    '))
+    }
+  } else {
+    console.log('in-render/in-commit setState sources: none')
+  }
+  process.exit(crashed || hit185 ? 1 : code)
+}

--- a/scripts/verify-unseen-report-once.tsx
+++ b/scripts/verify-unseen-report-once.tsx
@@ -1,0 +1,118 @@
+/**
+ * Contract verifier for the #185 follow-up fix (MessageList unseen-count
+ * report): onUnseenCount must fire ONLY when the reported count changes.
+ *
+ * Why this matters: the report calls the parent's setUnseenCount. Under dense
+ * streaming commits, pending passive effects flush INSIDE the next commit, so
+ * a same-value report dispatches an in-commit setState whose SyncLane stays
+ * pending at the commit epilogue — React's nested-update counter climbs, and
+ * 50+ consecutive dirty commits crash with React error #185 (post-#146 this
+ * chain, not the measure tick, was the live one). The ref gate in MessageList
+ * breaks it by never re-reporting an unchanged count.
+ *
+ * A/B: on unpatched HEAD every no-op commit re-reports (fails here); patched
+ * reports the settled value once (passes). Production mode like the
+ * measure-depth verifier.
+ */
+import { PassThrough, Writable } from 'node:stream'
+import React from 'react'
+import { render } from '../src/ui.js'
+import { MessageList } from '../src/components/MessageList.js'
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+class Output extends Writable {
+  columns = 100
+  rows = 30
+  isTTY = true
+  text = ''
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    this.text += String(chunk)
+    callback()
+  }
+}
+class Input extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+
+// 30 settled rows (~2 terminal lines each) so plenty sit below the fold.
+const rows = Array.from({ length: 30 }, (_, i) => ({
+  id: i + 1,
+  kind: (i % 2 ? 'assistant' : 'user') as 'assistant' | 'user',
+  text: `row ${i + 1}\nsecond line of row ${i + 1}`,
+  streaming: false,
+}))
+// Every row with id > 5 is "new"; rows past the viewport bottom count as unseen.
+const ANCHOR_ID = 5
+
+const reports: number[] = []
+const props = {
+  expanded: false,
+  expandedRows: new Set<number>(),
+  selectedId: null,
+  onToggleRow: () => {},
+  model: 'deepseek-chat',
+  showAll: true,
+  onToggleAll: () => {},
+  newSinceRowId: ANCHOR_ID as number | null,
+  onUnseenCount: (count: number) => { reports.push(count) },
+}
+
+const stdout = new Output()
+const stderr = new Output()
+const instance = await render(<MessageList rows={rows} {...props} />, {
+  stdout,
+  stderr,
+  stdin: new Input(),
+  exitOnCtrlC: false,
+  patchConsole: false,
+})
+
+// Let measurements settle (heights land, base corrects, count stabilizes).
+await sleep(500)
+const settledLen = reports.length
+const settledValue = reports[settledLen - 1]
+if (settledLen === 0 || settledValue === undefined || settledValue <= 0) {
+  console.error(`FAIL: expected a positive settled unseen count, got reports=${JSON.stringify(reports)}`)
+  process.exit(1)
+}
+
+// Six no-op commits: identical tree, identical rows — nothing about the unseen
+// count changes, so a correct report stays silent.
+for (let i = 0; i < 6; i++) {
+  instance.rerender(<MessageList rows={rows} {...props} />)
+  await sleep(60)
+}
+const afterNoop = reports.length
+if (afterNoop !== settledLen) {
+  console.error(
+    `FAIL: onUnseenCount re-reported ${afterNoop - settledLen} time(s) across no-op commits ` +
+    `(values ${JSON.stringify(reports.slice(settledLen))}) — same-value in-commit setState ` +
+    `is what drives the nested-update counter to React #185 under dense streaming`,
+  )
+  process.exit(1)
+}
+
+// A real change MUST still report exactly once: append a new row below the fold.
+rows.push({ id: 31, kind: 'assistant', text: 'fresh row\nwith two lines', streaming: false })
+instance.rerender(<MessageList rows={rows} {...props} />)
+await sleep(300)
+const finalLen = reports.length
+if (finalLen !== settledLen + 1 || reports[finalLen - 1] === settledValue) {
+  console.error(
+    `FAIL: expected exactly one new report with a changed value after appending a row, ` +
+    `got reports=${JSON.stringify(reports)} (settled at ${settledValue})`,
+  )
+  process.exit(1)
+}
+
+await instance.unmount()
+const output = stdout.text + stderr.text
+if (/Maximum update depth|Minified React error #185/.test(output)) {
+  console.error('FAIL: nested measurement update loop detected')
+  process.exit(1)
+}
+console.log(`PASS: unseen count reported on change only (settled=${settledValue}, after row append=${reports[finalLen - 1]})`)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -214,8 +214,12 @@ export function MessageList({
       }
     }
   }
+  const lastUnseenReportRef = React.useRef(-1)
   React.useEffect(() => {
-    onUnseenCount?.(unseenCount)
+    if (unseenCount !== lastUnseenReportRef.current) {
+      lastUnseenReportRef.current = unseenCount
+      onUnseenCount?.(unseenCount)
+    }
   })
 
   // Post-commit: measure mounted rows, derive the content-space base from


### PR DESCRIPTION
## 问题

#129 的 React error #185 在 #146（042f9ec）之后仍会崩。#146 把 MessageList 测量 tick 改成 `queueMicrotask`，测量级联确实退出了 commit 上下文；但同文件的**无依赖 useEffect** 仍在每次渲染调用 `onUnseenCount`（即 Chat 的 `setUnseenCount`）：

- 密集流式 commit 下，pending passive effects 被拖进下一次 commit 内同步 flush；
- 同值 setState 因 `fiber.lanes ≠ 0` 绕过 eager-bailout，SyncLane 在 commit 收尾挂起；
- `nestedUpdateCount` 单调连涨，连续 50+ 次后下一次派发在 `getRootForUpdatedFiber` 抛 #185（与 #129 同一抛出点）。

崩溃栈落在撞线的无辜派发上（常是 channel notify 的 `forceStoreRerender`），不指真凶——这也是现场难以定位的原因。

复现（生产模式）：`CHUNK_MS=5 COLS=90 node --import tsx/esm scripts/repro-185.tsx`，未修复代码 3/3 崩 #185；正常 25ms 节奏锯齿峰 ~25/50 不崩，与"长会话+长流式+复杂内容才偶发"的现场特征一致。

## 修复

- `MessageList`：ref 记录上次上报值，仅 unseenCount **变化**时才调用 `onUnseenCount`。Chat 侧唯一自重置点（isSticky 翻转置 0）与子组件计算同步，无漏报窗口。
- `scripts/verify-unseen-report-once.tsx`：契约门禁（生产模式，挂 CI）——6 次无变化 commit 断言零重报（未修复基线重报 6 次同值），追加行断言恰好一次上报（防止过度修复成从不上报）。
- `scripts/repro-185.tsx`：长会话+长流式压测（`CHUNK_MS`/`COLS`/`VARIANT=base|scroll|resize|remount` 旋钮），作补充覆盖。Error Boundary 捕获的 #185 记入 crash 直接失败，不会误判 PASS；启动计时提到异常处理器注册前，消除 TDZ 掩盖。

## 验证

- 契约探针 A/B：未修复 FAIL（6 次重报）/ 修复 PASS
- 压测 A/B（生产）：未修复 3/3 崩 #185 / 修复同配置 exit 0
- `verify-message-measure-depth` / `verify-scroll` / `verify-shrink` / `repro-pill`（pill 出现→递减→消失全链路）/ `tsc -p tsconfig.json` 全绿

Refs #129, #146