### PR TITLE
fix(deps): dsh-working-activity 升级 ^0.2.6——profile 框架包拷贝归零（#198 尾巴）

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ compaction 和持久化继续由 DSH 服务拥有。更详细的模块边界与�
 - **TPS 仪表**：参考 pi-tps-meter——流式 1/8 格 gauge、历史 min-max sparkline、
   速度语义色（≥50 绿 / ≥20 黄 / <20 红）。
 - **working-activity 生态**：工作状态行复用
-  [dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity)
+  [dsh-working-activity](https://github.com/ccch1mneyyy/working-activity)
   的纯状态机，在进程内从基础会话事件派生，不向共享日志写入 UI 状态。
 - **终端粘贴**：raw 模式下 Ctrl+V 由应用接管，按平台读取系统剪贴板——Windows
   走 PowerShell `Get-Clipboard`，macOS 走 `osascript`/`pbpaste`，Linux 自动探测

--- a/README_EN.md
+++ b/README_EN.md
@@ -225,7 +225,7 @@ chat / tool base events ──> persisted Session log ──> TUI / Web
 - **TPS meter**: based on pi-tps-meter — a streaming 1/8-block gauge, historical
   min-max sparkline, and speed-based semantic colors (≥50 green / ≥20 yellow / <20 red).
 - **working-activity ecosystem**: the working-status line reuses the pure state machine of
-  [dsh-working-activity](https://github.com/ccch1mneyyy/dsh-working-activity),
+  [dsh-working-activity](https://github.com/ccch1mneyyy/working-activity),
   deriving it in-process from base session events without writing UI state into the shared log.
 - **Terminal paste**: in raw mode `Ctrl+V` is handled by the app and reads the system
   clipboard per platform — PowerShell `Get-Clipboard` on Windows, `osascript`/`pbpaste`

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -134,12 +134,13 @@ seam.
   it). Framework packages used only by tests/scripts (e.g. dsh-settings,
   dsh-tools, dsh-session-persistence-*) stay dev-only — do NOT declare peers
   for them. Non-host packages such as `dsh-working-activity` stay runtime
-  dependencies.
-  Known exception: `@deepseek-ai/schemastery` still lands as a real copy in the
-  profile via `dsh-working-activity`'s runtime dependency and resolves ahead of
-  the fallback tree — until that package peers it too, schemastery is NOT a
-  host singleton (no symptom observed in production, but the structural risk
-  stands).
+  dependencies. Historical exception, now resolved: `dsh-working-activity@0.2.4`
+  and earlier pulled a real copy of `@deepseek-ai/schemastery` (plus cosmokit)
+  into the profile via its runtime dependency, shadowing the fallback tree;
+  0.2.5 peer-ified it (working-activity#2), so profiles no longer carry any
+  framework copies. Keep the dependency range at `^0.2.6` or above (0.2.6 also
+  fixes the web-side WorkingLine absent-field guard on unpatched hosts,
+  working-activity#5).
 - Do not expose, persist, or print credentials. Interactive startup reads
   `DEEPSEEK_API_KEY`; diagnostics may report whether it is set but must not
   reveal the complete value.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -105,11 +105,11 @@ Cordis config
   （verify:manifest-deps 门禁会校验）。仅测试/脚本使用的框架包
   （如 dsh-settings、dsh-tools、dsh-session-persistence-*）只需 dev 依赖，
   不要为它们声明 peer。`dsh-working-activity` 等非宿主包仍是 runtime
-  dependency。
-  已知例外：`@deepseek-ai/schemastery` 目前仍会被 `dsh-working-activity` 的
-  runtime dependency 带一份拷贝进 profile 并优先于回退树被解析——在它同样
-  peer 化之前，schemastery 不是宿主单实例（生产上未观察到症状，结构性
-  风险仍在）。
+  dependency。历史例外已消除：`dsh-working-activity@0.2.4` 及更早版本会经其
+  runtime dependency 把 `@deepseek-ai/schemastery`（连带 cosmokit）的真实拷贝
+  带进 profile；0.2.5 起已 peer 化（working-activity#2），profile 内不再
+  有任何框架包拷贝。保持依赖范围不低于 `^0.2.6`（0.2.6 另修复了 web 端
+  WorkingLine 在未打补丁宿主上的空值守卫，working-activity#5）。
 - 不要暴露、持久化或打印凭证。交互启动读取 `DEEPSEEK_API_KEY`；诊断可以
   报告是否已设置，但绝不能泄露完整值。
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "cli-boxes": "^3.0.0 || ^4.0.0",
     "cli-highlight": "^2.1.11",
     "code-excerpt": "^3.0.0 || ^4.0.0",
-    "dsh-working-activity": "^0.2.4",
+    "dsh-working-activity": "^0.2.6",
     "emoji-regex": "^10.0.0",
     "figures": "^6.1.0",
     "get-east-asian-width": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.0
       dsh-working-activity:
-        specifier: ^0.2.4
-        version: 0.2.4(f36dac642f92772d0cc55eca21904cb5)
+        specifier: ^0.2.6
+        version: 0.2.6(5e23b040c590f56902f12f1002418d07)
       emoji-regex:
         specifier: ^10.0.0
         version: 10.6.0
@@ -1971,8 +1971,8 @@ packages:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
-  dsh-working-activity@0.2.4:
-    resolution: {integrity: sha512-UwTFlL6XDwUuahGx57HB72uKAXpyEuPGA1sXFKlG1A8ggQVfZkrjpt4N4oq8UcA8a944oQUuY2aTcngErNzgGg==}
+  dsh-working-activity@0.2.6:
+    resolution: {integrity: sha512-laywtmoti+Y71/LJoju6kDRoZazwG1Yu7BQNVLlXdIzJrvCAFgL4te6tVWaKtJP6UntkJqU64WEEs8foL4I+tw==}
     engines: {node: ^22.19 || >=24}
     peerDependencies:
       '@deepseek-ai/cordis': ^4.0.1
@@ -1983,6 +1983,7 @@ packages:
       '@deepseek-ai/dsh-invariants': ^0.1.0-rc.6
       '@deepseek-ai/dsh-session': ^0.1.0-rc.6
       '@deepseek-ai/dsh-system-prompt': ^0.1.0-rc.6
+      '@deepseek-ai/schemastery': ^3.18.1
       react: ^18.2.0
     peerDependenciesMeta:
       '@deepseek-ai/dsh-client-runtime':
@@ -4379,7 +4380,7 @@ snapshots:
 
   diff@9.0.0: {}
 
-  dsh-working-activity@0.2.4(f36dac642f92772d0cc55eca21904cb5):
+  dsh-working-activity@0.2.6(5e23b040c590f56902f12f1002418d07):
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.0-rc.6(b0514d7a320728b6d8f5a31eb3960e10)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,5 +41,5 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-user-approval@0.1.0-rc.6'
   - '@deepseek-ai/dsh-user-questions@0.1.0-rc.6'
   - '@deepseek-ai/schemastery@3.18.1'
-  - dsh-working-activity@0.2.2 || 0.2.4
+  - dsh-working-activity@0.2.6
   - '@deepseek-ai/dsh-session-persistence-jsonl@0.1.0-rc.6'


### PR DESCRIPTION
## 背景

dsh-working-activity 发布 0.2.5/0.2.6，吸收了我们提的三个 issue：`@deepseek-ai/schemastery` 从 `dependencies` 移入 `peerDependencies`（working-activity#2，0.2.5）——这是 #198 修完后 profile 内仅剩的框架包拷贝来源（schemastery 及其连带的 cosmokit，共 2 份）；0.2.6 另修复 web 端 `WorkingLine` 在未打补丁宿主上的空值守卫（working-activity#5，selector 归一化 `?? null`）。依赖范围直接钉到 `^0.2.6`。

## 改动

- `dsh-working-activity` `^0.2.4` → `^0.2.6`，锁文件纯搬位（peer 声明出现在 packages 段，快照边形态不变）；
- `pnpm-workspace.yaml` 的 `minimumReleaseAgeExclude` 收敛到 `dsh-working-activity@0.2.6`（清掉 0.2.2/0.2.4/0.2.5 死模式）；
- `docs/contributing` 中英双语：「已知例外」段落改为历史说明，并要求依赖范围不低于 `^0.2.6`；
- README 中英双语的 dsh-working-activity 链接从**已归档**的 `ccch1mneyyy/dsh-working-activity` 改指合并后的 `ccch1mneyyy/working-activity` monorepo。

## 验证

- `compile` + `verify:build` 七道门禁 + `verify:package` + `verify-working-activity` 全绿；
- 干净 profile 安装打包 tarball：`node_modules/@deepseek-ai/` 拷贝数 **0**（#207 后为 2：schemastery + cosmokit；#207 前为 24）；
- 插件视角 `createRequire` 解析框架包的 realpath 全部落入 dsh CLI 安装树＝宿主同实例；回退树的软链指向宿主拷贝，解析路径符合契约。

## 范围说明

- wa 侧的 registration 补边（working-activity#4 缺口一，0.2.5 已含）不需要本仓改动——`ensureLegacySessionEventTypes()` 继续覆盖「插件未挂载进程」的场景，两者互为冗余而非冲突；
- 本 PR 不含 `lib/` 重编译产物：main 上 #201 改了 `src/screens/SessionBrowser.tsx` 未同步再生成 lib，属既有的 src/lib 失配，建议单独处理。
