### PR TITLE
fix(completion): 大型工程的 @ 文件补全不再被构建产物挤占

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,9 @@ jobs:
       # stdin 批量按键回归：同一读取内的文本、方向键、文本必须依次基于
       # 前一事件的输入状态执行，不能因 React 批处理读取旧闭包而丢字符。
       - run: node scripts/verify-batched-prompt-input.mjs
+      # 文件补全回归（issue #278）：CMake 构建目录与任意大型兄弟目录不得
+      # 独占 100 条全局预算，普通深层源码也不能被固定深度静默截断。
+      - run: node scripts/verify-file-completion.mjs
       # /resume 会话管理回归（issue #112）：picker 重命名追加帧（seq 连续、
       # 已有字节不动、last-title-wins）、删除目录、路径穿越 id 拒绝。
       - run: node scripts/verify-resume-manage.mjs

--- a/scripts/verify-file-completion.mjs
+++ b/scripts/verify-file-completion.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/** Regression coverage for `@` completion in large generated trees (#278). */
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createChannel } from '../lib/types/dsh-adapter/channel.js'
+
+const fixture = await mkdtemp(join(tmpdir(), 'dsh-tui-file-completion-'))
+
+function makeAgent() {
+  return {
+    id: 'file-completion-agent',
+    ctx: { on: () => () => {} },
+    status: 'idle',
+    session: { id: 'file-completion-session', seq: 0, events: [] },
+  }
+}
+
+const fsService = {
+  async resolve(path) {
+    return { displayPath: path }
+  },
+  async listDir(target) {
+    const entries = await readdir(target.displayPath, { withFileTypes: true })
+    return entries
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(entry => ({
+        name: entry.name,
+        type: entry.isDirectory() ? 'directory' : entry.isFile() ? 'file' : 'other',
+        target: { displayPath: join(target.displayPath, entry.name) },
+      }))
+  },
+}
+
+try {
+  const cmakeFiles = join(fixture, 'build_u22', 'CMakeFiles')
+  const cmakePresetFiles = join(fixture, 'cmake-build-debug', 'CMakeFiles')
+  const sourceDir = join(fixture, 'src')
+  await mkdir(cmakeFiles, { recursive: true })
+  await mkdir(cmakePresetFiles, { recursive: true })
+  await mkdir(sourceDir)
+  await Promise.all([
+    ...Array.from({ length: 120 }, (_, index) =>
+      writeFile(join(cmakeFiles, `artifact-${String(index).padStart(3, '0')}.o`), ''),
+    ),
+    writeFile(join(cmakePresetFiles, 'compiler_depend.make'), ''),
+    writeFile(join(sourceDir, 'main.cpp'), 'int main() {}\n'),
+  ])
+
+  const ctx = {
+    on: () => () => {},
+    get(name) {
+      return name === 'fs' ? fsService : undefined
+    },
+    logger: { warn() {} },
+  }
+  const channel = createChannel(ctx, makeAgent(), {
+    model: 'test-model',
+    provider: 'test-provider',
+    cwd: fixture,
+    activity: false,
+  })
+
+  const files = await channel.listFiles()
+  assert.ok(
+    files.includes('src/main.cpp'),
+    `source file was crowded out by generated files:\n${files.join('\n')}`,
+  )
+  assert.ok(files.every(file => !file.startsWith('build_u22/')))
+  assert.ok(files.every(file => !file.startsWith('cmake-build-debug/')))
+  console.log('PASS: CMake build output cannot crowd source files out of @ completion')
+
+  const generatedDir = join(fixture, 'generated')
+  await mkdir(generatedDir)
+  await Promise.all(
+    Array.from({ length: 120 }, (_, index) =>
+      writeFile(join(generatedDir, `generated-${String(index).padStart(3, '0')}.ts`), ''),
+    ),
+  )
+
+  const filesWithLargeSibling = await channel.listFiles()
+  assert.ok(
+    filesWithLargeSibling.includes('src/main.cpp'),
+    `an earlier sibling directory consumed the global completion budget:\n${filesWithLargeSibling.join('\n')}`,
+  )
+  console.log('PASS: a large sibling directory cannot crowd source files out of @ completion')
+
+  const nestedSourceDir = join(sourceDir, 'features', 'editor')
+  await mkdir(nestedSourceDir, { recursive: true })
+  await writeFile(join(nestedSourceDir, 'view.ts'), 'export const view = true\n')
+
+  const filesWithNestedSource = await channel.listFiles()
+  assert.ok(
+    filesWithNestedSource.includes('src/features/editor/view.ts'),
+    `ordinary nested source exceeded the completion depth limit:\n${filesWithNestedSource.join('\n')}`,
+  )
+  console.log('PASS: ordinary nested source remains reachable in @ completion')
+} finally {
+  await rm(fixture, { recursive: true, force: true })
+}

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -4276,11 +4276,12 @@ function usageOutputTokens(usage: unknown): number | undefined {
 }
 
 /**
- * Recursive `@` file listing through the leaf's fs service (dsh-fs-local):
- * walks up to MAX_DEPTH levels below `root`, skipping VCS/dependency dirs,
- * returning relative paths (directories with a trailing `/`, matching the
- * FileSuggestions tag logic) capped at MAX_FILES entries. Best-effort —
- * unreadable subtrees are skipped, not fatal.
+ * `@` file listing through the leaf's fs service (dsh-fs-local): skips
+ * VCS/dependency/build dirs and rotates across directory listings so one
+ * large subtree cannot consume the global MAX_FILES budget. That budget also
+ * bounds directory reads without imposing an arbitrary source-tree depth.
+ * Relative directories retain the trailing `/` that FileSuggestions expects.
+ * Unreadable subtrees are skipped, not fatal.
  */
 async function listFilesDeep(
   fs: {
@@ -4297,38 +4298,58 @@ async function listFilesDeep(
 ): Promise<string[]> {
   if (!fs) return []
   const out: string[] = []
-  const SKIP = new Set(['node_modules', '.git', '.hg', '.svn', '.DS_Store', 'dist', 'build'])
-  const MAX_DEPTH = 3
+  const SKIP = new Set(['node_modules', '.git', '.hg', '.svn', '.DS_Store', 'dist'])
+  const BUILD_DIR = /^(?:build(?:[-_].*)?|cmake-build(?:[-_].*)?)$/i
   const MAX_FILES = 100
 
-  const walk = async (dir: string, prefix: string, depth: number): Promise<void> => {
-    if (depth > MAX_DEPTH || out.length >= MAX_FILES) return
-    let entries: Array<{
-      name: string
-      type: 'file' | 'directory' | 'other'
-      target: { displayPath: string }
-    }> = []
-    try {
-      const target = await fs.resolve(dir)
-      entries = await fs.listDir(target)
-    } catch {
-      return // unreadable subtree — skip
-    }
-    for (const entry of entries) {
-      if (out.length >= MAX_FILES) return
-      if (SKIP.has(entry.name)) continue
-      const rel = prefix ? `${prefix}/${entry.name}` : entry.name
-      if (entry.type === 'directory') {
-        out.push(`${rel}/`)
-        // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: symlink targets optional
-        await walk(entry.target?.displayPath ?? join(dir, entry.name), rel, depth + 1)
-      } else if (entry.type === 'file') {
-        out.push(rel)
+  type Entry = {
+    name: string
+    type: 'file' | 'directory' | 'other'
+    target: { displayPath: string }
+  }
+  type Directory = {
+    dir: string
+    prefix: string
+    entries?: Entry[]
+    index: number
+  }
+  const directories: Directory[] = [{ dir: root, prefix: '', index: 0 }]
+
+  while (directories.length > 0 && out.length < MAX_FILES) {
+    const current = directories.shift()
+    if (!current) continue
+    if (!current.entries) {
+      try {
+        const target = await fs.resolve(current.dir)
+        current.entries = await fs.listDir(target)
+      } catch {
+        continue // unreadable subtree — skip
       }
     }
-  }
 
-  await walk(root, '', 1)
+    let entry: Entry | undefined
+    while (current.index < current.entries.length) {
+      const candidate = current.entries[current.index++]
+      if (SKIP.has(candidate.name) || BUILD_DIR.test(candidate.name)) continue
+      entry = candidate
+      break
+    }
+    if (!entry) continue
+    if (current.index < current.entries.length) directories.push(current)
+
+    const rel = current.prefix ? `${current.prefix}/${entry.name}` : entry.name
+    if (entry.type === 'directory') {
+      out.push(`${rel}/`)
+      directories.push({
+        // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: symlink targets optional
+        dir: entry.target?.displayPath ?? join(current.dir, entry.name),
+        prefix: rel,
+        index: 0,
+      })
+    } else if (entry.type === 'file') {
+      out.push(rel)
+    }
+  }
   return out
 }
 


### PR DESCRIPTION
## 动机

大型 CMake 工程中，`@` 文件候选会被 `build_u22/CMakeFiles` 等构建产物占满。用户即使继续输入 `@src/`，所需源码也可能在初次扫描时已被截断，无法出现在补全列表。

Closes #278

## 根因与复现

- 文件扫描采用深度优先遍历，第一个大型子树可以独占全部 100 条全局预算；
- 跳过规则只精确匹配 `build`，无法识别 `build_u22`、`build-debug` 和 `cmake-build-debug`；
- 固定 `MAX_DEPTH=3` 会把普通的 `src/features/editor/view.ts` 静默截断。

新增回归通过真实 `createChannel(...).listFiles()` 和临时目录复现。修复前，120 个 CMake 产物占满结果：

```text
build_u22/
build_u22/CMakeFiles/
build_u22/CMakeFiles/artifact-000.o
...
build_u22/CMakeFiles/artifact-097.o
```

`src/main.cpp` 不在 100 条候选中；把噪音换成不能直接跳过的普通 `generated/` 目录后同样失败，深层源码则只扫描到 `src/features/editor/`。

## 修改

- 识别 `build`、`build-*`、`build_*` 与 `cmake-build-*` 构建目录变体，大小写不敏感；
- 将递归 DFS 改为目录队列轮转，每个目录每轮贡献一个候选，避免单个大型子树独占预算；
- 移除固定深度截断，继续由 100 条结果预算约束目录读取次数；
- 新增大型 CMake 目录、普通大型兄弟目录和深层源码三组公开行为回归，并接入 CI。

## 行为边界

- 候选总数仍最多 100 条，不扩大大项目扫描的结果上限；
- `node_modules`、VCS 目录、`dist` 以及上述构建目录继续跳过，不改变不可读目录的 best-effort 降级；
- 不新增“跳过所有隐藏项”的规则，避免误伤 `.env`、`.github` 等有补全价值的路径；
- 候选改为在目录之间公平轮转，不再保证旧 DFS 的整棵子树连续顺序；
- 不修改 `@` mention 的提交、附件读取或上下文预算逻辑。

## 截图

真实 `FileSuggestions` + `createChannel().listFiles()` + headless xterm（`90×18`）。夹具含 120 个 `build_u22/CMakeFiles` 产物；`@src/` 可见 `main.cpp` 和深层源码，构建产物未进入候选：

![大型 CMake 工程文件补全修复后](https://github.com/Qiuner/dsh-TUI/releases/download/issue-278-images/after.png)

## dsh-ecosystem-spec 影响

- **Scope**：TUI 内部 `@` 文件候选遍历策略
- **Normative change**：None
- 不修改插件 manifest、Community contract、registry、schema、公共生态 API 或持久化格式
- **Migration**：None
- **Rollback**：回退提交 `2bca4e8` 即恢复旧行为
- 本 PR 不声明生态认证或规范符合性等级

## 验证

- `corepack pnpm build`：通过（含 adapter boundary、upstream contract、manifest deps、patch surface 等 7 道门禁）
- `node scripts/verify-file-completion.mjs`：连续 3 次通过
- `corepack pnpm verify:package`：通过，852 files / 19 entry targets
- `corepack pnpm smoke`：通过
- `node scripts/verify-batched-prompt-input.mjs`：通过
- `git diff --check`：通过
- headless xterm `90×18` 截图人工检查：`@src/` 可见源码候选，构建产物未进入列表
