### PR TITLE
feat(tools): 状态点分类着色 + 小点定型 + 失败红 ✗

### DIFF
--- a/docs/themes.en.md
+++ b/docs/themes.en.md
@@ -87,6 +87,7 @@ Common override groups:
 | Group | Keys |
 | --- | --- |
 | Tool card surfaces (two depths) | `toolCardBackground`, `toolCardBackgroundDim` |
+| Tool status dots (by category) | `toolDotExec`, `toolDotRead`, `toolDotWrite`, `toolDotWeb`, `toolDotTask` |
 | Diff rows | `diffAdded`, `diffRemoved`, `diffAddedDimmed`, `diffRemovedDimmed`, `diffAddedWord`, `diffRemovedWord` |
 | Diff syntax highlighting | `syntaxKeyword`, `syntaxString`, `syntaxComment`, `syntaxNumber`, `syntaxFunction`, `syntaxType`, `syntaxVariable`, `syntaxOperator`, `syntaxPunctuation`, `syntaxConstant` |
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -84,6 +84,7 @@ DSH_TUI_THEME
 | 分组 | 键 |
 | --- | --- |
 | 工具卡衬底（深浅两档） | `toolCardBackground`、`toolCardBackgroundDim` |
+| 工具状态点（按分类） | `toolDotExec`、`toolDotRead`、`toolDotWrite`、`toolDotWeb`、`toolDotTask` |
 | diff 行色 | `diffAdded`、`diffRemoved`、`diffAddedDimmed`、`diffRemovedDimmed`、`diffAddedWord`、`diffRemovedWord` |
 | diff 语法高亮 | `syntaxKeyword`、`syntaxString`、`syntaxComment`、`syntaxNumber`、`syntaxFunction`、`syntaxType`、`syntaxVariable`、`syntaxOperator`、`syntaxPunctuation`、`syntaxConstant` |
 

--- a/scripts/repro-toolcards.tsx
+++ b/scripts/repro-toolcards.tsx
@@ -224,6 +224,28 @@ await show('running-diff', {
 })
 check('运行中展示待定 diff', rowOf('- old') >= 0 && rowOf('+ new') >= 0)
 
