### PR TITLE
feat(diff): 宽屏双栏对照 diff 视图

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - run: node --import tsx/esm scripts/verify-askpanel-layout.tsx
 
       - run: node --import tsx/esm scripts/repro-toolcards.tsx
+      - run: node --import tsx/esm scripts/repro-diff-split.tsx
 
       # 滚动/pill/内联模式回归：新消息 pill 计数递减、Ctrl+C 交互、
       # 内联 scrollback 第三方终端适配。曾因 mock channel 缺新字段而

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "cli-boxes": "^3.0.0 || ^4.0.0",
     "cli-highlight": "^2.1.11",
     "code-excerpt": "^3.0.0 || ^4.0.0",
+    "diff": "^8.0.4",
     "dsh-working-activity": "^0.2.6",
     "emoji-regex": "^10.0.0",
     "figures": "^6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       code-excerpt:
         specifier: ^3.0.0 || ^4.0.0
         version: 4.0.0
+      diff:
+        specifier: ^8.0.4
+        version: 8.0.4
       dsh-working-activity:
         specifier: ^0.2.6
         version: 0.2.6(5e23b040c590f56902f12f1002418d07)
@@ -1966,6 +1969,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
 
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
@@ -4377,6 +4384,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@8.0.4: {}
 
   diff@9.0.0: {}
 

