### PR TITLE
fix(history): 修复历史搜索过滤与持久化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,10 @@ jobs:
       # 输入历史草稿回归（issue #287）：首次 ↑ 保存未提交草稿，遍历历史后
       # ↓ 回到末尾必须恢复原文，重复越界不能把草稿清空。
       - run: node scripts/verify-prompt-history-draft.mjs
+      # 持久化历史搜索回归（issue #271）：重复文本过滤后不留旧行；并发进程
+      # 写入不互相覆盖且物理文件有界，非法时间戳被归一化。
+      - run: node --import tsx/esm scripts/verify-history-filter.tsx
+      - run: node scripts/verify-history-persistence.mjs
       # 文件补全回归（issue #278）：CMake 构建目录与任意大型兄弟目录不得
       # 独占 100 条全局预算，普通深层源码也不能被固定深度静默截断。
       - run: node scripts/verify-file-completion.mjs

--- a/docs/project-documentation/input-commands.md
+++ b/docs/project-documentation/input-commands.md
@@ -28,9 +28,11 @@ PromptInput 为单一 value 字符串 + 整数 cursor 双状态（无选区 API�
 会话内历史（:15,141-142,539-580）：↑/↓ 在非多行、非 overlay 时走
 history.current 环形数组（提交时 push trimmed 文本，上限 HISTORY_LIMIT=50，↑
 回退 ↓ 前进，越界回空串）；**该数组初始化即为空，从不从磁盘历史文件加载**。
-持久化历史（`src/history.ts`）：history.jsonl 每行一个 JSON（text+ts），容量
-HISTORY_LIMIT=200，appendHistory 对紧邻重复只更新时间戳、坏行跳过；historyEntryId
-用 sha1(text) 前 12 位做 React key；只有 Ctrl+R 能检索磁盘历史（见下）。
+持久化历史（`src/history.ts`）：history.jsonl 每行一个 JSON（text+ts），appendHistory
+在跨进程锁下写入临时文件并原子替换，物理文件始终只保留最近 HISTORY_LIMIT=200 条；
+读取时折叠紧邻重复、跳过坏行、归一化非法 ts。historyEntryId 用 sha1(text) 前 12 位
+做 React key 前缀，结果位置保证重复文本的 key 唯一；只有 Ctrl+R 能检索磁盘历史
+（见下）。
 
 ## 键盘链路
 
@@ -233,7 +235,9 @@ Enter 填充、Esc/Ctrl+C/Ctrl+D 取消、其余键编辑 query；HistorySearchD
 自身无 useInput（:11-17 注释 "Keyboard handling lives in the caller (Chat)"）。
 setHistoryFill(entry.text) → PromptInput fillText effect 替换输入并置光标到
 末尾（src/components/PromptInput.tsx:146-153，lastFill ref 去重）。对话框打开时 PromptInput
-因 promptSelectionActive（含 historyOpen 等所有模态）忽略全部键。
+因 promptSelectionActive（含 historyOpen 等所有模态）忽略全部键。中文输入法仍在预编辑时，
+SearchBox 中由终端绘制的字符尚未进入 historyQuery，结果会暂时保持上一个已提交查询；完成
+候选提交后才会重新过滤。
 
 ## 冲突
 

--- a/docs/project-documentation/session-context.md
+++ b/docs/project-documentation/session-context.md
@@ -108,8 +108,9 @@ SQLite 声称标为「文档冲突/待确认」**。文档描述的是 43f271f�
 
 `src/history.ts` 管理的是**输入命令历史**（与会话历史无关）：
 `~/.dsh-cc/history.jsonl`，每行一个 {text, ts} JSON（:6-14）；appendHistory
