### PR TITLE
release: v0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-harness-tui/dsh-tui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 亮点

- **fix(update)**：Windows 首次升级崩 pnpm tmp 竞态自动重试 + 升级后状态校验（#225，疑似 #209 同源）
- **fix(skills)**：技能命令改走内核 /name 手势——参数不再被吞，与 web 端同架构
- **feat(spinner)**：工作行显示真实上传 token（↑ input+cache）（#230）
- 社区：IME 预编辑锚定（#206）、Windows 批量按键/Termy 输入（#208 #211）、JediTerm 渲染（#221）、cpSync 非 ASCII 主目录（#227）、问卷长列表窗口化（#229）、profile 双模块实例根治（#207 #226）等

合入后打 v0.7.3 标签发版。