### PR TITLE
feat(diff): 语法高亮 + 工具卡衬底（全部主题可覆盖）

### DIFF
--- a/docs/themes.en.md
+++ b/docs/themes.en.md
@@ -82,6 +82,17 @@ Fields:
 When the file declares `name`, its filename remains a loading alias. See the
 `Theme` type in [`src/theme.ts`](../src/theme.ts) for every semantic key.
 
+Common override groups:
+
+| Group | Keys |
+| --- | --- |
+| Tool card surfaces (two depths) | `toolCardBackground`, `toolCardBackgroundDim` |
+| Diff rows | `diffAdded`, `diffRemoved`, `diffAddedDimmed`, `diffRemovedDimmed`, `diffAddedWord`, `diffRemovedWord` |
+| Diff syntax highlighting | `syntaxKeyword`, `syntaxString`, `syntaxComment`, `syntaxNumber`, `syntaxFunction`, `syntaxType`, `syntaxVariable`, `syntaxOperator`, `syntaxPunctuation`, `syntaxConstant` |
+
+Diff semantics outrank syntax colors: changed words always render in
+`diffAddedWord` / `diffRemovedWord`; syntax colors apply to unchanged text only.
+
 ## Color formats
 
 Accepted forms:

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -79,6 +79,17 @@ DSH_TUI_THEME
 如果文件声明了 `name`，文件名仍可作为加载别名。完整语义键见
 [`src/theme.ts`](../src/theme.ts) 中的 `Theme` 类型。
 
+常用可覆盖键分组：
+
+| 分组 | 键 |
+| --- | --- |
+| 工具卡衬底（深浅两档） | `toolCardBackground`、`toolCardBackgroundDim` |
+| diff 行色 | `diffAdded`、`diffRemoved`、`diffAddedDimmed`、`diffRemovedDimmed`、`diffAddedWord`、`diffRemovedWord` |
+| diff 语法高亮 | `syntaxKeyword`、`syntaxString`、`syntaxComment`、`syntaxNumber`、`syntaxFunction`、`syntaxType`、`syntaxVariable`、`syntaxOperator`、`syntaxPunctuation`、`syntaxConstant` |
+
+diff 语义优先于语法色：改动词组总是使用 `diffAddedWord` / `diffRemovedWord`，
+语法色只作用于未变更的文本。
+
 ## 颜色格式
 
 支持：

--- a/scripts/repro-diff-split.tsx
+++ b/scripts/repro-diff-split.tsx
@@ -63,7 +63,9 @@ async function renderAt(cols, tool) {
     React.createElement(AssistantToolUseMessage, { tool, addMargin: false, verbose: false }),
     { stdout: new FakeStdout(), debug: true, exitOnCtrlC: false },
   )
-  await sleep(300)
+  // cli-highlight loads lazily on first use; give it room to land so the
+  // syntax-color assertions see the settled frame.
+  await sleep(900)
   const buf = term.buffer.active
   const lines = []
   for (let y = 0; y < rows; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
@@ -89,7 +91,14 @@ async function renderAt(cols, tool) {
     check('右栏（new）改动行底色为暗绿系', bgAt(dividerX + 2, pairRow) === 0x2b352c, `bg=${bgAt(dividerX + 2, pairRow).toString(16)}`)
     const markX = lines[pairRow]!.indexOf('mark="!"')
     check('右栏改动词组使用亮绿词色', markX > 0 && fgAt(markX, pairRow) === 0x57956b, `fg=${fgAt(Math.max(markX, 0), pairRow).toString(16)}`)
+    const defX = lines[pairRow]!.indexOf('def')
+    check('关键字使用语法色（syntaxKeyword）', defX > 0 && fgAt(defX, pairRow) === 0x8fa8e8, `fg=${fgAt(Math.max(defX, 0), pairRow).toString(16)}`)
   }
+  if (ctxRow >= 0) {
+    check('上下文行底色为浅档卡片色', bgAt(6, ctxRow) === 0x272c35, `bg=${bgAt(6, ctxRow).toString(16)}`)
+  }
+  const headerRow = lines.findIndex(line => line.includes('Edit /tmp/utils.py'))
+  check('工具卡头部带深档衬底', headerRow >= 0 && bgAt(2, headerRow) === 0x1e2229, `bg=${bgAt(Math.max(headerRow, 0), 2).toString(16)}`)
 }
 
 // ---- 3. Narrow terminal: unified fallback

