### PR TITLE
feat(input): 支持高频快捷键自定义

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,9 @@ jobs:
       # 按键解析回归（issue #110）：Option+Enter（ESC CR）精确/合并/分块
       # 三种到达形态、CSI-u 与 modifyOtherKeys 的 Shift/Ctrl/Meta+Enter。
       - run: node --import tsx/esm scripts/verify-keys.tsx
+      # 可配置快捷键（issue #113）：非法/冲突回退、真实 stdin 动作路径、
+      # 帮助菜单显示最终生效 chord。
+      - run: node --import tsx/esm scripts/verify-keybindings.tsx
 
       # 终端能力探测回归：延迟 OSC/XTVERSION 回复期间保持 raw mode，
       # 回复只进 querier，不回显成终端残影。

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ TUI 启动后会在后台检查 npm 是否有新版本；发现更新时会提�
 | `?` | 快捷键菜单 |
 | `Shift+↑` | 消息选择模式（Enter 展开单条） |
 
+`Ctrl+R`、`Ctrl+O`、`Ctrl+C` 对应的高频动作可通过
+[`keybindings` 配置](docs/configuration.md#自定义快捷键)重新绑定；未配置时保持上表默认值。
+
 **macOS 修饰键**：上表中 Windows/Linux 的 `Ctrl+<键>` 在 macOS 上同时可用 `⌘<键>`
 （如 `⌘V` 粘贴、`⌘O` 展开详情、`⌘Enter` 立即发送）；仅 `Ctrl+C` / `Ctrl+D`
 （中断/退出）保持 Ctrl 不变，避免与 macOS 系统级 `⌘C` 复制等肌肉记忆冲突。

--- a/README_EN.md
+++ b/README_EN.md
@@ -117,6 +117,10 @@ For migration from the former `dsh-cc-tui` package and `cc-tui` profile, see
 | `?` | Keybinding menu |
 | `Shift+↑` | Message selection mode (`Enter` expands a single message) |
 
+The high-frequency actions behind `Ctrl+R`, `Ctrl+O`, and `Ctrl+C` can be
+remapped through the [`keybindings` configuration](docs/configuration.en.md#custom-keybindings).
+Defaults remain unchanged when the field is absent.
+
 **macOS modifier keys**: the `Ctrl+<key>` bindings above also work with `⌘<key>`
 on macOS (e.g. `⌘V` paste, `⌘O` expand details, `⌘Enter` send immediately);
 only `Ctrl+C` / `Ctrl+D` (interrupt/exit) stay on Ctrl, to avoid clashing

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -39,6 +39,10 @@ A complete common override looks like this:
     activityFrames: claude
     contextBar: true
     fullscreen: false
+    keybindings:
+      historySearch: ctrl+y
+      toggleDetails: alt+o
+      interrupt: ctrl+g
     preset: !!js process.env.DSH_TUI_PRESET ?? undefined
     workspace: !!js process.env.DSH_TUI_WORKSPACE_TARGET ?? undefined
     sessionId: !!js process.env.DSH_TUI_RESUME_SESSION ?? undefined
@@ -56,8 +60,27 @@ A complete common override looks like this:
 | `activityFrames` | persisted choice or `claude` | Activity animation preset; `/activity` changes it at runtime |
 | `contextBar` | `true` | Segmented context-usage bar below the input box; `false` hides the row |
 | `fullscreen` | `false` | `true` uses the alternate screen, app scrolling, and mouse selection; `false` uses inline mode |
+| `keybindings` | defaults below | Remap the history-search, detail-toggle, and interrupt global actions |
 | `preset` | roster default `standard` | Agent preset for new sessions; explicit configuration wins over persisted preference |
 | `sessionId` | unset | Session to resume, normally injected by the Windows `--resume` launcher |
+
+## Custom keybindings
+
+Phase 1 exposes three global actions:
+
+| Action | Default | Meaning |
+| --- | --- | --- |
+| `historySearch` | `mod+r` | Open input-history search; `mod` means Ctrl on Windows/Linux and Ctrl or Cmd on macOS |
+| `toggleDetails` | `mod+o` | Expand/collapse transcript details |
+| `interrupt` | `ctrl+c` | Interrupt while working; clear input or double-press to exit while idle |
+
+A chord uses one letter or digit and at least one of `ctrl`, `alt`, or `mod`;
+`shift` may be added. Modifier order and case are ignored. Examples:
+`ctrl+y`, `alt+shift+o`, and `mod+g`. Unmodified and shift-only bindings are
+rejected so ordinary typing cannot be captured. `mod` already represents the
+platform primary modifier and cannot be combined with `ctrl`. Invalid or conflicting values
+produce a startup warning and the affected action falls back to its default.
+`Ctrl+D` is not remappable and always remains the exit fallback.
 
 ## Live activity row
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,10 @@ Profile 启动按顺序叠加 `dsh-base`、已安装 bundle、`@deepseek-harness
     activityFrames: claude
     contextBar: true
     fullscreen: false
+    keybindings:
+      historySearch: ctrl+y
+      toggleDetails: alt+o
+      interrupt: ctrl+g
     preset: !!js process.env.DSH_TUI_PRESET ?? undefined
     workspace: !!js process.env.DSH_TUI_WORKSPACE_TARGET ?? undefined
     sessionId: !!js process.env.DSH_TUI_RESUME_SESSION ?? undefined
@@ -54,8 +58,25 @@ Profile 启动按顺序叠加 `dsh-base`、已安装 bundle、`@deepseek-harness
 | `activityFrames` | 持久化选择或 `claude` | 工作状态动画预设；也可通过 `/activity` 修改 |
 | `contextBar` | `true` | 输入框下方的分段上下文进度条；`false` 隐藏该行 |
 | `fullscreen` | `false` | `true` 使用 alternate screen、应用内滚动和鼠标选区；`false` 使用 inline 模式 |
+| `keybindings` | 见下文默认值 | 重映射历史搜索、详情切换和中断三个高频全局动作 |
 | `preset` | 名册默认 `standard` | 新会话 Agent preset；显式配置优先于持久化偏好 |
 | `sessionId` | 未设置 | 要恢复的会话 ID，通常由 Windows `--resume` 启动器注入 |
+
+## 自定义快捷键
+
+Phase 1 开放三个全局动作：
+
+| 动作 | 默认值 | 语义 |
+| --- | --- | --- |
+| `historySearch` | `mod+r` | 打开输入历史搜索；`mod` 在 Windows/Linux 为 Ctrl，在 macOS 为 Ctrl 或 Cmd |
+| `toggleDetails` | `mod+o` | 展开/收起 transcript 详情 |
+| `interrupt` | `ctrl+c` | 工作时中断；空闲时清输入或双按退出 |
+
+每个 chord 使用一个字母或数字键，并至少包含 `ctrl`、`alt`、`mod` 之一；可额外加
+`shift`，修饰键顺序和大小写不敏感。例如 `ctrl+y`、`alt+shift+o`、`mod+g`。
+`mod` 已代表平台主修饰键，不可再与 `ctrl` 组合。不接受无修饰键或只有 `shift` 的配置，
+以免吞掉普通输入。非法值或动作间冲突会在
+启动时警告，并把相关动作回退到默认值。`Ctrl+D` 不可重映射，始终作为退出后备键。
 
 ## 工作状态行
 

--- a/docs/interaction.en.md
+++ b/docs/interaction.en.md
@@ -25,6 +25,11 @@
 | `?` | Open shortcut and command help when the input is empty |
 | `Shift+Up` | Enter message selection; arrows move, `Enter` expands one row, `Esc` exits |
 
+`Ctrl+R` (history search), `Ctrl+O` (detail toggle), and `Ctrl+C`
+(interrupt/clear/double-press exit) can be remapped through
+[`keybindings`](configuration.en.md#custom-keybindings). `Ctrl+D` always remains
+an idle double-press exit fallback.
+
 `/` has two meanings. In normal input it opens slash-command completion. In
 the `Ctrl+O` transcript view it opens full-session search; use `n` and `N` to
 move forward and backward through matches.

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -25,6 +25,10 @@
 | `?` | 输入框为空时打开快捷键和命令帮助 |
 | `Shift+Up` | 进入消息选择模式；方向键移动，`Enter` 展开单条，`Esc` 退出 |
 
+`Ctrl+R`（历史搜索）、`Ctrl+O`（详情切换）和 `Ctrl+C`（中断/清空/双按退出）
+可通过 [`keybindings`](configuration.md#自定义快捷键)重新绑定。`Ctrl+D` 始终保留为
+空闲双按退出的后备键。
+
 `/` 有两种语义：普通输入模式中打开 slash command 补全；`Ctrl+O` 的
 transcript 模式中打开会话全文搜索。全文搜索使用 `n`/`N` 在结果间前后跳转。
 

--- a/scripts/verify-keybindings.tsx
+++ b/scripts/verify-keybindings.tsx
@@ -1,0 +1,234 @@
+/**
+ * Configurable keybinding regression (issue #113).
+ *
+ * Drives the real stdin -> Ink -> Chat path so the checks cover parsed
+ * terminal input and the user-visible action, not only a matcher helper.
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_LANG = 'en'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { resolveKeybindings }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/keybindings.js'),
+])
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+let failed = 0
+function check(name: string, ok: boolean, detail = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${!ok && detail ? `\n${detail}` : ''}`)
+  if (!ok) failed += 1
+}
+
+const invalid = resolveKeybindings({ historySearch: 'shift+r' })
+check('unsafe modifier-only chord falls back to the default', invalid.bindings.historySearch === 'mod+r')
+check('invalid chord produces a configuration warning', invalid.warnings[0]?.reason === 'invalid')
+
+const conflict = resolveKeybindings({ historySearch: 'alt+x', toggleDetails: 'alt+x' })
+check(
+  'conflicting custom chords fall back to distinct defaults',
+  conflict.bindings.historySearch === 'mod+r' && conflict.bindings.toggleDetails === 'mod+o',
+)
+check('each conflicting action produces a warning', conflict.warnings.filter(warning => warning.reason === 'conflict').length === 2)
+
+const mixed = resolveKeybindings({ historySearch: 'shift+r', toggleDetails: 'mod+r' })
+check(
+  'an invalid chord is not warned again as a conflict after fallback',
+  mixed.warnings.length === 2
+    && mixed.warnings.some(warning => warning.action === 'historySearch' && warning.reason === 'invalid')
+    && mixed.warnings.some(warning => warning.action === 'toggleDetails' && warning.reason === 'conflict'),
+)
+
+const aliasConflict = resolveKeybindings({ historySearch: 'mod+x', toggleDetails: 'ctrl+x' })
+check(
+  'mod and ctrl aliases are treated as conflicting chords',
+  aliasConflict.bindings.historySearch === 'mod+r'
+    && aliasConflict.bindings.toggleDetails === 'mod+o'
+    && aliasConflict.warnings.filter(warning => warning.reason === 'conflict').length === 2,
+)
+
+const cascadeConflict = resolveKeybindings({ historySearch: 'ctrl+c', toggleDetails: 'mod+r' })
+check(
+  'conflicts introduced by a fallback are resolved in a second pass',
+  cascadeConflict.bindings.historySearch === 'mod+r'
+    && cascadeConflict.bindings.toggleDetails === 'mod+o'
+    && cascadeConflict.warnings.filter(warning => warning.reason === 'conflict').length === 2,
+)
+check(
+  'mod cannot be combined with its ctrl alias',
+  resolveKeybindings({ historySearch: 'mod+ctrl+x' }).warnings[0]?.reason === 'invalid',
+)
+
+const COLS = 100
+const ROWS = 32
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 100, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    term.write(String(chunk), callback)
+  }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+
+const listeners = new Set<() => void>()
+let cancelCount = 0
+const channel: Record<string, unknown> = {
+  version: 0,
+  rows: [{
+    id: 1,
+    kind: 'reasoning',
+    text: 'KEYBINDING_DETAIL_SENTINEL',
+    streaming: false,
+    durationMs: 1000,
+  }],
+  status: 'idle',
+  sessionTitle: 'keybinding probe',
+  agentId: 'probe',
+  provider: 'deepseek',
+  model: 'deepseek-v4-flash',
+  tokens: { input: 0, output: 0 },
+  cwd: '/repo',
+  displayCwd: '/repo',
+  gitBranch: 'main',
+  working: false,
+  spinnerMode: 'requesting',
+  responseChars: 0,
+  activeToolCount: 0,
+  turnStart: Date.now(),
+  lastUserText: '',
+  pending: [],
+  commandList: [],
+  notifications: [],
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  reasoningEffort: 'max',
+  activityEnabled: false,
+  contextBarEnabled: true,
+  contextSegments: { system: 0, prompt: 0, assistant: 0, thinking: 0, tools: 0 },
+  subscribe(listener: () => void) { listeners.add(listener); return () => listeners.delete(listener) },
+  submit() {},
+  cancel() { cancelCount += 1 },
+  clear() {},
+  notify() {},
+  listModels: async () => [],
+  listSessions: async () => [],
+  listFiles: async () => [],
+  listWorkspaces: async () => [],
+  setResumeTarget() {},
+  loadOlder() { return 0 },
+  mcpStatus: () => [],
+  traceEvents: () => [],
+}
+
+const stdin = new FakeStdin()
+let exited = false
+const TestChat = Chat as React.ComponentType<Record<string, unknown>>
+const instance = await render(
+  <TestChat
+    channel={channel}
+    questionStore={new QuestionStore()}
+    onExit={() => { exited = true }}
+    keybindings={{ historySearch: 'ctrl+y', toggleDetails: 'ctrl+u', interrupt: 'alt+i' }}
+  />,
+  {
+    stdout: new FakeStdout(),
+    stdin,
+    stderr: new FakeStdout(),
+    exitOnCtrlC: false,
+    patchConsole: false,
+  },
+)
+
+const screen = (): string => {
+  const buffer = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) =>
+    buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '',
+  ).join('\n')
+}
+
+await sleep(500)
+stdin.write('\x19') // Ctrl+Y
+await sleep(400)
+check('custom historySearch chord opens history search', screen().includes('Search history'))
+
+stdin.write('\x1b')
+await sleep(250)
+stdin.write('\x12') // Default Ctrl+R must no longer be an alias.
+await sleep(300)
+check('custom historySearch chord replaces the default chord', !screen().includes('Search history'))
+check('reasoning starts collapsed', !screen().includes('KEYBINDING_DETAIL_SENTINEL'))
+stdin.write('draft survives global shortcut')
+await sleep(300)
+stdin.write('\x15') // Ctrl+U is normally the prompt's clear-before-caret action.
+await sleep(400)
+check('custom toggleDetails chord expands transcript details', screen().includes('KEYBINDING_DETAIL_SENTINEL'))
+check('custom global chord does not also edit the prompt', screen().includes('draft survives global shortcut'), screen())
+
+stdin.write('\x1b')
+await sleep(250)
+
+channel.working = true
+channel.version = Number(channel.version) + 1
+for (const listener of listeners) listener()
+await sleep(200)
+stdin.write('\x03') // Default Ctrl+C must no longer be an alias.
+await sleep(250)
+check('custom interrupt chord replaces the default chord', cancelCount === 0)
+stdin.write('\x1bi') // Alt+I
+await sleep(300)
+check('custom interrupt chord cancels a running turn', cancelCount === 1)
+
+channel.working = false
+channel.version = Number(channel.version) + 1
+for (const listener of listeners) listener()
+await sleep(200)
+stdin.write('?')
+await sleep(350)
+const help = screen()
+check(
+  'help menu shows the effective custom chords',
+  help.includes('ctrl+y to search history')
+    && help.includes('ctrl+u for verbose output')
+    && help.includes('alt+i to interrupt'),
+)
+if (process.env.DSH_TUI_CAPTURE_KEYBINDINGS === '1') {
+  const [{ mkdirSync, writeFileSync }, { resolve }] = await Promise.all([
+    import('node:fs'),
+    import('node:path'),
+  ])
+  const directory = resolve('artifacts/issue-113')
+  const escaped = help
+    .replace(/&/gu, '&amp;')
+    .replace(/</gu, '&lt;')
+    .replace(/>/gu, '&gt;')
+  mkdirSync(directory, { recursive: true })
+  writeFileSync(resolve(directory, 'after.txt'), help)
+  writeFileSync(
+    resolve(directory, 'after.html'),
+    `<!doctype html><meta charset="utf-8"><style>html,body{margin:0;background:#111318;color:#e5e7eb}body{padding:28px}pre{font:16px/1.35 "Cascadia Mono","Consolas",monospace;white-space:pre;margin:0}</style><pre>${escaped}</pre>`,
+  )
+}
+
+stdin.write('\x1b')
+await sleep(200)
+stdin.write('\x04')
+await sleep(150)
+check('first Ctrl+D only arms the fixed exit fallback', !exited)
+stdin.write('\x04')
+await sleep(200)
+check('second Ctrl+D still exits with a custom interrupt chord', exited)
+
+instance.unmount()
+term.dispose()
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -5,6 +5,7 @@ import type { LocalCommand } from '../commands.js'
 import { localizedDescription } from '../commands.js'
 import { t } from '../i18n.js'
 import { modLabel } from '../utils/modifiers.js'
+import { keybindingLabel, resolveKeybindings, type KeybindingConfig } from '../keybindings.js'
 
 /**
  * The `?` help menu, mirroring Claude Code's `PromptInputHelpMenu.tsx`
@@ -18,10 +19,13 @@ import { modLabel } from '../utils/modifiers.js'
  */
 export function HelpMenu({
   commands,
+  keybindings,
 }: {
   commands: readonly LocalCommand[]
+  keybindings?: KeybindingConfig
 }): React.ReactNode {
   const chrome = commands.filter(command => !command.skill)
+  const effective = resolveKeybindings(keybindings).bindings
   return (
     <Box paddingX={2} flexDirection="row" gap={4}>
       <Box flexDirection="column" width={26} flexShrink={0}>
@@ -32,16 +36,16 @@ export function HelpMenu({
           <Text dimColor>{t('help-this-help')}</Text>
         </Box>
         <Box>
-          <Text dimColor>{t('help-verbose-output', { mod: modLabel })}</Text>
+          <Text dimColor>{t('help-verbose-output', { key: keybindingLabel(effective.toggleDetails) })}</Text>
         </Box>
         <Box>
           <Text dimColor>{t('help-toggle-context', { mod: modLabel })}</Text>
         </Box>
         <Box>
-          <Text dimColor>{t('help-search-history', { mod: modLabel })}</Text>
+          <Text dimColor>{t('help-search-history', { key: keybindingLabel(effective.historySearch) })}</Text>
         </Box>
         <Box>
-          <Text dimColor>{t('help-interrupt')}</Text>
+          <Text dimColor>{t('help-interrupt', { key: keybindingLabel(effective.interrupt) })}</Text>
         </Box>
         <Box>
           <Text dimColor>{t('help-exit')}</Text>

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -16,6 +16,7 @@ import { CommandSuggestions } from './CommandSuggestions.js'
 import { FileSuggestions } from './FileSuggestions.js'
 import { HelpMenu } from './HelpMenu.js'
 import { OverlayAbove } from './OverlayAbove.js'
+import { DEFAULT_KEYBINDINGS, matchesKeybinding, resolveKeybindings, type KeybindingConfig } from '../keybindings.js'
 
 const HISTORY_LIMIT = 50
 
@@ -70,6 +71,8 @@ export interface PromptController {
 
 export interface PromptInputProps {
   channel: Channel
+  /** Effective global shortcuts displayed by the help menu. */
+  keybindings?: KeybindingConfig
   /** Whether the `?` help menu is open (state lives in the Chat screen). */
   helpOpen: boolean
   onToggleHelp(): void
@@ -125,6 +128,7 @@ export interface PromptInputProps {
  */
 export function PromptInput({
   channel,
+  keybindings,
   helpOpen,
   onToggleHelp,
   onRunCommand,
@@ -134,6 +138,10 @@ export function PromptInput({
   onRewindRequest,
   controllerRef,
 }: PromptInputProps) {
+  const effectiveKeybindings = React.useMemo(
+    () => resolveKeybindings(keybindings).bindings,
+    [keybindings?.historySearch, keybindings?.toggleDetails, keybindings?.interrupt],
+  )
   const [value, setValue] = React.useState('')
   const [cursor, setCursor] = React.useState(0)
   const valueRef = React.useRef(value)
@@ -404,6 +412,11 @@ export function PromptInput({
     // outcome lands — drop any key squeezed into that gap so the prompt's
     // setValue can never overwrite fresh typing (and vice versa).
     if (editorBusyRef.current) return
+    if (
+      matchesKeybinding(effectiveKeybindings.historySearch, DEFAULT_KEYBINDINGS.historySearch, input, key)
+      || matchesKeybinding(effectiveKeybindings.toggleDetails, DEFAULT_KEYBINDINGS.toggleDetails, input, key)
+      || matchesKeybinding(effectiveKeybindings.interrupt, DEFAULT_KEYBINDINGS.interrupt, input, key)
+    ) return
 
     // App deliberately dispatches every parsed key from one stdin read in a
     // single React update. Read the synchronous mirrors so each event sees
@@ -940,7 +953,7 @@ export function PromptInput({
       <OverlayAbove maxHeight={Math.max(terminalRows - 6, 4)}>
         {helpOpen && (
           <Box marginBottom={1}>
-            <HelpMenu commands={channel.commandList} />
+            <HelpMenu commands={channel.commandList} keybindings={keybindings} />
           </Box>
         )}
         {channel.pending.length > 0 && (

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -9,6 +9,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
 import type { SessionModeSpec } from '../sessionModes.js'
+import type { KeybindingConfig } from '../keybindings.js'
 
 export const name = 'dsh-tui'
 // `tuiWorkspaces` must stay OUT of this code-level inject (issue #183): the
@@ -77,6 +78,8 @@ export interface Config {
    *  terminals (≥110 cols) and unified below; `split`/`unified` force one
    *  layout. Editable live from the `/settings` screen. */
   diffLayout?: 'auto' | 'split' | 'unified'
+  /** Optional high-frequency global shortcut overrides (issue #113). */
+  keybindings?: KeybindingConfig
   /** Shift+Tab session-mode cycle (array order IS the cycle order; index 0
    *  is the unmarked base mode). Each entry bundles any subset of the
    *  `plan`/`sandbox`/`approval` atoms; absent → the built-in
@@ -102,6 +105,11 @@ export const Config: Schema<Config> = Schema.object({
   lang: Schema.string().required(false),
   preset: Schema.string().required(false),
   diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
+  keybindings: Schema.object({
+    historySearch: Schema.string().required(false),
+    toggleDetails: Schema.string().required(false),
+    interrupt: Schema.string().required(false),
+  }).required(false),
   modes: Schema.array(
     Schema.object({
       id: Schema.string(),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -36,6 +36,7 @@ import instances from '../ink/instances.js'
 import { cursorMove, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE } from '../ink/termio/csi.js'
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, EXIT_ALT_SCREEN, SHOW_CURSOR } from '../ink/termio/dec.js'
 import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, supportsTabStatus, wrapForMultiplexer } from '../ink/termio/osc.js'
+import { DEFAULT_KEYBINDINGS, keybindingLabel, resolveKeybindings } from '../keybindings.js'
 
 /**
  * Claude Code style interactive TUI front door for DeepSeek Harness agents.
@@ -81,6 +82,22 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   // language.
   const envLang = process.env.DSH_TUI_LANG
   setLang(isLang(envLang) ? envLang : isLang(config.lang) ? config.lang : resolveStartupLang())
+  const keybindingResolution = resolveKeybindings(config.keybindings)
+  const keybindingWarnings = keybindingResolution.warnings.map(warning =>
+    warning.reason === 'conflict'
+      ? t('keybinding-conflict', {
+          action: warning.action,
+          value: warning.value,
+          other: warning.conflictWith ?? '',
+          fallback: keybindingLabel(DEFAULT_KEYBINDINGS[warning.action]),
+        })
+      : t('keybinding-invalid', {
+          action: warning.action,
+          value: warning.value,
+          fallback: keybindingLabel(DEFAULT_KEYBINDINGS[warning.action]),
+        }),
+  )
+  for (const warning of keybindingWarnings) ctx.logger.warn(`dsh-tui: ${warning}`)
 
   // Rename notices must land before the first render — stderr writes break
   // the fullscreen UI once it is up. The bin launcher prints the same
@@ -317,6 +334,9 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     diffLayout: config.diffLayout,
     handle,
   })
+  for (const warning of keybindingWarnings) {
+    channel.notify(warning, { color: 'warning', timeoutMs: 10000 })
+  }
   // Register the dsh-tui settings namespace so the /settings screen can
   // edit it (the section below was '命名空间未注册' without this): the
   // user layer in settings.yaml wins over cordis.yml's diffLayout, and
@@ -492,6 +512,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     // browser — enter the alt screen themselves in inline mode; in fullscreen
     // the tree is already wrapped below, so they must not nest.
     fullscreen: config.fullscreen === true,
+    keybindings: keybindingResolution.bindings,
     onExit: () => handleExit(),
     // Only a `dsh --profile <name>` launch has a profile installation for
     // `/update` to act on; source checkouts and `--config` overlays get the

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -331,10 +331,10 @@ const dict = {
   // ── components/HelpMenu.tsx ─────────────────────────────────────────
   'help-for-commands': { zh: '/ 查看命令', en: '/ for commands' },
   'help-this-help': { zh: '? 查看本帮助', en: '? for this help' },
-  'help-verbose-output': { zh: '{{mod}}o 详细输出', en: '{{mod}}o for verbose output' },
+  'help-verbose-output': { zh: '{{key}} 详细输出', en: '{{key}} for verbose output' },
   'help-toggle-context': { zh: '{{mod}}t 切换上下文', en: '{{mod}}t to toggle context' },
-  'help-search-history': { zh: '{{mod}}r 搜索历史', en: '{{mod}}r to search history' },
-  'help-interrupt': { zh: 'ctrl+c 打断', en: 'ctrl+c to interrupt' },
+  'help-search-history': { zh: '{{key}} 搜索历史', en: '{{key}} to search history' },
+  'help-interrupt': { zh: '{{key}} 打断', en: '{{key}} to interrupt' },
   'help-exit': { zh: 'ctrl+d 退出', en: 'ctrl+d to exit' },
   'help-redraw': { zh: '{{mod}}l 重绘', en: '{{mod}}l to redraw' },
   'help-clear-input': { zh: 'esc 清空输入', en: 'esc to clear input' },
@@ -345,6 +345,8 @@ const dict = {
   'help-cycle-mode': { zh: 'shift+tab 切换模式', en: 'shift+tab to cycle mode' },
   'help-open-editor': { zh: 'ctrl+x 打开编辑器', en: 'ctrl+x to open editor' },
   'help-commands-title': { zh: '命令：', en: 'commands:' },
+  'keybinding-invalid': { zh: '快捷键 {{action}} 的配置“{{value}}”无效，已回退为 {{fallback}}', en: 'Invalid {{action}} shortcut "{{value}}"; using {{fallback}}' },
+  'keybinding-conflict': { zh: '快捷键 {{action}} 的配置“{{value}}”与 {{other}} 冲突，已回退为 {{fallback}}', en: '{{action}} shortcut "{{value}}" conflicts with {{other}}; using {{fallback}}' },
 
   // ── components/InterruptedByUser.tsx ────────────────────────────────
   'interrupted-by-user': { zh: '已打断 ', en: 'Interrupted ' },

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -1,0 +1,166 @@
+import { isMac } from './utils/modifiers.js'
+
+export interface KeybindingConfig {
+  historySearch?: string
+  toggleDetails?: string
+  interrupt?: string
+}
+
+export interface KeypressModifiers {
+  ctrl?: boolean
+  meta?: boolean
+  shift?: boolean
+  super?: boolean
+}
+
+interface ParsedKeybinding {
+  readonly canonical: string
+  readonly key: string
+  readonly ctrl: boolean
+  readonly meta: boolean
+  readonly shift: boolean
+  readonly super: boolean
+  readonly primary: boolean
+}
+
+export const DEFAULT_KEYBINDINGS = {
+  historySearch: 'mod+r',
+  toggleDetails: 'mod+o',
+  interrupt: 'ctrl+c',
+} as const
+
+export type KeybindingAction = keyof typeof DEFAULT_KEYBINDINGS
+
+export interface KeybindingWarning {
+  readonly action: KeybindingAction
+  readonly value: string
+  readonly reason: 'invalid' | 'conflict'
+  readonly conflictWith?: KeybindingAction
+}
+
+export interface KeybindingResolution {
+  readonly bindings: Record<KeybindingAction, string>
+  readonly warnings: readonly KeybindingWarning[]
+}
+
+function parseKeybinding(value: string): ParsedKeybinding | undefined {
+  const parts = value.trim().toLowerCase().split('+').map(part => part.trim())
+  const key = parts.pop()
+  if (!key || !/^[a-z0-9]$/u.test(key)) return undefined
+
+  const modifiers = new Set(parts)
+  if (modifiers.size !== parts.length) return undefined
+  if (![...modifiers].every(part => ['alt', 'ctrl', 'mod', 'shift'].includes(part))) return undefined
+  if (!modifiers.has('alt') && !modifiers.has('ctrl') && !modifiers.has('mod')) return undefined
+  if (modifiers.has('mod') && modifiers.has('ctrl')) return undefined
+
+  const canonical = [
+    modifiers.has('mod') ? 'mod' : undefined,
+    modifiers.has('ctrl') ? 'ctrl' : undefined,
+    modifiers.has('alt') ? 'alt' : undefined,
+    modifiers.has('shift') ? 'shift' : undefined,
+    key,
+  ].filter(Boolean).join('+')
+
+  return {
+    canonical,
+    key,
+    ctrl: modifiers.has('ctrl'),
+    meta: modifiers.has('alt'),
+    shift: modifiers.has('shift'),
+    super: false,
+    primary: modifiers.has('mod'),
+  }
+}
+
+function keybindingsConflict(leftValue: string, rightValue: string): boolean {
+  const left = parseKeybinding(leftValue)!
+  const right = parseKeybinding(rightValue)!
+  if (left.key !== right.key || left.meta !== right.meta || left.shift !== right.shift) return false
+  const variants = (binding: ParsedKeybinding): Array<{ ctrl: boolean; super: boolean }> =>
+    binding.primary
+      ? [{ ctrl: true, super: false }, ...(isMac ? [{ ctrl: false, super: true }] : [])]
+      : [{ ctrl: binding.ctrl, super: false }]
+  const leftVariants = variants(left)
+  const rightVariants = variants(right)
+  return leftVariants.some(leftVariant => rightVariants.some(rightVariant =>
+    leftVariant.ctrl === rightVariant.ctrl && leftVariant.super === rightVariant.super,
+  ))
+}
+
+export function resolveKeybindings(config: KeybindingConfig | undefined): KeybindingResolution {
+  const bindings: Record<KeybindingAction, string> = { ...DEFAULT_KEYBINDINGS }
+  const warnings: KeybindingWarning[] = []
+  const validCustom = new Set<KeybindingAction>()
+  const actions = Object.keys(DEFAULT_KEYBINDINGS) as KeybindingAction[]
+  for (const action of actions) {
+    const value = config?.[action]
+    if (value === undefined) continue
+    const parsed = parseKeybinding(value)
+    if (parsed === undefined) {
+      warnings.push({ action, value, reason: 'invalid' })
+      continue
+    }
+    bindings[action] = parsed.canonical
+    validCustom.add(action)
+  }
+
+  while (validCustom.size > 0) {
+    const conflicts = new Map<KeybindingAction, KeybindingAction>()
+    for (let leftIndex = 0; leftIndex < actions.length; leftIndex++) {
+      for (let rightIndex = leftIndex + 1; rightIndex < actions.length; rightIndex++) {
+        const left = actions[leftIndex]!
+        const right = actions[rightIndex]!
+        if (!keybindingsConflict(bindings[left], bindings[right])) continue
+        if (validCustom.has(left) && !conflicts.has(left)) conflicts.set(left, right)
+        if (validCustom.has(right) && !conflicts.has(right)) conflicts.set(right, left)
+      }
+    }
+    if (conflicts.size === 0) break
+    for (const [action, conflictWith] of conflicts) {
+      const value = config?.[action]
+      if (value === undefined) continue
+      warnings.push({
+        action,
+        value,
+        reason: 'conflict',
+        conflictWith,
+      })
+      bindings[action] = DEFAULT_KEYBINDINGS[action]
+      validCustom.delete(action)
+    }
+  }
+  return { bindings, warnings }
+}
+
+export function keybindingLabel(value: string): string {
+  const binding = parseKeybinding(value)
+  if (binding === undefined) return value
+  const modifiers = [
+    binding.primary ? (isMac ? '⌘' : 'ctrl') : undefined,
+    binding.ctrl ? 'ctrl' : undefined,
+    binding.meta ? 'alt' : undefined,
+    binding.shift ? 'shift' : undefined,
+  ].filter((part): part is string => part !== undefined)
+  if (isMac && modifiers[0] === '⌘') {
+    return `⌘${[...modifiers.slice(1), binding.key].join('+')}`
+  }
+  return [...modifiers, binding.key].join('+')
+}
+
+export function matchesKeybinding(
+  configured: string | undefined,
+  fallback: string,
+  input: string,
+  key: KeypressModifiers,
+): boolean {
+  const binding = parseKeybinding(configured ?? fallback) ?? parseKeybinding(fallback)!
+  const primary = binding.primary && (key.ctrl === true || (isMac && key.super === true))
+  const ctrl = binding.primary ? primary : key.ctrl === binding.ctrl
+  const superKey = binding.primary ? primary : key.super === binding.super
+  return input.toLowerCase() === binding.key
+    && ctrl
+    && key.meta === binding.meta
+    && key.shift === binding.shift
+    && superKey
+}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -57,6 +57,7 @@ import type { SessionEvent } from '../dsh-adapter/types.js'
 import { LoadingState } from '../components/design-system/LoadingState.js'
 import { Pane } from '../components/design-system/Pane.js'
 import { loadHistory, type HistoryEntry } from '../history.js'
+import { DEFAULT_KEYBINDINGS, matchesKeybinding, resolveKeybindings, type KeybindingConfig } from '../keybindings.js'
 
 /** Shared empty snapshot for hosts whose channel has no event log. */
 const NO_EVENTS: readonly SessionEvent[] = []
@@ -143,6 +144,7 @@ export function Chat({
   onUpdate,
   fullscreen = false,
   trajectorySeen: trajectorySeenProp,
+  keybindings,
 }: {
   channel: Channel
   questionStore: QuestionStore
@@ -172,6 +174,8 @@ export function Chat({
    * persisted flag when the host does not supply one.
    */
   trajectorySeen?: boolean
+  /** Optional high-frequency shortcut overrides from the plugin config. */
+  keybindings?: KeybindingConfig
 }) {
   // Re-render whenever the channel mutates; rows/status are read fresh below.
   React.useSyncExternalStore(channel.subscribe, () => channel.version)
@@ -191,6 +195,10 @@ export function Chat({
   const approvalSnapshot = React.useSyncExternalStore(
     listener => approvals.subscribe(listener),
     () => approvals.getSnapshot(),
+  )
+  const effectiveKeybindings = React.useMemo(
+    () => resolveKeybindings(keybindings).bindings,
+    [keybindings?.historySearch, keybindings?.toggleDetails, keybindings?.interrupt],
   )
   // When a questionnaire batch completes, fold a Q&A summary into the
   // transcript (the tool card itself is hidden from the message list).
@@ -1335,6 +1343,18 @@ export function Chat({
     const returnNow = Date.now()
     const plainReturn = returnCandidate && returnNow - lastModalEnterAtRef.current >= 80
     if (plainReturn) lastModalEnterAtRef.current = returnNow
+    const interruptKey = matchesKeybinding(
+      effectiveKeybindings.interrupt,
+      DEFAULT_KEYBINDINGS.interrupt,
+      input,
+      key,
+    )
+    const historySearchKey = matchesKeybinding(
+      effectiveKeybindings.historySearch,
+      DEFAULT_KEYBINDINGS.historySearch,
+      input,
+      key,
+    )
     // Mouse wheel scrolls the transcript — in fullscreen there is no
     // terminal scrollback (alt-screen), so this is the only way back.
     // Imperative scrollBy: no React re-render per notch (CC semantics).
@@ -1644,7 +1664,7 @@ export function Chat({
         setHistoryFocus(index =>
           historyMatches.length === 0 ? 0 : (index <= 0 ? historyMatches.length - 1 : index - 1),
         )
-      } else if (key.downArrow || (isMod(key) && input === 'r')) {
+      } else if (key.downArrow || historySearchKey) {
         // CC's historySearch:next — ↓ and repeat ctrl+r walk to the next match.
         setHistoryFocus(index =>
           historyMatches.length === 0 ? 0 : (index >= historyMatches.length - 1 ? 0 : index + 1),
@@ -1735,12 +1755,13 @@ export function Chat({
       openScene()
       return
     }
-    if (isMod(key) && input === 'r' && !helpOpen) {
+    if (historySearchKey && !helpOpen) {
       setHistoryQuery('')
       setHistoryCursor(0)
       setHistoryFocus(0)
       setHistoryEntries(loadHistory())
       setHistoryOpen(true)
+      event.stopImmediatePropagation()
       return
     }
     if (key.shift && key.upArrow && !selectionActive) {
@@ -1770,9 +1791,15 @@ export function Chat({
         channel.cancel()
       }
       event.stopImmediatePropagation()
-    } else if (isMod(key) && input === 'o') {
+    } else if (matchesKeybinding(
+      effectiveKeybindings.toggleDetails,
+      DEFAULT_KEYBINDINGS.toggleDetails,
+      input,
+      key,
+    )) {
       // Leaving transcript mode (Ctrl+O) — search was already handled above.
       setExpanded(previous => !previous)
+      event.stopImmediatePropagation()
     } else if (input === '/' && !key.ctrl && !key.meta && !key.super) {
       // `/` in transcript mode (Ctrl+O expanded, CC's REPL semantics:
       // search is active on the transcript screen where `/` isn't a command).
@@ -1785,14 +1812,14 @@ export function Chat({
         setSearchOpen(true)
         event.stopImmediatePropagation()
       }
-    } else if (key.ctrl && (input === 'c' || input === 'd')) {
+    } else if (interruptKey || (key.ctrl && input === 'd')) {
       // CC's app:exit — ctrl+c interrupts a running turn; idle ctrl+c
       // CLEARS a non-empty prompt (single press) and only arms the
       // double-press exit when the input is empty; ctrl+d keeps the
       // time-based double-press exit regardless.
       if (channel.working) {
         channel.cancel()
-      } else if (input === 'c' && promptControllerRef.current?.hasText()) {
+      } else if (interruptKey && promptControllerRef.current?.hasText()) {
         promptControllerRef.current.clear()
         // A pending exit arm no longer makes sense once the user is editing.
         exitPendingRef.current = false
@@ -1800,6 +1827,7 @@ export function Chat({
       } else {
         requestExit()
       }
+      event.stopImmediatePropagation()
     } else if (isMod(key) && input === 'l') {
       // CC's app:redraw — clear the physical terminal and repaint.
       instances.get(process.stdout)?.forceRedraw()
@@ -2038,6 +2066,7 @@ export function Chat({
         ) : (
           <PromptInput
             channel={channel}
+            keybindings={effectiveKeybindings}
             helpOpen={helpOpen}
             onToggleHelp={() =>{  setHelpOpen(previous => !previous) }}
             onRunCommand={runCommand}


### PR DESCRIPTION
## 变更内容

- 在插件配置中新增 `keybindings`，Phase 1 支持 `historySearch`、`toggleDetails` 和 `interrupt`
- 未配置时保持现有默认键位：`mod+r`、`mod+o`、`ctrl+c`
- 支持单字母/数字与 `ctrl`、`alt`、`mod`，并可组合 `shift`
- 非法绑定或动作冲突会回退默认值，并显示中英文启动警告
- 帮助菜单显示最终生效键位；`Ctrl+D` 始终保留为退出后备键
- 自定义全局键优先于输入框编辑键，避免同一次按键被两个处理器消费

## 配置示例

```yaml
keybindings:
  historySearch: ctrl+y
  toggleDetails: alt+o
  interrupt: ctrl+g
```

## 实现说明

- 自定义绑定替换默认绑定，不额外保留旧键别名
- `mod+x` 与 `ctrl+x` 按实际平台触发语义参与冲突判断
- 冲突回退采用迭代消解，覆盖回退默认值后产生的二阶冲突
- 历史搜索打开后，重复按自定义历史键仍可切换下一项
- README 与中英文配置、交互文档已同步更新

## 验证

- `npm run build`
- `npm run verify:package`
- `node --import tsx/esm scripts/verify-keybindings.tsx`（18 项通过）
- `node --import tsx/esm scripts/repro-ctrlc.tsx`
- `node --import tsx/esm scripts/verify-keys.tsx`
- `node --import tsx/esm scripts/verify-batched-prompt-input.mjs`
- `node --import tsx/esm scripts/verify-i18n-command-descriptions.tsx`
- `node --import tsx/esm scripts/repro-inline-scrollback.tsx`
- `git diff --check`

Closes #113