### PR TITLE
fix(input): 浏览历史后恢复未提交草稿

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
       # stdin 批量按键回归：同一读取内的文本、方向键、文本必须依次基于
       # 前一事件的输入状态执行，不能因 React 批处理读取旧闭包而丢字符。
       - run: node scripts/verify-batched-prompt-input.mjs
+      # 输入历史草稿回归（issue #287）：首次 ↑ 保存未提交草稿，遍历历史后
+      # ↓ 回到末尾必须恢复原文，重复越界不能把草稿清空。
+      - run: node scripts/verify-prompt-history-draft.mjs
       # /resume 会话管理回归（issue #112）：picker 重命名追加帧（seq 连续、
       # 已有字节不动、last-title-wins）、删除目录、路径穿越 id 拒绝。
       - run: node scripts/verify-resume-manage.mjs

--- a/scripts/verify-prompt-history-draft.mjs
+++ b/scripts/verify-prompt-history-draft.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Regression for issue #287: traversing prompt history must preserve the
+ * unfinished draft that was present before the first Up key.
+ *
+ * Drives the real PromptInput through fake stdin. After walking past both
+ * ends of a two-entry history, Enter must submit the original draft rather
+ * than nothing.
+ *
+ * Run after build: `node scripts/verify-prompt-history-draft.mjs`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough, Writable } from 'node:stream'
+
+const home = mkdtempSync(join(tmpdir(), 'dsh-tui-history-draft-'))
+process.env.HOME = home
+process.env.USERPROFILE = home
+
+const [{ default: React }, { render }, { PromptInput }] = await Promise.all([
+  import('react'),
+  import('../lib/types/ui.js'),
+  import('../lib/types/components/PromptInput.js'),
+])
+
+function makeStreams() {
+  const stdout = new Writable({ write(_chunk, _encoding, callback) { callback() } })
+  stdout.columns = 100
+  stdout.rows = 30
+  stdout.isTTY = true
+  const stderr = new Writable({ write(_chunk, _encoding, callback) { callback() } })
+  stderr.isTTY = true
+  const stdin = new PassThrough()
+  stdin.isTTY = true
+  stdin.setRawMode = () => stdin
+  stdin.setEncoding = () => stdin
+  stdin.ref = () => stdin
+  stdin.unref = () => stdin
+  return { stdout, stderr, stdin }
+}
+
+const submitted = []
+const channel = {
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  cycleMode() {},
+  commandList: [],
+  commandCompletions: () => [],
+  notifications: [],
+  pending: [],
+  working: false,
+  notify() {},
+  submit(text) { submitted.push(text) },
+  steer() {},
+  interruptAndDeliver() { return 0 },
+  removePending() { return false },
+  stageImage() {},
+  listFiles: async () => [],
+}
+
+const { stdout, stderr, stdin } = makeStreams()
+const instance = await render(
+  React.createElement(PromptInput, {
+    channel,
+    helpOpen: false,
+    onToggleHelp() {},
+    onRunCommand: () => false,
+    selectionActive: false,
+  }),
+  { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
+)
+
+const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+const write = async (input) => {
+  stdin.write(input)
+  await wait(120)
+}
+
+try {
+  await wait(300)
+  await write('first')
+  await write('\r')
+  await write('second')
+  await write('\r')
+  await write('unfinished draft')
+
+  // Repeated Up clamps at the oldest entry; repeated Down returns to and
+  // stays on the draft after passing the newest entry.
+  for (let i = 0; i < 3; i += 1) await write('\x1b[A')
+  for (let i = 0; i < 3; i += 1) await write('\x1b[B')
+  await write('\r')
+
+  if (submitted.length !== 3 || submitted[2] !== 'unfinished draft') {
+    console.error(`FAIL: unfinished draft was not restored: ${JSON.stringify(submitted)}`)
+    process.exitCode = 1
+  } else {
+    console.log('verify-prompt-history-draft OK')
+  }
+} finally {
+  instance.unmount()
+  rmSync(home, { recursive: true, force: true })
+}

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -160,6 +160,7 @@ export function PromptInput({
   const [selectedCommand, setSelectedCommand] = React.useState(0)
   const history = React.useRef<string[]>([])
   const historyIndex = React.useRef(-1)
+  const historyDraft = React.useRef('')
   // ctrl+r history fill: replace the input when a new fill arrives, then
   // tell the caller to clear it.
   const lastFill = React.useRef<string | null>(null)
@@ -659,9 +660,12 @@ export function PromptInput({
         return
       }
       if (history.current.length === 0) return
-      historyIndex.current = historyIndex.current < 0
-        ? history.current.length - 1
-        : Math.max(0, historyIndex.current - 1)
+      if (historyIndex.current < 0) {
+        historyDraft.current = value
+        historyIndex.current = history.current.length - 1
+      } else {
+        historyIndex.current = Math.max(0, historyIndex.current - 1)
+      }
       const entry = history.current[historyIndex.current] ?? ''
       setInput(entry)
       return
@@ -692,11 +696,13 @@ export function PromptInput({
         return
       }
       if (historyIndex.current < 0) return
-      historyIndex.current += 1
-      const entry = historyIndex.current >= history.current.length
-        ? ''
-        : (history.current[historyIndex.current] ?? '')
-      setInput(entry)
+      if (historyIndex.current >= history.current.length - 1) {
+        historyIndex.current = -1
+        setInput(historyDraft.current)
+      } else {
+        historyIndex.current += 1
+        setInput(history.current[historyIndex.current] ?? '')
+      }
       return
     }
     if (isMod(key) && key.leftArrow) {


### PR DESCRIPTION
## 恢复说明

原 PR #289 因提交来源 fork 被删除而由 GitHub 自动关闭，且旧 PR 无法重新关联。本 PR 已在最新 `main` 上重新同步并复测。

## 动机

输入框已有会话内历史浏览，但用户在正在编辑的草稿上误按 `↑` 后，当前文本会被历史项覆盖；即使再按 `↓` 回到历史末尾，输入框也只会变成空串，未提交内容无法恢复。该行为与常见 shell/Claude Code 的历史导航不一致，并会造成真实输入丢失。

Closes #287

## 根因与复现

`PromptInput` 仅保存历史数组和当前位置，没有保存首次进入历史浏览前的输入。`↓` 越过最新历史时直接执行 `setInput('')`。

新增回归通过真实 `PromptInput` + fake stdin 执行：

```text
提交 first
提交 second
输入 unfinished draft
按 ↑ ↑ ↑ ↓ ↓ ↓ Enter
```

修复前第三次提交不存在：

```text
["first", "second"]
```

## 修改

- 首次从普通输入进入历史时保存当前草稿
- `↓` 越过最新历史时恢复草稿，并退出历史浏览状态
- 在最老历史继续按 `↑`、回到草稿后继续按 `↓` 都保持边界稳定
- 新增隔离 HOME 的 headless PromptInput 回归，并挂入 CI 输入测试区

## 行为边界

- 多行输入中的 `↑` / `↓` 仍优先移动行间光标
- 文件补全、命令补全和 Alt+↑ 撤回逻辑不变
- Ctrl+R 持久化历史搜索不变
- 会话内历史条目、数量上限和持久化格式不变

## dsh-ecosystem-spec 影响

- **Scope**：TUI prompt 的会话内历史导航
- **Normative change**：None
- 不修改插件 manifest、Community contract、registry、schema、公共 API 或持久化格式
- **Migration**：None
- **Rollback**：回退提交 `9905290` 即恢复旧行为
- 本 PR 不声明生态认证或规范符合性等级

## 验证

- `corepack pnpm build`：通过
- `corepack pnpm verify:package`：通过，852 files / 19 entry targets
- `node scripts/verify-prompt-history-draft.mjs`：连续 3 次通过
- `node scripts/verify-batched-prompt-input.mjs`：通过
- `node scripts/verify-word-jump.mjs`：通过
- `DSH_TUI_LANG=zh node scripts/verify-queue.mjs`：通过
- `corepack pnpm smoke`：通过
- 真实 headless xterm 帧人工检查：历史遍历后输入框完整恢复 `unfinished draft`
- `git diff --check`：通过

替代因 fork 删除而关闭的 #289。