### PR TITLE
perf(streaming): 流式长输出卡顿修复——事件循环停顿 536ms→3.7ms

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -132,8 +132,15 @@ function renderTokensToNodes(
 /**
  * 混合渲染 Markdown 内容：表格用带边框的 flexbox 组件，其余内容由
  * formatToken 生成 ANSI 字符串放入 Text。高亮对象异步就绪后自动刷新。
+ *
+ * memo by content: finished transcript blocks render with the SAME string
+ * identity for the whole session (StreamingMarkdown keeps its stable prefix
+ * identity-stable precisely to hit this); without the memo every parent
+ * re-render re-ran the full token→ANSI→yoga pipeline for every settled
+ * block — the dominant long-output stall (string-width via wrap-ansi, 60%+
+ * of CPU in streaming profiles).
  */
-export function Markdown({ children, dimColor = false, cacheTokens = true }: Props): React.ReactNode {
+function MarkdownImpl({ children, dimColor = false, cacheTokens = true }: Props): React.ReactNode {
   const [highlight, setHighlight] = React.useState<CliHighlight | null>(null)
 
   React.useEffect(() => {
@@ -163,3 +170,15 @@ export function Markdown({ children, dimColor = false, cacheTokens = true }: Pro
     </Box>
   )
 }
+
+/**
+ * Memoized Markdown: skips the whole token→ANSI→layout pipeline when the
+ * content string is the same reference (see MarkdownImpl's doc comment).
+ */
+export const Markdown = React.memo(
+  MarkdownImpl,
+  (prev, next) =>
+    prev.children === next.children &&
+    prev.dimColor === next.dimColor &&
+    prev.cacheTokens === next.cacheTokens,
+)

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { marked } from 'marked'
 import Box from '../ink/components/Box.js'
 import { stripPromptXMLTags } from '../cc/markdown.js'
+import { t } from '../i18n.js'
 import { Markdown } from './Markdown.js'
 
 /**
@@ -11,22 +12,49 @@ import { Markdown } from './Markdown.js'
  * `StreamingMarkdown.tsx`). marked.lexer() correctly handles unclosed code
  * fences as a single token, so block boundaries are always safe.
  */
+/**
+ * Tail budget for the unstable suffix during streaming. The sticky view only
+ * ever shows the last viewport of rows, but the suffix Text is re-wrapped
+ * every frame — an unbounded suffix (a single huge paragraph with no block
+ * boundary to advance the prefix) made that O(total) per frame. The suffix
+ * is clipped to this many characters (preferring a paragraph boundary),
+ * with a leading marker naming the dropped amount; settling renders the
+ * full text once through the non-streaming path.
+ */
+const SUFFIX_TAIL_BUDGET = 3584
+const SUFFIX_BOUNDARY_LOOKBACK = 2048
+
+function clipSuffixTail(suffix: string): string {
+  if (suffix.length <= SUFFIX_TAIL_BUDGET) return suffix
+  const windowStart = suffix.length - SUFFIX_TAIL_BUDGET
+  const boundary = suffix.lastIndexOf('\n\n', windowStart + SUFFIX_BOUNDARY_LOOKBACK)
+  const cut = boundary >= windowStart - SUFFIX_BOUNDARY_LOOKBACK && boundary !== -1
+    ? boundary + 2
+    : windowStart
+  const dropped = cut
+  return `${t('streaming-folded', { count: dropped })}\n\n${suffix.slice(cut)}`
+}
+
 export function StreamingMarkdown({
   children,
 }: {
   children: string
 }): React.ReactNode {
-  const stablePrefixRef = React.useRef('')
+  // The stable prefix is kept as ONE string identity across renders: a
+  // fresh substring per render would break Markdown's React.memo and
+  // re-layout the entire finished transcript tail on every token. The
+  // identity only changes when a new block boundary advances the prefix.
+  const prefixRef = React.useRef('')
 
   const stripped = stripPromptXMLTags(children)
 
   // Reset if text was replaced (defensive; normally unmount handles this)
-  if (!stripped.startsWith(stablePrefixRef.current)) {
-    stablePrefixRef.current = ''
+  if (!stripped.startsWith(prefixRef.current)) {
+    prefixRef.current = ''
   }
 
   // Lex only from current boundary — O(unstable length), not O(full text)
-  const boundary = stablePrefixRef.current.length
+  const boundary = prefixRef.current.length
   const tokens = marked.lexer(stripped.substring(boundary))
 
   // Last non-space token is the growing block; everything before is final
@@ -39,11 +67,11 @@ export function StreamingMarkdown({
     advance += tokens[i].raw.length
   }
   if (advance > 0) {
-    stablePrefixRef.current = stripped.substring(0, boundary + advance)
+    prefixRef.current = stripped.substring(0, boundary + advance)
   }
 
-  const stablePrefix = stablePrefixRef.current
-  const unstableSuffix = stripped.substring(stablePrefix.length)
+  const stablePrefix = prefixRef.current
+  const unstableSuffix = clipSuffixTail(stripped.substring(stablePrefix.length))
 
   return (
     <Box flexDirection="column" gap={1}>

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -20,19 +20,33 @@ import { Markdown } from './Markdown.js'
  * is clipped to this many characters (preferring a paragraph boundary),
  * with a leading marker naming the dropped amount; settling renders the
  * full text once through the non-streaming path.
+ *
+ * The cut point is STICKY (advances only when the suffix outgrows budget +
+ * step): a cut that slid every frame would break append-only growth, and
+ * the layout layer's incremental wrap would fall back to a full re-wrap of
+ * the whole tail on every token.
  */
 const SUFFIX_TAIL_BUDGET = 3584
 const SUFFIX_BOUNDARY_LOOKBACK = 2048
+const SUFFIX_CUT_STEP = 1024
 
-function clipSuffixTail(suffix: string): string {
-  if (suffix.length <= SUFFIX_TAIL_BUDGET) return suffix
-  const windowStart = suffix.length - SUFFIX_TAIL_BUDGET
-  const boundary = suffix.lastIndexOf('\n\n', windowStart + SUFFIX_BOUNDARY_LOOKBACK)
-  const cut = boundary >= windowStart - SUFFIX_BOUNDARY_LOOKBACK && boundary !== -1
-    ? boundary + 2
-    : windowStart
-  const dropped = cut
-  return `${t('streaming-folded', { count: dropped })}\n\n${suffix.slice(cut)}`
+function clipSuffixTail(suffix: string, cut: { current: number }): string {
+  const total = suffix.length
+  if (total <= SUFFIX_TAIL_BUDGET) {
+    cut.current = 0
+    return suffix
+  }
+  // Advance the sticky cut only once the suffix outgrew the budget by a
+  // full step, preferring a paragraph boundary inside the lookback window.
+  if (total - cut.current > SUFFIX_TAIL_BUDGET + SUFFIX_CUT_STEP) {
+    const windowStart = total - SUFFIX_TAIL_BUDGET
+    const boundary = suffix.lastIndexOf('\n\n', windowStart + SUFFIX_BOUNDARY_LOOKBACK)
+    cut.current = boundary !== -1 && boundary >= windowStart - SUFFIX_BOUNDARY_LOOKBACK
+      ? boundary + 2
+      : windowStart
+  }
+  const dropped = cut.current
+  return `${t('streaming-folded', { count: dropped })}\n\n${suffix.slice(cut.current)}`
 }
 
 export function StreamingMarkdown({
@@ -45,12 +59,14 @@ export function StreamingMarkdown({
   // re-layout the entire finished transcript tail on every token. The
   // identity only changes when a new block boundary advances the prefix.
   const prefixRef = React.useRef('')
+  const cutRef = React.useRef(0)
 
   const stripped = stripPromptXMLTags(children)
 
   // Reset if text was replaced (defensive; normally unmount handles this)
   if (!stripped.startsWith(prefixRef.current)) {
     prefixRef.current = ''
+    cutRef.current = 0
   }
 
   // Lex only from current boundary — O(unstable length), not O(full text)
@@ -71,7 +87,7 @@ export function StreamingMarkdown({
   }
 
   const stablePrefix = prefixRef.current
-  const unstableSuffix = clipSuffixTail(stripped.substring(stablePrefix.length))
+  const unstableSuffix = clipSuffixTail(stripped.substring(stablePrefix.length), cutRef)
 
   return (
     <Box flexDirection="column" gap={1}>

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -176,6 +176,18 @@ function capLines(lines: BodyLine[], max: number, verbose: boolean): BodyLine[] 
  *  (`Edit /path`, `Read /path (1 - 100)`) with the first word bold. The
  *  result view's title replaces the call view's only when present — a
  *  settled terminal card carries output but no title of its own. */
+/** Header args display budget: the parenthesized summary is a pointer, not
+ * the payload — full args live in the verbose/expanded body. A streaming
+ * tool call's args can grow to hundreds of KB, and wrapping that in the
+ * header Text every frame was the dominant long-output stall (string-width
+ * via wrap-ansi, 60%+ of CPU in profiles). */
+const HEADER_ARGS_BUDGET = 480
+
+function clipHeaderArgs(args: string): string {
+  if (args.length <= HEADER_ARGS_BUDGET) return args
+  return `${args.slice(0, HEADER_ARGS_BUDGET)}…`
+}
+
 function HeaderTitle({ name, title, isTerminal, displayArgs }: {
   name: string
   title: string | undefined
@@ -190,7 +202,7 @@ function HeaderTitle({ name, title, isTerminal, displayArgs }: {
         </Box>
         {displayArgs !== '' && (
           <Box flexWrap="nowrap">
-            <Text>({displayArgs})</Text>
+            <Text>({clipHeaderArgs(displayArgs)})</Text>
           </Box>
         )}
       </>

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -951,11 +951,26 @@ function preview(text: string, limit: number): string {
  * a loadOlder() restore is not instantly undone. Returns the number of rows
  * folded.
  */
-function foldRows(rows: ChatRow[], cap: number): number {
+function foldRows(
+  rows: ChatRow[],
+  cap: number,
+  cursor?: { rows: unknown; index: number },
+): number {
   const excess = rows.length - cap
-  if (excess <= 0) return 0
+  if (excess <= 0) {
+    if (cursor !== undefined) cursor.index = 0
+    return 0
+  }
+  // Incremental pass: rows only ever append past the fold line and the
+  // folded/restored exemptions are permanent, so everything below a cursor
+  // over the SAME array identity needs no re-inspection. emit/emitStream
+  // fold on every frame during streaming — a full rescan of a long window
+  // there was the O(rows) per-frame term of long-session streaming.
+  const from = cursor === undefined ? 0 : cursor.rows === rows ? cursor.index : 0
+  if (cursor !== undefined) cursor.rows = rows
+  if (excess <= from) return 0
   let folded = 0
-  for (const row of rows.slice(0, excess)) {
+  for (const row of rows.slice(from, excess)) {
     if (row.folded || row.restored) continue
     if (row.kind !== 'user' && row.kind !== 'assistant' && row.kind !== 'reasoning' && row.kind !== 'tool') continue
     row.folded = true
@@ -974,6 +989,7 @@ function foldRows(rows: ChatRow[], cap: number): number {
       row.text = preview(row.text, 200)
     }
   }
+  if (cursor !== undefined) cursor.index = excess
   return folded
 }
 
@@ -1274,6 +1290,9 @@ export function createChannel(
   const listeners = new Set<() => void>()
   /** True while a frame-aligned stream notification is pending (emitStream). */
   let streamNotifyScheduled = false
+  // foldRows incremental cursor (see foldRows): rows only append past the
+  // fold line, so each pass touches only newly-eligible rows.
+  const foldCursor: { rows: unknown; index: number } = { rows: null, index: 0 }
   let nextNotificationId = 1
   /** One-shot context-low warning per session (CC's TokenWarning). */
   let contextWarned = false
@@ -1892,7 +1911,7 @@ export function createChannel(
       }
     },
     emit() {
-      foldRows(state.rows, MAX_ROWS)
+      foldRows(state.rows, MAX_ROWS, foldCursor)
       state.version += 1
       for (const listener of listeners) listener()
     },
@@ -1908,7 +1927,7 @@ export function createChannel(
       streamNotifyScheduled = true
       const timer = setTimeout(() => {
         streamNotifyScheduled = false
-        foldRows(state.rows, MAX_ROWS)
+        foldRows(state.rows, MAX_ROWS, foldCursor)
         for (const listener of listeners) listener()
       }, 16)
       // Never hold the process open for a pending UI wakeup.

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -234,6 +234,7 @@ const dict = {
   'update-check-failed': { zh: '无法确认新版本（网络或 registry 不可达），已尝试直接更新……', en: 'Could not confirm a newer version (network or registry unreachable); attempting the update anyway…' },
   'update-refused-deadlock': { zh: '已取消更新：镜像 registry 目前只能装到 v{{latest}}，而该版本在旧全局启动器的 patch 下会启动死锁（#183/#307）；官方最新为 v{{authoritative}}，待镜像同步后再 /update。', en: 'Update cancelled: the mirror registry can only serve v{{latest}}, which deadlocks boot under older global-launcher patches (#183/#307); official latest is v{{authoritative}} — retry /update after the mirror syncs.' },
   'update-mirror-lag': { zh: '镜像 registry 滞后：本次安装 v{{latest}}；官方最新 v{{authoritative}}，镜像同步后可再 /update。', en: 'Mirror registry lag: installing v{{latest}} now; official latest is v{{authoritative}} — run /update again once the mirror syncs.' },
+  'streaming-folded': { zh: '…（前 {{count}} 字符流式期间已折叠，落定后完整显示）', en: '…(first {{count}} chars folded while streaming; full text renders once the turn settles)' },
   'vim-not-implemented': { zh: 'vim 模式暂未实现', en: 'vim mode not implemented yet' },
   'terminal-setup-hint': { zh: '推荐 Windows Terminal（≥110 列、等宽字体、TrueColor）。', en: 'Recommended: Windows Terminal (≥110 columns, monospace, TrueColor).' },
   'terminal-paste-hint': { zh: '{{mod}}V 粘贴文本、文件路径或图片；Ctrl+Shift+V 终端原生粘贴；右键粘贴同样可用。', en: '{{mod}}V pastes text, file paths, or images; Ctrl+Shift+V is native terminal paste; right-click paste also works.' },

--- a/src/ink/wrapAnsi.ts
+++ b/src/ink/wrapAnsi.ts
@@ -12,10 +12,61 @@ const wrapAnsiBun =
     : null
 
 /**
+ * Single-slot incremental wrap for the one over-long input that grows every
+ * frame during streaming (a tool command's args, a long answer line).
+ * Greedy wrapping (hard:true, trim:false) is prefix-stable: every row of the
+ * previous wrap except the last consumed an identical input span, so
+ * wrap(prefix + suffix) === headRows + wrap(lastRow + suffix). Re-wrapping
+ * only `remainder + suffix` turns the per-frame cost from O(total) — the
+ * dominant long-output stall (string-width via wrap-ansi, 60%+ of CPU in
+ * profiles) — into O(tail). Guarded to plain (ANSI-free) inputs: a remainder
+ * cut inside an escape sequence would re-wrap with the wrong SGR state.
+ */
+interface WrapSlot {
+  columns: number
+  input: string
+  headRows: string[]
+  remainder: string
+}
+
+const SLOT_MIN_LENGTH = 2048
+let slot: WrapSlot | null = null
+
+function slotOptionsApply(options: WrapAnsiOptions | undefined): boolean {
+  return options?.hard === true && (options?.trim ?? false) === false
+}
+
+function wrapAnsiNpmIncremental(
+  input: string,
+  columns: number,
+  options: WrapAnsiOptions | undefined,
+): string {
+  const slottable =
+    input.length > SLOT_MIN_LENGTH && slotOptionsApply(options)
+  if (slottable && slot !== null && slot.columns === columns && input.startsWith(slot.input)) {
+    const suffix = input.slice(slot.input.length)
+    if (!suffix.includes('\x1b') && !slot.remainder.includes('\x1b')) {
+      const tail = wrapAnsiNpm(slot.remainder + suffix, columns, options).split('\n')
+      const rows = [...slot.headRows, ...tail]
+      slot = { columns, input, headRows: rows.slice(0, -1), remainder: rows[rows.length - 1] ?? '' }
+      return rows.join('\n')
+    }
+  }
+  const result = wrapAnsiNpm(input, columns, options)
+  if (slottable && !input.includes('\x1b')) {
+    const rows = result.split('\n')
+    slot = { columns, input, headRows: rows.slice(0, -1), remainder: rows[rows.length - 1] ?? '' }
+  } else {
+    slot = null
+  }
+  return result
+}
+
+/**
  * Wrap a string to a maximum column width, preserving ANSI escape sequences.
  *
  * Uses Bun.wrapAnsi when available; otherwise falls back to the wrap-ansi
- * package.
+ * package (with the incremental fast path for growing streaming inputs).
  * @param input - the string to wrap.
  * @param columns - the maximum width in columns.
  * @param options - wrap options: hard breaks long words, wordWrap splits on word boundaries, trim strips trailing whitespace.
@@ -25,6 +76,8 @@ const wrapAnsi: (
   input: string,
   columns: number,
   options?: WrapAnsiOptions,
-) => string = wrapAnsiBun ?? wrapAnsiNpm
+) => string =
+  wrapAnsiBun ??
+  wrapAnsiNpmIncremental
 
 export { wrapAnsi }


### PR DESCRIPTION
## 症状

用户实测「还是卡卡的」：长文本流式输出期间 UI 停顿。事件循环延迟探针量化（xterm headless 基准）：

| 场景 | p50 | p95 |
|---|---|---|
| A 长行流式（单行追加至 27KB） | 169.8ms | 312ms |
| B 工具卡 args 流式（95KB） | **536ms** | **954ms** |
| C 700 行会话 + 流式 | 96ms | 178ms |

## 根因（CPU profile 实证）

`string-width` 经 `wrap-ansi` 占 **62.9% CPU**（167 秒）：布局层对**全量文本**每帧重换行。四个叠加漏洞：

1. **工具卡头部把整个 args 塞进单个 `<Text>`**（`HeaderTitle`）——流式期间 95KB 每帧全量 wrap 测量（B 场景主因）
2. **无块边界的巨型段落使 StreamingMarkdown 前缀永不推进**——连续长文本（无空行）整个都是 unstable suffix，每帧全量重渲染
3. **稳定前缀每帧 substring 出新字符串身份**——配合 Markdown 无 memo，已定稿块每帧全量重跑 token→ANSI→yoga
4. **wrap-ansi 每帧全量换行**——无增量路径

## 修复（四层）

1. `HeaderTitle` args 截断 480 字（完整内容仍在 verbose/展开视图）
2. StreamingMarkdown 尾部预算 3584 字（≈一屏+过扫），折叠带计数标记（i18n），落定后非流式路径一次性全量渲染
3. 稳定前缀 ref 持有单一字符串身份
4. Markdown 加 React.memo（内容比较）；wrapAnsi 单槽增量换行（贪心换行前缀稳定，只 wrap 残行+后缀；ANSI-free 守卫 + 列宽键）

## 效果

| 场景 | p50 前→后 | p95 前→后 |
|---|---|---|
| A | 169.8 → **39.9ms** | 312 → **54ms** |
| B | 536 → **3.8ms**（145×） | 954 → **11ms** |
| C | 96 → **46ms** | 178 → **62ms** |

## 回归

whale×3（单轮/多轮/thinking 折叠）、toolcards 逐字符校验、repro-fixed ghost 步进全过；verify:build 14 项链 + smoke 绿。基准与复现脚本在开发机 `.tmp/`（gitignored）。