--- a/src/components/SplitDiffView.tsx
+++ b/src/components/SplitDiffView.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { Box, Text } from '../ui.js'
-import { stringWidth } from '../ink/stringWidth.js'
 import * as JsDiff from 'diff'
+import chalk from 'chalk'
+import { extname } from 'node:path'
 import type { ToolFileDiff } from '../dsh-adapter/channel.js'
+import type { Color } from '../ink/styles.js'
+import { getCliHighlightPromise, type CliHighlight } from '../cc/cliHighlight.js'
+import { getTheme } from '../theme.js'
+import { useTheme } from './design-system/ThemeProvider.js'
 
 /**
  * Side-by-side (two-pane) diff view for Edit/Write tool cards.
@@ -14,29 +19,170 @@ import type { ToolFileDiff } from '../dsh-adapter/channel.js'
  * highlights. Row backgrounds use the dimmed palette, changed words the
  * bright word palette — same six tokens the unified view already consumes.
  *
+ * On top of the diff semantics, code is syntax-highlighted with
+ * cli-highlight (language from the file extension): syntax colors come from
+ * the theme's syntax* tokens, so user themes (`~/.dsh-tui/themes/*.json`)
+ * restyle both the diff furniture and the code. Changed words always win
+ * over syntax colors — diff semantics outrank decoration.
+ *
  * One source line = one terminal row (truncate, never wrap): the two panes
  * must stay row-aligned, and a wrapped long line would tear the pairing.
  * Tabs become 3 spaces so column math holds.
  */
 
-/** One aligned row across the two panes. */
-interface DiffRow {
-  /** Left (old) pane content; undefined = blank counterpart. */
-  readonly old?: { readonly lineNo: number; readonly segments: readonly Segment[] }
-  /** Right (new) pane content; undefined = blank counterpart. */
-  readonly new?: { readonly lineNo: number; readonly segments: readonly Segment[] }
-  /** Row kind drives background tone. */
-  readonly kind: 'context' | 'del' | 'add' | 'change'
-}
-
-/** One styled run inside a pane line (word-diff output). */
+/** One styled run inside a pane line. */
 interface Segment {
   readonly text: string
+  /** Word-level diff change: renders in the bright word palette, bold. */
   readonly changed: boolean
+  /** Syntax color (raw theme value); undefined = default text color. */
+  readonly color?: string
+}
+
+/** One aligned row across the two panes. */
+interface DiffRow {
+  readonly old?: { readonly lineNo: number; readonly segments: readonly Segment[] }
+  readonly new?: { readonly lineNo: number; readonly segments: readonly Segment[] }
+  readonly kind: 'context' | 'del' | 'add' | 'change'
 }
 
 /** Replace tabs so width math and alignment hold (pi convention). */
 const expandTabs = (text: string): string => text.replaceAll('\t', '   ')
