### PR TITLE
fix(process): 子进程提前退出时不再因 stdin EPIPE 崩溃

### DIFF
--- a/scripts/verify-clipboard.mjs
+++ b/scripts/verify-clipboard.mjs
@@ -395,6 +395,17 @@ exit 1
     "process.stdout.write(Buffer.from([0xE5])); setTimeout(() => { process.stdout.write(Buffer.from([0x89, 0xAA])); }, 60)",
   ])
   check('execFileNoThrow decodes UTF-8 across chunk boundaries', r.stdout === '剪', `got ${JSON.stringify(r.stdout)}`)
+
+  const closedStdin = await execFileNoThrow(
+    process.execPath,
+    ['-e', 'process.stdin.destroy(); setTimeout(() => process.exit(0), 50)'],
+    { input: 'x'.repeat(16 * 1024 * 1024) },
+  )
+  check(
+    'execFileNoThrow survives a child closing stdin before the input is written',
+    closedStdin.code === 0,
+    `got ${JSON.stringify(closedStdin)}`,
+  )
 }
 
 if (failed > 0) {

--- a/src/utils/execFileNoThrow.ts
+++ b/src/utils/execFileNoThrow.ts
@@ -51,6 +51,9 @@ export function execFileNoThrow(
     child.stderr.on('data', (chunk: Buffer) => {
       stderrChunks.push(chunk)
     })
+    // A child may exit before consuming the supplied input. The resulting
+    // EPIPE/EOF belongs to that child outcome and must not crash the caller.
+    child.stdin.on('error', () => {})
     child.on('error', () => {
       resolve({
         code: 1,


### PR DESCRIPTION
## 动机

#295 报告 SSH 断连相关问题时，同时指出 `execFileNoThrow` 在子进程提前退出后可能因 stdin `EPIPE` 崩溃。该 helper 被 Linux/macOS 剪贴板命令和 tmux OSC 路径共用，契约本身是“命令失败也返回结果、不向调用方抛出”；未处理的 stdin stream error 会绕过这个契约并终止整个 TUI 进程。

关联 #295。本 PR 只修复其中可在本仓库独立复现的 stdin 管道崩溃，不关闭该 issue。

## 根因与复现

`execFileNoThrow()` 已监听 child process 的 `error` 和 `close`，但在传入 `options.input` 时直接调用 `child.stdin.write()` / `end()`，没有监听 `child.stdin` 自身的 `error`。

新增回归启动真实 Node 子进程，让它立即关闭 stdin，同时由父进程写入 16 MiB 输入。修复前 verifier 在断言前稳定以 exit 1 退出：

```text
Error: write EOF
Emitted 'error' event on Socket instance
code: 'EOF'
syscall: 'write'
```

Windows 报 `EOF`；Unix 同一管道关闭通常表现为 `EPIPE`。

## 修改

- 在写入前为 `child.stdin` 注册错误监听，消费子进程提前关闭管道产生的 `EPIPE` / `EOF`；
- 保持原返回语义：最终结果仍由 child process 的 `error` / `close`、退出码及 stdout/stderr 决定；
- 扩展 `verify-clipboard.mjs`，通过公开 `execFileNoThrow()` 和真实子进程锁定“不带崩父进程”的行为。

## 行为边界

- 不把 stdin 管道错误改写成新的退出码，也不改变 stdout/stderr 收集方式；
- spawn 失败和非零退出仍按现有 `ExecFileNoThrowResult` 返回；
- 不修改 clipboard/OSC 调用方；
- 不处理 #295 的 session log 撕裂、stale working 或 `/resume` 误导性文案，这些需要分别确认所属边界后单独修复；
- 不修改或提交 `lib/` 构建产物。

## 截图

无。该修改是子进程管道错误边界，不改变终端可见 UI；使用真实子进程红/绿回归验证。

## dsh-ecosystem-spec 影响

- **Scope**：TUI 内部 no-throw 子进程 helper 的 stdin 错误处理
- **Normative change**：None
- 不修改插件 manifest、Community contract、registry、schema、公共生态 API 或持久化格式
- **Migration**：None
- **Rollback**：回退提交 `80de4cf` 即恢复旧行为
- 本 PR 不声明生态认证或规范符合性等级

## 验证

- 修复前最小复现：稳定触发未处理的 `write EOF`，进程 exit 1
- `corepack pnpm exec node scripts/verify-clipboard.mjs`：修复后连续 4 次通过
- `corepack pnpm build`：通过（compile + 7 道构建门禁）
- `corepack pnpm verify:package`：通过，852 files / 19 entry targets
- `corepack pnpm smoke`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-clipboard-image.ts`：通过
- `corepack pnpm exec node --import tsx/esm scripts/verify-terminal-queries.tsx`：通过
- `corepack pnpm exec node scripts/verify-copy-on-select.mjs`：通过
- `corepack pnpm exec node --import tsx/esm scripts/repro-clipboard.tsx`：Windows 按脚本约定跳过 Linux-only `wl-paste` stub
- `git diff --check`：通过