### PR TITLE
fix(skills): 防止会话切换后返回旧技能目录

### DIFF
--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -359,5 +359,89 @@ await tick()
   check('releaseContributions leaves other owners alone', registered.has('plan'))
 }
 
+// ---- /skills: an isolated channel must discard a snapshot from its old agent
+{
+  const staleAgentA = {
+    id: 'stale-a',
+    status: 'idle',
+    session: { id: 'stale-s1', seq: 0, events: [], header: { cwd: '/tmp' } },
+    ctx: { on: () => () => {} },
+    followups: [],
+    followup(message) { this.followups.push(message) },
+  }
+  const staleAgentB = {
+    id: 'stale-b',
+    status: 'idle',
+    session: { id: 'stale-s2', seq: 0, events: [], header: { cwd: '/tmp' } },
+    ctx: { on: () => () => {} },
+    followups: [],
+    followup(message) { this.followups.push(message) },
+  }
+  let holdNextAgentASnapshot = false
+  let pendingSnapshotResolve = () => {}
+  let pendingSnapshotStarted = false
+  let lastSnapshotScope
+  const skillService = {
+    list: async () => [],
+    snapshot(options) {
+      lastSnapshotScope = options?.scope
+      if (options?.scope === staleAgentA && holdNextAgentASnapshot) {
+        holdNextAgentASnapshot = false
+        pendingSnapshotStarted = true
+        return new Promise(resolve => { pendingSnapshotResolve = resolve })
+      }
+      return Promise.resolve({
+        skills: options?.scope === staleAgentA
+          ? [{ name: 'stable', description: 'Stable skill', invocation: { modelInvocable: true, userInvocable: true } }]
+          : [{ name: 'fresh', description: 'Fresh skill', invocation: { modelInvocable: true, userInvocable: true } }],
+        complete: true,
+      })
+    },
+    get: async () => undefined,
+  }
+  const staleCtx = {
+    on: () => () => {},
+    get(name) {
+      if (name === 'agents') {
+        return {
+          create: async () => ({ agent: staleAgentB }),
+        }
+      }
+      if (name === 'skills') return skillService
+      return undefined
+    },
+    logger: { warn() {} },
+  }
+  const staleChannel = createChannel(staleCtx, staleAgentA, {
+    model: 'deepseek-chat',
+    cwd: '/tmp',
+    provider: 'deepseek',
+    activity: false,
+  })
+
+  holdNextAgentASnapshot = true
+  const pendingList = staleChannel.listSkills()
+  check(
+    'pending /skills read starts from the independent agent A',
+    pendingSnapshotStarted && lastSnapshotScope === staleAgentA,
+  )
+  const switched = await staleChannel.newSession()
+  check('newSession switches the independent channel to agent B', switched === true)
+  pendingSnapshotResolve({
+    skills: [{ name: 'stale', description: 'Stale skill', invocation: { modelInvocable: true, userInvocable: true } }],
+    complete: true,
+  })
+  const staleSkills = await pendingList
+  check(
+    'stale /skills snapshot is hidden after an agent swap',
+    staleSkills === undefined,
+  )
+  const freshSkills = await staleChannel.listSkills()
+  check(
+    'current agent B returns a fresh /skills snapshot',
+    freshSkills?.some(skill => skill.name === 'fresh') === true,
+  )
+}
+
 console.log(failed === 0 ? 'ALL PASS' : `${failed} FAILED`)
 process.exit(failed === 0 ? 0 : 1)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -2958,11 +2958,14 @@ export function createChannel(
       // snapshot() over list(): only a COMPLETE observation is authoritative
       // (same contract as the skill-command merge above) — a partial catalog
       // must surface as "failed", not as a misleading near-empty picker.
-      const registry = skillRegistryFor(agent)
+      const target = agent
+      const registry = skillRegistryFor(target)
       if (registry === undefined) return []
       try {
-        const observation = await registry.snapshot(skillViewOptions(agent))
-        if (!observation.complete) return undefined
+        const observation = await registry.snapshot(skillViewOptions(target))
+        if (target !== agent || !observation.complete) {
+          return undefined
+        }
         return observation.skills.map(skill => ({
           name: skill.name,
           description: skill.description,


### PR DESCRIPTION
Follow-up to #214。

listSkills() 等待技能快照期间可能发生 agent 切换，导致旧 agent 的快照返回后仍被 /skills 使用。

## 修改

- `listSkills()` 在读取技能快照前固定当前 agent
- 快照返回后校验该 agent 是否仍为 live agent，避免会话切换后暴露旧技能目录
- 补充 stale-agent 回归测试，覆盖旧 agent snapshot pending、切换新 agent、旧结果返回的竞态
- 验证切换后的 live agent 仍能正常返回最新技能目录

## 验证

- `pnpm build`
- `pnpm verify:package`
- `node scripts/verify-skill-commands.mjs`
- `git diff --check`

以上均通过。