+
+// --- syntax highlighting ----------------------------------------------------
+
+/** highlight.js token classes → theme syntax tokens. */
+const SYNTAX_CLASS_TO_TOKEN: Record<string, string> = {
+  keyword: 'syntaxKeyword',
+  built_in: 'syntaxKeyword',
+  literal: 'syntaxKeyword',
+  string: 'syntaxString',
+  subst: 'syntaxString',
+  quote: 'syntaxString',
+  comment: 'syntaxComment',
+  number: 'syntaxNumber',
+  title: 'syntaxFunction',
+  'title.function_': 'syntaxFunction',
+  'title.class_': 'syntaxType',
+  type: 'syntaxType',
+  class: 'syntaxType',
+  attr: 'syntaxVariable',
+  attribute: 'syntaxVariable',
+  variable: 'syntaxVariable',
+  'template-variable': 'syntaxVariable',
+  operator: 'syntaxOperator',
+  punctuation: 'syntaxPunctuation',
+  symbol: 'syntaxConstant',
+  regexp: 'syntaxConstant',
+}
+
+/** chalk style for one raw theme value (#hex / rgb(r,g,b) / ansi:name). */
+function chalkFromToken(token: string): (text: string) => string {
+  let match = /^#[0-9a-fA-F]{6}$/.exec(token)
+  if (match !== null) return chalk.hex(token)
+  match = /^rgb\((\d+),(\d+),(\d+)\)$/.exec(token)
+  if (match !== null) return chalk.rgb(Number(match[1]), Number(match[2]), Number(match[3]))
+  match = /^ansi:(\w+)$/.exec(token)
+  if (match !== null) {
+    const name = match[1] === 'blackBright' ? 'gray' : match[1]
+    const style = (chalk as unknown as Record<string, ((text: string) => string) | undefined>)[name]
+    if (style !== undefined) return style
+  }
+  return (text: string) => text
+}
+
+/** ANSI 16-color SGR codes → rgb() strings (the dark-ansi palette path). */
+const ANSI16: Record<number, string> = {
+  30: 'rgb(0,0,0)', 31: 'rgb(128,0,0)', 32: 'rgb(0,128,0)', 33: 'rgb(128,128,0)',
+  34: 'rgb(0,0,128)', 35: 'rgb(128,0,128)', 36: 'rgb(0,128,128)', 37: 'rgb(192,192,192)',
+  90: 'rgb(128,128,128)', 91: 'rgb(255,0,0)', 92: 'rgb(0,255,0)', 93: 'rgb(255,255,0)',
+  94: 'rgb(0,0,255)', 95: 'rgb(255,0,255)', 96: 'rgb(0,255,255)', 97: 'rgb(255,255,255)',
+}
+
+/** Parse a cli-highlight ANSI line into colored runs (truecolor + 16-color). */
+function parseAnsiRuns(line: string): { text: string; color?: string }[] {
+  const runs: { text: string; color?: string }[] = []
+  let color: string | undefined
+  let rest = line
+  // eslint-disable-next-line no-control-regex -- parsing SGR is the point
+  const sgr = /\[([0-9;]+)m/
+  while (rest.length > 0) {
+    const match = sgr.exec(rest)
+    const text = match === null ? rest : rest.slice(0, match.index)
+    if (text !== '') runs.push(color === undefined ? { text } : { text, color })
+    if (match === null) break
+    const codes = match[1]!.split(';').map(Number)
+    if (codes.includes(0) || codes.includes(39)) color = undefined
+    else if (codes[0] === 38 && codes[1] === 2 && codes.length >= 5) {
+      color = `rgb(${codes[2]},${codes[3]},${codes[4]})`
+    } else if (codes.length === 1 && ANSI16[codes[0]!] !== undefined) {
+      color = ANSI16[codes[0]!]
+    }
+    rest = rest.slice(match.index + match[0].length)
+  }
+  return runs
+}
+
+/** Small per-language memo: syntax runs for one source line. */
+const syntaxCache = new Map<string, readonly { text: string; color?: string }[]>()
+const SYNTAX_CACHE_MAX = 500
+
+function syntaxRuns(
+  text: string,
+  language: string | undefined,
+  hl: CliHighlight | null,
+  chTheme: Record<string, (text: string) => string> | undefined,
+): readonly { text: string; color?: string }[] | undefined {
+  if (hl === null || chTheme === undefined || language === undefined) return undefined
+  if (!hl.supportsLanguage(language)) return undefined
+  const key = `${language}${text}`
+  const cached = syntaxCache.get(key)
+  if (cached !== undefined) return cached
+  let runs: readonly { text: string; color?: string }[]
+  try {
+    runs = parseAnsiRuns(hl.highlight(text, { language, theme: chTheme }))
+  } catch {
+    runs = [{ text }]
+  }
+  if (syntaxCache.size >= SYNTAX_CACHE_MAX) syntaxCache.clear()
+  syntaxCache.set(key, runs)
+  return runs
+}
+
+/**
+ * Merge syntax runs with word-diff change flags over the same string: both
+ * partition it, so an offset sweep yields runs carrying a syntax color AND
+ * a changed flag. The render layer lets `changed` override the color.
+ */
+function mergeRuns(
+  syntax: readonly { text: string; color?: string }[],
+  words: readonly Segment[],
+): Segment[] {
+  const out: Segment[] = []
+  let si = 0
+  let wi = 0
+  let sOff = 0
+  let wOff = 0
+  while (si < syntax.length && wi < words.length) {
+    const s = syntax[si]!
+    const w = words[wi]!
+    const sLen = s.text.length - sOff
+    const wLen = w.text.length - wOff
+    const take = Math.min(sLen, wLen)
+    out.push({
+      text: w.text.slice(wOff, wOff + take),
+      changed: w.changed,
+      color: w.changed ? undefined : s.color,
+    })
+    sOff += take
+    wOff += take
+    if (sOff >= s.text.length) { si++; sOff = 0 }
+    if (wOff >= w.text.length) { wi++; wOff = 0 }
+  }
+  return out
+}
+
+// --- word-level diff --------------------------------------------------------
 
 /** Strip the shared leading whitespace before word-diffing: otherwise the
  *  whole indent reads as one changed blob (pi's renderIntraLineDiff trick). */
@@ -60,26 +206,42 @@ function wordSegments(oldLine: string, newLine: string): { old: Segment[]; new: 
 
 const plainSegments = (line: string): readonly Segment[] => [{ text: line, changed: false }]
 
-/**
- * Align one file's hunks into paired rows. jsdiff emits ordered parts;
- * a removed part immediately followed by an added part is a changed region
- * whose lines pair index-for-index (pi's generateDiffString convention).
- */
-function alignFileDiff(oldText: string | null, newText: string): DiffRow[] {
+// --- hunk alignment ---------------------------------------------------------
+
+/** Segments for one line: syntax runs merged over word flags when a
+ *  highlighter is available; the word/plain segmentation otherwise. */
+function styleLine(
+  line: string,
+  words: readonly Segment[],
+  language: string | undefined,
+  hl: CliHighlight | null,
+  chTheme: Record<string, (text: string) => string> | undefined,
+): readonly Segment[] {
+  const syntax = syntaxRuns(line, language, hl, chTheme)
+  if (syntax === undefined) return words
+  return mergeRuns(syntax, words)
+}
+
+function alignFileDiff(
+  oldText: string | null,
+  newText: string,
+  language: string | undefined,
+  hl: CliHighlight | null,
+  chTheme: Record<string, (text: string) => string> | undefined,
+): DiffRow[] {
   const rows: DiffRow[] = []
   let oldLineNo = 1
   let newLineNo = 1
-  const parts = JsDiff.diffLines((oldText ?? '').replaceAll('\t', '   '), expandTabs(newText))
+  const parts = JsDiff.diffLines(expandTabs(oldText ?? ''), expandTabs(newText))
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]!
-    // diffLines values end with a trailing newline except possibly the last.
     const lines = part.value.replace(/\n$/, '').split('\n')
     if (!part.added && !part.removed) {
       for (const line of lines) {
         rows.push({
           kind: 'context',
-          old: { lineNo: oldLineNo++, segments: plainSegments(line) },
-          new: { lineNo: newLineNo++, segments: plainSegments(line) },
+          old: { lineNo: oldLineNo++, segments: styleLine(line, plainSegments(line), language, hl, chTheme) },
+          new: { lineNo: newLineNo++, segments: styleLine(line, plainSegments(line), language, hl, chTheme) },
         })
       }
       continue
@@ -92,26 +254,27 @@ function alignFileDiff(oldText: string | null, newText: string): DiffRow[] {
         const segments = wordSegments(lines[p]!, addedLines[p]!)
         rows.push({
           kind: 'change',
-          old: { lineNo: oldLineNo++, segments: segments.old },
-          new: { lineNo: newLineNo++, segments: segments.new },
+          old: { lineNo: oldLineNo++, segments: styleLine(lines[p]!, segments.old, language, hl, chTheme) },
+          new: { lineNo: newLineNo++, segments: styleLine(addedLines[p]!, segments.new, language, hl, chTheme) },
         })
       }
       for (let d = pairCount; d < lines.length; d++) {
-        rows.push({ kind: 'del', old: { lineNo: oldLineNo++, segments: plainSegments(lines[d]!) } })
+        rows.push({ kind: 'del', old: { lineNo: oldLineNo++, segments: styleLine(lines[d]!, plainSegments(lines[d]!), language, hl, chTheme) } })
       }
       for (let a = pairCount; a < addedLines.length; a++) {
-        rows.push({ kind: 'add', new: { lineNo: newLineNo++, segments: plainSegments(addedLines[a]!) } })
+        rows.push({ kind: 'add', new: { lineNo: newLineNo++, segments: styleLine(addedLines[a]!, plainSegments(addedLines[a]!), language, hl, chTheme) } })
       }
       if (addedPart !== undefined) i++
       continue
     }
-    // add-only part (no adjacent removed): all rows land on the right pane.
     for (const line of lines) {
-      rows.push({ kind: 'add', new: { lineNo: newLineNo++, segments: plainSegments(line) } })
+      rows.push({ kind: 'add', new: { lineNo: newLineNo++, segments: styleLine(line, plainSegments(line), language, hl, chTheme) } })
     }
   }
   return rows
 }
+
+// --- rendering --------------------------------------------------------------
 
 function PaneLine({
   side,
@@ -126,12 +289,11 @@ function PaneLine({
   readonly width: number
   readonly lineNoWidth: number
   readonly tone: 'old' | 'new'
-  /** Right pane: one space of air between the divider and the line number. */
   readonly padLeft?: boolean
 }): React.ReactNode {
   const backgroundColor =
     kind === 'context'
-      ? undefined
+      ? 'toolCardBackground'
       : tone === 'old'
         ? 'diffRemovedDimmed'
         : 'diffAddedDimmed'
@@ -151,7 +313,7 @@ function PaneLine({
                 {segment.text}
               </Text>
             ) : (
-              <Text key={index} backgroundColor={backgroundColor}>
+              <Text key={index} color={segment.color as Color | undefined} backgroundColor={backgroundColor}>
                 {segment.text}
               </Text>
             ),
@@ -175,9 +337,28 @@ export function SplitDiffView({
   readonly maxRows: number
   readonly verbose: boolean
 }): React.ReactNode {
-  // Assemble rows across files; a `⋯` separator row keeps scattered hunks
-  // of one file apart (unified view's convention), a path row separates
-  // files when several changed at once.
+  // cli-highlight loads lazily (it pulls highlight.js); until the promise
+  // settles the view renders diff colors only, then syntax colors fade in.
+  const [hl, setHl] = React.useState<CliHighlight | null>(null)
+  React.useEffect(() => {
+    let mounted = true
+    void getCliHighlightPromise().then(loaded => {
+      if (mounted) setHl(loaded)
+    })
+    return () => { mounted = false }
+  }, [])
+
+  const [themeName] = useTheme()
+  const chTheme = React.useMemo(() => {
+    const theme = getTheme(themeName)
+    const out: Record<string, (text: string) => string> = {}
+    for (const [tokenClass, tokenKey] of Object.entries(SYNTAX_CLASS_TO_TOKEN)) {
+      const value = (theme as unknown as Record<string, string>)[tokenKey]
+      if (value !== undefined) out[tokenClass] = chalkFromToken(value)
+    }
+    return out
+  }, [themeName])
+
   const rows: (DiffRow | { readonly separator: string })[] = []
   let prevPath: string | undefined
   for (const diff of diffs) {
@@ -186,7 +367,8 @@ export function SplitDiffView({
       else rows.push({ separator: '⋯' })
     }
     prevPath = diff.path
-    rows.push(...alignFileDiff(diff.oldText, diff.newText))
+    const language = extname(diff.path).replace(/^\./, '') || undefined
+    rows.push(...alignFileDiff(diff.oldText, diff.newText, language, hl, chTheme))
   }
 
   const totalRows = rows.length
@@ -202,7 +384,7 @@ export function SplitDiffView({
   const paneWidth = Math.max(20, Math.floor((width - 1) / 2))
 
   return (
-    <Box flexDirection="column" width={paneWidth * 2 + 1}>
+    <Box flexDirection="column" width={paneWidth * 2 + 1} backgroundColor="toolCardBackgroundDim">
       {visible.map((row, index) =>
         'separator' in row ? (
           <Box key={index} width={paneWidth * 2 + 1}>
@@ -213,7 +395,7 @@ export function SplitDiffView({
         ) : (
           <Box key={index} flexDirection="row">
             <PaneLine side={row.old} kind={row.kind === 'add' ? 'context' : row.kind} tone="old" width={paneWidth} lineNoWidth={lineNoWidth} />
-            <Box width={1} flexShrink={0}>
+            <Box width={1} flexShrink={0} backgroundColor="toolCardBackgroundDim">
               <Text dimColor>│</Text>
             </Box>
             <PaneLine side={row.new} kind={row.kind === 'del' ? 'context' : row.kind} tone="new" width={paneWidth} lineNoWidth={lineNoWidth} padLeft />

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -303,7 +303,7 @@ export function AssistantToolUseMessage({
           ? 'messageActionsBackground'
           : isExpanded
             ? 'userMessageBackgroundHover'
-            : undefined
+            : 'toolCardBackgroundDim'
       }
     >
       <Box flexDirection="column" flexGrow={1}>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -50,6 +50,21 @@ export type Theme = {
   diffRemovedDimmed: string
   diffAddedWord: string
   diffRemovedWord: string
+  // Tool card surfaces (two depth levels; the card itself takes the dim
+  // shade, diff context rows the lighter one, changed rows the diff palette)
+  toolCardBackground: string
+  toolCardBackgroundDim: string
+  // Diff syntax highlighting (user themes may override any of these)
+  syntaxKeyword: string
+  syntaxString: string
+  syntaxComment: string
+  syntaxNumber: string
+  syntaxFunction: string
+  syntaxType: string
+  syntaxVariable: string
+  syntaxOperator: string
+  syntaxPunctuation: string
+  syntaxConstant: string
   // Agent colors
   red_FOR_SUBAGENTS_ONLY: string
   blue_FOR_SUBAGENTS_ONLY: string
@@ -178,6 +193,18 @@ const darkTheme: Theme = {
   diffRemovedDimmed: rgb('#362B2C'),
   diffAddedWord: rgb('#57956B'),
   diffRemovedWord: rgb('#B26671'),
+  toolCardBackground: rgb('#272C35'), // lighter card surface
+  toolCardBackgroundDim: rgb('#1E2229'), // deeper substrate
+  syntaxKeyword: rgb('#8FA8E8'), // mist blue
+  syntaxString: rgb('#9FBF8F'), // soft sage
+  syntaxComment: rgb('#6B7280'), // neutral grey
+  syntaxNumber: rgb('#D9A97E'), // warm tan
+  syntaxFunction: rgb('#82B8C7'), // cyan blue
+  syntaxType: rgb('#B39DDB'), // soft violet
+  syntaxVariable: rgb('#C9D1D9'), // near-text
+  syntaxOperator: rgb('#93A1B0'), // blue grey
+  syntaxPunctuation: rgb('#7A8694'), // dim blue grey
+  syntaxConstant: rgb('#D98C9B'), // soft rose
   red_FOR_SUBAGENTS_ONLY: rgb('#D4685E'),
   blue_FOR_SUBAGENTS_ONLY: rgb('#7496D6'),
   green_FOR_SUBAGENTS_ONLY: rgb('#66B285'),
@@ -256,6 +283,18 @@ const lightTheme: Theme = {
   diffRemovedDimmed: rgb('#F5E6E4'),
   diffAddedWord: rgb('#A9D3B4'),
   diffRemovedWord: rgb('#E5B3AE'),
+  toolCardBackground: rgb('#F0EBDD'), // lighter warm card
+  toolCardBackgroundDim: rgb('#E8E0CD'), // deeper warm substrate
+  syntaxKeyword: rgb('#4A63A8'),
+  syntaxString: rgb('#4E7A4E'),
+  syntaxComment: rgb('#8A8F98'),
+  syntaxNumber: rgb('#A96B32'),
+  syntaxFunction: rgb('#3F7E8F'),
+  syntaxType: rgb('#7A5CA8'),
+  syntaxVariable: rgb('#343945'),
+  syntaxOperator: rgb('#5B6672'),
+  syntaxPunctuation: rgb('#9AA0A8'),
+  syntaxConstant: rgb('#B04A5A'),
   red_FOR_SUBAGENTS_ONLY: rgb('#BE5A52'),
   blue_FOR_SUBAGENTS_ONLY: rgb('#3F6CC4'),
   green_FOR_SUBAGENTS_ONLY: rgb('#4E9675'),
@@ -336,6 +375,18 @@ const darkAnsiTheme: Theme = {
   diffRemovedDimmed: 'ansi:red',
   diffAddedWord: 'ansi:greenBright',
   diffRemovedWord: 'ansi:redBright',
+  toolCardBackground: 'ansi:blackBright',
+  toolCardBackgroundDim: 'ansi:black',
+  syntaxKeyword: 'ansi:blueBright',
+  syntaxString: 'ansi:greenBright',
+  syntaxComment: 'ansi:blackBright',
+  syntaxNumber: 'ansi:yellowBright',
+  syntaxFunction: 'ansi:cyanBright',
+  syntaxType: 'ansi:magentaBright',
+  syntaxVariable: 'ansi:white',
+  syntaxOperator: 'ansi:white',
+  syntaxPunctuation: 'ansi:blackBright',
+  syntaxConstant: 'ansi:redBright',
   red_FOR_SUBAGENTS_ONLY: 'ansi:redBright',
   blue_FOR_SUBAGENTS_ONLY: 'ansi:blueBright',
   green_FOR_SUBAGENTS_ONLY: 'ansi:greenBright',


### PR DESCRIPTION
## 改动

- **工具卡衬底**：所有工具卡（含 diff）带底色，`toolCardBackgroundDim`（深档衬底）+ `toolCardBackground`（浅档，diff 上下文行）两层深度，按内置色板分别定义，主题切换自动跟随
- **diff 语法高亮**：cli-highlight 按文件扩展名着色，10 个 `syntax*` 主题键（keyword/string/comment/number/function/type/variable/operator/punctuation/constant）映射 highlight.js 词类，逐行缓存；高亮器懒加载落地前只渲染 diff 色，不闪变
- **diff 语义优先**：改动词组永远用 `diffAddedWord`/`diffRemovedWord`，语法色只作用于未变更文本
- **用户自定义口**：新色全部是 Theme 键，`~/.dsh-tui/themes/*.json` 任意覆盖；themes 文档（中英）已补覆盖分组表

## 验证

repro-diff-split 扩到 15 断言（双栏底色深浅、关键字语法色、卡片衬底、窄屏回退、新建单栏填充），repro-toolcards 无回归，build 全门禁绿。