-追加、去重相邻重复项（CC 行为：重复提交只推进时间戳）、slice(-200) 截断
-（HISTORY_LIMIT=200，:45-68）；loadHistory 返回倒序（最新在前，:70-85）供
+在跨进程锁下写入临时文件并原子替换，避免多进程整文件覆盖；loadHistory 读取时折叠
+相邻重复项、归一化非法 ts，并只保留最近 200 条（HISTORY_LIMIT=200）；返回倒序
+（最新在前）供
 Ctrl+R 搜索框（见 [input-commands.md](input-commands.md#ctrlr-历史搜索)）；
 historyEntryId 用 sha1(text) 前 12 位做 React key。写入点全部在 PromptInput
 五条发送路径（submit/steer/queue/interrupt/slash，:238/263/281/327/351）。

--- a/scripts/verify-history-filter.tsx
+++ b/scripts/verify-history-filter.tsx
@@ -1,0 +1,96 @@
+/** Regression: duplicate history rows must disappear when filtering reaches zero results. */
+process.env.DSH_TUI_LANG = 'zh'
+
+import { PassThrough, Writable } from 'node:stream'
+import React from 'react'
+const [
+  { Box, Text, render },
+  { HistorySearchDialog },
+  { OverlayAbove },
+  { t },
+  { Terminal },
+] = await Promise.all([
+  import('../src/ui.js'),
+  import('../src/components/HistorySearchDialog.js'),
+  import('../src/components/OverlayAbove.js'),
+  import('../src/i18n.js'),
+  import('@xterm/headless'),
+])
+
+const COLS = 100
+const ROWS = 24
+const term = new Terminal({ cols: COLS, rows: ROWS, scrollback: 100, allowProposedApi: true })
+class Out extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void) { term.write(String(chunk), callback) }
+}
+class Err extends Writable {
+  isTTY = true
+  _write(_chunk: unknown, _encoding: BufferEncoding, callback: () => void) { callback() }
+}
+class In extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+const consoleErrors: string[] = []
+const originalConsoleError = console.error
+console.error = (...args: unknown[]) => {
+  consoleErrors.push(args.map(String).join(' '))
+}
+const entries = Array.from({ length: 5 }, (_, index) => ({
+  text: '你好',
+  ts: Date.now() - index * 60_000,
+}))
+
+function Probe(): React.ReactNode {
+  const [query, setQuery] = React.useState('')
+  React.useEffect(() => {
+    const timer = setTimeout(() => setQuery('知道'), 300)
+    return () => clearTimeout(timer)
+  }, [])
+  const matches = query === '' ? entries : entries.filter(entry => entry.text.includes(query))
+  return React.createElement(
+    Box,
+    { height: ROWS, flexDirection: 'column' },
+    React.createElement(Box, { flexGrow: 1 }),
+    React.createElement(
+      Box,
+      { height: 1 },
+      React.createElement(
+        OverlayAbove,
+        null,
+        React.createElement(HistorySearchDialog, {
+          query,
+          cursorOffset: query.length,
+          matches,
+          focusIndex: 0,
+        }),
+      ),
+      React.createElement(Text, null, 'prompt'),
+    ),
+  )
+}
+
+const app = await render(
+  React.createElement(Probe),
+  { stdout: new Out(), stderr: new Err(), stdin: new In(), exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(800)
+const lines = Array.from({ length: ROWS }, (_, index) => term.buffer.active.getLine(index)?.translateToString(true) ?? '')
+const staleLines = lines.filter(line => line.includes('你好'))
+const emptyText = t('history-search-empty')
+const emptyLine = lines.find(line => line.includes(emptyText))
+app.unmount()
+console.error = originalConsoleError
+
+const ok = staleLines.length === 0 && emptyLine !== undefined && consoleErrors.length === 0
+console.log(`${ok ? 'PASS' : 'FAIL'}: duplicate history rows are cleared after a zero-result filter`)
+if (!ok) {
+  console.error(JSON.stringify({ staleLines, emptyLine, consoleErrors }, null, 2))
+  process.exit(1)
+}

--- a/scripts/verify-history-persistence.mjs
+++ b/scripts/verify-history-persistence.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/** Regression: persisted history survives concurrent writers and bad timestamps. */
+import { spawn } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const home = mkdtempSync(join(tmpdir(), 'dsh-tui-history-persistence-'))
+process.env.HOME = home
+process.env.USERPROFILE = home
+
+const historyDir = join(home, '.dsh-tui')
+const historyFile = join(historyDir, 'history.jsonl')
+const historyModule = pathToFileURL(resolve('lib/types/history.js')).href
+const { appendHistory, loadHistory } = await import(historyModule)
+
+let failed = 0
+function check(name, ok, detail = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail ? ` (${detail})` : ''}`)
+  if (!ok) failed += 1
+}
+
+function appendInChild(text) {
+  const source = `
+    const { appendHistory } = await import(${JSON.stringify(historyModule)});
+    appendHistory(process.env.HISTORY_TEST_TEXT);
+  `
+  return new Promise((resolveChild, reject) => {
+    const child = spawn(process.execPath, ['--input-type=module', '--eval', source], {
+      env: { ...process.env, HOME: home, USERPROFILE: home, HISTORY_TEST_TEXT: text },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+    let stderr = ''
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', chunk => { stderr += chunk })
+    child.on('error', reject)
+    child.on('exit', code => {
+      if (code === 0) resolveChild()
+      else reject(new Error(`history writer exited ${code}: ${stderr}`))
+    })
+  })
+}
+
+try {
+  mkdirSync(historyDir, { recursive: true })
+  writeFileSync(historyFile, [
+    JSON.stringify({ text: 'negative timestamp', ts: -1 }),
+    JSON.stringify({ text: 'missing timestamp' }),
+    JSON.stringify({ text: 'repeat', ts: 100 }),
+    JSON.stringify({ text: 'repeat', ts: 200 }),
+    JSON.stringify({ text: 'separator', ts: 300 }),
+    JSON.stringify({ text: 'repeat', ts: 400 }),
+  ].join('\n') + '\n')
+
+  const parsed = loadHistory()
+  check(
+    'invalid timestamps are normalized to finite non-negative values',
+    parsed.every(entry => Number.isFinite(entry.ts) && entry.ts >= 0),
+  )
+  check(
+    'only adjacent duplicate entries collapse',
+    parsed.map(entry => entry.text).join('|') ===
+      'repeat|separator|repeat|missing timestamp|negative timestamp',
+    parsed.map(entry => entry.text).join('|'),
+  )
+
+  writeFileSync(historyFile, JSON.stringify({ text: 'legacy-no-newline', ts: 1 }))
+  appendHistory('after-boundary')
+  const repairedBoundary = loadHistory()
+  check(
+    'append repairs a missing terminal newline',
+    repairedBoundary.map(entry => entry.text).join('|') === 'after-boundary|legacy-no-newline',
+    repairedBoundary.map(entry => entry.text).join('|'),
+  )
+
+  writeFileSync(
+    historyFile,
+    Array.from({ length: 250 }, (_, index) =>
+      JSON.stringify({ text: `bounded-${index}`, ts: index }),
+    ).join('\n') + '\n',
+  )
+  const bounded = loadHistory()
+  check(
+    'history search exposes only the latest 200 entries',
+    bounded.length === 200 && bounded[0]?.text === 'bounded-249' && bounded[199]?.text === 'bounded-50',
+  )
+
+  writeFileSync(historyFile, '')
+  for (let index = 0; index < 250; index += 1) {
+    appendHistory(`bounded-write-${index}`)
+  }
+  const persistedBoundedLines = readFileSync(historyFile, 'utf8').split('\n').filter(Boolean)
+  check('append keeps the physical history file bounded', persistedBoundedLines.length === 200)
+
+  writeFileSync(historyFile, '')
+  const texts = Array.from({ length: 32 }, (_, index) => `writer-${index}`)
+  await Promise.all(texts.map(appendInChild))
+
+  const lines = readFileSync(historyFile, 'utf8').split('\n').filter(Boolean)
+  const records = lines.map(line => JSON.parse(line))
+  check('concurrent writers leave complete JSONL records', records.length === texts.length)
+  check(
+    'concurrent writers do not overwrite one another',
+    new Set(records.map(record => record.text)).size === texts.length &&
+      texts.every(text => records.some(record => record.text === text)),
+  )
+} finally {
+  rmSync(home, { recursive: true, force: true })
+}
+
+if (failed > 0) process.exit(1)
+console.log('verify-history-persistence OK')

--- a/src/components/HistorySearchDialog.tsx
+++ b/src/components/HistorySearchDialog.tsx
@@ -60,7 +60,10 @@ export function HistorySearchDialog({
             const absoluteIndex = start + index
             return (
               <ListItem
-                key={historyEntryId(entry)}
+                // Text is not unique in persisted history. Include the
+                // current result position so duplicate commands never share
+                // a React key and leave stale rows after filtering.
+                key={`${historyEntryId(entry)}:${absoluteIndex}`}
                 isFocused={absoluteIndex === focusIndex}
                 // The SearchBox owns the native-cursor declaration while this
                 // dialog is open — result rows must not park the cursor on

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,10 +1,20 @@
-import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { createHash, randomUUID } from 'node:crypto'
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
 import { join } from 'node:path'
 import { DATA_DIR } from './utils/paths.js'
 
 const HISTORY_DIR = DATA_DIR
 const HISTORY_FILE = join(HISTORY_DIR, 'history.jsonl')
+const HISTORY_LOCK = join(HISTORY_DIR, 'history.jsonl.lock')
+const HISTORY_LOCK_OWNER = join(HISTORY_LOCK, 'owner')
 
 /** One persisted input-history entry. */
 export type HistoryEntry = {
@@ -14,10 +24,77 @@ export type HistoryEntry = {
 }
 
 const HISTORY_LIMIT = 200
+const HISTORY_LOCK_WAIT_MS = 5_000
+const HISTORY_LOCK_STALE_MS = 30_000
+const LOCK_WAIT_BUFFER = new Int32Array(new SharedArrayBuffer(4))
+
+function sleepSync(ms: number): void {
+  Atomics.wait(LOCK_WAIT_BUFFER, 0, 0, ms)
+}
+
+function ownerProcessIsAlive(): boolean | undefined {
+  try {
+    const owner = JSON.parse(readFileSync(HISTORY_LOCK_OWNER, 'utf8')) as { pid?: unknown }
+    if (typeof owner.pid !== 'number' || !Number.isInteger(owner.pid)) return undefined
+    try {
+      process.kill(owner.pid, 0)
+      return true
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function staleHistoryLock(): boolean {
+  try {
+    const alive = ownerProcessIsAlive()
+    if (alive !== undefined) return !alive
+    return Date.now() - statSync(HISTORY_LOCK).mtimeMs > HISTORY_LOCK_STALE_MS
+  } catch {
+    return false
+  }
+}
+
+function acquireHistoryLock(): (() => void) | undefined {
+  mkdirSync(HISTORY_DIR, { recursive: true })
+  const deadline = Date.now() + HISTORY_LOCK_WAIT_MS
+  for (;;) {
+    try {
+      mkdirSync(HISTORY_LOCK)
+      try {
+        writeFileSync(HISTORY_LOCK_OWNER, JSON.stringify({ pid: process.pid }), 'utf8')
+      } catch {
+        rmSync(HISTORY_LOCK, { recursive: true, force: true })
+        return undefined
+      }
+      return () => {
+        try {
+          rmSync(HISTORY_LOCK, { recursive: true, force: true })
+        } catch {
+          // Best effort; a later writer can recover a stale lock.
+        }
+      }
+    } catch {
+      if (staleHistoryLock()) {
+        try {
+          rmSync(HISTORY_LOCK, { recursive: true, force: true })
+        } catch {
+          // Another writer may have released or replaced the lock.
+        }
+        continue
+      }
+      if (Date.now() >= deadline) return undefined
+      sleepSync(10)
+    }
+  }
+}
 
 function loadRaw(): HistoryEntry[] {
   if (!existsSync(HISTORY_FILE)) return []
   const entries: HistoryEntry[] = []
+  const readAt = Date.now()
   try {
     for (const line of readFileSync(HISTORY_FILE, 'utf8').split('\n')) {
       const trimmed = line.trim()
@@ -25,7 +102,17 @@ function loadRaw(): HistoryEntry[] {
       try {
         const parsed = JSON.parse(trimmed) as Partial<HistoryEntry>
         if (typeof parsed.text === 'string' && parsed.text.length > 0) {
-          entries.push({ text: parsed.text, ts: typeof parsed.ts === 'number' ? parsed.ts : 0 })
+          const ts = typeof parsed.ts === 'number' && Number.isFinite(parsed.ts) && parsed.ts >= 0
+            ? parsed.ts
+            : readAt
+          const last = entries[entries.length - 1]
+          if (last?.text === parsed.text) {
+            // Fold adjacent repeats while reading to retain the previous
+            // "latest repeat wins" behavior, including legacy snapshots.
+            last.ts = ts
+          } else {
+            entries.push({ text: parsed.text, ts })
+          }
         }
       } catch {
         // Skip malformed lines; the file is best-effort.
@@ -34,36 +121,53 @@ function loadRaw(): HistoryEntry[] {
   } catch {
     return []
   }
-  return entries
+  return entries.slice(-HISTORY_LIMIT)
 }
 
 /**
- * Append an input to the persisted history, deduping the immediately
- * previous entry and capping the file at 200 entries.
+ * Persist one input under a cross-process lock. The snapshot is written to a
+ * temporary file and atomically renamed so readers see either the old or new
+ * complete JSONL file; the physical file remains capped at 200 entries.
  * @param text - Input to persist; blank inputs are ignored.
  */
 export function appendHistory(text: string): void {
   const trimmed = text.trim()
   if (!trimmed) return
-  const entries = loadRaw()
-  // Skip consecutive duplicates (CC behavior: repeated submits of the same
-  // command only advance the existing entry's timestamp).
-  const last = entries[entries.length - 1]
-  if (last && last.text === trimmed) {
-    last.ts = Date.now()
-  } else {
-    entries.push({ text: trimmed, ts: Date.now() })
-  }
-  const sliced = entries.slice(-HISTORY_LIMIT)
+  let release: (() => void) | undefined
   try {
-    mkdirSync(HISTORY_DIR, { recursive: true })
-    writeFileSync(
-      HISTORY_FILE,
-      sliced.map(e => JSON.stringify(e)).join('\n') + '\n',
-      'utf8',
-    )
+    release = acquireHistoryLock()
+  } catch {
+    return
+  }
+  if (!release) return
+  try {
+    const entries = loadRaw()
+    const last = entries[entries.length - 1]
+    if (last?.text === trimmed) {
+      last.ts = Date.now()
+    } else {
+      entries.push({ text: trimmed, ts: Date.now() })
+    }
+    const snapshot = entries.slice(-HISTORY_LIMIT)
+    const temporaryFile = join(HISTORY_DIR, `.history-${process.pid}-${randomUUID()}.tmp`)
+    try {
+      writeFileSync(
+        temporaryFile,
+        snapshot.map(entry => JSON.stringify(entry)).join('\n') + '\n',
+        'utf8',
+      )
+      renameSync(temporaryFile, HISTORY_FILE)
+    } finally {
+      try {
+        rmSync(temporaryFile, { force: true })
+      } catch {
+        // Best effort cleanup; the next write uses a unique temporary path.
+      }
+    }
   } catch {
     // Best-effort persistence; history still works for the session.
+  } finally {
+    release()
   }
 }
 
@@ -76,7 +180,9 @@ export function loadHistory(): HistoryEntry[] {
 }
 
 /**
- * Stable id for a history entry (dedupes React keys across identical texts).
+ * Stable text-derived id prefix for a history entry. Callers rendering a
+ * list must add a positional or record-specific suffix because repeated text
+ * is valid persisted history.
  * @param entry - The history entry to hash.
  * @returns A 12-char hex id derived from the entry text.
  */


### PR DESCRIPTION
## 背景

本 PR 只修复持久化历史搜索的结果残留和写入可靠性问题，不改变主分支既有的输入快捷键行为。

当历史中存在多条相同文本时，搜索结果可能复用相同的 React key。查询从有结果变为无结果后，Ink/React 可能错误复用旧行，导致界面仍显示不匹配的历史内容。

## 修复内容

- 历史结果 key 使用“历史项标识 + 当前结果绝对位置”，重复文本也能稳定独立渲染。
- 查询结果收缩为零时，旧行会被正确清除。
- 持久化历史写入增加跨进程锁和临时文件原子替换。
- 历史文件最多保留 200 条记录，相邻重复项折叠，非法时间戳归一化。
- 保留过滤和持久化回归测试。


## 验证

```text
pnpm build
node --import tsx/esm scripts/verify-history-filter.tsx
node scripts/verify-history-persistence.mjs
git diff --check
```

Closes #271

## dsh-ecosystem-spec 符合性

本 PR 仅涉及 TUI 历史搜索和本地历史文件写入，不修改插件 manifest、Community contract、registry、schema、市场准入或 claim；不新增规范性要求，也不声明生态认证或规范稳定性。