### PR TITLE
chore(commands): 移除无实际功能的 /memory 占位命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ macOS 自带 Terminal.app 会自行消费 `⌘` 快捷键，请继续使用 `Ctr
 | 会话 | `/new` 新会话 · `/resume` 会话浏览器（搜索、预览、跨项目、折叠子 agent 运行） · `/rename` 重命名会话 · `/workspace resume|rename|open` 管理工作区 · `/clear` 清屏 · `/compact` 压缩 · `/export` 导出 Markdown · `/trace` 轨迹场景（亦可 `Ctrl+T`） |
 | 状态 | `/status` 会话信息 · `/cost` token 用量 · `/doctor` 环境自检 · `/config` 配置来源 · `/init` 创建 AGENTS.md |
 | 模型 | `/model` 选择器 · `/thinking` 思考显示 · `/tokens` token 明细 · `/theme` 主题选择器 · `/lang` 中英界面切换 |
-| 账号/策略 | `/provider` 添加模型提供方 · `/login` 凭证状态 · `/logout` 登出说明 · `/permissions` 权限说明 · `/add-dir` 文件策略范围 · `/hooks` · `/mcp` · `/memory` |
+| 账号/策略 | `/provider` 添加模型提供方 · `/login` 凭证状态 · `/logout` 登出说明 · `/permissions` 权限说明 · `/add-dir` 文件策略范围 · `/hooks` · `/mcp` |
 | 技能 | `/audit` 代码审计 · `/bug` bug 报告 · `/review` 代码评审 · `/practice` 编程练习 · `/pr_comments` PR 评论 · `/release-notes` 发布说明 · `/vuln-check` 漏洞检查 |
 | 其它 | `/agents` 子代理列表 · `/update` 自动更新并重启 · `/vim` · `/terminal-setup` · `/connect` · `/help` · `/exit` |
 | 注册表 | `/plan` `/goal`（DSH 命令注册表插件，随插件自动并入 `/` 菜单） |
@@ -231,7 +231,7 @@ compaction 和持久化继续由 DSH 服务拥有。更详细的模块边界与�
   权限提升命令会弹出审批条。`/permission` 预设切换由 dsh-base 的
   `permission-presets` 插件提供，profile 组合默认可用；裸组合 `cordis.yml`
   未挂载该插件（无 `/permission` 命令）。
-- `/vim` `/connect` `/hooks` `/memory` 为 CC 同名占位：对应能力在 DSH 侧无等价
+- `/vim` `/connect` `/hooks` 为 CC 同名占位：对应能力在 DSH 侧无等价
   机制，命令会给出明确说明而非静默。
 
 完整已知限制与安全边界见[架构与限制](docs/architecture.md)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -147,7 +147,7 @@ so keep using `Ctrl`.
 | Session | `/new` new session · `/resume` session browser (search, preview, cross-project, sub-agent runs folded) · `/rename` rename session · `/workspace resume|rename|open` manage workspaces · `/clear` clear screen · `/compact` compact · `/export` export Markdown · `/trace` trace timeline |
 | Status | `/status` session info · `/cost` token usage · `/doctor` environment self-check · `/config` configuration sources · `/init` create AGENTS.md |
 | Model | `/model` picker · `/thinking` thinking display · `/tokens` token details · `/theme` theme picker · `/lang` zh/en UI switch |
-| Accounts/Policy | `/provider` add a model provider · `/login` credential status · `/logout` logout notes · `/permissions` permission notes · `/add-dir` file-policy scope · `/hooks` · `/mcp` · `/memory` |
+| Accounts/Policy | `/provider` add a model provider · `/login` credential status · `/logout` logout notes · `/permissions` permission notes · `/add-dir` file-policy scope · `/hooks` · `/mcp` |
 | Skills | `/audit` code audit · `/bug` bug report · `/review` code review · `/practice` coding practice · `/pr_comments` PR comments · `/release-notes` release notes · `/vuln-check` vulnerability check |
 | Other | `/agents` subagent list · `/update` auto-update and restart · `/vim` · `/terminal-setup` · `/connect` · `/help` · `/exit` |
 | Registry | `/plan` `/goal` (DSH command-registry plugins, merged into the `/` menu automatically with the plugin) |
@@ -257,7 +257,7 @@ chat / tool base events ──> persisted Session log ──> TUI / Web
   an approval bar. `/permission` preset switching comes from dsh-base's
   `permission-presets` plugin and is available in the profile composition by default;
   the bare `cordis.yml` composition does not mount that plugin (no `/permission` command).
-- `/vim` `/connect` `/hooks` `/memory` are CC-named placeholders: the corresponding
+- `/vim` `/connect` `/hooks` are CC-named placeholders: the corresponding
   capabilities have no equivalent mechanism on the DSH side, and the commands give an
   explicit explanation rather than staying silent.
 

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -156,7 +156,7 @@ visual TUI alone does not describe the effective policy.
   answerer); `/permission` preset switching is provided by the dsh-base
   `permission-presets` plugin and works in profile compositions — the bare
   `cordis.yml` mounts only the approval service, not `permission-presets`.
-- `/vim`, `/connect`, `/hooks`, and `/memory` are compatibility placeholders,
+- `/vim`, `/connect`, and `/hooks` are compatibility placeholders,
   not evidence that those DSH capabilities are mounted.
 - There is no automated full-flow suite that requires real model credentials;
   CI uses headless rendering and fake services, while live model integration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,7 @@ answerer（`approval/request` waterfall），仅允许一次/拒绝两种决定�
 - 工具级审批面板已实现（approval 服务 + TUI answerer）；`/permission` 的沙箱
   预设切换由 dsh-base 的 `permission-presets` 插件提供，profile 组合下可用；
   裸组合 `cordis.yml` 只挂了 approval 服务，未挂 `permission-presets`。
-- `/vim`、`/connect`、`/hooks`、`/memory` 是兼容占位命令，不代表对应 DSH 能力已挂载。
+- `/vim`、`/connect`、`/hooks` 是兼容占位命令，不代表对应 DSH 能力已挂载。
 - 没有一套需要真实模型凭证的自动化全流程测试；CI 使用 headless renderer 与假服务，
   真实模型集成仍需要在目标终端手动验证。
 

--- a/docs/interaction.en.md
+++ b/docs/interaction.en.md
@@ -252,7 +252,7 @@ zh; unmapped registry commands fall back to the registry's own text.
 | Sessions | `/new`, `/resume`, `/rename`, `/workspace resume|rename|open`, `/clear`, `/compact`, `/export`, `/btw`, `/trace` (trajectory scene, also `Ctrl+T`) |
 | Status | `/status`, `/cost`, `/config`, `/doctor`, `/init`, `/agents` |
 | Model and display | `/model`, `/effort`, `/thinking`, `/tokens`, `/activity`, `/preset`, `/theme`, `/lang` |
-| Account and policy | `/provider`, `/login`, `/logout`, `/permissions`, `/add-dir`, `/hooks`, `/mcp`, `/memory` |
+| Account and policy | `/provider`, `/login`, `/logout`, `/permissions`, `/add-dir`, `/hooks`, `/mcp` |
 | Packaged skills | `/audit`, `/bug`, `/practice`, `/review`, `/pr_comments`, `/release-notes`, `/vuln-check` |
 | Other | `/update`, `/vim`, `/terminal-setup`, `/connect`, `/help`, `/exit` |
 | Registry | `/plan`, `/goal`, and any other command registered by the DSH composition |
@@ -281,6 +281,6 @@ Additional forms:
   the DSH skill registry. Packaged `skills/` register at startup and may be
   overridden by same-name project or user skills.
 
-`/vim`, `/connect`, `/hooks`, and `/memory` are currently compatibility
+`/vim`, `/connect`, and `/hooks` are currently compatibility
 placeholders. When the DSH composition has no matching capability, each
 command explains that explicitly rather than silently doing nothing.

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -221,7 +221,7 @@ transcript。
 | 会话 | `/new`、`/resume`、`/rename`、`/workspace resume|rename|open`、`/clear`、`/compact`、`/export`、`/btw`、`/trace`（轨迹场景，亦可 `Ctrl+T`） |
 | 状态 | `/status`、`/cost`、`/config`、`/doctor`、`/init`、`/agents` |
 | 模型与显示 | `/model`、`/effort`、`/thinking`、`/tokens`、`/activity`、`/preset`、`/theme`、`/lang` |
-| 账号与策略 | `/provider`、`/login`、`/logout`、`/permissions`、`/add-dir`、`/hooks`、`/mcp`、`/memory` |
+| 账号与策略 | `/provider`、`/login`、`/logout`、`/permissions`、`/add-dir`、`/hooks`、`/mcp` |
 | 打包 Skills | `/audit`、`/bug`、`/practice`、`/review`、`/pr_comments`、`/release-notes`、`/vuln-check` |
 | 其他 | `/update`、`/vim`、`/terminal-setup`、`/connect`、`/help`、`/exit` |
 | 注册表 | `/plan`、`/goal`，以及当前 DSH 组合注册的其他命令 |
@@ -245,5 +245,5 @@ transcript。
 - Skill 命令只发送激活提示；实际 skill 通过 DSH skill 注册表加载。包内
   `skills/` 会在插件启动时自动注册，也可用项目或用户目录中的同名 skill 覆盖。
 
-`/vim`、`/connect`、`/hooks` 与 `/memory` 当前是兼容占位命令；当 DSH 组合没有
+`/vim`、`/connect`、`/hooks` 当前是兼容占位命令；当 DSH 组合没有
 对应能力时会给出明确说明，而不是静默执行。

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -95,7 +95,6 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
   { name: 'add-dir', description: 'Show the filesystem policy scope' },
   { name: 'hooks', description: 'Show hooks status' },
   { name: 'mcp', description: 'Show MCP status' },
-  { name: 'memory', description: 'Show memory status' },
   { name: 'skills', description: 'List available skills' },
   { name: 'update', description: 'Update dsh-tui and restart' },
   // Built-in skills (CC's skill commands, driven through DSH skills)

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -226,8 +226,6 @@ const dict = {
   'permissions-path-hint': { zh: '模型工具相对路径均解析自该目录；跨目录访问由 fs-policy 拦截。', en: 'Relative paths of model tools resolve from this directory; cross-directory access is blocked by fs-policy.' },
   'hooks-not-mounted': { zh: 'DSH hooks（dsh-hooks-claude / dsh-hooks-codex）未在本 leaf 挂载。', en: 'DSH hooks (dsh-hooks-claude / dsh-hooks-codex) are not mounted in this leaf.' },
   'hooks-mount-hint': { zh: '需要时可在 cordis.yml 挂载对应 hooks 插件。', en: 'Mount the matching hooks plugin in cordis.yml when needed.' },
-  'memory-none': { zh: 'DSH 暂无持久记忆服务。', en: 'DSH has no persistent memory service yet.' },
-  'memory-hint': { zh: '长期约定可写入 AGENTS.md（工作区上下文）或技能（~/.dsh/skills）。', en: 'Long-term conventions can go into AGENTS.md (workspace context) or skills (~/.dsh/skills).' },
   'update-unavailable': { zh: '当前运行方式不支持自动更新（需经 dsh --profile 启动），请在终端执行 dsh plugin --profile <name> update @deepseek-harness-tui/dsh-tui', en: 'Automatic update is unavailable in this launch mode (needs dsh --profile). Run dsh plugin --profile <name> update @deepseek-harness-tui/dsh-tui in a terminal.' },
   'update-working': { zh: '当前回合仍在运行，请等待完成后再更新 TUI。', en: 'The current turn is still running. Wait for it to finish before updating the TUI.' },
   'update-starting': { zh: '正在更新 @deepseek-harness-tui/dsh-tui，完成后会自动重启并恢复当前会话……', en: 'Updating @deepseek-harness-tui/dsh-tui. The TUI will restart and resume this session when finished…' },
@@ -605,7 +603,6 @@ const dict = {
   'cmd-desc-add-dir': { zh: '查看文件系统策略范围' },
   'cmd-desc-hooks': { zh: '查看 hooks 状态' },
   'cmd-desc-mcp': { zh: '查看 MCP 状态' },
-  'cmd-desc-memory': { zh: '查看记忆状态' },
   'cmd-desc-skills': { zh: '列出所有可用技能' },
   'cmd-desc-update': { zh: '更新 dsh-tui 并重启' },
   // Built-in skills

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -999,13 +999,6 @@ export function Chat({
         setHelpOpen(false)
         channel.pushLocal('/mcp', channel.mcpStatus())
         return true
-      case 'memory':
-        setHelpOpen(false)
-        channel.pushLocal('/memory', [
-          t('memory-none'),
-          t('memory-hint'),
-        ])
-        return true
       case 'update':
         setHelpOpen(false)
         if (onUpdate === undefined) {


### PR DESCRIPTION
## 动机

`/memory` 是一个 CC 同名占位命令，执行后只输出“DSH 暂无持久记忆服务”的固定提示，背后没有任何实际能力，属于多余命令。

## 改动

- `src/commands.ts`：从 `LOCAL_COMMANDS` 删除 `memory` 条目
- `src/screens/Chat.tsx`：删除 `case 'memory':` 派发分支
- `src/i18n.ts`：删除仅被该命令使用的 `cmd-desc-memory`、`memory-none`、`memory-hint` 三个键
- `README.md` / `README_EN.md` / `docs/interaction.{md,en.md}` / `docs/architecture.{md,en.md}`：命令表与“CC 同名占位命令”清单同步去掉 `/memory`

## 验证

- 全仓（排除 `lib/` 构建产物）无 `memory-none` / `memory-hint` / `cmd-desc-memory` / `/memory` 残留引用
- `tsc --noEmit` 通过