### PR TITLE
feat(balance): 状态栏余额显示与低余额预警

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prompt:debug": "node scripts/read-prompt-debug.mjs",
     "tui": "node --import tsx/esm scripts/run.ts",
     "smoke": "node --import tsx/esm scripts/smoke.tsx",
-    "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap",
+    "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap && npm run verify:balance",
     "verify:boundary": "node --import tsx/esm scripts/verify-adapter-boundary.ts",
     "verify:contract": "node --import tsx/esm scripts/verify-upstream-contract.ts",
     "verify:manifest-deps": "node --import tsx/esm scripts/verify-manifest-deps.ts",
@@ -86,6 +86,7 @@
     "verify:packaged-presets": "node scripts/verify-packaged-presets.mjs",
     "verify:minimal-preset-tools": "node scripts/verify-minimal-preset-tools.mjs",
     "verify:liangshen-bootstrap": "node scripts/verify-liangshen-bootstrap.mjs",
+    "verify:balance": "node --import tsx/esm scripts/verify-balance.ts",
     "verify:package": "npm pack --dry-run --json --ignore-scripts | node scripts/verify-package.mjs",
     "verify:prompt-debug": "npm run build && node scripts/verify-prompt-debug.mjs",
     "verify:clipboard-image": "node --import tsx/esm scripts/verify-clipboard-image.ts"

