### PR TITLE
fix(update): 重启时释放旧进程的输入监听

### DIFF
--- a/scripts/verify-shutdown-stderr.tsx
+++ b/scripts/verify-shutdown-stderr.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react'
 import { PassThrough } from 'node:stream'
-import { render, Text } from '../src/ui.js'
+import { render, Text, useInput } from '../src/ui.js'
 import instances from '../src/ink/instances.js'
 
 let failures = 0
@@ -20,8 +20,30 @@ const originalStderrWrite = process.stderr.write
 const originalConsoleLog = console.log
 const stdout = new PassThrough() as unknown as NodeJS.WriteStream
 Object.assign(stdout, {isTTY: true, columns: 80, rows: 24})
-const instance = await render(React.createElement(Text, null, 'shutdown regression'), {
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  isRaw = false
+
+  setRawMode(value: boolean): this {
+    this.isRaw = value
+    return this
+  }
+
+  ref(): this { return this }
+  unref(): this { return this }
+}
+
+const stdin = new FakeStdin()
+let receivedInput = ''
+function InputProbe(): React.ReactNode {
+  useInput(input => { receivedInput += input })
+  return React.createElement(Text, null, 'shutdown regression')
+}
+
+const instance = await render(React.createElement(InputProbe), {
   stdout,
+  stdin: stdin as unknown as NodeJS.ReadStream,
   exitOnCtrlC: false,
   patchConsole: true,
 })
@@ -31,6 +53,7 @@ check('Ink installs the stderr guard while the TUI is mounted', patchedStderrWri
 
 const sigcontListenersBefore = process.listenerCount('SIGCONT')
 const resizeListenersBefore = stdout.listenerCount('resize')
+const stdinListenersBefore = stdin.listenerCount('readable')
 const runtime = instances.get(stdout)
 runtime?.detachForShutdown()
 
@@ -38,6 +61,12 @@ check('shutdown detach restores process.stderr.write before post-exit work', pro
 check('shutdown detach restores console output before post-exit work', console.log === originalConsoleLog)
 check('shutdown detach removes the SIGCONT listener', process.listenerCount('SIGCONT') < sigcontListenersBefore)
 check('shutdown detach removes the stdout resize listener', stdout.listenerCount('resize') < resizeListenersBefore)
+check('Ink owns a stdin reader before shutdown detach', stdinListenersBefore > 0)
+check('shutdown detach removes the stdin reader', stdin.listenerCount('readable') < stdinListenersBefore)
+
+stdin.write('x')
+await new Promise(resolve => setImmediate(resolve))
+check('detached Ink does not consume input meant for the replacement process', receivedInput === '')
 
 // detach intentionally makes unmount a no-op. Remove the test-only map entry
 // without attempting a second terminal cleanup.

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -261,7 +261,11 @@ export default class App extends PureComponent<Props, State> {
 		if (this.props.stdout.isTTY) {
 			this.props.stdout.write(SHOW_CURSOR);
 		}
+		this.detachForShutdown();
+	}
 
+	/** Release timers and stdin ownership without requiring a React unmount. */
+	detachForShutdown() {
 		// Clear any pending timers
 		if (this.incompleteEscapeTimer) {
 			clearTimeout(this.incompleteEscapeTimer);

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -77,6 +77,7 @@ export type Options = {
 export default class Ink {
   private readonly log: LogUpdate;
   private readonly terminal: Terminal;
+  private app: App | null = null;
   private scheduleRender: (() => void) & {
     cancel?: () => void;
   };
@@ -1001,6 +1002,7 @@ export default class Ink {
     // Cancel any pending throttled render so it doesn't fire between
     // cleanupTerminalModes() and process.exit() and write to main screen.
     this.scheduleRender.cancel?.();
+    this.app?.detachForShutdown();
     // Shutdown bypasses the normal unmount path, so release the process and
     // stdout listeners here as well. Otherwise a SIGCONT or resize arriving
     // while an updater is running can re-enter the alternate screen or render
@@ -1543,9 +1545,12 @@ export default class Ink {
     }
     this.cursorDeclaration = decl;
   };
+  private setAppRef(app: App | null): void {
+    this.app = app;
+  }
   render(node: ReactNode): void {
     this.currentNode = node;
-    const tree = <App stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.unmount} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onHoverAt={this.dispatchHover} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onStdinResume={this.reassertTerminalModes} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
+    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.unmount} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onHoverAt={this.dispatchHover} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onStdinResume={this.reassertTerminalModes} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
         <TerminalWriteProvider value={this.writeRaw}>
           {node}
         </TerminalWriteProvider>


### PR DESCRIPTION
Closes #284

## 问题与根因

`/update` 启动替代进程后，旧进程仍会等待新 TUI 退出，两者在此期间共享同一个 TTY。

退出路径调用 `Ink.detachForShutdown()`，为避免重复写入终端恢复序列，它会刻意绕过 React unmount；但 `App.componentWillUnmount()` 原先还负责释放 stdin reader。结果是旧 App 的 `readable` listener 没有移除，继续消费本应交给新进程的按键，表现为每个字符需要按多次才响应。

最小复现中，修复前 detach 后仍为：

```json
{"before":1,"after":1,"received":"x","isRaw":false}
```

对应两个回归断言均为 RED：旧 reader 未释放，且旧实例仍收到替代进程的输入。

## 修复

- 将 App 的计时器、终端查询、raw mode 与 stdin reader 清理收敛到公开的 `detachForShutdown()`
- `componentWillUnmount()` 复用同一清理逻辑
- Ink 保存 App ref，在 renderer 的 shutdown detach 路径中主动调用 App 清理
- 保留原有“不执行完整 React unmount”的边界，避免退出时重复绘制或恢复终端

修复后 listener 数量从 `1` 降为 `0`，detach 后写入的字符不会再被旧实例接收。

## 验证

- `pnpm build`：通过
- `pnpm verify:package`：通过
- `pnpm smoke`：通过
- `node --import tsx/esm scripts/verify-shutdown-stderr.tsx`：8 项通过，包含 reader 释放与输入隔离
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/repro-askpanel.tsx`：通过
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/verify-askpanel-layout.tsx`：通过
- `node --import tsx/esm scripts/repro-toolcards.tsx`：通过
- `git diff --check`：通过

## 截图

不适用。本次只修复 shutdown 生命周期中的输入所有权，没有可见 UI 变化；行为通过真实 fake TTY 输入回归验证。

Normative change: None