### PR TITLE
fix(process): 子进程提前退出时不再因 stdin EPIPE 崩溃

### DIFF
--- a/scripts/verify-clipboard.mjs
+++ b/scripts/verify-clipboard.mjs
@@ -395,6 +395,17 @@ exit 1
     "process.stdout.write(Buffer.from([0xE5])); setTimeout(() => { process.stdout.write(Buffer.from([0x89, 0xAA])); }, 60)",
   ])
   check('execFileNoThrow decodes UTF-8 across chunk boundaries', r.stdout === '剪', `got ${JSON.stringify(r.stdout)}`)
+
+  const closedStdin = await execFileNoThrow(
+    process.execPath,
+    ['-e', 'process.stdin.destroy(); setTimeout(() => process.exit(0), 50)'],
+    { input: 'x'.repeat(16 * 1024 * 1024) },
+  )
+  check(
+    'execFileNoThrow survives a child closing stdin before the input is written',
+    closedStdin.code === 0,
+    `got ${JSON.stringify(closedStdin)}`,
+  )
 }
 
 if (failed > 0) {

--- a/src/utils/execFileNoThrow.ts
+++ b/src/utils/execFileNoThrow.ts
@@ -51,6 +51,9 @@ export function execFileNoThrow(
     child.stderr.on('data', (chunk: Buffer) => {
       stderrChunks.push(chunk)
     })
+    // A child may exit before consuming the supplied input. The resulting
+    // EPIPE/EOF belongs to that child outcome and must not crash the caller.
+    child.stdin.on('error', () => {})
     child.on('error', () => {
       resolve({
         code: 1,


### PR DESCRIPTION
## 动机

原 PR #297 因提交来源 fork 被删除而由 GitHub 自动关闭，且旧 PR 无法在同名 fork 重建后重新关联。本 PR 在最新 `main` 上恢复该修复。

当外部命令在父进程写完输入前提前退出时，`child.stdin` 会产生 `EPIPE` / `EOF`。当前 `execFileNoThrow()` 没有消费这个流错误，可能触发未处理的 `error` 事件并让 TUI 直接崩溃。

## 修改

- 在创建子进程后立即监听 `child.stdin` 的错误事件；
- 将子进程提前关闭输入管道视为该子进程的正常结果边界，仍由 `close` 事件返回退出码和输出；
- 新增跨平台回归：子进程主动销毁 stdin，父进程写入 16 MiB 输入，验证调用不会崩溃。

## 验证

在 Windows / Node.js 24 上实际运行：

```text
corepack pnpm build
node scripts/verify-clipboard.mjs
node scripts/verify-clipboard.mjs
git diff --check origin/main...HEAD
```

结果：完整 build 与 `verify:build` 全部通过；stdin 提前关闭回归连续两次通过。

替代因 fork 删除而关闭的 #297。