### PR TITLE
fix(memory): 长会话 4GB OOM——直载路径 dev reconciler 回归 + 三处无界结构封顶

### DIFF
--- a/src/dsh-adapter/childStderr.ts
+++ b/src/dsh-adapter/childStderr.ts
@@ -177,6 +177,15 @@ export function createChildStderrReporter(
         groups.delete(line)
         // A burst inside the cooldown window is counted but stays silent.
         if ((mutedUntil.get(line) ?? 0) > Date.now()) return
+        // Prune expired cooldowns on the way in: entries are child-stderr
+        // lines and a long-lived MCP reconnect loop would otherwise grow the
+        // dedup table without bound.
+        if (mutedUntil.size > 64) {
+          const now = Date.now()
+          for (const [key, until] of mutedUntil) {
+            if (until <= now) mutedUntil.delete(key)
+          }
+        }
         mutedUntil.set(line, Date.now() + cooldownMs)
         const text =
           group.count > 1

--- a/src/dsh-adapter/promptDebug.ts
+++ b/src/dsh-adapter/promptDebug.ts
@@ -98,11 +98,19 @@ function captureRequest(
 }
 
 /**
- * Register `/debug-prompt` and retain every final request observed for each
- * live session. The command writes one private, atomic snapshot into the
- * receiving session's workspace; it never records credentials, transport
- * headers, or AbortSignals.
+ * Register `/debug-prompt` and retain the final requests observed for each
+ * live session (most recent {@link DEBUG_PROMPT_MAX_REQUESTS} kept). The
+ * command writes one private, atomic snapshot into the receiving session's
+ * workspace; it never records credentials, transport headers, or
+ * AbortSignals.
  */
+
+/** Retention cap per session: every capture holds the fully assembled
+ * request context (messages + tools), so an unbounded list grows
+ * quadratically with an uncompacted conversation — the dominant long-session
+ * memory term. Retries of the current step stay well inside this window. */
+const DEBUG_PROMPT_MAX_REQUESTS = 8
+
 export function registerPromptDebug(ctx: Context): void {
   const commands = ctx.get('commands') as CommandRuntime | undefined
   const agents = ctx.get('agents') as AgentRegistryLike | undefined
@@ -126,6 +134,9 @@ export function registerPromptDebug(ctx: Context): void {
       request.turn === position.turn && request.step === position.step)
     const attempt = (previous?.attempt ?? 0) + 1
     capture.requests.push(captureRequest(agent, options, capture.requests.length + 1, position, attempt))
+    if (capture.requests.length > DEBUG_PROMPT_MAX_REQUESTS) {
+      capture.requests.splice(0, capture.requests.length - DEBUG_PROMPT_MAX_REQUESTS)
+    }
     return next()
   })
 

--- a/src/force-production-react.ts
+++ b/src/force-production-react.ts
@@ -1,0 +1,11 @@
+/**
+ * React-reconciler selects its dev/production build at require time from
+ * NODE_ENV; the dev build records one performance.measure() per render into
+ * an unbounded buffer — the 4 GB long-session OOM (b1e06d8). Every launcher
+ * forces production, but a direct `dsh --profile dsh-tui` boot loads this
+ * plugin without one and silently regressed to the dev build. This module
+ * must stay the FIRST import of the package entry so its body runs before
+ * any module in the plugin graph requires react. `??=` keeps an explicit
+ * environment choice (a debugging session) in control.
+ */
+process.env.NODE_ENV ??= 'production'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import './force-production-react.js'
+
 // Re-export shim: the plugin factory lives in src/dsh-adapter/index.ts
 // (the only module tree allowed to import official @deepseek-ai/* packages).
 export * from './dsh-adapter/index.js'

--- a/src/ink/output.ts
+++ b/src/ink/output.ts
@@ -266,6 +266,14 @@ type StreamingLineSlot = {
 type EscapeTailState = 'none' | 'complete' | 'dangling' | 'bare'
 
 /**
+ * Slot-reuse ceiling: the clustered array is a second full memory image of
+ * the line, and pathological single-line output (base64 blobs, minified
+ * code) would pin it across frames on top of the string itself. Past this
+ * length every frame takes the full path — transient, GC-able.
+ */
+const STREAMING_SLOT_MAX_LINE = 65_536
+
+/**
  * Classify the tail of the line relative to its LAST ESC character.
  * - 'none': no ESC at all
  * - 'dangling': the last ESC starts an escape sequence that is cut off at
@@ -336,6 +344,7 @@ function updateStreamingSlot(
 ): void {
   if (
     line.length <= MAX_CACHEABLE_LINE ||
+    line.length > STREAMING_SLOT_MAX_LINE ||
     endsWithOpenGrapheme(line) ||
     hasRtlChars(line)
   ) {


### PR DESCRIPTION
## 背景

社区反馈：长时间多步骤会话后 TUI 崩溃，堆涨到 ~4GB（Node 默认上限），`Ineffective mark-compacts near heap limit`。反馈者的会话证据：1 轮 / 35 步 / 70 分钟 / **19,177 个 `assistant/chunk` 事件**（原始 3.5MB）。

原始数据只有 3.5MB、对象化后几十 MB——千倍放大另有主因，本 PR 修掉 TUI 侧的两个 GB 级源头和两个中小无界点。

## 修复

### 1. 插件入口强制 production react（GB 级主因）
react-reconciler 按 require 时的 NODE_ENV 选构建；dev 版每次渲染写一条 `performance.measure()` 进无界缓冲（b1e06d8 修过的 4GB OOM）。三处启动器都设 production，但 **`dsh --profile` 直载不经启动器**，插件构建产物此前零自我保护——反馈者的缓解命令 `NODE_OPTIONS=... dsh --profile tui` 恰好就是这条路径。入口第一个 import `??= production`，外部显式设置（调试）仍尊重。

### 2. /debug-prompt 环形保留（GB 级主因）
每个 LLM 请求驻留完整组装上下文（messages + tools + system），未 compact 的长会话累计**随对话二次方增长**。每会话保留最近 8 条（重试排查足够）。

### 3. StreamingLineSlot 行长上限
clustered 数组是整行的第二份内存映像；base64/压缩产物的超长单行流式输出会跨帧钉住双份。>64k 字符放弃前缀复用，退回逐帧全量路径（瞬态可回收）。

### 4. childStderr 去重表过期清理
`mutedUntil` 只 set 不 delete，MCP server 重连循环长期运行无界增长。插入时清理已过期项。

## 不在本 PR（已定位、属上游 harness）

- 19K chunk 事件冗余持久化 + `packChunks` 被步骤边界打散（加载路径过滤/跨边界打包/分页加载 → deepseek-harness）
- `agent.session.events` 全量驻留（harness 设计，TUI 仅引用）

明确拒绝的"偏方"：加载后 `session.events.length = 0`——会话日志是 /export、resume、compaction、路由记录的事实来源，清空连环炸。

## 验证

- tsc / compile / verify:build（14 项链）/ smoke 全绿
- 考古确认历史防护（CharCache/line-width/tokenCache/heightsRef FIFO/NODE_ENV 三启动器）全部仍在 HEAD，本次是补直载缺口，不是找回丢失修复