### PR TITLE
fix: keep long questionnaire focus visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
       # 带断言的回归：提问面板内联输入（issue #9）+ 工具卡排版
       # （⎿ 缩进、diff 红绿行、信封剥离），失败即非零退出。
       - run: node --import tsx/esm scripts/repro-askpanel.tsx
+      # 长选项问卷窗口化回归：焦点必须在小终端中始终可见。
+      - run: pnpm verify:askpanel-windowing
 
       # 提问面板全应用布局回归：短/长高录、activity tick 差分、resize 风暴。
       - run: node --import tsx/esm scripts/verify-askpanel-layout.tsx

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "dev:test": "node scripts/verify-dev-command.mjs && node scripts/dev-test.mjs --no-launch",
     "tui": "node --import tsx/esm scripts/run.ts",
     "smoke": "node --import tsx/esm scripts/smoke.tsx",
+    "verify:askpanel-windowing": "node --import tsx/esm scripts/repro-askpanel-windowing.tsx",
     "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap",
     "verify:boundary": "node --import tsx/esm scripts/verify-adapter-boundary.ts",
     "verify:contract": "node --import tsx/esm scripts/verify-upstream-contract.ts",

--- a/scripts/repro-askpanel-windowing.tsx
+++ b/scripts/repro-askpanel-windowing.tsx
@@ -1,0 +1,91 @@
+/**
+ * Regression for long option questionnaires: the absolute keyboard focus
+ * must remain visible when the option list is taller than the terminal.
+ *
+ * Run with `node --import tsx/esm scripts/repro-askpanel-windowing.tsx`.
+ */
+process.env.FORCE_COLOR = '3'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/questions/AskUserQuestionPanel.js'),
+])
+
+const COLS = 100
+const ROWS = 18
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void) {
+    term.write(String(chunk), callback)
+  }
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+
+const stdout = new FakeStdout()
+const stdin = new FakeStdin()
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+function screen(): string {
+  const buffer = term.buffer.active
+  return Array.from({ length: ROWS }, (_, row) => buffer.getLine(row)?.translateToString(true) ?? '').join('\n')
+}
+
+function focused(label: string): boolean {
+  return screen().split('\n').some(line => line.includes('❯') && line.includes(label))
+}
+
+const options = Array.from({ length: 30 }, (_, index) => ({
+  label: `provider-${String(index).padStart(2, '0')}`,
+  description: `description-${String(index).padStart(2, '0')}`,
+}))
+
+const app = await render(
+  React.createElement(AskUserQuestionPanel, {
+    question: {
+      header: 'provider',
+      question: 'Choose a provider',
+      options,
+      hideCustomInput: true,
+    },
+    position: 1,
+    total: 1,
+    answered: 0,
+    onAnswer: () => {},
+    onCancel: () => {},
+  }),
+  { stdout, stdin, stderr: new FakeStdout(), exitOnCtrlC: false, patchConsole: false },
+)
+
+await sleep(300)
+let failures = 0
+const check = (name: string, ok: boolean) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}`)
+  if (!ok) failures++
+}
+
+check('initial focus is visible', focused('provider-00'))
+
+for (let index = 0; index < 15; index++) {
+  stdin.write('\u001b[B')
+  await sleep(20)
+}
+await sleep(300)
+check('deep focus remains visible after navigation', focused('provider-15'))
+
+app.unmount()
+await sleep(100)
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURES`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify-provider-wizard.mjs
+++ b/scripts/verify-provider-wizard.mjs
@@ -59,13 +59,14 @@ function makeDeps(script, options = {}) {
     pushed: [],
     switches: [],
     asks: [],
+    optionLists: {},
     /** question id → hideCustomInput flag as submitted (panel contract). */
     hideFlags: {},
   }
   const host = {
     listCatalogProviders: () => [
       { provider: 'deepseek', displayName: 'DeepSeek' },
-      { provider: 'openai', displayName: 'OpenAI' },
+      { provider: 'openai', displayName: 'openai' },
     ],
     routeExists: () => false,
     discoverModels: async () => {
@@ -91,6 +92,7 @@ function makeDeps(script, options = {}) {
       for (const question of request.questions) {
         calls.asks.push(question.id)
         calls.hideFlags[question.id] = question.hideCustomInput === true
+        if (question.id === 'catalog') calls.optionLists.catalog = question.options
         const spec = script[question.id]
         if (spec === undefined) throw new Error(`unscripted question: ${question.id}`)
         if (spec === 'cancel') throw CANCEL
@@ -170,6 +172,8 @@ const KEEP_MODEL = { selected: [t('provider-opt-switch-keep')] }
     eq(calls.profiles, [['openai', { apiKeyEnv: 'OPENAI_API_KEY' }]]),
     JSON.stringify(calls.profiles))
   check('2 catalog bare: switch never asked', !calls.asks.includes('switch'))
+  check('2 catalog: duplicate provider name has no repeated description',
+    calls.optionLists.catalog?.find(option => option.label === 'openai')?.description === undefined)
 }
 
 // 3. custom path, discovery fails: manual model fallback question.

--- a/src/components/questions/AskUserQuestionPanel.tsx
+++ b/src/components/questions/AskUserQuestionPanel.tsx
@@ -14,17 +14,24 @@
 
 import React from 'react'
 import { t } from '../../i18n.js'
-import { Box, Text, useInput } from '../../ui.js'
+import { Box, Text, useInput, useTerminalSize } from '../../ui.js'
 import { useDeclaredCursor } from '../../ink/hooks/use-declared-cursor.js'
 import { Divider } from '../design-system/Divider.js'
-import { POINTER } from '../../cc/figures.js'
+import { DOWN_ARROW, POINTER, UP_ARROW } from '../../cc/figures.js'
 import type { QuestionSelection } from '../../dsh-adapter/questions.js'
 import { PlanReviewPanel } from './PlanReviewPanel.js'
 import { isPlainReturnInput } from '../../utils/modifiers.js'
+import { listWindow } from '../listWindow.js'
 
 const CHECKED = '◉'
 const UNCHECKED = '○'
 const PENCIL = '✎'
+
+// Keep a conservative amount of room for the divider, question text, footer,
+// and their margins. The exact question can wrap differently by terminal
+// width; leaving a little extra room is preferable to allowing the focused
+// option to fall below the viewport.
+const QUESTION_FRAME_ROWS = 16
 
 export type AskUserQuestionPanelProps = {
   /** The question to render (from the QuestionStore snapshot). */
@@ -82,6 +89,24 @@ export function AskUserQuestionPanel({
   const [error, setError] = React.useState<string | null>(null)
 
   const inputFocused = !hideCustomInput && focusIndex === options.length
+  const { rows: terminalRows } = useTerminalSize()
+
+  // Long provider catalogs and model lists must be windowed by rendered rows,
+  // not by option count. Labels and descriptions are deliberately kept to a
+  // single row below so this budget remains deterministic even for long text.
+  // When the custom row owns focus, keep the window anchored at the tail so
+  // the option immediately above it remains useful context.
+  const optionHeights = options.map(option => option.description === undefined ? 1 : 2)
+  const optionFocus = inputFocused ? Math.max(options.length - 1, 0) : focusIndex
+  const optionBudget = Math.max(
+    terminalRows - QUESTION_FRAME_ROWS - (hideCustomInput ? 0 : 2),
+    1,
+  )
+  const { start: optionStart, end: optionEnd } = listWindow(
+    optionHeights,
+    optionFocus,
+    optionBudget,
+  )
 
   // Park the native terminal cursor on the custom-answer caret: terminal
   // emulators render IME preedit (pinyin) at the physical cursor, so without
@@ -299,14 +324,22 @@ export function AskUserQuestionPanel({
 
   const renderOptions = (): React.ReactNode => (
     <Box flexDirection="column" marginTop={1}>
-      {options.map((option, index) => {
-        const focused = index === focusIndex
-        const selected = multiSelect ? checked.has(index) : focused
+      {options.slice(optionStart, optionEnd).map((option, index) => {
+        const absoluteIndex = optionStart + index
+        const focused = absoluteIndex === focusIndex
+        const selected = multiSelect ? checked.has(absoluteIndex) : focused
+        const indicator = focused
+          ? POINTER
+          : absoluteIndex === optionStart && optionStart > 0
+            ? UP_ARROW
+            : absoluteIndex === optionEnd - 1 && optionEnd < options.length
+              ? DOWN_ARROW
+              : ' '
         return (
-          <Box key={option.label} flexDirection="row" marginTop={focused ? 1 : 0}>
+          <Box key={option.label} flexDirection="row">
             <Box width={1} flexShrink={0}>
-              <Text color={focused ? 'claude' : undefined} bold={focused}>
-                {focused ? POINTER : ' '}
+              <Text color={focused ? 'claude' : undefined} dimColor={!focused} bold={focused}>
+                {indicator}
               </Text>
             </Box>
             <Box width={1} flexShrink={0}>
@@ -315,11 +348,11 @@ export function AskUserQuestionPanel({
               </Text>
             </Box>
             <Box flexDirection="column" marginLeft={1}>
-              <Text bold={focused || selected} color={focused ? 'claude' : undefined} wrap="wrap">
+              <Text bold={focused || selected} color={focused ? 'claude' : undefined} wrap="truncate">
                 {option.label}
               </Text>
               {option.description !== undefined && (
-                <Text dimColor wrap="wrap">
+                <Text dimColor wrap="truncate">
                   {option.description}
                 </Text>
               )}

--- a/src/dsh-adapter/providerWizard.ts
+++ b/src/dsh-adapter/providerWizard.ts
@@ -179,7 +179,9 @@ export async function runProviderWizard(
           questions: [optionQuestion('catalog', t('provider-q-catalog'), [
             ...candidates.map(candidate => ({
               label: candidate.provider,
-              description: candidate.displayName,
+              ...(candidate.displayName !== candidate.provider
+                ? { description: candidate.displayName }
+                : {}),
             })),
             { label: otherLabel, description: t('provider-opt-other-route-desc') },
           ], { hideCustomInput: true })],


### PR DESCRIPTION
Fixes #228

Long provider/model questionnaires now window options by rendered row height around the absolute focus. Labels and descriptions are truncated to one row, focus remains visible after navigation and resize, and edge arrows indicate hidden options. Provider catalog entries no longer repeat a display name when it is identical to the route.

Validation:
- `pnpm build`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/repro-askpanel-windowing.tsx`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/verify-askpanel-layout.tsx`
- `DSH_TUI_LANG=zh node scripts/verify-provider-wizard.mjs`
- `node scripts/verify-batched-prompt-input.mjs`
- `node --import tsx/esm scripts/verify-keys.tsx`
