### PR TITLE
feat(scenes): 插件全屏场景注册表 dsh-tui-scenes——插件命令可开 trajectory 式整屏页面

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,3 +326,7 @@ jobs:
       # 长问卷列表回归：24 行终端中的 36 个两行 provider 选项必须围绕
       # focusIndex 窗口化，初始和深度导航后焦点 label/单选标记始终可见。
       - run: node --import tsx/esm scripts/verify-askpanel-long-list.tsx
+
+      # 插件场景渲染崩溃边界：Thrower 场景必须被 PluginSceneBoundary 接住——
+      # onError 精确一次、崩溃场景停止绘制、进程存活；健康场景不受影响。
+      - run: node --import tsx/esm scripts/verify-plugin-scene-boundary.tsx

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -187,11 +187,16 @@
     # execution and durable command events remain owned by dsh-commands.
     - id: dsh-tui-command-trees
       name: '@deepseek-harness-tui/dsh-tui/command-trees'
-
     # Optional plugins declare editable settings sections here (issue #165);
     # storage, validation and writes remain owned by the dsh settings service.
     - id: dsh-tui-settings-sections
       name: '@deepseek-harness-tui/dsh-tui/settings-sections'
+
+    # Optional plugins register full-screen scenes (trajectory-style whole-
+    # terminal views) here and open them from their own command handlers;
+    # rendering and input ownership remain owned by the TUI's Chat screen.
+    - id: dsh-tui-scenes
+      name: '@deepseek-harness-tui/dsh-tui/scenes'
 
     # The agent-preset roster (issue #8): `ctx.agentPresets`, the service the
     # TUI composes every session's model-facing world from. No `roots` here —
@@ -222,17 +227,17 @@
       name: '@deepseek-harness-tui/dsh-tui'
       # The entry-level dependency augments the plugin's `agents` inject and
       # prevents startup Session creation from racing WorkspaceRegistry init.
-      inject: [workspaceRegistry, agents, tuiWorkspaces]
-      # `tuiWorkspaces` lives in the entry-level inject ONLY as an ordering
-      # guarantee alongside the dsh-tui-workspaces row above — it is
-      # deliberately absent from the plugin's code-level inject (issue
-      # #183): the dsh CLI may read this patch from an older copy of the
-      # package than the plugin module it loads, and a hard code-level
-      # inject then deadlocks the tree at boot ("pending (waiting for
-      # service: tuiWorkspaces)"). Without the row the TUI degrades to a
-      # local-only workspace runtime instead. (The comment sits below the
-      # inject line: verify-workspace-attachment.mjs asserts the
-      # name→inject distance.)
+      inject: [workspaceRegistry, agents, tuiWorkspaces, tuiScenes]
+      # `tuiWorkspaces`/`tuiScenes` live in the entry-level inject ONLY as an
+      # ordering (and reload-rebind) guarantee alongside their service rows
+      # above — they are deliberately absent from the plugin's code-level
+      # inject (issue #183): the dsh CLI may read this patch from an older
+      # copy of the package than the plugin module it loads, and a hard
+      # code-level inject then deadlocks the tree at boot ("pending (waiting
+      # for service: tuiWorkspaces)"). Without the rows the TUI degrades:
+      # /workspace falls back to the local-only runtime, plugin scenes never
+      # open. (The comment sits below the inject line:
+      # verify-workspace-attachment.mjs asserts the name→inject distance.)
       config:
         provider: deepseek-official
         # Alt-screen fullscreen（CC 同款）：应用内鼠标选区（选择即复制, OSC 52 +

--- a/cordis.yml
+++ b/cordis.yml
@@ -34,9 +34,12 @@
 - id: dsh-tui-settings-sections
   name: '@deepseek-harness-tui/dsh-tui/settings-sections'
 
+- id: dsh-tui-scenes
+  name: '@deepseek-harness-tui/dsh-tui/scenes'
+
 - id: dsh-tui
   name: '@deepseek-harness-tui/dsh-tui'
-  inject: [agents, tuiWorkspaces]
+  inject: [agents, tuiWorkspaces, tuiScenes]
   config:
     provider: deepseek-official
     # Alt-screen fullscreen (CC 同款): 应用内鼠标选区（选择即复制, OSC 52 +

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -414,6 +414,11 @@ React instance:
 - Per-frame render cost is the scene's own budget: use
   `ui.useAnimationFrame` for motion, and keep synchronous I/O out of the
   render path.
+- **Render-time exceptions are bounded**: an error thrown from the scene
+  component's render/lifecycle is caught by `PluginSceneBoundary` — the
+  transcript gets an error line, the scene closes itself, and the TUI keeps
+  running. Errors inside effects and async callbacks are beyond the
+  boundary's reach and remain the scene's own responsibility.
 
 ## Naming and Publishing Conventions
 

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -280,6 +280,141 @@ Rules (same as the core `cordis.patch.yml`):
   If your plugin is meant to be composed by other bundles, provide the same
   explicit subpath export.
 
