### PR TITLE
docs: 修正一些许可、版权和安全描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ pnpm smoke
 - **模板仓库**：[plugin-template](https://github.com/dsh-tui-ecosystem/plugin-template)（从模板起步，5 分钟出一个插件）
 - **参考实现**：`dsh-working-activity`（实时工作状态行：TUI 槽位 + `activity/status` 会话事件双出口）
 
-核心仓库不迁移、社区插件独立成仓——组织只负责收录与背书，插件作者对自己的仓库保持完全所有权。
+核心仓库不迁移、社区插件独立成仓。组织只维护收录列表与准入规范，不对社区插件
+的功能、质量或安全作背书或担保；插件作者对自己的仓库保持完全所有权，并自行承担
+维护与安全责任。
 
 ## 社区
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -296,7 +296,7 @@ Want to build a plugin or extension for dsh-TUI? Join the ecosystem:
 - **Reference implementation**: `dsh-working-activity` (live working-status
   line with dual outlets: TUI prompt slot + `activity/status` session events)
 
-The core repository is never migrated; community plugins live in their own
+The core repository remains independent; community plugins live in their own
 repos. The organization only maintains the listing and admission rules — it
 does not endorse or warrant the functionality, quality, or safety of community
 plugins. Plugin authors keep full ownership of their repositories and are

--- a/README_EN.md
+++ b/README_EN.md
@@ -297,8 +297,10 @@ Want to build a plugin or extension for dsh-TUI? Join the ecosystem:
   line with dual outlets: TUI prompt slot + `activity/status` session events)
 
 The core repository is never migrated; community plugins live in their own
-repos. The organization only curates and endorses — plugin authors keep full
-ownership of their repositories.
+repos. The organization only maintains the listing and admission rules — it
+does not endorse or warrant the functionality, quality, or safety of community
+plugins. Plugin authors keep full ownership of their repositories and are
+responsible for their maintenance and security.
 
 ## Community
 

--- a/docs/links.md
+++ b/docs/links.md
@@ -14,3 +14,7 @@
 | **deepseek-harness-ux** | <https://github.com/ayuanwong/deepseek-harness-ux> | 让你的 DeepSeek Harness 工作过程一目了然！ |
 | **dsh-tianshu-tui** | <https://github.com/huiliyi37/dsh-tianshu-tui> | Tianshu 风格的 dsh-tui |
 | **dsh-data-agent** | <https://github.com/omdsh-dev/dsh-data-agent> | 让 AI 帮你连数据库 |
+
+> 本页是社区与第三方项目的链接罗列。所列项目与组织由各自的维护者独立维护，
+> dsh-TUI 仓库与其不存在隶属关系，也不对其内容、质量或安全作任何担保，使用前
+> 请自行评估。

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -465,3 +465,8 @@ package's CI regressions (see [Contributing](contributing.en.md#verification)).
   - The organization README's listing (PR to `dsh-tui-ecosystem`)
 - State the minimum dsh-TUI version your plugin requires, and document
   compatibility as the core evolves.
+
+Listing is link-only: it involves no code review or runtime verification, and
+implies no endorsement or warranty of a plugin's functionality, quality, or
+safety by dsh-TUI, the organization, or its members. Plugins are maintained by
+their respective authors; evaluate a community plugin before installing it.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -403,3 +403,7 @@ DSH_TUI_DEBUG=1 dsh --profile dsh-tui      # 需要调试时
   - 主仓库的 [`docs/links.md`](links.md)（PR 到 `ccch1mneyyy/dsh-TUI`）
   - 组织主页 README 的收录列表（PR 到 `dsh-tui-ecosystem`）
 - 在 README 里注明依赖的 dsh-TUI 版本下限，随主包版本更新做兼容性说明。
+
+收录只做链接罗列，不包含代码审查或运行验证。收录本身不代表 dsh-TUI、生态组织
+或其成员对插件的功能、质量或安全作任何背书或担保；插件由各自作者维护，使用者
+安装社区插件前请自行评估。


### PR DESCRIPTION
去除为第三方“背书”的笔误，补充相应的许可、版权与安全描述。
