### PR TITLE
feat(status-bar): add tuiStatusItems seam for plugin status items

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -198,6 +198,11 @@
     - id: dsh-tui-scenes
       name: '@deepseek-harness-tui/dsh-tui/scenes'
 
+    # Optional plugins contribute status-bar items here; layout, separators
+    # and truncation remain owned by the TUI's StatusLine footer.
+    - id: dsh-tui-status-items
+      name: '@deepseek-harness-tui/dsh-tui/status-items'
+
     # The agent-preset roster (issue #8): `ctx.agentPresets`, the service the
     # TUI composes every session's model-facing world from. No `roots` here —
     # the dsh CLI's profile-boot overlays its shipped `config/agent-presets/`

--- a/cordis.yml
+++ b/cordis.yml
@@ -37,6 +37,12 @@
 - id: dsh-tui-scenes
   name: '@deepseek-harness-tui/dsh-tui/scenes'
 
+# Optional plugins contribute status-bar items (connection badges, latency
+# readouts, …) here; layout, separators and truncation remain owned by the
+# TUI's StatusLine footer.
+- id: dsh-tui-status-items
+  name: '@deepseek-harness-tui/dsh-tui/status-items'
+
 - id: dsh-tui
   name: '@deepseek-harness-tui/dsh-tui'
   inject: [agents, tuiWorkspaces, tuiScenes]

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       "types": "./lib/types/scenes.d.ts",
       "import": "./lib/types/scenes.js"
     },
