### PR TITLE
fix(render): Ctrl+T 轨迹返回后恢复主屏帧

### DIFF
--- a/scripts/verify-trace-scene.tsx
+++ b/scripts/verify-trace-scene.tsx
@@ -321,7 +321,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   // into an obvious number rather than hiding as a rounding error.
   for (let round = 0; round < 20; round++) {
     stdin.write('\x14') // Ctrl+T
-    await sleep(60)
+    await sleep(round === 0 ? 160 : 60)
     if (round === 0) {
       // Assert the PROTOCOL, not the pixels. `<AlternateScreen>` notifies the
       // Ink instance via `instances.get(process.stdout)`, and this harness
@@ -391,6 +391,134 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
 
   stdin.write('q')
   await sleep(120)
+  instance.unmount()
+  instances.delete(process.stdout)
+  term.dispose()
+}
+
+// ───────────────────────── part B2: main-screen frame restore ─────────────
+
+{
+  const { stdout, stdin, screen, term, writes } = makeHarness(120, 30, 500)
+  const marker = 'unchanged conversation marker'
+  const listeners = new Set<() => void>()
+  const channel = makeChannel({
+    traceEvents: () => [],
+    working: false,
+    rows: [{ id: 1, kind: 'assistant', text: marker }],
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  })
+  const publish = (changes: Record<string, unknown>): void => {
+    Object.assign(channel, changes)
+    channel.version = Number(channel.version) + 1
+    for (const listener of listeners) listener()
+  }
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+  )
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  await sleep(500)
+  writes.length = 0
+
+  stdin.write('\x14')
+  await sleep(250)
+  check('frame-restore probe enters the alternate screen', term.buffer.active.type === 'alternate')
+  instances.get(process.stdout)?.resetPools()
+  stdin.write('q')
+  await sleep(500)
+
+  const roundTrip = writes.join('')
+  const exitIndex = roundTrip.lastIndexOf('\x1b[?1049l')
+  const afterExit = exitIndex < 0 ? roundTrip : roundTrip.slice(exitIndex + '\x1b[?1049l'.length)
+  const afterExitText = afterExit
+    .replace(/\x1b\][^\x07]*\x07/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+  check(
+    'an unchanged main screen is not repainted after DEC 1049 restores it',
+    exitIndex >= 0 && !afterExitText.includes(marker),
+    `post-exit bytes=${afterExit.length}`,
+  )
+
+  const reasoning = Array.from({ length: 80 }, (_, index) =>
+    `reasoning line ${String(index).padStart(2, '0')}`,
+  ).join('\n')
+  publish({
+    working: true,
+    spinnerMode: 'thinking',
+    rows: [
+      { id: 1, kind: 'user', text: 'investigate the rendering issue' },
+      { id: 2, kind: 'reasoning', text: reasoning.split('\n').slice(0, 40).join('\n'), streaming: true },
+    ],
+    lastUserText: 'investigate the rendering issue',
+  })
+  await sleep(500)
+  stdin.write('\x14')
+  await sleep(250)
+  publish({
+    rows: [
+      { id: 1, kind: 'user', text: 'investigate the rendering issue' },
+      { id: 2, kind: 'reasoning', text: reasoning, streaming: true },
+    ],
+  })
+  await sleep(250)
+  publish({
+    spinnerMode: 'requesting',
+    rows: [
+      { id: 1, kind: 'user', text: 'investigate the rendering issue' },
+      { id: 2, kind: 'reasoning', text: reasoning, streaming: false, durationMs: 12_000 },
+      { id: 3, kind: 'assistant', text: 'FIRST RESPONSE SECTION', streaming: true },
+    ],
+  })
+  await sleep(250)
+  stdin.write('q')
+  await sleep(400)
+  publish({
+    rows: [
+      { id: 1, kind: 'user', text: 'investigate the rendering issue' },
+      { id: 2, kind: 'reasoning', text: reasoning, streaming: false, durationMs: 12_000 },
+      { id: 3, kind: 'assistant', text: 'FIRST RESPONSE SECTION\n\nSECOND RESPONSE SECTION', streaming: true },
+    ],
+  })
+  await sleep(400)
+
+  const buffer = term.buffer.active
+  const lines = Array.from({ length: buffer.length }, (_, row) =>
+    buffer.getLine(row)?.translateToString(true) ?? '',
+  )
+  const secondIndex = lines.findLastIndex(line => line.includes('SECOND RESPONSE SECTION'))
+  let firstIndex = -1
+  for (let index = secondIndex - 1; index >= 0; index--) {
+    if (lines[index]?.includes('FIRST RESPONSE SECTION')) {
+      firstIndex = index
+      break
+    }
+  }
+  const gap = firstIndex < 0 || secondIndex < 0
+    ? Number.POSITIVE_INFINITY
+    : lines.slice(firstIndex + 1, secondIndex).filter(line => line.trim() === '').length
+  check(
+    'reasoning that settles in the trajectory leaves no blank answer gap',
+    firstIndex >= 0 && secondIndex >= 0 && gap <= 1,
+    `first=${firstIndex}, second=${secondIndex}, blank=${gap}, buffer=${buffer.length}`,
+  )
+
+  stdin.write('\x0f') // Ctrl+O
+  await sleep(400)
+  check('Ctrl+O expands settled reasoning after the round trip', screen().includes('reasoning line 79'))
+  stdin.write('\x0f')
+  await sleep(400)
+  check('a second Ctrl+O folds settled reasoning again', !screen().includes('reasoning line 79'))
+
   instance.unmount()
   instances.delete(process.stdout)
   term.dispose()

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -152,6 +152,16 @@ export default class Ink {
   // Set alongside altScreenActive so SIGCONT resume knows whether to
   // re-enable mouse tracking (not all <AlternateScreen> uses want it).
   private altScreenMouseTracking = false;
+  // DEC 1049 preserves the physical main screen and cursor. Keep the matching
+  // renderer state while an inline full-screen view is active so its exit can
+  // diff from what the terminal actually restores instead of printing a full
+  // duplicate frame into main-screen scrollback.
+  private mainScreenFrameState: {
+    frontFrame: Frame;
+    displayCursor: { x: number; y: number } | null;
+    columns: number;
+    rows: number;
+  } | null = null;
   // True when the previous frame's screen buffer cannot be trusted for
   // blit — selection overlay mutated it, resetFramesForAltScreen()
   // replaced it with blanks, or forceRedraw() reset it to 0×0. Forces
@@ -905,18 +915,38 @@ export default class Ink {
   /**
    * Called by the <AlternateScreen> component on mount/unmount.
    * Controls cursor.y clamping in the renderer and gates alt-screen-aware
-   * behavior in SIGCONT/resize/unmount handlers. Repaints on change so
-   * the first alt-screen frame (and first main-screen frame on exit) is
-   * a full redraw with no stale diff state.
+   * behavior in SIGCONT/resize/unmount handlers. The first alt-screen frame
+   * redraws from blank; exit restores the saved main frame for a physical-
+   * screen-matched diff, with repaint as the resize fallback.
    */
   setAltScreenActive(active: boolean, mouseTracking = false): void {
     if (this.altScreenActive === active) return;
     this.altScreenActive = active;
     this.altScreenMouseTracking = active && mouseTracking;
     if (active) {
+      this.mainScreenFrameState = {
+        frontFrame: this.frontFrame,
+        displayCursor: this.displayCursor,
+        columns: this.terminalColumns,
+        rows: this.terminalRows
+      };
       this.resetFramesForAltScreen();
     } else {
-      this.repaint();
+      const saved = this.mainScreenFrameState;
+      this.mainScreenFrameState = null;
+      if (saved && saved.columns === this.terminalColumns && saved.rows === this.terminalRows) {
+        this.frontFrame = saved.frontFrame;
+        this.displayCursor = saved.displayCursor;
+        this.log.reset();
+        // The main React subtree may have changed while the alternate screen
+        // was mounted. Disable blitting once, but keep the restored frame as
+        // the diff baseline that matches the terminal's physical contents.
+        this.prevFrameContaminated = true;
+      } else {
+        // A resize reflows the terminal's saved main buffer, so the old frame
+        // is no longer a trustworthy physical baseline.
+        this.repaint();
+      }
     }
   }
   get isAltScreenActive(): boolean {
@@ -1673,6 +1703,9 @@ export default class Ink {
     // them at the new pools so the next frame's IDs are comparable.
     this.backFrame.screen.charPool = this.charPool;
     this.backFrame.screen.hyperlinkPool = this.hyperlinkPool;
+    if (this.mainScreenFrameState) {
+      migrateScreenPools(this.mainScreenFrameState.frontFrame.screen, this.charPool, this.hyperlinkPool);
+    }
   }
   patchConsole(): () => void {
     // biome-ignore lint/suspicious/noConsole: intentionally patching global console

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -294,15 +294,9 @@ export function Chat({
   /**
    * Close the scene.
    *
-   * Leaving the alternate screen makes the terminal restore the main buffer
-   * itself; Ink then repaints once, because `setAltScreenActive(false)` blanks
-   * its front frame. In inline mode that costs one frame of scrollback per
-   * round trip — the same, already-accepted cost as the Ctrl+X external-editor
-   * handoff, and bounded per OPEN rather than per keystroke. Making it zero
-   * needs the render core to save and restore the pre-alt front frame, which
-   * is a separate change to `setAltScreenActive` and deliberately not made
-   * here. `verify-trace-scene` pins the property that matters meanwhile:
-   * navigating inside the scene adds nothing at all.
+   * Leaving the alternate screen makes the terminal restore the main buffer;
+   * Ink restores the matching saved frame and diffs any conversation changes
+   * that happened while the scene was open.
    */
   const closeScene = React.useCallback(() => {
     setSceneOpen(false)


### PR DESCRIPTION
## 动机

长时间 thinking 期间按 `Ctrl+T` 打开轨迹视图，待推理在轨迹中结束后退出，主屏正文会出现大量空白行，且 `Ctrl+O` 无法正常展开/折叠已完成的推理。Issue #283 已由维护者确认属实。

Closes #283

## 根因与复现

轨迹视图使用 DEC 1049 备用屏。终端退出备用屏时会自行恢复物理主屏及光标，但 Ink 旧实现同时丢弃主屏 frame，并从空 frame 全量重绘正文。长 reasoning 在轨迹中继续更新、收束后，这次重复输出会让主屏 scrollback、光标和 React 的逻辑 frame 脱节，表现为正文间大段空行及 `Ctrl+O` 状态异常。

新增的 headless xterm 回归覆盖真实交互顺序：40 行 streaming reasoning → `Ctrl+T` → 在轨迹中增长到 80 行并结束 → `q` 返回 → 正文继续输出 → 两次 `Ctrl+O`。修复前，即使主屏内容不变，退出 DEC 1049 后仍会额外输出约 12 KB 并重复正文 marker。

## 修改

- 进入备用屏前保存主屏 `frontFrame`、显示光标和终端尺寸；
- 尺寸未变化时，退出后恢复与物理主屏匹配的 frame，并从该基线对轨迹期间的会话变化做完整 damage diff，不再从空 frame 重画整屏；
- 备用屏期间发生 resize 时继续使用原有 `repaint()` 兜底，因为终端可能已重排保存的主缓冲区；
- `resetPools()` 同步迁移保存 frame 的字符池和超链接池；
- 扩展 `verify-trace-scene.tsx`，锁定无重复主屏输出、正文正常间距及 `Ctrl+O` 展开/折叠行为。

## 行为边界

- 只保存 `frontFrame`，不保留可能很大的 `backFrame`，避免长会话额外持有两份待渲染状态；
- 不改变 DEC 1049 序列、轨迹交互、reasoning 折叠规则或会话数据；
- resize 场景保留全量重绘兜底；
- 不修改或提交 `lib/` 构建产物。

## 截图

Windows PowerShell 5.1 + ConPTY，`209×49`，200 行中文增量 reasoning。推理未结束时进入轨迹、在轨迹中完成后返回；两段正文之间只有正常单行间距，`Ctrl+O` 可继续展开/折叠，无空白带、残影或重叠：

![Issue #283 Windows ConPTY 修复后验证](https://github.com/Qiuner/dsh-TUI/releases/download/issue-283-images/fixed-conpty.png)

## dsh-ecosystem-spec 影响

- **Scope**：TUI 内部 Ink 备用屏 frame 恢复与差分渲染
- **Normative change**：None
- 不修改插件 manifest、Community contract、registry、schema、公共生态 API 或持久化格式
- **Migration**：None
- **Rollback**：回退提交 `dbe34f2` 即恢复旧行为
- 本 PR 不声明生态认证或规范符合性等级

## 验证

- `corepack pnpm build`：通过（compile + 7 道构建门禁）
- `corepack pnpm verify:package`：通过，852 files / 19 entry targets
- `corepack pnpm exec node --import tsx/esm scripts/verify-trace-scene.tsx`：连续 3 次通过
- `corepack pnpm smoke`：通过
- `DSH_TUI_LANG=zh corepack pnpm exec node --import tsx/esm scripts/repro-askpanel.tsx`：通过
- `DSH_TUI_LANG=zh corepack pnpm exec node --import tsx/esm scripts/verify-askpanel-layout.tsx`：通过
- `DSH_TUI_LANG=zh corepack pnpm exec node --import tsx/esm scripts/repro-toolcards.tsx`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-resize-reflow.tsx`：通过
- `corepack pnpm exec node --import tsx/esm scripts/repro-collapse-shrink.tsx`：通过
- `corepack pnpm exec node --import tsx/esm scripts/repro-fullscreen-ghost.tsx`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-copy-on-select.mjs`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-session-browser.mjs`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-scroll.mjs`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-resticky.mjs`：通过
- `corepack pnpm exec tsc -p tsconfig.json --noEmit`：通过
- `git diff --check`：通过
- 真实 Windows ConPTY `209×49`、200 行中文 reasoning：修复流程与 `Ctrl+O` 展开/折叠通过，截图人工检查通过