+## Seam 8: Plugin Full-Screen Scenes (tuiScenes)
+
+A plugin can register a **full-screen React scene** with the TUI and open it
+from its own slash command — the same "takes the whole terminal, hands it
+back untouched" shape as `/trace` (the trajectory timeline) and `/settings`.
+Command execution stays with dsh-commands (the `command/run`/`command/done`
+pair is logged as usual); the TUI only provides the rendering surface and
+keyboard ownership. Opening/closing a scene never touches the conversation
+and appends no session events.
+
+### Three steps
+
+**1. Register the scene** (`id` is globally unique, kebab-case; duplicate or
+invalid ids throw at registration):
+
+```ts
+import type { TuiSceneProps } from '@deepseek-harness-tui/dsh-tui/scenes'
+
+ctx.inject(['tuiScenes'], (sceneCtx) => {
+  const dispose = sceneCtx.tuiScenes.register({
+    id: 'my-dashboard',
+    title: 'My dashboard',        // optional, for logs/debugging; the scene draws its own header
+    component: MyDashboard,
+  })
+  ctx.effect(() => () => dispose())   // disposing the OPEN scene closes it
+})
+```
+
+**2. Register the command that opens it** (execution and logging stay with
+dsh-commands; the handler returns a silent `success`, leaving just the
+command's own line in the transcript):
+
+```ts
+ctx.inject(['commands'], (commandCtx) => {
+  const dispose = commandCtx.commands.register({
+    name: 'dashboard',
+    description: 'Open my dashboard',
+    handler: () => {
+      const opened = sceneCtx.tuiScenes.open('my-dashboard')
+      return opened
+        ? { kind: 'success' as const }
+        : { kind: 'error' as const, text: 'dashboard scene is not registered' }
+    },
+  })
+  ctx.effect(() => () => dispose())
+})
+```
+
+**3. Write the scene component** — the props inject the host's `React` and
+`ui` kit, and that is a **hard contract** (see the next section):
+
+```tsx
+// tsconfig: "jsx": "react-jsx",
+//           "jsxImportSource": "@deepseek-harness-tui/dsh-tui"
+import type { TuiSceneProps } from '@deepseek-harness-tui/dsh-tui/scenes'
+
+export function MyDashboard({ React, ui, channel, close }: TuiSceneProps) {
+  // Hooks MUST come from the injected React; JSX goes through the host
+  // jsx-runtime via jsxImportSource.
+  const { Box, Text, useInput, useTerminalSize } = ui
+  const { columns, rows } = useTerminalSize()
+  // channel is reactive: subscribe to version like Chat does and the data
+  // follows the session live.
+  React.useSyncExternalStore(channel.subscribe, () => channel.version)
+  // The scene owns the keyboard while open — conventions like Esc/q to
+  // close are the scene's own job.
+  useInput((input, key) => {
+    if (key.escape || input === 'q') close()
+  })
+  return (
+    <Box flexDirection="column" width="100%" paddingX={1}>
+      <Text bold>My dashboard</Text>
+      <Text>{channel.rows.length} rows · {columns}×{rows}</Text>
+    </Box>
+  )
+}
+```
+
+No JSX? `React.createElement(ui.Box, …)` is equally valid (`React` IS the
+host instance, so `createElement`/`Fragment` are always safe).
+
+### The React contract (read this — violations crash on first render)
+
+The TUI's reconciler is **React 19**, and scene components run on the host's
+React instance:
+
+- **Hooks must come from the props-injected `React`.** A plugin importing its
+  own React copy from node_modules and calling its hooks hits a dispatcher
+  mismatch — invalid hook call on the very first render.
+- **Elements must be created through the host runtime.** React 19's JSX
+  factory emits `Symbol.for('react.transitional.element')` elements; JSX
+  compiled against a plugin-bundled older React (18 and below) emits
+  `Symbol.for('react.element')`, which the host reconciler rejects outright.
+  So JSX authors must point tsconfig's `jsxImportSource` at
+  `@deepseek-harness-tui/dsh-tui` (its `./jsx-runtime` subpath re-exports the
+  host's own `react/jsx-runtime` verbatim), or stick to the injected
+  `React`'s `createElement`. A plugin-owned React copy only produces legal
+  elements when it is the SAME 19.x line — and its hooks remain off-limits
+  regardless.
+
+### Runtime semantics
+
+- **Screen stack**: a plugin scene sits at the TOP of Chat's early-return
+  chain — above `/settings`, the `/resume` browser, and the trajectory
+  scene. Those screens stay mounted but yield the screen and the keyboard
+  while a scene is open; `close()` lands back on whatever was up before.
+- **Inline and fullscreen alike**: in inline mode the TUI wraps the scene in
+  `<AlternateScreen>` for you (DEC 1049 enter/exit, frame churn never reaches
+  scrollback); in fullscreen mode the host's alt screen is reused. Scene
+  components must NOT nest another `<AlternateScreen>` themselves.
+- **Async opens are safe**: handlers may be async and call `open()` after the
+  command settles — the open rides the channel's version bump into a
+  re-render, independent of the command's return timing.
+- **Graceful degradation without the service**: probe with
+  `ctx.get('tuiScenes')`; on an older patch without the `dsh-tui-scenes` row,
+  `open()` warns and returns `false` and the TUI never opens a scene — a
+  missing seam must never break startup (the #183 rule).
+- **Lifecycle**: registration and open state do NOT reset on agent swaps
+  (`/new`, `/resume`, rewind); `channel` always points at the live agent.
+  Unmounting (closing) destroys the component's hook state — reopening is a
+  fresh mount.
+
+### Scene red lines
+
+- The scene owns the WHOLE terminal while open: lay out with
+  `flexGrow`/`useTerminalSize()` instead of assuming fixed dimensions, and
+  never write to stdout (debug through `DSH_TUI_DEBUG`'s stderr).
+- A scene is an OBSERVER of the session: read from `channel` (rows, tokens,
+  working, traceEvents, …); writes (submit/steer/cancel) are available too,
+  but opening/closing itself produces no session events — never append
+  events from a scene; if you must emit, follow seam 1's log-only rules.
+- Per-frame render cost is the scene's own budget: use
+  `ui.useAnimationFrame` for motion, and keep synchronous I/O out of the
+  render path.
+
 ## Naming and Publishing Conventions
 
 - **Package name**: ecosystem convention `@dsh-tui-ecosystem/<name>` (check npm

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -243,6 +243,123 @@ ctx.inject(['tuiSettingsSections'], (settingsCtx) => {
   `@deepseek-harness-tui/dsh-tui/working-activity` 子路径再导出后挂载。你的插件
   如果也要被别的 bundle 组合，提供同样的显式子路径导出。
 
+## 接缝八：插件全屏场景（tuiScenes）
+
+插件可以把一个**整屏 React 场景**注册给 TUI，再从自己的 slash 命令里打开它——
+就是 `/trace`（轨迹时间线）和 `/settings` 那种"接管整个终端、退出后原样归还"
+的页面形态。命令执行权仍在 dsh-commands（`command/run`/`command/done` 日志对
+照记），TUI 只提供渲染面与键盘所有权；场景的打开/关闭不碰会话流，不落任何
+session 事件。
+
+### 三步接入
+
+**1. 注册场景**（`id` 全局唯一，kebab-case；重复或非法 id 注册即抛错）：
+
+```ts
+import type { TuiSceneProps } from '@deepseek-harness-tui/dsh-tui/scenes'
+
+ctx.inject(['tuiScenes'], (sceneCtx) => {
+  const dispose = sceneCtx.tuiScenes.register({
+    id: 'my-dashboard',
+    title: 'My dashboard',        // 可选，调试/日志用；标题栏由场景自绘
+    component: MyDashboard,
+  })
+  ctx.effect(() => () => dispose())   // dispose 当前打开的场景会自动关屏
+})
+```
+
+**2. 注册打开它的命令**（执行与日志仍归 dsh-commands；handler 返回静默
+`success`，转录里只留下命令本身的一行）：
+
+```ts
+ctx.inject(['commands'], (commandCtx) => {
+  const dispose = commandCtx.commands.register({
+    name: 'dashboard',
+    description: 'Open my dashboard',
+    handler: () => {
+      const opened = sceneCtx.tuiScenes.open('my-dashboard')
+      return opened
+        ? { kind: 'success' as const }
+        : { kind: 'error' as const, text: 'dashboard scene is not registered' }
+    },
+  })
+  ctx.effect(() => () => dispose())
+})
+```
+
+**3. 写场景组件**——props 注入宿主的 `React` 与 `ui` kit，**这是硬契约**
+（原因见下节）：
+
+```tsx
+// tsconfig: "jsx": "react-jsx",
+//           "jsxImportSource": "@deepseek-harness-tui/dsh-tui"
+import type { TuiSceneProps } from '@deepseek-harness-tui/dsh-tui/scenes'
+
+export function MyDashboard({ React, ui, channel, close }: TuiSceneProps) {
+  // hook 必须用注入的 React；JSX 经 jsxImportSource 走宿主 jsx-runtime
+  const { Box, Text, useInput, useTerminalSize } = ui
+  const { columns, rows } = useTerminalSize()
+  // channel 是响应式的：照 Chat 的用法订阅 version，数据随会话实时刷新
+  React.useSyncExternalStore(channel.subscribe, () => channel.version)
+  // 场景打开期间独占键盘——Esc/q 关闭这类约定由场景自己实现
+  useInput((input, key) => {
+    if (key.escape || input === 'q') close()
+  })
+  return (
+    <Box flexDirection="column" width="100%" paddingX={1}>
+      <Text bold>My dashboard</Text>
+      <Text>{channel.rows.length} rows · {columns}×{rows}</Text>
+    </Box>
+  )
+}
+```
+
+不用 JSX 也可以：`React.createElement(ui.Box, …)` 完全合法（`React` 就是宿主
+实例，`createElement`/`Fragment` 都安全）。
+
+### React 契约（必读，违反即首渲染崩溃）
+
+TUI 的 reconciler 是 **React 19**，场景组件运行在宿主的 React 实例上：
+
+- **hook 必须用 props 注入的 `React`**。插件从自己 node_modules 里 import 一个
+  React 副本调 hook，dispatcher 对不上，第一次渲染就是 invalid hook call。
+- **元素必须过宿主 runtime**。React 19 的 JSX 工厂产出
+  `Symbol.for('react.transitional.element')` 元素；插件自带的旧版 React（18 及
+  更早）编译出的 JSX 是 `Symbol.for('react.element')`，宿主 reconciler 直接拒绝。
+  所以 JSX 作者必须把 tsconfig 的 `jsxImportSource` 指向
+  `@deepseek-harness-tui/dsh-tui`（它的 `./jsx-runtime` 子路径原样 re-export 宿主
+  的 `react/jsx-runtime`），或者干脆只用注入 `React` 的 `createElement`。
+  插件自带的 React 副本**仅当同为 19.x 时**产出的元素才合法，且 hook 依然禁用。
+
+### 运行时语义
+
+- **屏幕栈**：插件场景位于 Chat early-return 链的最顶端——在 `/settings`、
+  `/resume` 浏览器、轨迹场景之上。场景打开期间这些屏幕保持挂载但让出屏幕与
+  键盘；`close()` 后落回之前所在的屏幕。
+- **inline / fullscreen 通吃**：inline 模式下 TUI 自动为场景包
+  `<AlternateScreen>`（DEC 1049 进出、帧 churn 不进 scrollback）；fullscreen
+  模式直接复用宿主已有的 alt screen，场景组件**不要**自己再包一层。
+- **命令异步打开也安全**：handler 是 async 的，命令结束后才 `open()` 也没问题——
+  打开动作经 channel 的 version bump 驱动重渲染，不依赖命令的返回时机。
+- **服务缺失时静默降级**：`ctx.get('tuiScenes')` 探测；旧版 patch 未挂
+  `dsh-tui-scenes` 行时 `open()` 打 warn 并返回 `false`，TUI 侧永不打开，
+  绝不拖垮启动（#183 原则）。
+- **生命周期**：场景注册与打开状态不随 `/new`、`/resume`、rewind 的 agent
+  切换重置；`channel` 始终指向当前 live agent。场景组件卸载（关屏）时 hook
+  状态随之销毁，重开是全新挂载。
+
+### 场景的红线
+
+- 场景打开期间**独占整个终端**：布局用 `flexGrow`/`useTerminalSize()` 自适应，
+  别假设固定行列数；也别往 stdout 写任何东西（调试走 `DSH_TUI_DEBUG` 的
+  stderr）。
+- 场景是会话的**观察者**：数据从 `channel` 读（rows、tokens、working、
+  traceEvents……），写操作（submit/steer/cancel）也能用，但打开/关闭本身
+  不产生任何 session 事件——别在场景里 append 事件，要发就走接缝一的
+  log-only 铁律。
+- 每一帧的重渲染成本由场景自己兜着：高频动画用 `ui.useAnimationFrame`，
+  别在渲染路径里做同步 I/O。
+
 ## 命名与发布规范
 
 - **包名**：生态约定 `@dsh-tui-ecosystem/<name>`（发布前先查 npm 是否被占）；

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -359,6 +359,9 @@ TUI 的 reconciler 是 **React 19**，场景组件运行在宿主的 React 实�
   log-only 铁律。
 - 每一帧的重渲染成本由场景自己兜着：高频动画用 `ui.useAnimationFrame`，
   别在渲染路径里做同步 I/O。
+- **渲染期异常有边界兜底**：场景组件 render/生命周期里抛错会被
+  `PluginSceneBoundary` 接住——转录里报一条错误、场景自动关闭，不会拖垮整个
+  TUI。但 boundary 管不到 effect 与异步回调里的异常，那些仍是场景自己的责任。
 
 ## 命名与发布规范
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,14 @@
       "types": "./lib/types/settings-sections.d.ts",
       "import": "./lib/types/settings-sections.js"
     },
+    "./scenes": {
+      "types": "./lib/types/scenes.d.ts",
+      "import": "./lib/types/scenes.js"
+    },
+    "./jsx-runtime": {
+      "types": "./lib/types/jsx-runtime.d.ts",
+      "import": "./lib/types/jsx-runtime.js"
+    },
     "./invariant": {
       "types": "./lib/types/dsh-adapter/invariant.d.ts",
       "default": "./lib/types/dsh-adapter/invariant.js"

--- a/patch-surface.snapshot.json
+++ b/patch-surface.snapshot.json
@@ -7,6 +7,7 @@
     "dsh-tui-workspaces",
     "dsh-tui-command-trees",
     "dsh-tui-settings-sections",
+    "dsh-tui-scenes",
     "agent-presets",
     "cordis-host-runner",
     "dsh-tui",

--- a/scripts/smoke.tsx
+++ b/scripts/smoke.tsx
@@ -211,6 +211,66 @@ if (settingsCtx.tuiSettingsSections.list().length !== 0) {
 }
 await settingsCtx.fiber.dispose()
 
+// Plugin scene seam: registration validates and dedupes ids, open/close
+// drive the subscribe feed exactly once per transition, and disposing the
+// open scene closes it instead of stranding the user on a dead screen.
+const scenesModule = await import('../src/scenes.js')
+const sceneCtx = new Context()
+await sceneCtx.plugin(scenesModule.default).await()
+const sceneRuntime = sceneCtx.tuiScenes
+let sceneNotifications = 0
+const unsubscribeScenes = sceneRuntime.subscribe(() => { sceneNotifications += 1 })
+if (sceneRuntime.active !== undefined) throw new Error('scene smoke: active scene before any open')
+if (sceneRuntime.open('missing') !== false) throw new Error('scene smoke: opening an unregistered id must fail')
+const demoScene = { id: 'demo', component: () => null }
+const disposeDemo = sceneRuntime.register(demoScene)
+if (sceneRuntime.open('DEMO') !== true || sceneRuntime.active?.id !== 'demo') {
+  throw new Error('scene smoke: ids must normalize to lowercase on open')
+}
+if (sceneNotifications !== 1) throw new Error('scene smoke: open must notify exactly once')
+sceneRuntime.open('demo')
+if (sceneNotifications !== 1) throw new Error('scene smoke: re-opening the active scene must not notify')
+sceneRuntime.close()
+if (sceneRuntime.active !== undefined || sceneNotifications !== 2) {
+  throw new Error('scene smoke: close must clear the active scene and notify')
+}
+sceneRuntime.open('demo')
+disposeDemo()
+if (sceneRuntime.active !== undefined || sceneNotifications !== 4) {
+  throw new Error('scene smoke: disposing the open scene must close it')
+}
+let invalidIdThrew = false
+try {
+  sceneRuntime.register({ id: 'not a scene id', component: () => null })
+} catch {
+  invalidIdThrew = true
+}
+if (!invalidIdThrew) throw new Error('scene smoke: invalid ids must be rejected')
+const sceneDisposeDup = sceneRuntime.register({ id: 'dup', component: () => null })
+let sceneDuplicateThrew = false
+try {
+  sceneRuntime.register({ id: 'DUP', component: () => null })
+} catch {
+  sceneDuplicateThrew = true
+}
+if (!sceneDuplicateThrew) throw new Error('scene smoke: duplicate ids must be rejected')
+sceneDisposeDup()
+unsubscribeScenes()
+await sceneCtx.fiber.dispose()
+
+// Host JSX runtime (./jsx-runtime subpath): elements it creates must carry
+// the React 19 transitional-element symbol — the only flavor this app's
+// reconciler accepts — so plugin JSX compiled with
+// `"jsxImportSource": "@deepseek-harness-tui/dsh-tui"` renders on first try.
+const jsxRuntimeModule = await import('../src/jsx-runtime.js')
+if (typeof jsxRuntimeModule.jsx !== 'function' || typeof jsxRuntimeModule.jsxs !== 'function') {
+  throw new Error('jsx-runtime smoke: jsx/jsxs factories missing')
+}
+const probe = jsxRuntimeModule.jsx('div', {}) as { $$typeof?: symbol }
+if (probe.$$typeof !== Symbol.for('react.transitional.element')) {
+  throw new Error('jsx-runtime smoke: element is not a React 19 transitional element')
+}
+
 // Generic workspace seam: prove the TUI works with only its local fallback,
 // and that an anonymous provider can add URI/path/shell behavior without the
 // TUI knowing its protocol.

--- a/scripts/verify-plugin-scene-boundary.tsx
+++ b/scripts/verify-plugin-scene-boundary.tsx
@@ -1,0 +1,84 @@
+/**
+ * Plugin scene boundary regression (dsh-tui-scenes): a scene component that
+ * throws during render must be caught by PluginSceneBoundary — onError fires
+ * exactly once with the scene id and the thrown error, the boundary stops
+ * painting the scene afterwards, and the app process survives. A healthy
+ * scene renders untouched, and a second scene id never crosses the report.
+ *
+ * Without the boundary the error bubbles to ink's app-level boundary
+ * (src/ink/components/App.tsx), whose componentDidCatch runs the crash-exit
+ * path — one plugin's render bug would take the whole TUI down.
+ *
+ * Run: node --import tsx/esm scripts/verify-plugin-scene-boundary.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+const [{ Writable }, React, { render, Text }, { PluginSceneBoundary }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/components/PluginSceneBoundary.js'),
+])
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const frames: string[] = []
+class FakeStdout extends Writable {
+  columns = 80
+  rows = 24
+  isTTY = true
+  override _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    frames.push(String(chunk))
+    cb()
+  }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  override _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+// --- 1. healthy scene renders through untouched ----------------------------
+const healthy = await render(
+  <PluginSceneBoundary id="ok" onError={() => { check('healthy scene never reports', false) }}>
+    <Text>scene-ok-content</Text>
+  </PluginSceneBoundary>,
+  { stdout: new FakeStdout() as never, stderr: new FakeStderr() as never, patchConsole: false, exitOnCtrlC: false },
+)
+await sleep(100)
+check('healthy scene content painted', frames.join('').includes('scene-ok-content'))
+await healthy.unmount()
+
+// --- 2. throwing scene is caught, reported once, and stops painting --------
+frames.length = 0
+const reports: Array<{ id: string; message: string }> = []
+function Thrower(): React.ReactNode {
+  throw new Error('boom-场景炸了')
+}
+const crashed = await render(
+  <PluginSceneBoundary
+    id="demo"
+    onError={(id, error) => { reports.push({ id, message: error.message }) }}
+  >
+    <Thrower />
+  </PluginSceneBoundary>,
+  { stdout: new FakeStdout() as never, stderr: new FakeStderr() as never, patchConsole: false, exitOnCtrlC: false },
+)
+await sleep(150)
+check('boundary reports the crash exactly once', reports.length === 1, `reports=${reports.length}`)
+check('report carries scene id and error message',
+  reports[0]?.id === 'demo' && reports[0]?.message.includes('boom-场景炸了'),
+  JSON.stringify(reports[0]))
+check('crashed scene paints nothing afterwards', !frames.join('').includes('boom-'))
+await crashed.unmount()
+
+if (failed > 0) {
+  console.log(`\n${failed} boundary check(s) FAILED`)
+  process.exit(1)
+}
+console.log('\nAll plugin-scene boundary checks passed')

--- a/src/components/PluginSceneBoundary.tsx
+++ b/src/components/PluginSceneBoundary.tsx
@@ -1,0 +1,48 @@
+/**
+ * Error boundary for plugin scenes (dsh-tui-scenes). A scene component is
+ * third-party code rendered inside Chat's tree: without a boundary a render
+ * error propagates to ink's app-level boundary (src/ink/components/App.tsx)
+ * and takes the whole TUI down with it. Catching here collapses the blast
+ * radius to the scene itself — the host reports the error to the transcript
+ * and closes the scene, landing the user back on the conversation.
+ *
+ * Boundaries catch render/lifecycle errors only; errors thrown from async
+ * handlers and effects remain the scene's own responsibility (see the
+ * 场景红线 section in docs/plugins.md).
+ */
+import React from 'react'
+
+type PluginSceneBoundaryProps = {
+  /** Scene id, echoed into the error report. */
+  readonly id: string
+  /** Called once per caught error; the host reports it and closes the scene. */
+  readonly onError: (id: string, error: Error) => void
+  readonly children: React.ReactNode
+}
+
+type PluginSceneBoundaryState = {
+  readonly crashed: boolean
+}
+
+export class PluginSceneBoundary extends React.Component<
+  PluginSceneBoundaryProps,
+  PluginSceneBoundaryState
+> {
+  override state: PluginSceneBoundaryState = { crashed: false }
+
+  static getDerivedStateFromError(): PluginSceneBoundaryState {
+    // Suppress the scene's next render. The host's onError closes the scene
+    // in the same commit turn, so this null fallback normally never paints;
+    // it exists only to keep a closed-nowhere crash from remounting the
+    // throwing component in a loop.
+    return { crashed: true }
+  }
+
+  override componentDidCatch(error: Error): void {
+    this.props.onError(this.props.id, error)
+  }
+
+  override render(): React.ReactNode {
+    return this.state.crashed ? null : this.props.children
+  }
+}

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -55,6 +55,7 @@ import { createLocalWorkspaceRuntime, type TuiWorkspaceCommand, type TuiWorkspac
 import type { TuiCommandTreeRuntime } from './command-trees.js'
 import type { TuiSettingsSection, TuiSettingsSectionsRuntime } from './settings-sections.js'
 import type { SettingsHost } from './settingsEditor.js'
+import type { TuiSceneDescriptor, TuiSceneRuntime } from './scenes.js'
 
 type ChannelImageBlock = Extract<ContentBlock, { type: 'image' }>
 type ChannelImageMediaType = ChannelImageBlock['attachment']['mediaType']
@@ -393,6 +394,22 @@ export interface Channel {
    * back to sending the line to the model).
    */
   runExternalCommand(name: string, rawInput: string): Promise<string | undefined>
+  /**
+   * Plugin-registered full-screen scene currently replacing the conversation
+   * (the `dsh-tui-scenes` runtime), if any. The chat screen renders its
+   * component INSTEAD of the transcript — the same whole-terminal treatment
+   * the trajectory scene gets — and hands it the keyboard; `undefined`
+   * renders the conversation normally.
+   */
+  readonly pluginScene: TuiSceneDescriptor | undefined
+  /**
+   * Open a registered plugin scene by id. Plugin command handlers usually
+   * call the runtime directly (`ctx.tuiScenes.open`); this passthrough lets
+   * host-side UI code do the same without touching cordis services.
+   */
+  openPluginScene(id: string): boolean
+  /** Close the open plugin scene, if any (a no-op otherwise). */
+  closePluginScene(): void
   /** 侧问（CC /btw）：无工具单轮 LLM 调用，复用当前会话上下文；结果不落 session log。 */
   sideQuestion(
     question: string,
@@ -666,6 +683,12 @@ export interface ChannelState {
   commandCompletions(input: string): readonly CommandCompletion[]
   /** Run a plugin-registered command (see the public Channel type). */
   runExternalCommand(name: string, rawInput: string): Promise<string | undefined>
+  /** Open plugin scene mirrored from the scenes runtime (see the public Channel type). */
+  pluginScene: TuiSceneDescriptor | undefined
+  /** Open a plugin scene by id (see the public Channel type). */
+  openPluginScene(id: string): boolean
+  /** Close the open plugin scene (see the public Channel type). */
+  closePluginScene(): void
   /** Estimated context segments by content type (pi-nano-context style bar). */
   contextSegments: {
     system: number
@@ -1081,6 +1104,10 @@ export function createChannel(
   // so compute once and cache.
   let settingsHostCache: SettingsHost | undefined
   let settingsHostResolved = false
+  // Plugin scene runtime (optional service, same degradation rule as
+  // tuiWorkspaces/tuiCommandTrees): mounted by the bundle patch's
+  // dsh-tui-scenes row; absent the row, `pluginScene` simply stays undefined.
+  const sceneRuntime = ctx.get('tuiScenes') as TuiSceneRuntime | undefined
   // Shift+Tab session-mode cycle: cordis.yml `modes` wins; absent/empty/
   // atom-less → the built-in default/plan/full cycle (sessionModes.ts).
   const { modes: sessionModes, dropped: droppedModeIds } = resolveSessionModes(options.modes)
@@ -2747,6 +2774,13 @@ export function createChannel(
     runExternalCommand(name, rawInput) {
       return executeRegistryCommand(name, rawInput)
     },
+    pluginScene: sceneRuntime?.active,
+    openPluginScene(id: string) {
+      return sceneRuntime?.open(id) ?? false
+    },
+    closePluginScene() {
+      sceneRuntime?.close()
+    },
     pushLocal(title, lines) {
       state.rows.push({ id: nextRowId++, kind: 'local', text: title })
       for (const line of lines) {
@@ -2934,6 +2968,7 @@ export function createChannel(
     },
     releaseContributions() {
       releaseSkillCommands()
+      unsubscribeScenes?.()
     },
     traceEvents() {
       // Immutable per-append snapshot (dsh-session caches the frozen array);
@@ -3278,6 +3313,16 @@ export function createChannel(
   }
   ctx.on('skills/change', () => {
     void refreshSkillCommands()
+  })
+  /**
+   * Mirror the scene runtime's active scene into channel state, so screens
+   * swap to it through the ordinary version-bump re-render instead of a
+   * second subscription channel.
+   */
+  const unsubscribeScenes = sceneRuntime?.subscribe(() => {
+    if (state.pluginScene === sceneRuntime.active) return
+    state.pluginScene = sceneRuntime.active
+    state.emit()
   })
   /** See {@link Channel.releaseContributions}. */
   const releaseSkillCommands = (): void => {

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -229,6 +229,16 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     )
   }
   const workspaceService = mountedWorkspaceService ?? createLocalWorkspaceRuntime()
+  // Same skew guard for the plugin-scene registry (dsh-tui-scenes row): the
+  // channel degrades to never opening scenes when the service is absent, so
+  // say why on profile launches — a plugin's open() otherwise fails with only
+  // its own warn to go on.
+  if (ctx.get('tuiScenes') === undefined && resolveDshProfileName() !== undefined) {
+    ctx.logger.warn(
+      'dsh-tui: tuiScenes service is not mounted; plugin scenes will never open. ' +
+      'The bundle patch is older than the installed dsh-tui package — update the globally installed dsh-tui launcher to match the profile (issue #183).',
+    )
+  }
   const initialWorkspace = requestedWorkspace === undefined
     ? undefined
     : await workspaceService.resolve(requestedWorkspace)

--- a/src/dsh-adapter/scenes.ts
+++ b/src/dsh-adapter/scenes.ts
@@ -1,0 +1,128 @@
+/** Provider-neutral full-screen scene registry for terminal front doors. */
+
+import type React from 'react'
+import { Context, Service } from '@deepseek-ai/cordis'
+import type { Channel } from './channel.js'
+
+/**
+ * Props every plugin scene receives. Both element creation and hooks must go
+ * through the HOST's React, never the plugin's own copy:
+ *
+ * - Hooks: a component rendered by this TUI's reconciler but calling hooks
+ *   imported from a second React copy (the plugin's own node_modules) dies
+ *   with an invalid-hook-call on first render. Use the injected `React`.
+ * - Elements: this app's reconciler (React 19) accepts only
+ *   `Symbol.for('react.transitional.element')` elements. JSX compiled
+ *   against a plugin-bundled older React emits `Symbol.for('react.element')`
+ *   and throws on first render. Create elements with the injected `React`
+ *   (`React.createElement`/`React.Fragment`), or compile JSX against the
+ *   host runtime via tsconfig
+ *   `"jsxImportSource": "@deepseek-harness-tui/dsh-tui"` (its `./jsx-runtime`
+ *   subpath re-exports this app's own react/jsx-runtime). A plugin-owned
+ *   React copy works ONLY if it is the same React 19 line — and its hooks
+ *   remain off-limits regardless.
+ */
+export interface TuiSceneProps {
+  /** The TUI's React instance — use THIS for every hook and element. */
+  React: typeof React
+  /** The TUI's ui kit (Box/Text/useInput/useTerminalSize/…). */
+  ui: typeof import('../ui.js')
+  /** Live session channel: rows, status, trace events, notifications. */
+  channel: Channel
+  /** Leave the scene and return to whatever screen was up before. */
+  close(): void
+}
+
+export interface TuiSceneDescriptor {
+  /** Unique scene id (kebab-case); the plugin's own commands open it by id. */
+  id: string
+  /** Optional human label for logs/debugging; the scene renders its own header. */
+  title?: string
+  component: React.ComponentType<TuiSceneProps>
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    tuiScenes: TuiSceneRuntime
+  }
+}
+
+export const name = 'dsh-tui-scenes'
+
+/**
+ * Small host-only registry; command execution remains owned by dsh-commands.
+ *
+ * A plugin registers a scene once (`ctx.tuiScenes.register(...)`, keep the
+ * dispose) and opens it from anywhere host-side — typically its own
+ * dsh-commands handler: `ctx.tuiScenes.open('my-scene')` plus a silent
+ * `success` result, so the conversation stays untouched while the scene
+ * takes the whole terminal the way the trajectory scene does.
+ */
+export class TuiSceneRuntime extends Service {
+  private readonly scenes = new Map<string, TuiSceneDescriptor>()
+  private readonly listeners = new Set<() => void>()
+  private current: TuiSceneDescriptor | undefined
+
+  constructor(ctx: Context) {
+    super(ctx, 'tuiScenes')
+  }
+
+  register(descriptor: TuiSceneDescriptor): () => void {
+    const id = descriptor.id.trim().toLowerCase()
+    if (!/^[a-z][a-z0-9_-]*$/u.test(id)) throw new TypeError(`invalid TUI scene id: ${descriptor.id}`)
+    if (this.scenes.has(id)) throw new Error(`TUI scene "${id}" is already registered`)
+    const normalized = { ...descriptor, id }
+    this.scenes.set(id, normalized)
+    return () => {
+      if (this.scenes.get(id) !== normalized) return
+      this.scenes.delete(id)
+      // Disposing the open scene must not strand the user on a dead screen.
+      if (this.current === normalized) {
+        this.current = undefined
+        this.notify()
+      }
+    }
+  }
+
+  /**
+   * Swap the conversation for the named scene. Returns false (and warns)
+   * when no plugin registered that id — a mistyped id must fail visibly in
+   * the log, not silently do nothing in the UI.
+   */
+  open(id: string): boolean {
+    const scene = this.scenes.get(id.trim().toLowerCase())
+    if (scene === undefined) {
+      this.ctx.logger.warn(`dsh-tui: no TUI scene registered as "${id}"`)
+      return false
+    }
+    if (scene === this.current) return true
+    this.current = scene
+    this.notify()
+    return true
+  }
+
+  close(): void {
+    if (this.current === undefined) return
+    this.current = undefined
+    this.notify()
+  }
+
+  /** The scene currently replacing the conversation, if any. */
+  get active(): TuiSceneDescriptor | undefined {
+    return this.current
+  }
+
+  /** UI-side change feed: fired after every open/close/dispose transition. */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) listener()
+  }
+}
+
+export default TuiSceneRuntime

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -440,6 +440,7 @@ const dict = {
   'skills-loading-subtitle': { zh: '正在查询技能注册表…', en: 'Querying the skill registry…' },
   'skills-empty': { zh: '当前会话没有可用技能', en: 'No skills available in this session' },
   'skills-load-failed': { zh: '技能列表加载失败', en: 'Failed to load the skill list' },
+  'plugin-scene-crashed': { zh: '插件场景「{{id}}」渲染崩溃：{{err}}（已自动关闭）', en: 'Plugin scene "{{id}}" crashed while rendering: {{err}} (closed)' },
   'skills-source-bundled': { zh: '内置', en: 'built-in' },
   'skills-source-user': { zh: '用户', en: 'user' },
   'skills-source-project': { zh: '项目', en: 'project' },

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,13 @@
+// Host JSX factory for plugin scenes: re-exports the TUI's OWN
+// react/jsx-runtime, so JSX a plugin compiles against this subpath produces
+// React 19 elements (`Symbol.for('react.transitional.element')`) — the only
+// element flavor this app's reconciler accepts. A plugin bundling its own
+// older React emits `Symbol.for('react.element')` and dies on first render.
+//
+// Plugin tsconfig:
+//   "jsx": "react-jsx",
+//   "jsxImportSource": "@deepseek-harness-tui/dsh-tui"
+//
+// Hooks still come from the scene props' injected `React` — this module
+// covers element creation only.
+export * from 'react/jsx-runtime'

--- a/src/scenes.ts
+++ b/src/scenes.ts
@@ -1,0 +1,4 @@
+// Re-export shim: the Cordis-backed implementation lives behind the adapter
+// boundary so UI consumers never import official @deepseek-ai/* packages.
+export * from './dsh-adapter/scenes.js'
+export { default } from './dsh-adapter/scenes.js'

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -29,6 +29,7 @@ import { StatusLine } from './StatusLine.js'
 import { WorkingSpinner, useThinkingStatus } from '../components/WorkingSpinner.js'
 import { ActivityLine, contextPressurePct } from '../components/ActivityLine.js'
 import { ModelPicker } from '../components/ModelPicker.js'
+import { PluginSceneBoundary } from '../components/PluginSceneBoundary.js'
 import { SkillsPicker, SkillsPickerLoading } from '../components/SkillsPicker.js'
 import { SessionBrowser } from './SessionBrowser.js'
 import { Settings } from './Settings.js'
@@ -1823,14 +1824,27 @@ export function Chat({
   // across renders and its hook state survives re-renders; it receives the
   // TUI's own React + ui kit because a plugin importing its own React copy
   // would die on the first hook call under this reconciler.
+  // The scene is third-party code, so it renders inside a boundary: a render
+  // crash reports to the transcript and closes the scene instead of taking
+  // the whole TUI down through ink's app-level boundary.
   const pluginScene = channel.pluginScene
   if (pluginScene !== undefined) {
-    const node = React.createElement(pluginScene.component, {
-      React,
-      ui: tuiKit,
-      channel,
-      close: () => channel.closePluginScene(),
-    })
+    const node = (
+      <PluginSceneBoundary
+        id={pluginScene.id}
+        onError={(id, error) => {
+          channel.notify(t('plugin-scene-crashed', { id, err: error.message }), { color: 'error' })
+          channel.closePluginScene()
+        }}
+      >
+        {React.createElement(pluginScene.component, {
+          React,
+          ui: tuiKit,
+          channel,
+          close: () => channel.closePluginScene(),
+        })}
+      </PluginSceneBoundary>
+    )
     return fullscreen ? node : <AlternateScreen>{node}</AlternateScreen>
   }
 

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { t, getLang, setLang, isLang, writeLangPref, subscribeLang, type I18nKey } from '../i18n.js'
 import { AlternateScreen, Box, Text, useInput, ScrollBox, type ScrollBoxHandle, useTheme, useTerminalSize } from '../ui.js'
+import * as tuiKit from '../ui.js'
 import { POINTER } from '../cc/figures.js'
 import { isMod, isPlainReturnInput, modLabel } from '../utils/modifiers.js'
 import { formatTokens } from '../cc/format.js'
@@ -1320,6 +1321,11 @@ export function Chat({
     // Same for the settings screen: plain letters (s save / d discard) and
     // the field draft editor belong to it alone.
     if (settingsOpen) return
+    // A plugin scene (dsh-tui-scenes) or the trajectory scene owns the whole
+    // screen while open: every key belongs to it. Unguarded, an Esc meant to
+    // CLOSE the scene also reached the chat:cancel branch below whenever a
+    // turn was in flight — closing the view and killing the turn in one key.
+    if (sceneOpen || channel.pluginScene !== undefined) return
     // The questionnaire / approval panel owns the keyboard while one is
     // pending (the panel's own useInput handles ↑/↓/Space/Tab/Enter/Esc;
     // the prompt input is unmounted, so nothing else should see these keys).
@@ -1806,6 +1812,28 @@ export function Chat({
   // Working-activity line (spinner slot): context-pressure prefix shares the
   // StatusLine thresholds (amber ≥ 80, red ≥ 95).
   const activityWarnPct = contextPressurePct(channel.lastUsage, channel.contextWindow)
+
+  // A plugin scene (dsh-tui-scenes) takes the whole terminal the same way
+  // the trajectory scene does, and sits at the TOP of this return chain:
+  // an open() landing while the session browser or the trajectory scene is
+  // up must still take the screen (and the keyboard, via the useInput guard
+  // above), not queue silently behind them. Closing the plugin scene lands
+  // back on whatever screen was up before, so these early returns read as a
+  // stack. The component comes from the registry, so its identity is stable
+  // across renders and its hook state survives re-renders; it receives the
+  // TUI's own React + ui kit because a plugin importing its own React copy
+  // would die on the first hook call under this reconciler.
+  const pluginScene = channel.pluginScene
+  if (pluginScene !== undefined) {
+    const node = React.createElement(pluginScene.component, {
+      React,
+      ui: tuiKit,
+      channel,
+      close: () => channel.closePluginScene(),
+    })
+    return fullscreen ? node : <AlternateScreen>{node}</AlternateScreen>
+  }
+
   // The browser is a screen, not an overlay: it REPLACES the conversation
   // rather than floating above it. Rendering it as an early return (after
   // every hook above has run) is what makes that literal — there is no


### PR DESCRIPTION
## 动机

`/trace`、`/settings` 证明了"整屏页面"形态的价值，但机制是各自硬编码的：Chat.tsx 里的局部 boolean state + early return 整树替换。插件命令的返回通道是纯文本（`runExternalCommand: Promise<string | undefined>`），没有任何"开一个页面"的能力。本 PR 把这个机制通用化为一条插件接缝。

## 方案：照搬 tuiCommandTrees 四件套

- **新服务 `tuiScenes`**（`src/dsh-adapter/scenes.ts` + 根部 shim `src/scenes.ts`）：`register({id, title?, component})`（查重/非法 id 即抛、返回 dispose、dispose 当前打开的场景自动关屏）、`open(id)`（未注册 warn + false）、`close()`、`active`、`subscribe()`
- **exports**：`./scenes` + `./jsx-runtime` 子路径
- **服务行**：`cordis.patch.yml` 与裸组合 `cordis.yml` 双入口挂载；dsh-tui 行 inject 加 `tuiScenes`（entry-level 排序与重载重绑；code-level 保持 `ctx.get` 软消费，缺行降级为永不打开——#183 原则），profile 启动缺服务时 plugin.ts 给出 skew 警告
- **channel 镜像**：`pluginScene`/`openPluginScene`/`closePluginScene`，订阅 runtime 走既有 version-bump 管线，退订挂 `releaseContributions`
- **Chat 渲染**：插件场景 early return 位于栈顶（settings/浏览器/trace 之上），打开即接管屏幕与键盘，`close()` 落回原屏幕；inline 模式自动包 `<AlternateScreen>`

打开链路不动命令层：插件自己经 dsh-commands 注册 `/xxx`，handler 里 `ctx.tuiScenes.open(id)` + 静默 `success`，`command/run`/`command/done` 日志对照记。

## React 契约（插件作者必读，已写进 docs）

宿主 reconciler 是 React 19：hook 必须用 props 注入的 `React`（双副本 dispatcher 必炸）；元素必须过宿主 runtime（19 的 transitional element vs 旧版 `react.element`）——JSX 作者用 `jsxImportSource: '@deepseek-harness-tui/dsh-tui'`（`./jsx-runtime` 子路径原样 re-export 宿主 react/jsx-runtime），或直接 `React.createElement`。

## 顺手修复

Chat 的 `useInput` 此前只门控 `browserOpen` 没门控 `sceneOpen`：trace 打开时按 Esc，关场景的同时若 agent 正在工作会误触 `chat:cancel` 杀 turn。现在 `sceneOpen || pluginScene` 一并门控。

## 文档

`docs/plugins.md` / `plugins.en.md` 新增「接缝八：插件全屏场景」——三步接入完整示例（注册场景/注册命令/场景组件）、React 契约、运行时语义（屏幕栈、inline/fullscreen、异步 open、降级、生命周期）、场景红线。

## 验证

- `tsc` 零错误；`smoke` 新增场景注册表语义断言（id 归一化/查重/非法拒绝/open-close-dispose 精确通知次数）+ `./jsx-runtime` 产物的 transitional element 断言
- `verify:build` 七项全绿（patch 快照已重生成：12 inserts）、`verify:package` OK（843 文件 19 入口）、`verify-cordis-approval` / `verify-workspace-attachment` OK
- 已变基到 `6df1b2b`（#238 settings 屏之后），与其 `tuiSettingsSections` 接缝共存无冲突