### PR TITLE
fix(transcript): 纯思考/纯工具步骤不再产生裸 ● 空行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,11 @@ jobs:
 
       - run: node --import tsx/esm scripts/verify-channel-goal-todo.mjs
 
+      # 裸 ● 空行回归：纯思考/纯工具步骤（无文本块）的 assistant/message
+      # 不得创建空 assistant 行，否则思考块折叠后转录里多出一个只有
+      # ● 前缀、内容为空的行。
+      - run: node scripts/verify-empty-assistant-row.mjs
+
       # 技能斜杠命令补全回归（issue #86）：user-invocable 技能合并进 /
       # 菜单与 Tab 补全（skill 标记、与 locals/注册表撞名让位），
       # skills/change 实时增删，读取失败保留 last-good。

--- a/scripts/verify-empty-assistant-row.mjs
+++ b/scripts/verify-empty-assistant-row.mjs
@@ -1,0 +1,121 @@
+/**
+ * Channel-level regression for the bare-`●` transcript row: an assistant
+ * step that emits only reasoning (then straight to tool calls) used to leave
+ * an empty assistant row behind, which rendered as a `●` bullet with no
+ * content right after the thinking block folded.
+ *
+ * - reasoning-only assistant/message creates NO assistant row (the empty
+ *   `●` culprit); the reasoning row itself is kept
+ * - a non-streaming assistant/message with text still lands its assistant row
+ * - text deltas followed by assistant/message still settle the streamed row
+ *
+ * Run with plain node against the compiled lib: `node scripts/verify-empty-assistant-row.mjs`
+ */
+import { createChannel } from '../lib/types/dsh-adapter/channel.js'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const handlers = new Map()
+const ctx = {
+  on(event, handler) {
+    handlers.set(event, handler)
+    return () => handlers.delete(event)
+  },
+  get() {
+    return undefined
+  },
+  logger: { warn() {} },
+}
+const agent = {
+  id: 'a1',
+  status: 'idle',
+  session: { id: 's1', seq: 0, events: [] },
+  ctx: { on: () => () => {} },
+  followup() {},
+  steer() {},
+}
+const channel = createChannel(ctx, agent, {
+  model: 'deepseek-chat',
+  cwd: '/tmp',
+  provider: 'deepseek',
+  activity: false,
+})
+const emit = event => {
+  const handler = handlers.get('session/event')
+  if (handler) handler(agent.session, event)
+}
+
+emit({
+  type: 'user/message',
+  seq: 1,
+  data: { source: { kind: 'user' }, content: [{ type: 'text', text: 'go' }] },
+})
+
+// Step 1: reasoning-only assistant step (thinking, then straight to tools).
+emit({
+  type: 'assistant/chunk',
+  seq: 2,
+  data: { turn: 1, step: 0, chunk: { type: 'reasoning-delta', text: '先想想' } },
+})
+emit({
+  type: 'assistant/message',
+  seq: 3,
+  data: { message: { content: [{ type: 'tool_use', id: 't1', name: 'Read', input: {} }] } },
+})
+
+check(
+  'reasoning-only step leaves no assistant row',
+  channel.rows.every(row => row.kind !== 'assistant'),
+  JSON.stringify(channel.rows.map(row => row.kind)),
+)
+check(
+  'reasoning row kept',
+  channel.rows.some(row => row.kind === 'reasoning' && row.text === '先想想'),
+)
+
+// Step 2: non-streaming text message (provider without chunk deltas).
+emit({
+  type: 'assistant/message',
+  seq: 4,
+  data: { message: { content: [{ type: 'text', text: '答复全文' }] } },
+})
+const settled = channel.rows.filter(row => row.kind === 'assistant').at(-1)
+check(
+  'non-streaming text still lands its assistant row',
+  settled?.text === '答复全文' && settled.streaming === false,
+  JSON.stringify(settled),
+)
+
+// Step 3: streamed text deltas settled by the final assistant/message.
+emit({
+  type: 'assistant/chunk',
+  seq: 5,
+  data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: '流式' } },
+})
+emit({
+  type: 'assistant/chunk',
+  seq: 6,
+  data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: '文本' } },
+})
+emit({
+  type: 'assistant/message',
+  seq: 7,
+  data: { message: { content: [{ type: 'text', text: '流式文本' }] } },
+})
+const streamed = channel.rows.filter(row => row.kind === 'assistant').at(-1)
+check(
+  'streamed row settles with full text',
+  streamed?.text === '流式文本' && streamed.streaming === false,
+  JSON.stringify(streamed),
+)
+
+check(
+  'no empty-text assistant rows anywhere',
+  channel.rows.every(row => row.kind !== 'assistant' || row.text !== ''),
+)
+
+process.exit(failed > 0 ? 1 : 0)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -3695,11 +3695,17 @@ ${output}
         break
       }
       case 'assistant/message': {
-        const row = ensureStreaming(event.seq)
-        row.time = event.time
         const text = textOf(event.data.message.content)
-        if (text) row.text = text
-        row.streaming = false
+        // Reasoning/tool-only steps emit no text: creating an assistant row
+        // anyway leaves an empty `●` bullet in the transcript. A pre-existing
+        // streaming row always has text (ensureStreaming is only reached on
+        // non-empty text deltas), so only create one when text arrives.
+        const row = streaming ?? (text ? ensureStreaming(event.seq) : undefined)
+        if (row !== undefined) {
+          row.time = event.time
+          if (text) row.text = text
+          row.streaming = false
+        }
         streaming = undefined
         if (reasoning !== undefined) {
           // Seal, don't fold: the per-step duration settles here, but the


### PR DESCRIPTION
Closes #247

## 动机

开启思考链的会话中，当某一步模型只输出推理内容、没有文本块时（典型场景：思考完直接调工具），该步结束后思考块正常折叠，但其下方会出现一个只有 `●` 前缀、内容为空的 assistant 行。实时会话与 `/resume` 回放均复现。

## 原因

- `channel.ts` 的 `assistant/message` 处理无条件调用 `ensureStreaming()`，无文本块的步骤也会创建一个 `text` 为空字符串的 assistant 行落入 `state.rows`
- `AssistantTextMessage` 渲染时无条件输出 `BLACK_CIRCLE` 前缀，空文本行因此显示为裸 `●`

## 改动

`assistant/message` 处理改为：仅当消息含文本、或已存在 streaming 行时才创建/复用 assistant 行。

依据一个既有不变量：`ensureStreaming` 只会在收到非空 `text-delta` 时创建行，因此已存在的 streaming 行必有文本，可直接复用；只有「无既有行且无文本」这一组合会产生空行，将其跳过即可。非流式文本与流式 delta 两条路径行为不变。

## 验证

- 新增聚焦回归 `scripts/verify-empty-assistant-row.mjs`（已挂入 CI channel 层回归区块）：
  - 纯思考步骤不创建 assistant 行，reasoning 行保留
  - 非流式文本消息仍正常落行
  - 流式 delta 落定行为不变
  - 全程无空文本 assistant 行
- 已跑既有回归：`verify-submit` / `verify-compact` / `verify-channel-goal-todo` / `repro-thinking` 全过
- 实机验证：思考后直接调工具的场景，思考块折叠后不再出现裸 `●`