### PR TITLE
fix(resume): 模型切换后不再显示当前会话祖先

### DIFF
--- a/scripts/verify-session-browser.mjs
+++ b/scripts/verify-session-browser.mjs
@@ -88,9 +88,18 @@ const summary = (over) => ({
 })
 
 function makeChannel() {
-  // MRU order: gamma (newest) → beta → alpha, plus two delegated runs under
-  // beta and one boot artifact holding no conversation.
+  // The live session is a model-switch fork. Its current lineage must not be
+  // offered as a separate resumable conversation; the remaining MRU order is
+  // gamma (newest) → beta → alpha, plus two delegated runs under beta and one
+  // boot artifact holding no conversation.
   let sessions = [
+    summary({
+      id: 'live-session',
+      kind: { kind: 'fork', parent: 'live-parent' },
+      title: { text: 'after model switch', source: 'auto' },
+      updatedAt: 8,
+    }),
+    summary({ id: 'live-parent', title: { text: 'before model switch', source: 'auto' }, updatedAt: 7 }),
     summary({ id: 's-new', title: { text: 'gamma', source: 'auto' }, updatedAt: 5 }),
     summary({ id: 's-mid', title: { text: 'beta', source: 'auto' }, updatedAt: 4, childCount: 2 }),
     summary({ id: 's-old', title: { text: 'alpha', source: 'auto' }, updatedAt: 3 }),
@@ -252,6 +261,7 @@ await windowed(() => stdin.write('\r'), 600)
 let s = screen()
 check('the browser opens as a screen', /Resume session/.test(flat(s)), flat(s).slice(0, 120))
 check('conversations are listed', /gamma/.test(s) && /beta/.test(s) && /alpha/.test(s))
+check('the current model-switch lineage is not offered as another conversation', !/before model switch/.test(s) && !/after model switch/.test(s))
 check('delegated runs are NOT listed by default', !/delegated one/.test(s) && !/delegated two/.test(s))
 check('but they are counted', /2 runs folded/.test(flat(s)), flat(s).slice(0, 200))
 check('a session with no conversation is never a row', !/^\s*❯?\s*tmp\b/m.test(s))

--- a/scripts/verify-session-kinds.mjs
+++ b/scripts/verify-session-kinds.mjs
@@ -146,6 +146,18 @@ check(
   ['conv', 'fork'],
 )
 check('a rewind fork survives the sub-agent filter', base.rows.some(r => r.kind === 'session' && r.session.id === 'fork'), true)
+const modelSwitchLineage = [
+  summary({ id: 'model-v3', updatedAt: 100, kind: { kind: 'fork', parent: 'model-v2' } }),
+  summary({ id: 'model-v2', updatedAt: 90, kind: { kind: 'fork', parent: 'model-root' } }),
+  summary({ id: 'model-root', updatedAt: 80 }),
+  summary({ id: 'other-fork', updatedAt: 70, kind: { kind: 'fork', parent: 'other-root' } }),
+]
+check(
+  'current conversation ancestors are not resume targets, while unrelated forks remain visible',
+  buildView(modelSwitchLineage, DEFAULT_FILTERS, { ...context, currentId: 'model-v3' })
+    .rows.filter(r => r.kind === 'session').map(r => r.session.id),
+  ['other-fork'],
+)
 check('delegated runs are counted, not merely dropped', base.hiddenSubagents, 2)
 check('sessions with no conversation are counted', base.emptyCount, 1)
 check('and named, so they can be cleaned', base.emptyIds, ['empty'])

--- a/src/sessions/view.ts
+++ b/src/sessions/view.ts
@@ -6,8 +6,9 @@
  * flat list of rows. Two reasons it is shaped that way:
  *
  * - Filtering is where this feature's bugs were. Keeping it pure means the
- *   truth table — a sub-agent run is hidden, a rewind fork is not, a boot
- *   artifact is hidden but counted — is checkable without rendering anything.
+ *   truth table — a sub-agent run is hidden, an unrelated rewind fork is not,
+ *   a boot artifact is hidden but counted — is checkable without rendering
+ *   anything.
  * - Rows are flattened rather than nested. A windowed list of variable-height
  *   groups has to guess how much room each group needs; a flat list of
  *   single-line rows is windowed by arithmetic, and the group headers simply
@@ -87,8 +88,26 @@ export function buildView(
 ): BrowserView {
   const needle = filters.query.trim().toLowerCase()
 
+  // `/model` and `/rewind` continue the live conversation in a fork. Offering
+  // that fork's ancestors in `/resume` makes one conversation look like many,
+  // and selecting one silently jumps back before the fork. Only the live
+  // lineage is excluded: unrelated forks remain recoverable. Treat malformed
+  // cycles as a closed chain rather than looping forever over foreign data.
+  const byId = new Map(sessions.map(session => [session.id, session]))
+  const currentAncestors = new Set<string>()
+  const seen = new Set([context.currentId])
+  let cursor = byId.get(context.currentId)
+  while (cursor?.kind.kind === 'fork') {
+    const parent = cursor.kind.parent
+    if (seen.has(parent)) break
+    seen.add(parent)
+    currentAncestors.add(parent)
+    cursor = byId.get(parent)
+  }
+
   const inScope = (session: SessionSummary): boolean =>
     session.id !== context.currentId &&
+    !currentAncestors.has(session.id) &&
     (filters.allProjects || context.sameProject(context.cwd, session.cwd))
 
   // Empty sessions never reach a view, but they are counted — and the count


### PR DESCRIPTION
## 修改内容

- `/resume` 构建列表时沿当前 fork 的 `parent` 链排除祖先会话，避免一次 `/model` 切换显示成多条可恢复记录
- 仅排除当前 lineage；其他 `/rewind` / fork 分支仍可正常搜索和恢复
- 补充纯视图真值表与真实 Chat/xterm 屏幕级回归

## 根因与复现

`/model` 为了保留历史并切换路由，会在当前日志末尾创建 fork。会话浏览器原先只排除当前 session ID，没有排除它的祖先，因此模型每切换一次，切换前的 session 都会重新出现在 `/resume` 中；选中祖先后自然只能恢复到切换前的记录。

修复前新增回归稳定得到：

```text
actual:   model-v2, model-root, other-fork
expected: other-fork
```

修复后只隐藏当前会话的 `model-v2 -> model-root` 祖先链，`other-fork` 保持可见。遍历带已访问集合，损坏的循环 lineage 不会导致死循环。

## 验证

- `npm run build`：通过（boundary、contract、manifest deps、patch surface、packaged presets、minimal preset tools、liangshen bootstrap）
- `node scripts/verify-session-kinds.mjs`：通过，101 checks
- `node scripts/verify-session-browser.mjs`：通过，32 项屏幕与交互检查
- 使用真实 headless xterm 帧生成并人工检查修复后截图：列表只显示 `gamma / beta / alpha`，夹具中的 `before model switch / after model switch` 均未出现；右侧计数与底部操作栏无裁切

Closes #270