### PR TITLE
fix(dev): dev-test 打包改用 npm pack，修复 pnpm dev 在 bundledDependencies 下必败

### DIFF
--- a/scripts/dev-test.mjs
+++ b/scripts/dev-test.mjs
@@ -87,7 +87,11 @@ try {
 
   run('pnpm', ['install', '--frozen-lockfile'])
   run('pnpm', ['build'])
-  run('pnpm', ['pack', '--pack-destination', packDir], { stdio: 'ignore' })
+  // npm pack, not pnpm: @dsh-std/* are bundledDependencies (#308) and pnpm
+  // refuses to pack them under the isolated linker
+  // (ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED) - same reason publish.yml
+  // switched to npm publish (1801177).
+  run('npm', ['pack', '--pack-destination', packDir])
 
   const tarballs = readdirSync(packDir)
     .filter(file => file.endsWith('.tgz'))


### PR DESCRIPTION
## 问题

`pnpm dev`（`scripts/dev-test.mjs`）在 pack 一步必然失败：

```
ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED
bundledDependencies does not work with "nodeLinker: isolated"
```

#308 引入 `@dsh-std/*` bundledDependencies 后，pnpm 在 isolated linker 下拒绝打包。1801177 已为此把 `publish.yml` 的 `pnpm publish` 换成 `npm publish`，但 `dev-test.mjs` 里的 `pnpm pack` 漏改了。另外该步 `stdio: 'ignore'` 吞掉了真实报错，终端里只剩一句 `exited with 1`，排查无从下手。

## 修复

- `pnpm pack` -> `npm pack`，与 publish.yml 的修法同根同解
- 去掉 `stdio: 'ignore'`，后续失败可见

## 验证

Windows 11 + pnpm 10.33.2 实测 `pnpm dev` 全流程通过：install、build、14 项 verify:build 全绿，npm pack 出包（7 个 bundled 依赖全入，与 1801177 的 CI 注释一致），后续 plugin add 与启动正常。