+// 10. 状态点：分类定色、失败红 ✗。
+await show('dot-bash', { name: 'bash', argsText: '{"command":"ls"}' })
+{
+  const row = rowOf('Bash')
+  check('bash 点为鼠尾草绿小点', row >= 0 && lines()[row]!.includes('•') && fgAt(lines()[row]!.indexOf('•'), row) === 0x7fae99)
+}
+await show('dot-read', { name: 'read' })
+{
+  const row = rowOf('Read')
+  check('read 点为青蓝小点', row >= 0 && fgAt(lines()[row]!.indexOf('•'), row) === 0x82b8c7)
+}
+await show('dot-edit', { name: 'edit' })
+{
+  const row = rowOf('Edit')
+  check('edit 点为雾紫小点', row >= 0 && fgAt(lines()[row]!.indexOf('•'), row) === 0xb3a0d4)
+}
+await show('dot-error', { name: 'bash', status: 'error', errorText: 'boom' })
+{
+  const row = rowOf('Bash')
+  check('失败点变红 ✗', row >= 0 && lines()[row]!.includes('✗') && fgAt(lines()[row]!.indexOf('✗'), row) === 0xda8a93)
+}
+
 // 10. 多 hunk 编辑（settled contextual diff）：同文件相邻 hunk 用 ⋯ 分隔。
 await show('multi-hunk', {
   name: 'edit',

--- a/src/cc/figures.ts
+++ b/src/cc/figures.ts
@@ -20,6 +20,10 @@ export const POINTER = '\u276f' // ❯
 export const TICK = '\u2713' // ✓
 /** Small dot for separating operators (`∙`). */
 export const BULLET_OPERATOR = '\u2219' // ∙
+/** Settled tool-status dot, smaller than the running pulse (`•`). */
+export const BULLET = '\u2022' // •
+/** Failed tool status (`✗`). */
+export const MULTIPLICATION_X = '\u2717' // ✗
 /** Teardrop asterisk, decorative list marker (`✻`). */
 export const TEARDROP_ASTERISK = '\u273b' // ✻
 /** Lightning bolt, "fast / hot" marker (`↯`). */

--- a/src/components/ToolUseLoader.tsx
+++ b/src/components/ToolUseLoader.tsx
@@ -1,30 +1,75 @@
 import React from 'react'
 import Box from '../ink/components/Box.js'
-import Text from '../ink/components/Text.js'
+import { Text } from '../ui.js'
 import { useBlink } from '../hooks/useBlink.js'
-import { BLACK_CIRCLE } from '../cc/figures.js'
+import { BLACK_CIRCLE, BULLET, MULTIPLICATION_X } from '../cc/figures.js'
+import type { Theme } from '../theme.js'
 
 type Props = {
   isError: boolean
   isUnresolved: boolean
   shouldAnimate: boolean
+  /** Raw tool id (bash/read/edit/…) — picks the category color for a settled dot. */
+  toolName?: string
+}
+
+type ToolCategory = 'exec' | 'read' | 'write' | 'web' | 'task' | 'default'
+
+const CATEGORY_BY_TOOL: Record<string, ToolCategory> = {
+  bash: 'exec',
+  powershell: 'exec',
+  pwsh: 'exec',
+  read: 'read',
+  grep: 'read',
+  glob: 'read',
+  search: 'read',
+  file_search: 'read',
+  edit: 'write',
+  write: 'write',
+  str_replace_editor: 'write',
+  multiedit: 'write',
+  web_search: 'web',
+  web_fetch: 'web',
+  browser: 'web',
+  subagent: 'task',
+  task: 'task',
+  job: 'task',
+  workflow: 'task',
+}
+
+const CATEGORY_TOKEN: Record<ToolCategory, keyof Theme> = {
+  exec: 'toolDotExec',
+  read: 'toolDotRead',
+  write: 'toolDotWrite',
+  web: 'toolDotWeb',
+  task: 'toolDotTask',
+  default: 'success',
 }
 
 /**
- * The status dot on tool-call rows, mirroring Claude Code's ToolUseLoader:
- * blinking `●` while running, green on success, red on error, dim when queued.
+ * The status dot on tool-call rows. State shapes the glyph, the tool
+ * category picks the settled color: blinking `●` while running (attention),
+ * a smaller category-colored `•` once settled (quiet), and a red `✗` on
+ * error — a glyph swap, not just a hue, so failures read at a glance
+ * (Codex-style category colors; every color is a theme token).
  */
 export function ToolUseLoader({
   isError,
   isUnresolved,
   shouldAnimate,
+  toolName,
 }: Props): React.ReactNode {
   const [ref, isBlinking] = useBlink(shouldAnimate)
-  const color = isUnresolved ? undefined : isError ? 'error' : 'success'
-  const char =
-    !shouldAnimate || isBlinking || isError || !isUnresolved
-      ? BLACK_CIRCLE
-      : ' '
+  if (isError) {
+    return (
+      <Box ref={ref} minWidth={2}>
+        <Text color="error">{MULTIPLICATION_X}</Text>
+      </Box>
+    )
+  }
+  const category = CATEGORY_BY_TOOL[toolName ?? ''] ?? 'default'
+  const color = isUnresolved ? undefined : CATEGORY_TOKEN[category]
+  const char = shouldAnimate ? (isBlinking ? BLACK_CIRCLE : ' ') : BULLET
 
   return (
     <Box ref={ref} minWidth={2}>

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -316,6 +316,7 @@ export function AssistantToolUseMessage({
             shouldAnimate={isRunning}
             isUnresolved={isRunning}
             isError={isError}
+            toolName={tool.name}
           />
           <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} />
           {!isRunning && (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -54,6 +54,12 @@ export type Theme = {
   // shade, diff context rows the lighter one, changed rows the diff palette)
   toolCardBackground: string
   toolCardBackgroundDim: string
+  // Tool status dots, by tool category (error always wins with a red ✗)
+  toolDotExec: string
+  toolDotRead: string
+  toolDotWrite: string
+  toolDotWeb: string
+  toolDotTask: string
   // Diff syntax highlighting (user themes may override any of these)
   syntaxKeyword: string
   syntaxString: string
@@ -195,6 +201,11 @@ const darkTheme: Theme = {
   diffRemovedWord: rgb('#B26671'),
   toolCardBackground: rgb('#242B3A'), // lighter blue-grey card surface
   toolCardBackgroundDim: rgb('#1C2330'), // deeper blue substrate
+  toolDotExec: rgb('#7FAE99'), // sage green — bash/pwsh
+  toolDotRead: rgb('#82B8C7'), // cyan blue — read/grep/glob
+  toolDotWrite: rgb('#B3A0D4'), // soft violet — edit/write
+  toolDotWeb: rgb('#7DA1DE'), // mist blue — web search/fetch
+  toolDotTask: rgb('#D194AE'), // mist rose — subagent/jobs
   syntaxKeyword: rgb('#8FA8E8'), // mist blue
   syntaxString: rgb('#9FBF8F'), // soft sage
   syntaxComment: rgb('#6B7280'), // neutral grey
@@ -285,6 +296,11 @@ const lightTheme: Theme = {
   diffRemovedWord: rgb('#E5B3AE'),
   toolCardBackground: rgb('#E9EFF9'), // cool light blue card
   toolCardBackgroundDim: rgb('#DEE7F4'), // deeper blue-tinted substrate
+  toolDotExec: rgb('#4E7A4E'),
+  toolDotRead: rgb('#3F7E8F'),
+  toolDotWrite: rgb('#7A5CA8'),
+  toolDotWeb: rgb('#4A63A8'),
+  toolDotTask: rgb('#B04A5A'),
   syntaxKeyword: rgb('#4A63A8'),
   syntaxString: rgb('#4E7A4E'),
   syntaxComment: rgb('#8A8F98'),
@@ -377,6 +393,11 @@ const darkAnsiTheme: Theme = {
   diffRemovedWord: 'ansi:redBright',
   toolCardBackground: 'ansi:blackBright',
   toolCardBackgroundDim: 'ansi:black',
+  toolDotExec: 'ansi:greenBright',
+  toolDotRead: 'ansi:cyanBright',
+  toolDotWrite: 'ansi:magentaBright',
+  toolDotWeb: 'ansi:blueBright',
+  toolDotTask: 'ansi:redBright',
   syntaxKeyword: 'ansi:blueBright',
   syntaxString: 'ansi:greenBright',
   syntaxComment: 'ansi:blackBright',


### PR DESCRIPTION
## 设计

状态定形，分类定色（Codex 风格）：

- 运行中 `●` 呼吸闪烁
- 落定后 `•` 小点，按工具分类着色：exec 鼠尾草绿 / read 青蓝 / write 雾紫 / web 雾蓝 / task 雾玫
- 失败 `✗` 红色——换字形而非只换色，一眼报警

5 个新主题键（`toolDot*`）全部用户可覆盖，文档已补。

## 顺带修掉的两个潜伏 bug

- `ToolUseLoader` 用的是原始 ink Text，**主题 token 全被静默丢弃**——旧的绿/红点其实从来没上过色；换 ThemedText 后才真正生效
- 分类查找必须吃原始工具 id（`bash`），展示名（`Bash`）永远查不中

## 验证

repro-toolcards 新增分类色 + ✗ 断言，ALL PASS。