+    "./status-items": {
+      "types": "./lib/types/status-items.d.ts",
+      "import": "./lib/types/status-items.js"
+    },
     "./jsx-runtime": {
       "types": "./lib/types/jsx-runtime.d.ts",
       "import": "./lib/types/jsx-runtime.js"

--- a/patch-surface.snapshot.json
+++ b/patch-surface.snapshot.json
@@ -8,6 +8,7 @@
     "dsh-tui-command-trees",
     "dsh-tui-settings-sections",
     "dsh-tui-scenes",
+    "dsh-tui-status-items",
     "agent-presets",
     "cordis-host-runner",
     "dsh-tui",

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -56,6 +56,7 @@ import type { TuiCommandTreeRuntime } from './command-trees.js'
 import type { TuiSettingsSection, TuiSettingsSectionsRuntime } from './settings-sections.js'
 import type { SettingsHost } from './settingsEditor.js'
 import type { TuiSceneDescriptor, TuiSceneRuntime } from './scenes.js'
+import type { TuiStatusItem, TuiStatusItemsRuntime } from './status-items.js'
 
 type ChannelImageBlock = Extract<ContentBlock, { type: 'image' }>
 type ChannelImageMediaType = ChannelImageBlock['attachment']['mediaType']
@@ -405,6 +406,13 @@ export interface Channel {
    */
   readonly pluginScene: TuiSceneDescriptor | undefined
   /**
+   * Plugin-contributed status-bar items (the `dsh-tui-status-items` runtime),
+   * in registration order. The StatusLine footer renders them after the
+   * built-in model/tps fields; empty when no plugin contributes items or the
+   * service is not mounted.
+   */
+  readonly statusItems: readonly TuiStatusItem[]
+  /**
    * Open a registered plugin scene by id. Plugin command handlers usually
    * call the runtime directly (`ctx.tuiScenes.open`); this passthrough lets
    * host-side UI code do the same without touching cordis services.
@@ -691,6 +699,8 @@ export interface ChannelState {
   runExternalCommand(name: string, rawInput: string): Promise<string | undefined>
   /** Open plugin scene mirrored from the scenes runtime (see the public Channel type). */
   pluginScene: TuiSceneDescriptor | undefined
+  /** Plugin-contributed status-bar items (see the public Channel type). */
+  statusItems: readonly TuiStatusItem[]
   /** Open a plugin scene by id (see the public Channel type). */
   openPluginScene(id: string): boolean
   /** Close the open plugin scene (see the public Channel type). */
@@ -1117,6 +1127,10 @@ export function createChannel(
   // tuiWorkspaces/tuiCommandTrees): mounted by the bundle patch's
   // dsh-tui-scenes row; absent the row, `pluginScene` simply stays undefined.
   const sceneRuntime = ctx.get('tuiScenes') as TuiSceneRuntime | undefined
+  // Status-bar item registry (optional service, same degradation rule as
+  // tuiScenes): mounted by the bundle patch's dsh-tui-status-items row;
+  // absent the row, `statusItems` simply stays empty.
+  const statusItemsRuntime = ctx.get('tuiStatusItems') as TuiStatusItemsRuntime | undefined
   // Shift+Tab session-mode cycle: cordis.yml `modes` wins; absent/empty/
   // atom-less → the built-in default/plan/full cycle (sessionModes.ts).
   const { modes: sessionModes, dropped: droppedModeIds } = resolveSessionModes(options.modes)
@@ -2790,6 +2804,7 @@ export function createChannel(
       return executeRegistryCommand(name, rawInput)
     },
     pluginScene: sceneRuntime?.active,
+    statusItems: statusItemsRuntime?.items() ?? [],
     openPluginScene(id: string) {
       return sceneRuntime?.open(id) ?? false
     },
@@ -2984,6 +2999,7 @@ export function createChannel(
     releaseContributions() {
       releaseSkillCommands()
       unsubscribeScenes?.()
+      unsubscribeStatusItems?.()
     },
     traceEvents() {
       // Immutable per-append snapshot (dsh-session caches the frozen array);
@@ -3337,6 +3353,16 @@ export function createChannel(
   const unsubscribeScenes = sceneRuntime?.subscribe(() => {
     if (state.pluginScene === sceneRuntime.active) return
     state.pluginScene = sceneRuntime.active
+    state.emit()
+  })
+  /**
+   * Mirror the status-items runtime's aggregated list into channel state,
+   * same version-bump re-render path as the scene mirror above. The runtime
+   * only notifies on register/dispose/provider change, so every notification
+   * here is a real update.
+   */
+  const unsubscribeStatusItems = statusItemsRuntime?.subscribe(() => {
+    state.statusItems = statusItemsRuntime.items()
     state.emit()
   })
   /** See {@link Channel.releaseContributions}. */

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -245,6 +245,14 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       'The bundle patch is older than the installed dsh-tui package — update the globally installed dsh-tui launcher to match the profile (issue #183).',
     )
   }
+  // Same skew guard for the status-items registry (dsh-tui-status-items row):
+  // absent the service the footer shows no plugin items, with no other hint.
+  if (ctx.get('tuiStatusItems') === undefined && resolveDshProfileName() !== undefined) {
+    ctx.logger.warn(
+      'dsh-tui: tuiStatusItems service is not mounted; plugin status-bar items will never render. ' +
+      'The bundle patch is older than the installed dsh-tui package — update the globally installed dsh-tui launcher to match the profile (issue #183).',
+    )
+  }
   const initialWorkspace = requestedWorkspace === undefined
     ? undefined
     : await workspaceService.resolve(requestedWorkspace)

--- a/src/dsh-adapter/status-items.ts
+++ b/src/dsh-adapter/status-items.ts
@@ -1,0 +1,90 @@
+/** Provider-neutral status-bar item registry for terminal front doors. */
+
+import { Context, Service } from '@deepseek-ai/cordis'
+
+/**
+ * A single status-bar entry contributed by a plugin. Items are plain text —
+ * the TUI owns layout, separators and truncation; a plugin only supplies the
+ * label and an optional color name from the TUI's theme palette (the same
+ * names `Text`'s `color` prop accepts).
+ */
+export interface TuiStatusItem {
+  /** Unique within its provider; used as the render key. */
+  id: string
+  /** Compact label; keep it short — crowded footers truncate trailing fields. */
+  text: string
+  /** Optional theme color name (e.g. 'warning', 'professionalBlue'). */
+  color?: string
+  /** Render dimmed instead of at the default soft white. */
+  dimColor?: boolean
+}
+
+/**
+ * A plugin's contribution to the status bar. `items()` is read on every
+ * render; `subscribe` must fire whenever the returned list changes so the
+ * TUI repaints promptly (connection flaps, latency updates, …).
+ */
+export interface TuiStatusItemsProvider {
+  items(): readonly TuiStatusItem[]
+  subscribe(listener: () => void): () => void
+}
+
+declare module '@deepseek-ai/cordis' {
+  interface Context {
+    tuiStatusItems: TuiStatusItemsRuntime
+  }
+}
+
+export const name = 'dsh-tui-status-items'
+
+/**
+ * Small host-only registry; the StatusLine footer remains owned by the TUI.
+ *
+ * A plugin registers a provider once (`ctx.tuiStatusItems.register(...)`,
+ * keep the dispose). Items render in registration order after the built-in
+ * model/tps fields; absent the service (stale bundle patch or a bare
+ * embedder), the footer simply shows no plugin items.
+ */
+export class TuiStatusItemsRuntime extends Service {
+  private readonly providers = new Set<TuiStatusItemsProvider>()
+  private readonly listeners = new Set<() => void>()
+  private readonly providerUnsubscribes = new Map<TuiStatusItemsProvider, () => void>()
+
+  constructor(ctx: Context) {
+    super(ctx, 'tuiStatusItems')
+  }
+
+  register(provider: TuiStatusItemsProvider): () => void {
+    if (this.providers.has(provider)) throw new Error('TUI status-items provider is already registered')
+    this.providers.add(provider)
+    this.providerUnsubscribes.set(provider, provider.subscribe(() => this.notify()))
+    this.notify()
+    return () => {
+      if (!this.providers.delete(provider)) return
+      this.providerUnsubscribes.get(provider)?.()
+      this.providerUnsubscribes.delete(provider)
+      this.notify()
+    }
+  }
+
+  /** Every registered provider's items, in registration order. */
+  items(): readonly TuiStatusItem[] {
+    const items: TuiStatusItem[] = []
+    for (const provider of this.providers) items.push(...provider.items())
+    return items
+  }
+
+  /** UI-side change feed: fired after every register/dispose/provider update. */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) listener()
+  }
+}
+
+export default TuiStatusItemsRuntime

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -113,6 +113,19 @@ export function StatusLine({
     }
   }
 
+  // Plugin-contributed status items (dsh-tui-status-items runtime) sit
+  // between the built-in context fields and the token counter: they are
+  // glanceable health signals (connection state, latency) of the same rank.
+  const pluginParts = channel.statusItems.map(item => (
+    <Text
+      key={`plugin-${item.id}`}
+      color={item.color as React.ComponentProps<typeof Text>['color']}
+      dimColor={item.dimColor}
+    >
+      {item.text}
+    </Text>
+  ))
+
   // Left group: every field sits at soft white (inactiveShimmer) instead of
   // the previous uniform dim grey — readable against dark terminals.
   const leftParts = [
@@ -121,6 +134,7 @@ export function StatusLine({
     </Text>,
     ...tpsParts,
     ...contextParts,
+    ...pluginParts,
     <Text key="tokens" color="inactiveShimmer">
       {formatTokens(channel.tokens.input)}→{formatTokens(channel.tokens.output)}
     </Text>,

--- a/src/status-items.ts
+++ b/src/status-items.ts
@@ -1,0 +1,4 @@
+// Re-export shim: the Cordis-backed implementation lives behind the adapter
+// boundary so UI consumers never import official @deepseek-ai/* packages.
+export * from './dsh-adapter/status-items.js'
+export { default } from './dsh-adapter/status-items.js'


### PR DESCRIPTION
## What

New cordis service seam `dsh-tui-status-items`, mirroring the `tuiScenes` pattern: plugins register a `TuiStatusItemsProvider` contributing plain-text `TuiStatusItem` entries (label + optional theme color), and the `StatusLine` footer renders them in registration order between the built-in context fields and the token counter.

First consumer: the `dsh-remote` plugin (roadmap §2「Live UX 完善」), which surfaces SSH connection state, `user@host` target, and round-trip latency in the status bar.

## Changes

- `src/dsh-adapter/status-items.ts`: `TuiStatusItemsRuntime` (`register`/`items`/`subscribe`) with `Context` augmentation; provider subscribe changes re-notify the UI
- `src/status-items.ts` re-export shim + `./status-items` package subpath
- `cordis.yml` / `cordis.patch.yml`: mount the `dsh-tui-status-items` row; patch-surface snapshot regenerated (one new insert)
- `channel.ts`: bridge the runtime into `Channel.statusItems` with the same version-bump mirror as `pluginScene`; released in `releaseContributions`
- `StatusLine.tsx`: render `channel.statusItems` in the left group
- `plugin.ts`: skew-guard warn when the service is not mounted

## Degradation

Absent the service (stale bundle patch or bare embedder), the footer simply shows no plugin items — same rule as the other optional seams. Plugins that read `ctx.get('tuiStatusItems', false)` get `undefined` and skip registration.

## Verification

- `npm run compile` clean
- `npm run verify:build` all gates green (boundary / contract / manifest-deps / patch-surface / packaged-presets / minimal-preset-tools / liangshen-bootstrap)