--- a/scripts/repro-diff-split.tsx
+++ b/scripts/repro-diff-split.tsx
@@ -1,0 +1,123 @@
+/**
+ * Split-diff scenarios (side-by-side two-pane view):
+ * 1. 120 cols: an Edit card renders two aligned panes separated by │ — no
+ *    unified `- `/`+ ` rows; change pairs share one screen row; removed
+ *    rows leave the right pane blank
+ * 2. changed rows carry the dimmed row backgrounds; changed words use the
+ *    bright word palette
+ * 3. 70 cols (below SPLIT_DIFF_MIN_COLS): the card falls back to the
+ *    unified view
+ * 4. a new-file Write (oldText null) fills only the right pane
+ *
+ * Exits non-zero on the first failed assertion (CI convention).
+ */
+process.env.FORCE_COLOR = '3'
+// This script asserts English UI copy; pin the language before any
+// module import resolves the startup lang (env > persisted > locale).
+process.env.DSH_TUI_LANG = 'en'
+
+const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/messages/AssistantToolUseMessage.js'),
+])
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failures = 0
+const check = (name: string, ok: boolean, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${ok || extra === '' ? '' : `  (${extra})`}`)
+  if (!ok) failures++
+}
+
+const editTool = {
+  callId: 'c1',
+  name: 'edit',
+  argsText: '{"file_path":"/tmp/utils.py"}',
+  status: 'ok',
+  startedAt: 0,
+  durationMs: 12,
+  callView: {
+    card: 'diff',
+    title: 'Edit /tmp/utils.py',
+    diffs: [{
+      path: '/tmp/utils.py',
+      oldText: 'def shout(text):\n    return text.upper()\n# tail',
+      newText: 'def shout(text, mark="!"):\n    return text.upper() + mark\n# tail',
+    }],
+  },
+}
+
+/** Boot one headless terminal at the given width and render the card. */
+async function renderAt(cols, tool) {
+  const rows = 30
+  const term = new XTerm({ cols, rows, scrollback: 0, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk, _e, cb) { term.write(String(chunk), cb) }
+  }
+  const app = await render(
+    React.createElement(AssistantToolUseMessage, { tool, addMargin: false, verbose: false }),
+    { stdout: new FakeStdout(), debug: true, exitOnCtrlC: false },
+  )
+  await sleep(300)
+  const buf = term.buffer.active
+  const lines = []
+  for (let y = 0; y < rows; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
+  const bgAt = (x, y) => (buf.getLine(y)?.getCell(x)?.getBgColor() ?? 0) & 0xffffff
+  const fgAt = (x, y) => (buf.getLine(y)?.getCell(x)?.getFgColor() ?? 0) & 0xffffff
+  app.unmount()
+  return { lines, bgAt, fgAt, screen: () => lines.join('\n') }
+}
+
+// ---- 1&2. Wide terminal: two panes, aligned rows, word highlight
+{
+  const { lines, screen, bgAt, fgAt } = await renderAt(120, editTool)
+  const s = screen()
+  check('宽屏不出现统一式 - /+ 行', !s.includes('- def shout') && !s.includes('+ def shout'))
+  const pairRow = lines.findIndex(line => line.includes('def shout(text):') && line.includes('def shout(text, mark="!"):'))
+  check('改动对在同行双栏呈现', pairRow >= 0)
+  check('双栏以 │ 分隔', pairRow >= 0 && lines[pairRow]!.includes('│'))
+  const ctxRow = lines.findIndex(line => line.includes('# tail'))
+  check('上下文行双栏都有内容', ctxRow >= 0 && lines[ctxRow]!.split('│').length === 2)
+  if (pairRow >= 0) {
+    const dividerX = lines[pairRow]!.indexOf('│')
+    check('左栏（old）改动行底色为暗红系', bgAt(6, pairRow) === 0x362b2c, `bg=${bgAt(6, pairRow).toString(16)}`)
+    check('右栏（new）改动行底色为暗绿系', bgAt(dividerX + 2, pairRow) === 0x2b352c, `bg=${bgAt(dividerX + 2, pairRow).toString(16)}`)
+    const markX = lines[pairRow]!.indexOf('mark="!"')
+    check('右栏改动词组使用亮绿词色', markX > 0 && fgAt(markX, pairRow) === 0x57956b, `fg=${fgAt(Math.max(markX, 0), pairRow).toString(16)}`)
+  }
+}
+
+// ---- 3. Narrow terminal: unified fallback
+{
+  const { screen } = await renderAt(70, editTool)
+  const s = screen()
+  check('窄屏回退统一式 - 行', s.includes('- def shout(text):'))
+  check('窄屏回退统一式 + 行', s.includes('+ def shout(text, mark="!"):'))
+  check('窄屏不出现 │ 分隔', !s.includes('│'))
+}
+
+// ---- 4. New file: only the right pane fills
+{
+  const writeTool = {
+    ...editTool,
+    callId: 'c2',
+    name: 'write',
+    callView: {
+      card: 'diff',
+      title: 'Write /tmp/new.py',
+      diffs: [{ path: '/tmp/new.py', oldText: null, newText: 'hello\nworld' }],
+    },
+  }
+  const { lines } = await renderAt(120, writeTool)
+  const helloRow = lines.findIndex(line => line.includes('hello'))
+  check('新建文件的行落在右栏', helloRow >= 0 && lines[helloRow]!.includes('│') && lines[helloRow]!.indexOf('hello') > lines[helloRow]!.indexOf('│'))
+  check('新建文件左栏留空', helloRow >= 0 && lines[helloRow]!.slice(5, lines[helloRow]!.indexOf('│')).trim() !== 'hello')
+}
+
+console.log(failures === 0 ? 'repro-diff-split: all assertions passed' : `repro-diff-split: ${failures} FAILED`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/components/SplitDiffView.tsx
+++ b/src/components/SplitDiffView.tsx
@@ -1,0 +1,228 @@
+import React from 'react'
+import { Box, Text } from '../ui.js'
+import { stringWidth } from '../ink/stringWidth.js'
+import * as JsDiff from 'diff'
+import type { ToolFileDiff } from '../dsh-adapter/channel.js'
+
+/**
+ * Side-by-side (two-pane) diff view for Edit/Write tool cards.
+ *
+ * The structured ToolFileDiff hunks (oldText/newText) are re-aligned with
+ * jsdiff: unchanged lines render on both panes, del-only rows fill the left
+ * (old) pane, add-only rows fill the right (new) pane, and a del+add pair
+ * adjacent in the diff becomes a changed-line pair with word-level
+ * highlights. Row backgrounds use the dimmed palette, changed words the
+ * bright word palette — same six tokens the unified view already consumes.
+ *
+ * One source line = one terminal row (truncate, never wrap): the two panes
+ * must stay row-aligned, and a wrapped long line would tear the pairing.
+ * Tabs become 3 spaces so column math holds.
+ */
+
+/** One aligned row across the two panes. */
+interface DiffRow {
+  /** Left (old) pane content; undefined = blank counterpart. */
+  readonly old?: { readonly lineNo: number; readonly segments: readonly Segment[] }
+  /** Right (new) pane content; undefined = blank counterpart. */
+  readonly new?: { readonly lineNo: number; readonly segments: readonly Segment[] }
+  /** Row kind drives background tone. */
+  readonly kind: 'context' | 'del' | 'add' | 'change'
+}
+
+/** One styled run inside a pane line (word-diff output). */
+interface Segment {
+  readonly text: string
+  readonly changed: boolean
+}
+
+/** Replace tabs so width math and alignment hold (pi convention). */
+const expandTabs = (text: string): string => text.replaceAll('\t', '   ')
+
+/** Strip the shared leading whitespace before word-diffing: otherwise the
+ *  whole indent reads as one changed blob (pi's renderIntraLineDiff trick). */
+function wordSegments(oldLine: string, newLine: string): { old: Segment[]; new: Segment[] } {
+  const oldIndent = /^\s*/.exec(oldLine)?.[0] ?? ''
+  const newIndent = /^\s*/.exec(newLine)?.[0] ?? ''
+  const sharedIndent = oldIndent === newIndent ? oldIndent : ''
+  const parts = JsDiff.diffWords(oldLine.slice(sharedIndent.length), newLine.slice(sharedIndent.length))
+  const oldSegments: Segment[] = sharedIndent === '' ? [] : [{ text: sharedIndent, changed: false }]
+  const newSegments: Segment[] = sharedIndent === '' ? [] : [{ text: sharedIndent, changed: false }]
+  for (const part of parts) {
+    if (part.added) newSegments.push({ text: part.value, changed: true })
+    else if (part.removed) oldSegments.push({ text: part.value, changed: true })
+    else {
+      oldSegments.push({ text: part.value, changed: false })
+      newSegments.push({ text: part.value, changed: false })
+    }
+  }
+  return { old: oldSegments, new: newSegments }
+}
+
+const plainSegments = (line: string): readonly Segment[] => [{ text: line, changed: false }]
+
+/**
+ * Align one file's hunks into paired rows. jsdiff emits ordered parts;
+ * a removed part immediately followed by an added part is a changed region
+ * whose lines pair index-for-index (pi's generateDiffString convention).
+ */
+function alignFileDiff(oldText: string | null, newText: string): DiffRow[] {
+  const rows: DiffRow[] = []
+  let oldLineNo = 1
+  let newLineNo = 1
+  const parts = JsDiff.diffLines((oldText ?? '').replaceAll('\t', '   '), expandTabs(newText))
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]!
+    // diffLines values end with a trailing newline except possibly the last.
+    const lines = part.value.replace(/\n$/, '').split('\n')
+    if (!part.added && !part.removed) {
+      for (const line of lines) {
+        rows.push({
+          kind: 'context',
+          old: { lineNo: oldLineNo++, segments: plainSegments(line) },
+          new: { lineNo: newLineNo++, segments: plainSegments(line) },
+        })
+      }
+      continue
+    }
+    if (part.removed) {
+      const addedPart = parts[i + 1]?.added === true ? parts[i + 1] : undefined
+      const addedLines = addedPart === undefined ? [] : addedPart.value.replace(/\n$/, '').split('\n')
+      const pairCount = Math.min(lines.length, addedLines.length)
+      for (let p = 0; p < pairCount; p++) {
+        const segments = wordSegments(lines[p]!, addedLines[p]!)
+        rows.push({
+          kind: 'change',
+          old: { lineNo: oldLineNo++, segments: segments.old },
+          new: { lineNo: newLineNo++, segments: segments.new },
+        })
+      }
+      for (let d = pairCount; d < lines.length; d++) {
+        rows.push({ kind: 'del', old: { lineNo: oldLineNo++, segments: plainSegments(lines[d]!) } })
+      }
+      for (let a = pairCount; a < addedLines.length; a++) {
+        rows.push({ kind: 'add', new: { lineNo: newLineNo++, segments: plainSegments(addedLines[a]!) } })
+      }
+      if (addedPart !== undefined) i++
+      continue
+    }
+    // add-only part (no adjacent removed): all rows land on the right pane.
+    for (const line of lines) {
+      rows.push({ kind: 'add', new: { lineNo: newLineNo++, segments: plainSegments(line) } })
+    }
+  }
+  return rows
+}
+
+function PaneLine({
+  side,
+  kind,
+  width,
+  lineNoWidth,
+  tone,
+  padLeft = false,
+}: {
+  readonly side: { readonly lineNo: number; readonly segments: readonly Segment[] } | undefined
+  readonly kind: DiffRow['kind']
+  readonly width: number
+  readonly lineNoWidth: number
+  readonly tone: 'old' | 'new'
+  /** Right pane: one space of air between the divider and the line number. */
+  readonly padLeft?: boolean
+}): React.ReactNode {
+  const backgroundColor =
+    kind === 'context'
+      ? undefined
+      : tone === 'old'
+        ? 'diffRemovedDimmed'
+        : 'diffAddedDimmed'
+  const wordColor = tone === 'old' ? 'diffRemovedWord' : 'diffAddedWord'
+  const lineNoText = side === undefined ? '' : String(side.lineNo).padStart(lineNoWidth)
+  const prefix = padLeft ? ` ${lineNoText}` : lineNoText
+  return (
+    <Box width={width} flexShrink={0} backgroundColor={backgroundColor}>
+      <Text dimColor backgroundColor={backgroundColor}>{`${prefix} `}</Text>
+      {side === undefined ? (
+        <Text backgroundColor={backgroundColor}> </Text>
+      ) : (
+        <Text wrap="truncate" backgroundColor={backgroundColor}>
+          {side.segments.map((segment, index) =>
+            segment.changed ? (
+              <Text key={index} color={wordColor} bold backgroundColor={backgroundColor}>
+                {segment.text}
+              </Text>
+            ) : (
+              <Text key={index} backgroundColor={backgroundColor}>
+                {segment.text}
+              </Text>
+            ),
+          )}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+export function SplitDiffView({
+  diffs,
+  width,
+  maxRows,
+  verbose,
+}: {
+  readonly diffs: readonly ToolFileDiff[]
+  /** Content width available to the whole two-pane block (divider included). */
+  readonly width: number
+  /** Row budget when not verbose; overflow folds into one hint row. */
+  readonly maxRows: number
+  readonly verbose: boolean
+}): React.ReactNode {
+  // Assemble rows across files; a `⋯` separator row keeps scattered hunks
+  // of one file apart (unified view's convention), a path row separates
+  // files when several changed at once.
+  const rows: (DiffRow | { readonly separator: string })[] = []
+  let prevPath: string | undefined
+  for (const diff of diffs) {
+    if (diffs.length > 1) {
+      if (diff.path !== prevPath) rows.push({ separator: diff.path })
+      else rows.push({ separator: '⋯' })
+    }
+    prevPath = diff.path
+    rows.push(...alignFileDiff(diff.oldText, diff.newText))
+  }
+
+  const totalRows = rows.length
+  const capped = verbose || totalRows <= maxRows || totalRows - maxRows === 1
+  const visible = capped ? rows : rows.slice(0, maxRows)
+  const hidden = totalRows - visible.length
+
+  const maxLineNo = visible.reduce(
+    (acc, row) => ('separator' in row ? acc : Math.max(acc, row.old?.lineNo ?? 0, row.new?.lineNo ?? 0)),
+    1,
+  )
+  const lineNoWidth = String(maxLineNo).length
+  const paneWidth = Math.max(20, Math.floor((width - 1) / 2))
+
+  return (
+    <Box flexDirection="column" width={paneWidth * 2 + 1}>
+      {visible.map((row, index) =>
+        'separator' in row ? (
+          <Box key={index} width={paneWidth * 2 + 1}>
+            <Text dimColor wrap="truncate">
+              {row.separator === '⋯' ? '⋯' : `  ${row.separator}`}
+            </Text>
+          </Box>
+        ) : (
+          <Box key={index} flexDirection="row">
+            <PaneLine side={row.old} kind={row.kind === 'add' ? 'context' : row.kind} tone="old" width={paneWidth} lineNoWidth={lineNoWidth} />
+            <Box width={1} flexShrink={0}>
+              <Text dimColor>│</Text>
+            </Box>
+            <PaneLine side={row.new} kind={row.kind === 'del' ? 'context' : row.kind} tone="new" width={paneWidth} lineNoWidth={lineNoWidth} padLeft />
+          </Box>
+        ),
+      )}
+      {hidden > 0 && (
+        <Text dimColor>{`… +${hidden} lines (ctrl+o to expand)`}</Text>
+      )}
+    </Box>
+  )
+}

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { Box, Text } from '../../ui.js'
+import { Box, Text, useTerminalSize } from '../../ui.js'
 import { stringWidth } from '../../ink/stringWidth.js'
 import { useAnimationFrame } from '../../ink/hooks/use-animation-frame.js'
 import type { ToolCallView, ToolFileDiff, ToolResultView, ToolRow } from '../../dsh-adapter/channel.js'
 import { ToolUseLoader } from '../ToolUseLoader.js'
+import { SplitDiffView } from '../SplitDiffView.js'
 import { formatDuration } from '../../cc/format.js'
 
 type Props = {
@@ -64,6 +65,9 @@ const TEXT_BODY_MAX_LINES = 3
 /** Diff bodies cap at the upstream chat row's 8 (dsh-client-ui-tool's
  *  CHAT_DIFF_MAX_LINES) — denser information than log output. */
 const DIFF_BODY_MAX_LINES = 8
+/** Minimum terminal width for the two-pane diff: below this the panes
+ *  would squeeze under ~50 columns each and the unified view reads better. */
+const SPLIT_DIFF_MIN_COLS = 110
 
 const GUTTER_FIRST = '  ⎿  '
 const GUTTER_REST = '     '
@@ -263,10 +267,15 @@ export function AssistantToolUseMessage({
 
   // Body lines: the structured view first, raw result text as the fallback
   // (tools without a presenter, or a folded row awaiting loadOlder).
+  // Wide terminals render diffs as a two-pane side-by-side instead: one
+  // source line per terminal row (truncate) keeps the panes row-aligned,
+  // which the flat add/del line model cannot express.
+  const { columns } = useTerminalSize()
+  const useSplitDiff = !isError && view?.card === 'diff' && columns >= SPLIT_DIFF_MIN_COLS
   let body: BodyLine[] = []
   if (isError) {
     if (tool.errorText) body = [{ text: tool.errorText, tone: 'error' }]
-  } else {
+  } else if (!useSplitDiff) {
     if (view !== undefined) body = viewLines(view)
     if (body.length === 0 && result) {
       body = result.trimEnd().split('\n').map(dim)
@@ -311,32 +320,54 @@ export function AssistantToolUseMessage({
             </Box>
           )}
         </Box>
-        {rendered.map((line, index) => (
-          <Box key={index} flexDirection="row">
+        {useSplitDiff && view?.card === 'diff' ? (
+          <Box flexDirection="row">
             <Box width={5} flexShrink={0}>
-              <Text dimColor>{index === 0 ? GUTTER_FIRST : GUTTER_REST}</Text>
+              <Text dimColor>{GUTTER_FIRST}</Text>
             </Box>
-            <Box flexGrow={1}>
-              <Text
-                color={
-                  line.tone === 'add'
-                    ? 'diffAddedWord'
-                    : line.tone === 'del'
-                      ? 'diffRemovedWord'
-                      : line.tone === 'error'
-                        ? 'error'
-                        : line.tone === 'hint'
-                          ? 'subtle'
-                          : undefined
-                }
-                dimColor={line.tone === 'dim'}
-                wrap="wrap"
-              >
-                {line.text === '' ? ' ' : line.text}
-              </Text>
-            </Box>
+            <SplitDiffView
+              diffs={view.diffs}
+              width={columns - 6}
+              maxRows={DIFF_BODY_MAX_LINES}
+              verbose={verbose}
+            />
           </Box>
-        ))}
+        ) : (
+          rendered.map((line, index) => (
+            <Box key={index} flexDirection="row">
+              <Box width={5} flexShrink={0}>
+                <Text dimColor>{index === 0 ? GUTTER_FIRST : GUTTER_REST}</Text>
+              </Box>
+              <Box flexGrow={1}>
+                <Text
+                  color={
+                    line.tone === 'add'
+                      ? 'diffAddedWord'
+                      : line.tone === 'del'
+                        ? 'diffRemovedWord'
+                        : line.tone === 'error'
+                          ? 'error'
+                          : line.tone === 'hint'
+                            ? 'subtle'
+                            : undefined
+                  }
+                  dimColor={line.tone === 'dim'}
+                  wrap="wrap"
+                >
+                  {line.text === '' ? ' ' : line.text}
+                </Text>
+              </Box>
+            </Box>
+          ))
+        )}
+        {useSplitDiff && footnote !== undefined && (
+          <Box flexDirection="row">
+            <Box width={5} flexShrink={0}>
+              <Text dimColor>{GUTTER_REST}</Text>
+            </Box>
+            <Text color="subtle">{footnote}</Text>
+          </Box>
+        )}
       </Box>
     </Box>
   )


### PR DESCRIPTION
## 效果

终端 ≥110 列时，Edit/Write 工具卡的 diff 从统一式（红减绿增线性流）升级为**双栏对照视图**：

- jsdiff 对每个 hunk 重新对齐：上下文 / 纯删 / 纯增 / 改动对
- 改动对同行呈现，词级高亮用亮色 word 调色板 + 整行暗色背景（主题六色原样复用）
- 一个源行 = 一个终端行（truncate 不换行），双栏永不错位
- 新建文件只有右栏有内容；窄屏（<110 列）自动回退统一式

## 实现

- 新增 `src/components/SplitDiffView.tsx`；`AssistantToolUseMessage` 按宽度选视图
- 依赖只加了 jsdiff `^8.0.4`（与 pi 同款）
- tab 展开为 3 空格、剥离公共前导空白再做词级 diff（缩进不会整片高亮）

## 验证

`scripts/repro-diff-split.tsx`（12 断言：双栏对齐、│ 分隔、行底色、词色、窄屏回退、新建单栏填充），已挂 CI；repro-toolcards 24 断言无回归。