### PR TITLE
fix(tui): move loaded context details to /context

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ macOS 自带 Terminal.app 会自行消费 `⌘` 快捷键，请继续使用 `Ctr
 | 分组 | 命令 |
 |---|---|
 | 会话 | `/new` 新会话 · `/resume` 会话浏览器（搜索、预览、跨项目、折叠子 agent 运行） · `/rename` 重命名会话 · `/workspace resume|rename|open` 管理工作区 · `/clear` 清屏 · `/compact` 压缩 · `/export` 导出 Markdown · `/trace` 轨迹场景（亦可 `Ctrl+T`） |
-| 状态 | `/status` 会话信息 · `/cost` token 用量 · `/doctor` 环境自检 · `/config` 配置来源 · `/init` 创建 AGENTS.md |
+| 状态 | `/context` 已加载上下文明细 · `/status` 会话信息 · `/cost` token 用量 · `/doctor` 环境自检 · `/config` 配置来源 · `/init` 创建 AGENTS.md |
 | 模型 | `/model` 选择器 · `/thinking` 思考显示 · `/tokens` token 明细 · `/theme` 主题选择器 · `/lang` 中英界面切换 |
 | 账号/策略 | `/provider` 添加模型提供方 · `/login` 凭证状态 · `/logout` 登出说明 · `/permissions` 权限说明 · `/add-dir` 文件策略范围 · `/hooks` · `/mcp` |
 | 技能 | `/audit` 代码审计 · `/bug` bug 报告 · `/review` 代码评审 · `/practice` 编程练习 · `/pr_comments` PR 评论 · `/release-notes` 发布说明 · `/vuln-check` 漏洞检查 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -149,7 +149,7 @@ so keep using `Ctrl`.
 | Group | Commands |
 |---|---|
 | Session | `/new` new session · `/resume` session browser (search, preview, cross-project, sub-agent runs folded) · `/rename` rename session · `/workspace resume|rename|open` manage workspaces · `/clear` clear screen · `/compact` compact · `/export` export Markdown · `/trace` trace timeline |
-| Status | `/status` session info · `/cost` token usage · `/doctor` environment self-check · `/config` configuration sources · `/init` create AGENTS.md |
+| Status | `/context` loaded-context details · `/status` session info · `/cost` token usage · `/doctor` environment self-check · `/config` configuration sources · `/init` create AGENTS.md |
 | Model | `/model` picker · `/thinking` thinking display · `/tokens` token details · `/theme` theme picker · `/lang` zh/en UI switch |
 | Accounts/Policy | `/provider` add a model provider · `/login` credential status · `/logout` logout notes · `/permissions` permission notes · `/add-dir` file-policy scope · `/hooks` · `/mcp` |
 | Skills | `/audit` code audit · `/bug` bug report · `/review` code review · `/practice` coding practice · `/pr_comments` PR comments · `/release-notes` release notes · `/vuln-check` vulnerability check |

--- a/docs/interaction.en.md
+++ b/docs/interaction.en.md
@@ -250,7 +250,7 @@ zh; unmapped registry commands fall back to the registry's own text.
 | Group | Commands |
 | --- | --- |
 | Sessions | `/new`, `/resume`, `/rename`, `/workspace resume|rename|open`, `/clear`, `/compact`, `/export`, `/btw`, `/trace` (trajectory scene, also `Ctrl+T`) |
-| Status | `/status`, `/cost`, `/config`, `/doctor`, `/init`, `/agents` |
+| Status | `/context`, `/status`, `/cost`, `/config`, `/doctor`, `/init`, `/agents` |
 | Model and display | `/model`, `/effort`, `/thinking`, `/tokens`, `/activity`, `/preset`, `/theme`, `/lang` |
 | Account and policy | `/provider`, `/login`, `/logout`, `/permissions`, `/add-dir`, `/hooks`, `/mcp` |
 | Packaged skills | `/audit`, `/bug`, `/practice`, `/review`, `/pr_comments`, `/release-notes`, `/vuln-check` |

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -219,7 +219,7 @@ transcript。
 | 分组 | 命令 |
 | --- | --- |
 | 会话 | `/new`、`/resume`、`/rename`、`/workspace resume|rename|open`、`/clear`、`/compact`、`/export`、`/btw`、`/trace`（轨迹场景，亦可 `Ctrl+T`） |
-| 状态 | `/status`、`/cost`、`/config`、`/doctor`、`/init`、`/agents` |
+| 状态 | `/context`、`/status`、`/cost`、`/config`、`/doctor`、`/init`、`/agents` |
 | 模型与显示 | `/model`、`/effort`、`/thinking`、`/tokens`、`/activity`、`/preset`、`/theme`、`/lang` |
 | 账号与策略 | `/provider`、`/login`、`/logout`、`/permissions`、`/add-dir`、`/hooks`、`/mcp` |
 | 打包 Skills | `/audit`、`/bug`、`/practice`、`/review`、`/pr_comments`、`/release-notes`、`/vuln-check` |

--- a/docs/project-documentation/session-context.md
+++ b/docs/project-documentation/session-context.md
@@ -143,17 +143,16 @@ refreshLoadedContext（src/channel.ts:2165-2218）：
 触发点：createChannel 末尾（src/channel.ts:2244）+ rewindTo(1342) / resumeTo(1447) /
 newSession(1567) / switchModel(1672) 四个 agent 交换路径。
 
-### 面板
+### 启动摘要与 `/context`
 
-- 显示时机：仅当 `channel.rows.length === 0 && channel.loadedContext !==
-  undefined`（src/screens/Chat.tsx:1230-1240）——转录为空时才显示，首条消息行接管后消失。
-- Ctrl+T 切换展开/折叠（src/screens/Chat.tsx:1123-1127，纯键盘："the ported ink core
-  handles no mouse clicks"）。
+- 启动摘要仅在 `channel.rows.length === 0 && channel.loadedContext !==
+  undefined` 时显示；首条转录行接管后消失，并提示用 `/context` 查看明细。
+- `/context` 每次执行都通过 `channel.pushLocal` 向当前转录输出一次本地报告；它不切换
+  常驻状态，也不进入模型上下文或会话事件。Ctrl+T 始终只打开会话轨迹。
 - 单条文本上限 800 字符（src/utils/loaded-context.ts:5，CONTEXT_ENTRY_MAX_CHARS）；
   truncateContextText 只保留头部并追加截断标记，注释明确 "model-visible
-  text is the source of truth"，面板只约束自身渲染，会话日志保留全文
-  （src/utils/loaded-context.ts:15-18）；工具描述单独 160 字符截断（src/components/LoadedContextPanel.tsx:103-116，
-  截断调用 src/components/LoadedContextPanel.tsx:111）。
+  text is the source of truth"，本地报告只约束自身渲染，模型实际收到的内容不受影响；
+  工具描述单独按 160 字符截断。
 - summarizeLoadedContext 只把非空组拼接为一行摘要，全部为空时返回 '' 使
   面板整体隐藏（src/utils/loaded-context.ts:26-34）。
 

--- a/scripts/smoke.tsx
+++ b/scripts/smoke.tsx
@@ -491,8 +491,8 @@ console.log('--- has interrupted?', plain.includes('Interrupted') && plain.inclu
 console.log('--- has notification?', plain.includes('Test notification'))
 console.log('--- has help menu?', plain.includes('/ for commands') || true)
 
-// Startup loaded-context panel: collapsed by default, Ctrl+T (byte 0x14)
-// expands and collapses it — the keyboard path for mouse-less terminals.
+// Startup loaded-context summary: details live behind the one-shot `/context`
+// command; Ctrl+T remains exclusively owned by the trajectory scene.
 const panelChannel = {
   ...channel,
   version: 1,
@@ -520,15 +520,8 @@ const panelInstance = await render(
 )
 await new Promise(resolve => setTimeout(resolve, 600))
 const collapsed = plainText(panelStdout.frames)
-console.log('--- panel collapsed?', collapsed.includes('已加载上下文'), collapsed.includes('点击展开 · Ctrl+T'), !collapsed.includes('▼'))
-panelStdin.write(Buffer.from([0x14])) // Ctrl+T
-await new Promise(resolve => setTimeout(resolve, 400))
-const expanded = plainText(panelStdout.frames)
-console.log('--- panel expanded by Ctrl+T?', expanded.includes('▼'), expanded.includes('系统提示词 · 1 段'), expanded.includes('You are DeepSeek Harness.'))
-panelStdin.write(Buffer.from([0x14])) // Ctrl+T again
-await new Promise(resolve => setTimeout(resolve, 400))
-const recollapsed = plainText(panelStdout.frames)
-console.log('--- panel recollapsed by Ctrl+T?', recollapsed.includes('▶'))
+const hasContextSummary = collapsed.includes('已加载上下文') || collapsed.includes('Context loaded')
+console.log('--- context summary?', hasContextSummary, collapsed.includes('/context'), !collapsed.includes('Ctrl+T'))
 // ── Interaction panels: plan review + approval ─────────────────────────
 // Drives a third Chat with real QuestionStore/ApprovalStore instances. The
 // fake channel needs pushLocal: resolving a question folds a Q&A summary

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -1,23 +1,11 @@
 /**
- * Ctrl+T scope regression.
+ * Ctrl+T ownership regression.
  *
- * Two things in this UI can be "expanded", and they never share the screen:
- * the startup loaded-context panel renders only while the transcript is empty,
- * which is exactly the window where the trajectory — folded from the session's
- * own events — has nothing in it yet.
+ * Loaded-context details use the one-shot `/context` command. Ctrl+T has one
+ * stable meaning throughout the session: open the trajectory scene.
  *
- * The trajectory feature claimed Ctrl+T outright on the reasoning that the
- * panel binding was dead. It was not: the panel prints its own
- * `（Ctrl+T 展开）` hint, so the key carried a visible promise, and the scene
- * it opened instead was necessarily empty at that moment. The panel was left
- * reachable only by clicking its header — no keyboard path at all.
- *
- * These checks pin both halves, because fixing one half by hand is how the
- * halves drift apart:
- *
- * - while the panel is up, Ctrl+T expands the panel and does NOT open a scene;
- * - once the transcript has rows, Ctrl+T opens the scene;
- * - the panel's own hint still names the key it actually triggers.
+ * These checks pin both empty- and non-empty-transcript states so another
+ * context-sensitive shortcut does not creep back in.
  *
  * Run: node --import tsx/esm scripts/verify-ctrl-t-scope.tsx
  */
@@ -65,9 +53,7 @@ function events(): Record<string, unknown>[] {
 }
 const EVENTS = events()
 
-/** Shapes match the LoadedContext contract in dsh-adapter/channel.ts: the
- *  collapsed header only counts array lengths, so a fixture of bare strings
- *  renders fine until the panel is expanded and reads the fields. */
+/** Shapes match the LoadedContext contract in dsh-adapter/channel.ts. */
 const LOADED_CONTEXT = {
   sections: [
     { name: 'harness:identity', text: '你是 dsh。' },
@@ -105,7 +91,13 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     turnStart: T0,
     lastUserText: '',
     pending: [],
-    commandList: [],
+    commandList: [{ name: 'context', description: '查看上下文' }],
+    commandCompletions: () => [{
+      name: 'context',
+      description: '查看上下文',
+      replacement: '/context',
+      commandLine: '/context',
+    }],
     notifications: [],
     activityEnabled: false,
     contextBarEnabled: true,
@@ -191,44 +183,39 @@ async function mount(harness: ReturnType<typeof makeHarness>, channel: Record<st
 
 const CTRL_T = '\x14'
 const isScene = (text: string): boolean => /✦\s*轨迹/.test(text)
-/** The panel's own header line, so the open/closed marker is read where it
- *  belongs instead of searched for anywhere on screen. */
 const panelHeader = (text: string): string =>
   text.split('\n').find(line => line.includes('已加载上下文')) ?? ''
 
-// ── the panel is up (empty transcript): Ctrl+T belongs to the panel ─────────
+// ── empty transcript: summary is informational; Ctrl+T still means trace ───
 {
-  // Tall enough that the EXPANDED panel is actually on screen. At an ordinary
-  // height the expanded frame exceeds the viewport, so the terminal shows its
-  // bottom (prompt + status line) and the panel's own rows sit above the
-  // window — nothing to assert on. This says nothing about correctness at
-  // smaller sizes; the collapse below is checked either way.
-  const harness = makeHarness(100, 60)
-  const instance = await mount(harness, makeChannel({ rows: [] }))
+  const harness = makeHarness(100, 30)
+  const localReports: Array<{ title: string; lines: readonly string[] }> = []
+  const instance = await mount(harness, makeChannel({
+    rows: [],
+    pushLocal: (title: string, lines: readonly string[]) => { localReports.push({ title, lines }) },
+  }))
   await sleep(500)
 
-  const collapsed = harness.screen()
-  check('the startup panel is on screen', /已加载上下文/.test(collapsed))
-  check(
-    'and it advertises Ctrl+T',
-    collapsed.includes('Ctrl+T'),
-    collapsed.split('\n').find(line => line.includes('Ctrl+T'))?.trim(),
-  )
-  check('collapsed to begin with', panelHeader(collapsed).includes('▶'), panelHeader(collapsed).trim())
+  const summary = harness.screen()
+  check('the startup context summary is on screen', /已加载上下文/.test(summary))
+  check('the summary points to /context', panelHeader(summary).includes('/context'), panelHeader(summary).trim())
+  check('the summary does not claim Ctrl+T', !panelHeader(summary).includes('Ctrl+T'), panelHeader(summary).trim())
 
   harness.stdin.write(CTRL_T)
-  await sleep(700)
-  const expanded = harness.screen()
-  check('Ctrl+T expands the panel', /系统提示词 · 2 段/.test(expanded),
-    expanded.split('\n').find(line => line.includes('系统提示词'))?.trim())
-  check('and does NOT open the scene', !isScene(expanded))
+  await sleep(500)
+  check('Ctrl+T opens the trajectory even before the first message', isScene(harness.screen()),
+    harness.screen().split('\n')[0]?.trim())
 
-  harness.stdin.write(CTRL_T)
-  await sleep(700)
-  const recollapsed = harness.screen()
-  check('Ctrl+T collapses it again', panelHeader(recollapsed).includes('▶'),
-    panelHeader(recollapsed).trim())
-  check('and the expanded body is gone', !/系统提示词 · 2 段/.test(recollapsed))
+  harness.stdin.write('q')
+  await sleep(400)
+  check('q returns to the context summary', /已加载上下文/.test(harness.screen()))
+
+  harness.stdin.write('/context\r')
+  await sleep(400)
+  const report = localReports.at(-1)
+  check('/context emits one local report', report?.title === '/context')
+  check('the report contains loaded-context details',
+    report?.lines.some(line => line.includes('harness:identity')) === true)
 
   instance.unmount()
   instances.delete(process.stdout)
@@ -236,7 +223,7 @@ const panelHeader = (text: string): string =>
   await sleep(40)
 }
 
-// ── the transcript has rows: the panel is gone, the key is the scene's ──────
+// ── non-empty transcript: the same key still opens the scene ───────────────
 {
   const harness = makeHarness(100, 30)
   const instance = await mount(

--- a/scripts/verify-loaded-context-width.tsx
+++ b/scripts/verify-loaded-context-width.tsx
@@ -51,7 +51,7 @@ const context = {
 
 const app = await render(
   <ThemeProvider theme="dark">
-    <LoadedContextPanel context={context} open={false} onToggle={() => {}} />
+    <LoadedContextPanel context={context} />
   </ThemeProvider>,
   {
     stdout: new FakeStdout() as NodeJS.WriteStream,
@@ -77,6 +77,9 @@ if (contentLines.length !== 1) {
 }
 if (!contentLines[0]?.includes('Context loaded')) {
   throw new Error(`Collapsed context summary was not rendered: ${contentLines[0] ?? ''}`)
+}
+if (contentLines[0]?.includes('Ctrl+T')) {
+  throw new Error(`Context summary still claims the trajectory shortcut: ${contentLines[0] ?? ''}`)
 }
 
 process.stdout.write('loaded context narrow-width regression passed\n')

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -72,6 +72,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
   { name: 'btw', description: 'Ask a quick side question without interrupting the conversation' },
   { name: 'trace', description: 'Show the session event trace timeline' },
   // Session / environment
+  { name: 'context', description: 'Show loaded context details' },
   { name: 'status', description: 'Show session status' },
   { name: 'cost', description: 'Show session token usage' },
   { name: 'config', description: 'Show the dsh-tui configuration source' },

--- a/src/components/HelpMenu.tsx
+++ b/src/components/HelpMenu.tsx
@@ -35,7 +35,7 @@ export function HelpMenu({
           <Text dimColor>{t('help-verbose-output', { mod: modLabel })}</Text>
         </Box>
         <Box>
-          <Text dimColor>{t('help-toggle-context', { mod: modLabel })}</Text>
+          <Text dimColor>{t('help-open-trajectory', { mod: modLabel })}</Text>
         </Box>
         <Box>
           <Text dimColor>{t('help-search-history', { mod: modLabel })}</Text>

--- a/src/components/LoadedContextPanel.tsx
+++ b/src/components/LoadedContextPanel.tsx
@@ -1,123 +1,27 @@
 import React from 'react'
 import { t } from '../i18n.js'
 import { Box, Text } from '../ui.js'
-import type { LoadedContext, LoadedContextEntry } from '../dsh-adapter/channel.js'
-import { summarizeLoadedContext, truncateContextText } from '../utils/loaded-context.js'
-
-/** One named entry (section or dynamic context) with its full text. */
-function Entry({ entry }: { entry: LoadedContextEntry }): React.ReactNode {
-  return (
-    <Box flexDirection="column">
-      <Text bold dimColor>
-        {entry.name}
-      </Text>
-      <Text dimColor wrap="wrap">
-        {truncateContextText(entry.text)}
-      </Text>
-    </Box>
-  )
-}
-
-/** A titled group of rows inside the expanded panel. */
-function Group({ title, children }: { title: string; children: React.ReactNode }): React.ReactNode {
-  return (
-    <Box flexDirection="column" marginTop={1}>
-      <Text bold color="subtle">
-        {title}
-      </Text>
-      <Box flexDirection="column" paddingLeft={2}>
-        {children}
-      </Box>
-    </Box>
-  )
-}
+import type { LoadedContext } from '../dsh-adapter/channel.js'
+import { summarizeLoadedContext } from '../utils/loaded-context.js'
 
 /**
- * The startup context panel: a collapsed one-line summary of what a
+ * The startup context summary: a one-line inventory of what a
  * fresh conversation will load for the current agent (system prompt
  * sections, workspace instruction files, dynamic context, skill catalog,
- * tools). Toggle with Ctrl+T (see HelpMenu; the ported ink core has no
- * mouse-click handling, so the header is not clickable); the panel renders
- * only while the transcript is still empty — the first message's rows take
- * over. Renders nothing for an empty snapshot.
+ * tools). `/context` renders the existing details as a local report; the
+ * summary itself disappears once the transcript has rows. Renders nothing
+ * for an empty snapshot.
  * @param context - the channel's loaded-context snapshot.
- * @param open - whether the grouped details are shown.
- * @param onToggle - flips `open`; fired by the Ctrl+T keybinding.
  */
-export function LoadedContextPanel({
-  context,
-  open,
-  onToggle,
-}: {
-  context: LoadedContext
-  open: boolean
-  onToggle: () => void
-}): React.ReactNode {
+export function LoadedContextPanel({ context }: { context: LoadedContext }): React.ReactNode {
   const summary = summarizeLoadedContext(context)
   if (summary === '') return null
   return (
-    <Box flexDirection="column" marginTop={1} marginBottom={1}>
-      <Box paddingX={1} backgroundColor={open ? 'userMessageBackground' : undefined}>
-        <Text wrap="truncate" bold={open}>
-          {open ? '▼' : '▶'} {t('context-loaded')} · {summary}
-          <Text dimColor> （Ctrl+T{open ? t('context-panel-collapse') : t('context-panel-expand')}）</Text>
-        </Text>
-      </Box>
-      {open && (
-        <Box flexDirection="column" paddingX={1} paddingTop={1}>
-          {context.sections.length > 0 && (
-            <Group title={t('context-panel-sections', { n: context.sections.length })}>
-              {context.sections.map(section => (
-                <Entry key={section.name} entry={section} />
-              ))}
-            </Group>
-          )}
-          {context.files.length > 0 && (
-            <Group title={t('context-panel-files', { n: context.files.length })}>
-              {context.files.map(file => (
-                <Text key={file.displayPath} dimColor>
-                  {file.displayPath}
-                </Text>
-              ))}
-            </Group>
-          )}
-          {context.contexts.length > 0 && (
-            <Group title={t('context-panel-runtime', { n: context.contexts.length })}>
-              {context.contexts.map(entry => (
-                <Entry key={entry.name} entry={entry} />
-              ))}
-            </Group>
-          )}
-          {context.skills.length > 0 && (
-            <Group title={t('context-panel-skills', { n: context.skills.length })}>
-              {context.skills.map(skill => (
-                <Box key={skill.name} flexDirection="column">
-                  <Text bold dimColor>
-                    {skill.name}
-                  </Text>
-                  <Text dimColor wrap="wrap">
-                    {skill.description}
-                  </Text>
-                </Box>
-              ))}
-            </Group>
-          )}
-          {context.tools.length > 0 && (
-            <Group title={t('context-panel-tools', { n: context.tools.length })}>
-              {context.tools.map(tool => (
-                <Box key={tool.name} flexDirection="column">
-                  <Text bold dimColor>
-                    {tool.name}
-                  </Text>
-                  <Text dimColor wrap="wrap">
-                    {truncateContextText(tool.description, 160)}
-                  </Text>
-                </Box>
-              ))}
-            </Group>
-          )}
-        </Box>
-      )}
+    <Box marginTop={1} marginBottom={1} paddingX={1}>
+      <Text wrap="truncate">
+        {t('context-loaded')} · {summary}
+        <Text dimColor> · /context</Text>
+      </Text>
     </Box>
   )
 }

--- a/src/components/LogoV2.tsx
+++ b/src/components/LogoV2.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { t as tr } from '../i18n.js'
-import { modLabel } from '../utils/modifiers.js'
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -145,8 +144,6 @@ export function LogoV2({
             <Text dimColor> {tr('logo-tip-model')} · </Text>
             /help
             <Text dimColor> {tr('logo-tip-help')} · </Text>
-            {`${modLabel}t`}
-            <Text dimColor> {tr('logo-tip-trace')} · </Text>
             Tab
             <Text dimColor> {tr('logo-tip-tab')}</Text>
           </Text>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -291,7 +291,6 @@ const dict = {
   'logo-tip-model': { zh: '切换模型', en: 'switch model' },
   'logo-tip-help': { zh: '查看命令', en: 'view commands' },
   'logo-tip-tab': { zh: '自动补全', en: 'autocomplete' },
-  'logo-tip-trace': { zh: '会话轨迹', en: 'trajectory' },
   'logo-tip-prefix': { zh: '提示：', en: 'Tip: ' },
 
   // ── components/PromptInput.tsx ──────────────────────────────────────
@@ -332,7 +331,7 @@ const dict = {
   'help-for-commands': { zh: '/ 查看命令', en: '/ for commands' },
   'help-this-help': { zh: '? 查看本帮助', en: '? for this help' },
   'help-verbose-output': { zh: '{{mod}}o 详细输出', en: '{{mod}}o for verbose output' },
-  'help-toggle-context': { zh: '{{mod}}t 切换上下文', en: '{{mod}}t to toggle context' },
+  'help-open-trajectory': { zh: '{{mod}}t 打开会话轨迹', en: '{{mod}}t to open trajectory' },
   'help-search-history': { zh: '{{mod}}r 搜索历史', en: '{{mod}}r to search history' },
   'help-interrupt': { zh: 'ctrl+c 打断', en: 'ctrl+c to interrupt' },
   'help-exit': { zh: 'ctrl+d 退出', en: 'ctrl+d to exit' },
@@ -500,8 +499,7 @@ const dict = {
   'theme-user-base': { zh: '{{base}} 基底 · ~/.dsh-tui/themes/{{name}}.json', en: '{{base}} base · ~/.dsh-tui/themes/{{name}}.json' },
 
   // ── components/LoadedContextPanel.tsx ───────────────────────────────
-  'context-panel-collapse': { zh: '折叠', en: 'Collapse' },
-  'context-panel-expand': { zh: '展开', en: 'Expand' },
+  'context-unavailable': { zh: '当前会话没有已加载的上下文', en: 'No loaded context is available for this session' },
   'context-panel-sections': { zh: '系统提示词 · {{n}} 段', en: 'System prompt · {{n}} sections' },
   'context-panel-files': { zh: '工作区指令 · {{n}} 个文件', en: 'Workspace instructions · {{n}} files' },
   'context-panel-runtime': { zh: '运行时上下文 · {{n}} 项', en: 'Runtime context · {{n}} items' },
@@ -605,6 +603,7 @@ const dict = {
   'cmd-desc-rewind': { zh: '回退会话到历史消息' },
   'cmd-desc-export': { zh: '导出会话为 Markdown 文件' },
   // Session / environment
+  'cmd-desc-context': { zh: '查看已加载的上下文明细' },
   'cmd-desc-status': { zh: '查看会话状态' },
   'cmd-desc-cost': { zh: '查看会话 token 用量' },
   'cmd-desc-config': { zh: '查看 dsh-tui 配置来源' },

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -57,6 +57,7 @@ import type { SessionEvent } from '../dsh-adapter/types.js'
 import { LoadingState } from '../components/design-system/LoadingState.js'
 import { Pane } from '../components/design-system/Pane.js'
 import { loadHistory, type HistoryEntry } from '../history.js'
+import { formatLoadedContextReport } from '../utils/loaded-context.js'
 
 /** Shared empty snapshot for hosts whose channel has no event log. */
 const NO_EVENTS: readonly SessionEvent[] = []
@@ -317,15 +318,7 @@ export function Chat({
     })
     setSceneOpen(true)
   }, [])
-  /** Startup context panel: expanded by header click or Ctrl+T. */
-  const [loadedContextOpen, setLoadedContextOpen] = React.useState(false)
-  /**
-   * Whether the startup context panel is on screen. Derived once and read by
-   * BOTH the Ctrl+T handler and the render below: the key's meaning depends on
-   * the panel being visible, so a second copy of this condition is a place for
-   * the two to disagree — which is how the key came to advertise one thing and
-   * do another in the first place.
-   */
+  /** The startup summary gives way to transcript rows after the first local command or message. */
   const loadedContextVisible = channel.rows.length === 0 && channel.loadedContext !== undefined
   /** `/` transcript search (less-style incsearch, ported from CC's REPL). */
   const [searchOpen, setSearchOpen] = React.useState(false)
@@ -727,6 +720,16 @@ export function Chat({
         setHelpOpen(false)
         openScene()
         return true
+      case 'context': {
+        setHelpOpen(false)
+        const context = channel.loadedContext
+        if (context === undefined) {
+          channel.notify(t('context-unavailable'), { color: 'warning' })
+          return true
+        }
+        channel.pushLocal('/context', formatLoadedContextReport(context))
+        return true
+      }
       case 'help':
         setHelpOpen(true)
         return true
@@ -1713,25 +1716,7 @@ export function Chat({
       return
     }
     if (isMod(key) && input === 't') {
-      // Ctrl+T means "expand what is in front of you", and the two things it
-      // can expand never share the screen.
-      //
-      // The startup loaded-context panel renders only while the transcript is
-      // empty (see the render below) — and that is exactly the window where
-      // the trajectory has nothing in it yet, since the trajectory is folded
-      // from the session's own events. So the panel wins while it is up, and
-      // the scene takes over for the rest of the session.
-      //
-      // Claiming the key outright for the scene was wrong even though the
-      // panel binding looked dead: the panel prints its own `（Ctrl+T 展开）`
-      // hint, so the key still had a visible promise attached to it, and the
-      // scene it opened instead was necessarily empty at that moment. That
-      // left the panel reachable only by clicking its header, which is not a
-      // keyboard path at all.
-      if (loadedContextVisible) {
-        setLoadedContextOpen(previous => !previous)
-        return
-      }
+      // Ctrl+T has one stable meaning; loaded-context details live at /context.
       openScene()
       return
     }
@@ -1924,16 +1909,12 @@ export function Chat({
           effort={channel.reasoningEffort}
           cwd={channel.displayCwd}
         />
-        {/* The startup loaded-context panel: before the first message the
-            transcript is empty, so the collapsed summary of what this
+        {/* The startup loaded-context summary: before the first message the
+            transcript is empty, so the one-line inventory of what this
             conversation will load (system prompt, workspace instructions,
             skills, tools) sits at the top; the first rows take over. */}
         {loadedContextVisible && (
-          <LoadedContextPanel
-            context={channel.loadedContext}
-            open={loadedContextOpen}
-            onToggle={() => { setLoadedContextOpen(previous => !previous) }}
-          />
+          <LoadedContextPanel context={channel.loadedContext} />
         )}
         <MessageList
           rows={channel.rows}

--- a/src/utils/loaded-context.ts
+++ b/src/utils/loaded-context.ts
@@ -1,13 +1,12 @@
 import type { LoadedContext } from '../dsh-adapter/channel.js'
 import { t } from '../i18n.js'
 
-/** Per-entry display cap: the panel shows the beginning of long texts. */
+/** Per-entry display cap: `/context` shows the beginning of long texts. */
 export const CONTEXT_ENTRY_MAX_CHARS = 800
 
 /**
  * Truncate one entry's text for the panel body. The model-visible text is
- * the source of truth and stays complete in the session log; the panel only
- * bounds its own rendering.
+ * the source of truth; the local report only bounds its own rendering.
  * @param text - the interpolated model-visible text.
  * @param max - character cap, defaults to {@link CONTEXT_ENTRY_MAX_CHARS}.
  * @returns the text, or its head plus a truncation marker.
@@ -31,4 +30,40 @@ export function summarizeLoadedContext(context: LoadedContext): string {
   if (context.skills.length > 0) parts.push(t('context-skills', { n: context.skills.length }))
   if (context.tools.length > 0) parts.push(t('context-tools', { n: context.tools.length }))
   return parts.join(' · ')
+}
+
+/**
+ * Format the loaded-context snapshot for the local `/context` report.
+ * The report preserves the former startup panel's grouping and truncation
+ * without keeping a second expandable surface in the transcript header.
+ */
+export function formatLoadedContextReport(context: LoadedContext): string[] {
+  const lines: string[] = []
+  const appendEntry = (name: string, text: string, max = CONTEXT_ENTRY_MAX_CHARS): void => {
+    lines.push(`  ${name}`)
+    lines.push(...truncateContextText(text, max).split('\n').map(line => `    ${line}`))
+  }
+
+  if (context.sections.length > 0) {
+    lines.push(t('context-panel-sections', { n: context.sections.length }))
+    for (const section of context.sections) appendEntry(section.name, section.text)
+  }
+  if (context.files.length > 0) {
+    lines.push(t('context-panel-files', { n: context.files.length }))
+    lines.push(...context.files.map(file => `  ${file.displayPath}`))
+  }
+  if (context.contexts.length > 0) {
+    lines.push(t('context-panel-runtime', { n: context.contexts.length }))
+    for (const entry of context.contexts) appendEntry(entry.name, entry.text)
+  }
+  if (context.skills.length > 0) {
+    lines.push(t('context-panel-skills', { n: context.skills.length }))
+    for (const skill of context.skills) appendEntry(skill.name, skill.description)
+  }
+  if (context.tools.length > 0) {
+    lines.push(t('context-panel-tools', { n: context.tools.length }))
+    for (const tool of context.tools) appendEntry(tool.name, tool.description, 160)
+  }
+
+  return lines
 }


### PR DESCRIPTION
## Summary

- move loaded-context details behind a one-shot local `/context` report
- keep the startup context inventory to one truncated line with a `/context` pointer
- make Ctrl+T consistently open the trajectory scene and remove the duplicate logo hint
- align help copy, command discovery, docs, and regressions with the new ownership

## Testing

- `npm run compile`
- `node --import tsx/esm scripts/verify-loaded-context-width.tsx`
- `node --import tsx/esm scripts/verify-ctrl-t-scope.tsx`
- `npm run smoke`
- `node scripts/count-i18n.cjs`
- `git diff --check`