--- a/scripts/verify-balance.ts
+++ b/scripts/verify-balance.ts
@@ -1,0 +1,59 @@
+/**
+ * Balance-module checks: official-host gating and /user/balance response
+ * parsing stay correct — non-official gateways must never render, malformed
+ * payloads must never crash the status footer.
+ *
+ * Run via `node --import tsx/esm scripts/verify-balance.ts`.
+ */
+import { formatBalance, isOfficialHost, parseBalanceResponse } from '../src/dsh-adapter/balance.js'
+
+let failures = 0
+
+function check(name: string, actual: unknown, expected: unknown): void {
+  if (Object.is(actual, expected)) return
+  failures += 1
+  console.error(`  FAIL ${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+}
+
+// ---- isOfficialHost: 官方主机判定（决定整行显示/隐藏） ----
+check('official https', isOfficialHost('https://api.deepseek.com'), true)
+check('official /v1 suffix', isOfficialHost('https://api.deepseek.com/v1'), true)
+check('official port', isOfficialHost('https://api.deepseek.com:443'), true)
+check('official http', isOfficialHost('http://api.deepseek.com'), true)
+check('gateway rejected', isOfficialHost('https://ark.cn-beijing.volces.com'), false)
+check('proxy rejected', isOfficialHost('https://api.deepseek.com.example.com'), false)
+check('garbage rejected', isOfficialHost('not a url'), false)
+check('empty rejected', isOfficialHost(''), false)
+
+// ---- parseBalanceResponse: 余额响应解析 ----
+check('undefined payload', parseBalanceResponse(undefined), undefined)
+check('null payload', parseBalanceResponse(null), undefined)
+check('empty body', parseBalanceResponse({}), undefined)
+check('empty infos', parseBalanceResponse({ balance_infos: [] }), undefined)
+check('info without balance', parseBalanceResponse({ balance_infos: [{}] }), undefined)
+check('non-numeric balance', parseBalanceResponse({ balance_infos: [{ total_balance: 'abc' }] }), undefined)
+const stringTotal = parseBalanceResponse({ balance_infos: [{ total_balance: '68.64' }] })
+check('string total parsed', stringTotal?.total, 68.64)
+check('default currency CNY', stringTotal?.currency, 'CNY')
+check('default is available', stringTotal?.isAvailable, true)
+const usd = parseBalanceResponse({ balance_infos: [{ total_balance: 12.5, currency: 'USD' }] })
+check('numeric total parsed', usd?.total, 12.5)
+check('currency kept', usd?.currency, 'USD')
+const zero = parseBalanceResponse({ balance_infos: [{ total_balance: 0 }] })
+check('zero is a valid balance', zero?.total, 0)
+check('zero keeps currency', zero?.currency, 'CNY')
+const unavailable = parseBalanceResponse({ is_available: false, balance_infos: [{ total_balance: '0.5' }] })
+check('is_available false parsed', unavailable?.isAvailable, false)
+const explicitAvailable = parseBalanceResponse({ is_available: true, balance_infos: [{ total_balance: '1' }] })
+check('is_available true parsed', explicitAvailable?.isAvailable, true)
+
+// ---- formatBalance: 余额展示格式 ----
+check('CNY format', formatBalance({ total: 68.64, currency: 'CNY' }), '¥68.64')
+check('USD format', formatBalance({ total: 12.5, currency: 'USD' }), '$12.50')
+check('other currency', formatBalance({ total: 7, currency: 'EUR' }), 'EUR 7.00')
+
+if (failures > 0) {
+  console.error(`balance checks failed (${failures})`)
+  process.exit(1)
+}
+console.log('balance checks OK (parse + official-host gating)')

--- a/src/dsh-adapter/balance.ts
+++ b/src/dsh-adapter/balance.ts
@@ -1,0 +1,136 @@
+/**
+ * DeepSeek 官方账户余额查询（host 层）。
+ *
+ * 只服务官方 base URL（api.deepseek.com）：非官方网关没有官方余额语义，
+ * 查询返回 undefined，状态栏整行隐藏（与 ds-balance 插件同款降级语义）。
+ * key 只在本模块内经 credentials 服务解析，明文不进 React 层。
+ */
+
+import type { Balance } from './channel.js'
+
+const DEFAULT_BASE_URL = 'https://api.deepseek.com'
+const OFFICIAL_HOST = 'api.deepseek.com'
+const QUERY_TIMEOUT_MS = 8000
+/** 成功结果缓存时长（防频繁点击/重渲染触发的重复查询）。 */
+const CACHE_MS = 60_000
+
+let cachedAt = 0
+let cachedResult: Balance | undefined
+let inFlight: Promise<Balance | undefined> | null = null
+
+/** base URL 主机不是官方 api.deepseek.com 即视为非官方。 */
+export function isOfficialHost(base: string): boolean {
+  const match = /^https?:\/\/([^/?#]+)/.exec(base)
+  if (match === null) return false
+  const host = match[1]
+  return host === OFFICIAL_HOST || host.startsWith(OFFICIAL_HOST + ':')
+}
+
+/** 余额展示：CNY → `¥68.64`，USD → `$68.64`，其他货币 → `EUR 68.64`。 */
+export function formatBalance(balance: { total: number; currency: string }): string {
+  const amount = balance.total.toFixed(2)
+  switch (balance.currency.toUpperCase()) {
+    case 'CNY':
+      return `¥${amount}`
+    case 'USD':
+      return `$${amount}`
+    default:
+      return `${balance.currency} ${amount}`
+  }
+}
+
+/** 解析 /user/balance 响应（{is_available, balance_infos:[{total_balance,currency,...}]}）。 */
+export function parseBalanceResponse(json: unknown): Balance | undefined {
+  if (typeof json !== 'object' || json === null) return undefined
+  const body = json as Record<string, unknown>
+  const infos = Array.isArray(body.balance_infos) ? body.balance_infos : []
+  const info = infos[0]
+  if (typeof info !== 'object' || info === null) return undefined
+  const total = Number((info as Record<string, unknown>).total_balance)
+  if (!Number.isFinite(total)) return undefined
+  const currency = (info as Record<string, unknown>).currency
+  return {
+    total,
+    currency:
+      typeof currency === 'string' && currency !== '' ? currency : 'CNY',
+    // 缺省视为可用（旧字段兼容）；明确 false 才是预警信号。
+    isAvailable: body.is_available !== false,
+  }
+}
+
+interface CredentialsService {
+  resolve(ref: string): Promise<{ value: string } | undefined>
+}
+
+/** 查询一次余额；非官方/无 key/网络失败一律返回 undefined（静默）。 */
+export async function queryBalance(ctx: {
+  get(name: 'credentials'): CredentialsService | undefined
+}): Promise<Balance | undefined> {
+  if (cachedResult !== undefined && Date.now() - cachedAt < CACHE_MS) {
+    return cachedResult
+  }
+  if (inFlight !== null) return inFlight
+  const run = fetchBalance(ctx).catch(() => undefined)
+  inFlight = run.then((result) => {
+    if (result !== undefined) {
+      cachedResult = result
+      cachedAt = Date.now()
+    }
+    return result
+  })
+  return inFlight.finally(() => {
+    inFlight = null
+  })
+}
+
+async function fetchBalance(ctx: {
+  get(name: 'credentials'): CredentialsService | undefined
+}): Promise<Balance | undefined> {
+  const credentials = ctx.get('credentials')
+  if (credentials === undefined) return undefined
+  const key = await credentials.resolve('DEEPSEEK_API_KEY')
+  if (key === undefined) return undefined
+  const baseRef = await credentials.resolve('DEEPSEEK_BASE_URL')
+  const base = (baseRef === undefined ? DEFAULT_BASE_URL : baseRef.value)
+    .replace(/\/+$/, '')
+    .replace(/\/v1$/, '')
+  if (!isOfficialHost(base)) return undefined
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), QUERY_TIMEOUT_MS)
+  try {
+    const response = await fetch(base + '/user/balance', {
+      headers: { accept: 'application/json', authorization: 'Bearer ' + key.value },
+      signal: controller.signal,
+    })
+    if (!response.ok) return undefined
+    return parseBalanceResponse(await response.json())
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * 启动余额监控：立即查一次，之后每 intervalMs 查一次。
+ * 失败静默（下个周期重试）。返回停止函数（teardown 时调用）。
+ */
+export function startBalanceMonitor(
+  ctx: { get(name: 'credentials'): CredentialsService | undefined },
+  onBalance: (balance: Balance | undefined) => void,
+  intervalMs = 5 * 60_000,
+): () => void {
+  let stopped = false
+  let timer: NodeJS.Timeout | null = null
+  const tick = async (): Promise<void> => {
+    if (stopped) return
+    onBalance(await queryBalance(ctx))
+    if (stopped) return
+    timer = setTimeout(tick, intervalMs)
+    timer.unref()
+  }
+  void tick()
+  return () => {
+    stopped = true
+    if (timer !== null) clearTimeout(timer)
+  }
+}

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -187,6 +187,19 @@ export interface TokenUsage {
   output: number
 }
 
+/**
+ * DeepSeek 官方账户余额快照（host 层查询，key 不进 React 层）。
+ * `undefined` 表示不可用（非官方 base URL / 无 key / 查询失败，整行隐藏）。
+ */
+export interface Balance {
+  /** 总余额（total_balance，数值）。 */
+  total: number
+  /** 货币（`CNY`/`USD`，缺省 CNY）。 */
+  currency: string
+  /** 账户是否有余额可供调用（`is_available`，false = 欠费/不可用预警）。 */
+  isAvailable: boolean
+}
+
 /** In-process working-line snapshot derived from the base session stream. */
 export type ActivityStatus = ActivityState
 
@@ -352,6 +365,14 @@ export interface Channel {
   /** Whether the segmented context bar row shows in the status footer
    *  (config.contextBar; the status/mode lines are unaffected). */
   readonly contextBarEnabled: boolean
+  /**
+   * DeepSeek 官方账户余额（host 层每 5 分钟查询），未启用官方 base URL /
+   * 无 key / 查询失败时为 undefined（状态栏整行隐藏）。
+   */
+  readonly balance: Balance | undefined
+  /** 余额预警阈值（cordis.yml `balanceThreshold`，默认 10）：余额低于该值
+   *  状态栏余额转琥珀并一次性通知。 */
+  readonly balanceThreshold: number
   /**
    * Current same-session goal projection, when a goal exists. Derived live
    * from the durable `goal/change` context events (round-zero goal-sourced
@@ -669,6 +690,12 @@ export interface ChannelState {
   activityEnabled: boolean
   /** Context bar row switch (see the public Channel type). */
   contextBarEnabled: boolean
+  /** Balance snapshot (see the public Channel type). */
+  balance: Balance | undefined
+  /** Balance threshold (see the public Channel type). */
+  balanceThreshold: number
+  /** Push a fresh balance snapshot from the host layer. */
+  setBalance(balance: Balance | undefined): void
   /** Current same-session goal projection (see the public Channel type). */
   goal: ChannelGoal | undefined
   /** Latest todo-list snapshot (see the public Channel type). */
@@ -1074,6 +1101,11 @@ export function createChannel(
     /** Show the segmented context bar row in the status footer; default on
      *  (cordis.yml `contextBar: false` hides it, issue #29). */
     contextBar?: boolean
+    /** 余额预警阈值；默认 10。 */
+    balanceThreshold?: number
+    /** 每轮对话结束（turn/end，含中断）后触发的 host 回调——余额监控用它
+     *  立即刷新（60s 查询缓存自动防抖）。 */
+    onTurnEnd?: () => void
     /** cordis.yml's static preset choice (`preset` key): wins over the
      *  persisted `/preset` preference for NEW sessions this channel starts. */
     configuredPreset?: string
@@ -1505,6 +1537,22 @@ export function createChannel(
     diffLayout: options.diffLayout ?? 'auto',
     activityEnabled: options.activity !== false,
     contextBarEnabled: options.contextBar !== false,
+    balanceThreshold: options.balanceThreshold ?? 10,
+    balance: undefined,
+    setBalance(balance) {
+      const prev = state.balance
+      if (
+        prev !== undefined &&
+        balance !== undefined &&
+        prev.total === balance.total &&
+        prev.currency === balance.currency &&
+        prev.isAvailable === balance.isAvailable
+      ) {
+        return
+      }
+      state.balance = balance
+      state.emit()
+    },
     agentPreset: options.agentPreset,
     goal: undefined,
     todos: [],
@@ -3884,6 +3932,9 @@ ${output}
         settleStreaming()
         state.working = false
         state.activeToolCount = 0
+        // 对话结束（含中断）：通知 host 刷新余额，消耗立即反映。
+        options.onTurnEnd?.()
+
         if (tpsTurn !== undefined && tpsTurn === event.data.turn) {
           if (tpsTurnSampled && tpsTurnDecodeMs > 0) {
             const turnTps = tpsTurnDecodeTokens / (tpsTurnDecodeMs / 1000)

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -63,6 +63,10 @@ export interface Config {
    *  `ctx used/window` readout) in the status footer; off hides that row
    *  while the status/mode lines stay (issue #29). */
   contextBar?: boolean
+  /** 余额预警阈值：总余额低于该值（按 currency 数值比较）时状态栏余额转琥珀
+   *  并一次性通知；`is_available=false`（账户不可用）时转红，不受阈值影响。
+   *  默认 10。 */
+  balanceThreshold?: number
   /** Run in the terminal's alternate screen (Claude Code fullscreen layout). */
   fullscreen?: boolean
   /** UI language: `en` / `zh`. When absent, the `DSH_TUI_LANG` env var wins,
@@ -98,6 +102,7 @@ export const Config: Schema<Config> = Schema.object({
   activity: Schema.boolean().default(true),
   activityFrames: Schema.string().required(false),
   contextBar: Schema.boolean().default(true),
+  balanceThreshold: Schema.number().default(10),
   fullscreen: Schema.boolean().default(false),
   lang: Schema.string().required(false),
   preset: Schema.string().required(false),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -9,6 +9,7 @@ import { settingsNamespace } from '@deepseek-ai/dsh-settings'
 import Schema from '@deepseek-ai/schemastery'
 import { Config } from './index.js'
 import { createChannel } from './channel.js'
+import { formatBalance, queryBalance, startBalanceMonitor } from './balance.js'
 import { createChildStderrReporter, installChildStderrGuard } from './childStderr.js'
 import { logForDebugging } from '../utils/debug.js'
 import { QuestionStore } from './questions.js'
@@ -305,6 +306,12 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     activityFrames: config.activityFrames ?? readActivityFrames() ?? 'claude',
     // Static footer preference: cordis.yml `contextBar` (schema default on).
     contextBar: config.contextBar,
+    // 余额预警阈值（cordis.yml `balanceThreshold`，默认 10）。
+    balanceThreshold: config.balanceThreshold,
+    // 每轮对话结束立即刷新余额（60s 查询缓存自动防抖）。
+    onTurnEnd: () => {
+      void queryBalance(ctx).then((balance) => channel.setBalance(balance))
+    },
     // Same precedence for the agent preset: cordis.yml `preset` over the
     // persisted `/preset` choice; undefined adopts the roster default.
     configuredPreset: config.preset,
@@ -317,6 +324,42 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     diffLayout: config.diffLayout,
     handle,
   })
+  // DeepSeek 官方余额监控（host 层查询，key 不进 React 层）：立即查一次，
+  // 之后每 5 分钟刷新；非官方 base URL / 无 key / 失败静默隐藏。
+  // 预警只在状态变化时通知一次（转不可用 / 跌破阈值），恢复后再次跌破会重报。
+  ctx.effect(() => {
+    let unavailableReported = false
+    let lowReported = false
+    return startBalanceMonitor(ctx, (balance) => {
+      channel.setBalance(balance)
+      if (balance === undefined) return
+      const threshold = channel.balanceThreshold
+      if (!balance.isAvailable) {
+        if (!unavailableReported) {
+          unavailableReported = true
+          lowReported = true
+          channel.notify(t('balance-warning-unavailable'), { color: 'error' })
+        }
+        return
+      }
+      unavailableReported = false
+      if (balance.total < threshold) {
+        if (!lowReported) {
+          lowReported = true
+          channel.notify(
+            t('balance-warning-low', {
+              total: formatBalance(balance),
+              threshold: String(threshold),
+            }),
+            { color: 'warning', timeoutMs: 8000 },
+          )
+        }
+      } else {
+        lowReported = false
+      }
+    })
+  })
+
   // Register the dsh-tui settings namespace so the /settings screen can
   // edit it (the section below was '命名空间未注册' without this): the
   // user layer in settings.yaml wins over cordis.yml's diffLayout, and

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -666,6 +666,16 @@ const dict = {
   // ── screens/StatusLine.tsx ───────────────────────────────────────────
   'status-cache-label': { zh: '缓存 ', en: 'cache ' },
 
+  // ── 余额预警（host 层 balance 监控）───────────────────────────────────
+  'balance-warning-low': {
+    zh: '余额偏低：{{total}}（低于预警阈值 {{threshold}}）',
+    en: 'Low balance: {{total}} (below threshold {{threshold}})',
+  },
+  'balance-warning-unavailable': {
+    zh: '余额预警：账户不可用，API 调用将被拒绝',
+    en: 'Balance alert: account unavailable, API calls will be rejected',
+  },
+
   // ── screens/TrajectoryScene.tsx（issue #80 演进：全屏轨迹场景）──────────
   'traj-title': { zh: '轨迹', en: 'Trajectory' },
   'traj-totals': { zh: '{{turns}} 轮 · {{steps}} 步', en: '{{turns}} turns · {{steps}} rows' },

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -5,6 +5,7 @@ import { t } from '../i18n.js'
 import { Byline } from '../components/design-system/Byline.js'
 import { KeyboardShortcutHint } from '../components/design-system/KeyboardShortcutHint.js'
 import { ActivityLine, contextPressurePct } from '../components/ActivityLine.js'
+import { formatBalance } from '../dsh-adapter/balance.js'
 import type { Channel } from '../dsh-adapter/channel.js'
 import { modeDisplayName } from '../sessionModes.js'
 import { MiniWake } from '../components/trajectory/MiniWake.js'
@@ -124,6 +125,13 @@ export function StatusLine({
     <Text key="tokens" color="inactiveShimmer">
       {formatTokens(channel.tokens.input)}→{formatTokens(channel.tokens.output)}
     </Text>,
+    ...(channel.balance !== undefined
+      ? [
+          <Text key="balance" color={balanceColor(channel.balance, channel.balanceThreshold)}>
+            {formatBalance(channel.balance)}
+          </Text>,
+        ]
+      : []),
   ]
 
   // Right group: git branch in muted steel blue, cwd a soft white, the
@@ -251,4 +259,14 @@ export function StatusLine({
 function basename(path: string): string {
   const parts = path.split(/[\\/]/)
   return parts[parts.length - 1] ?? path
+}
+
+/** 余额预警配色：账户不可用 → 红（最严重）；低于阈值 → 琥珀；正常 → 常态。 */
+function balanceColor(
+  balance: { total: number; isAvailable: boolean },
+  threshold: number,
+): 'error' | 'warning' | 'inactiveShimmer' {
+  if (!balance.isAvailable) return 'error'
+  if (balance.total < threshold) return 'warning'
+  return 'inactiveShimmer'
 }


### PR DESCRIPTION
## 功能

状态栏左侧组尾部显示 DeepSeek 官方账户余额（`model · 12.3 tps · 34K→1.2K · ¥68.64`），并提供低余额预警：

| 状态 | 状态栏颜色 | 通知（仅状态变化触发一次） |
|---|---|---|
| `is_available = false` | 红 | 账户不可用，API 调用将被拒绝 |
| 余额 < `balanceThreshold`（默认 10） | 琥珀 | 余额偏低提示 |
| 正常 | 常态 | 无 |

## 实现要点

- **host 层查询**：新增 `src/dsh-adapter/balance.ts`，经 credentials 服务解析 `DEEPSEEK_API_KEY`，fetch 官方 `/user/balance`（8s 超时）；key 明文不进 React 层
- **刷新时机**：启动时立即查询 + 每 5 分钟轮询 + 每轮对话结束（`turn/end`，含中断）立即刷新；60s 查询缓存防抖
- **降级语义**：非官方 base URL / 无 key / 查询失败 → 静默隐藏整行（与 ds-balance 插件同款）
- **配置**：cordis.yml `balanceThreshold`（默认 10），对齐 `contextBar` 配置先例
- **测试**：`scripts/verify-balance.ts` 28 项断言（官方主机判定、响应解析、格式函数）挂入 `verify:build` 链

## 验证

- `tsc --noEmit` 通过
- `npm run verify:balance` 28/28 通过
- 实机（dsh-tui 0.8.0 + dsh 0.1.0-rc.6）验证余额显示与预警正常

一只小火柴๑҉_🤖