### PR TITLE
release: v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-harness-tui/dsh-tui",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## 亮点

- **双栏 diff 视图**（#245）：宽屏 old/new 对照、词级高亮、窄屏回退
- **diff 语法高亮 + 工具卡衬底**（#246）：主题全套可覆盖
- **diff 布局 /settings 可选 + #250 评审修复**（#249）：auto/split/unified，settings 命名空间 live 生效
- **/settings 插件设置屏**（#238）
- **/debug-prompt**（#243）、**/skills 命令**（#232）
- 修复：首次自举 pnpm ≥11 兜底（#241）、裸 ● 空行（#248）
