### PR TITLE
docs(readme): 添加 dshfind 目录卡片

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@
   <img src="screenshots/wechat-official.png" alt="DeepSeek Harness 官方公众号推文收录 dsh-TUI" width="560">
 </p>
 
+同时也被 [dshfind](https://dshfind.com/ccch1mneyyy/dsh-TUI) 插件目录收录：
+
+<p align="center">
+  <a href="https://dshfind.com/ccch1mneyyy/dsh-TUI"><img src="https://dshfind.com/api/card/ccch1mneyyy/dsh-TUI?lang=zh" alt="dsh-TUI on dshfind"></a>
+</p>
+
 ## 核心能力
 
   - **终端原生交互**：流式 Markdown、结构化工具卡、命令与文件补全、`@` 文件引用

--- a/README_EN.md
+++ b/README_EN.md
@@ -27,6 +27,10 @@ the interface, and removing it leaves no core modifications behind.
 > [Architecture and limitations](docs/architecture.en.md) before relying on its
 > permission model or terminal-specific behavior.
 
+<p align="center">
+  <a href="https://dshfind.com/ccch1mneyyy/dsh-TUI"><img src="https://dshfind.com/api/card/ccch1mneyyy/dsh-TUI?lang=en" alt="dsh-TUI on dshfind"></a>
+</p>
+
 ## Highlights
 
 - **Terminal-native interaction**: streaming Markdown, structured tool cards,


### PR DESCRIPTION
中文版放在「官方收录」后（同为收录展示），英文版放在 status 引言后；均链接到 dshfind 收录页。卡片 URL 已验证 200。