### PR TITLE
feat(spinner): 工作行显示实际上传 token 数（↑ input+cache）

### DIFF
--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -29,6 +29,9 @@ export type SpinnerAnimationRowProps = {
   hasActiveTools: boolean
   /** Raw response length (chars) — feeds the animated token counter. */
   responseLengthRef: React.RefObject<number>
+  /** Most recent request's real upload tokens (input + cache read/write);
+   *  0 until the first usage event lands. */
+  uploadTokensRef: React.RefObject<number>
   /** Stable within a turn. */
   message: string
   messageColor: keyof Theme
@@ -55,6 +58,7 @@ export function SpinnerAnimationRow({
   reducedMotion,
   hasActiveTools,
   responseLengthRef,
+  uploadTokensRef,
   message,
   messageColor,
   shimmerColor,
@@ -132,8 +136,13 @@ export function SpinnerAnimationRow({
   const timerWidth = stringWidth(timerText)
 
   const tokenCount = formatNumber(leaderTokens)
-  const tokensText = `${figures.arrowDown} ${tokenCount} tokens`
-  const tokensWidth = stringWidth(tokensText)
+  const uploadTokens = uploadTokensRef.current
+  // Real upload tokens (last request's input + cache) ride beside the
+  // animated download estimate; both labeled once to keep the row short.
+  const tokensLabel = uploadTokens > 0
+    ? `↑ ${formatNumber(uploadTokens)} · ↓ ${tokenCount} tokens`
+    : `↓ ${tokenCount} tokens`
+  const tokensWidth = stringWidth(tokensLabel)
 
   // === Thinking text (may shrink to fit) ===
   let thinkingText =
@@ -165,7 +174,7 @@ export function SpinnerAnimationRow({
   const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0)
   const showTokens =
     wantsTimerAndTokens &&
-    leaderTokens > 0 &&
+    (leaderTokens > 0 || uploadTokens > 0) &&
     availableSpace > usedAfterTimer + tokensWidth
   const thinkingOnly =
     showThinking &&
@@ -206,7 +215,7 @@ export function SpinnerAnimationRow({
       ? [
           <Box flexDirection="row" key="tokens">
             <SpinnerModeGlyph mode={mode} />
-            <Text dimColor>{tokenCount} tokens</Text>
+            <Text dimColor>{tokensLabel}</Text>
           </Box>,
         ]
       : []),

--- a/src/components/WorkingSpinner.tsx
+++ b/src/components/WorkingSpinner.tsx
@@ -18,6 +18,7 @@ export function WorkingSpinner({
   mode,
   hasActiveTools,
   responseLengthRef,
+  uploadTokensRef,
   loadingStartTimeRef,
   totalPausedMsRef,
   pauseStartTimeRef,
@@ -26,6 +27,8 @@ export function WorkingSpinner({
   mode: SpinnerMode
   hasActiveTools: boolean
   responseLengthRef: React.RefObject<number>
+  /** Most recent request's real upload tokens; 0 until the first usage event. */
+  uploadTokensRef: React.RefObject<number>
   loadingStartTimeRef: React.RefObject<number>
   totalPausedMsRef: React.RefObject<number>
   pauseStartTimeRef: React.RefObject<number | null>
@@ -44,6 +47,7 @@ export function WorkingSpinner({
         reducedMotion={false}
         hasActiveTools={hasActiveTools}
         responseLengthRef={responseLengthRef}
+        uploadTokensRef={uploadTokensRef}
         message={message}
         messageColor="claude"
         shimmerColor="claudeShimmer"

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -382,10 +382,17 @@ export function Chat({
   // Spinner timing refs, fed from channel state each render (the spinner
   // only mounts while working, so values are stable for the mount).
   const responseLengthRef = React.useRef(0)
+  const uploadTokensRef = React.useRef(0)
   const loadingStartTimeRef = React.useRef(0)
   const totalPausedMsRef = React.useRef(0)
   const pauseStartTimeRef = React.useRef<number | null>(null)
   responseLengthRef.current = channel.responseChars
+  // Most recent request's real upload (input + cache read/write occupy the
+  // wire exactly like the context window); 0 until the first usage event.
+  const lastUploadTokens = channel.lastUsage === undefined
+    ? 0
+    : channel.lastUsage.input + channel.lastUsage.cacheRead + channel.lastUsage.cacheWrite
+  uploadTokensRef.current = lastUploadTokens
   loadingStartTimeRef.current = channel.turnStart
   const thinkingStatus = useThinkingStatus(channel.spinnerMode === 'thinking')
 
@@ -1879,7 +1886,11 @@ export function Chat({
                   activityFrames={channel.activityFrames}
                   warnPct={activityWarnPct}
                   warnDanger={activityWarnPct !== undefined && activityWarnPct >= 95}
-                  suffix={` · ↓ ${channel.responseChars} tokens`}
+                  // Upload = real tokens of the last request; download =
+                  // the animated chars/4 estimate, matching the classic
+                  // spinner's counter (the suffix used raw chars before,
+                  // inflating the reading next to a real upload number).
+                  suffix={`${lastUploadTokens > 0 ? ` · ↑ ${formatTokens(lastUploadTokens)}` : ''} · ↓ ${formatTokens(Math.round(channel.responseChars / 4))} tokens`}
                 />
               </Box>
             ) : (
@@ -1887,6 +1898,7 @@ export function Chat({
                 mode={channel.spinnerMode}
                 hasActiveTools={channel.activeToolCount > 0}
                 responseLengthRef={responseLengthRef}
+                uploadTokensRef={uploadTokensRef}
                 loadingStartTimeRef={loadingStartTimeRef}
                 totalPausedMsRef={totalPausedMsRef}
                 pauseStartTimeRef={pauseStartTimeRef}


### PR DESCRIPTION
## 问题

对话中工作行只显示 `↓ N tokens`（流式输出计数），每次请求的上传 token 完全不可见。

## 方案

最近请求的 usage 本来就带着：`lastUsage.input + cacheRead + cacheWrite` 就是实际上线的字节量（与上下文压力条同一口径），每个 step 边界刷新。

- **ActivityLine 后缀**：` · ↑ <upload> · ↓ <download> tokens`（首个 usage 事件前不显示 ↑ 段）
- **经典 spinner**：上传数挂在同一个 tokens 部件里，通过 `uploadTokensRef` 与 `responseLengthRef` 并排透传，宽度门控相应调整（仅知道上传时也能显示）
- **顺带修正**：ActivityLine 的 ↓ 从原始字符数改为 chars/4 估算，与经典 spinner 计数器口径一致——之前是字符数冒名 tokens，和真实 ↑ 摆在一起会虚高

## 验证

- `pnpm build` 全门禁绿
- `verify-working-activity.mjs` OK、`repro-pill.tsx` PASS