### PR TITLE
fix(tui): plan mode 硬门禁与权限恢复

### DIFF
--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -59,6 +59,16 @@ A complete common override looks like this:
 | `preset` | roster default `standard` | Agent preset for new sessions; explicit configuration wins over persisted preference |
 | `sessionId` | unset | Session to resume, normally injected by the Windows `--resume` launcher |
 
+The `modes` entry declaring `plan: true` defines plan mode's hard boundary:
+entering plan mode (`/plan`, Shift+Tab, or resuming a plan-active session)
+automatically applies the `sandbox`/`approval` atoms that entry declares and
+remembers the pre-plan state; an approved plan review or `/plan off` restores
+it. The built-in plan entry is `read-only + ask` and adds a tool gate (only
+`exit_plan_mode`, `ask_user_question`, and read-only tools are admitted), so no
+file modification runs before the plan is confirmed. A plan entry that
+declares no `sandbox`/`approval` keeps the documented “undeclared atoms are
+not touched” behavior.
+
 ## Live activity row
 
 `dsh-working-activity` is installed with the package and inserted by its patch.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,13 @@ Profile 启动按顺序叠加 `dsh-base`、已安装 bundle、`@deepseek-harness
 | `preset` | 名册默认 `standard` | 新会话 Agent preset；显式配置优先于持久化偏好 |
 | `sessionId` | 未设置 | 要恢复的会话 ID，通常由 Windows `--resume` 启动器注入 |
 
+`modes` 中声明 `plan: true` 的那一档定义了计划模式的强制边界：进入计划模式
+（`/plan`、Shift+Tab、恢复计划中会话）时，TUI 自动应用该档声明的
+`sandbox`/`approval` 原子并记住进入前的状态；计划评审批准或 `/plan off`
+退出时恢复。内置计划档为 `read-only + ask`，并叠加工具门禁（仅放行
+`exit_plan_mode`、`ask_user_question` 与只读工具），因此确认计划前不会执行
+文件修改。计划档未声明 `sandbox`/`approval` 时仍按"未声明的原子不动"处理。
+
 ## 工作状态行
 
 `dsh-working-activity` 随包安装，并由本包 patch 插入。只需要按 ID 覆盖参数：

--- a/docs/interaction.en.md
+++ b/docs/interaction.en.md
@@ -226,6 +226,20 @@ FIFO order. A compact Q&A summary is added to the local transcript afterward.
 
 ## Plan review
 
+Entering plan mode (`/plan`, Shift+Tab, or resuming a session already in plan
+mode) makes plan mode a hard gate like qwen-code: the TUI automatically
+applies the `sandbox`/`approval` atoms declared by the configured plan mode
+(the built-in trio is **read-only sandbox + approval ask**) and remembers the
+pre-plan sandbox and approval policy. The built-in plan entry also installs a
+monotonic tool gate that only admits `exit_plan_mode`, `ask_user_question`, and
+read-only tools (`read`/`grep`/`glob`/`web_search`, …); `write`/`edit`/`bash`/
+subagents and unknown MCP tools are rejected. The model therefore cannot
+modify files before you approve the plan; only an approved `exit_plan_mode`
+review (or `/plan off`) leaves plan mode and restores the previous permission
+state. A custom `modes` entry whose plan mode declares no
+`sandbox`/`approval` keeps the previous “undeclared atoms are not touched”
+semantics.
+
 When the model calls `exit_plan_mode` in plan mode, the full plan is rendered
 as markdown in the review panel (the dedicated decision layout for
 `intent: plan-review`):

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -196,6 +196,16 @@ transcript。
 
 ## 计划评审（plan review）
 
+进入计划模式时（`/plan`、Shift+Tab 或恢复一个已处于计划模式的会话），TUI 会
+像 qwen-code 一样把计划模式当成硬门禁：自动套用配置中计划模式声明的
+`sandbox`/`approval` 原子（内置三档为 **只读沙箱 + 审批询问**），并记住进入前的
+沙箱与审批策略。内置计划档还会挂载一个单调工具门禁：只放行
+`exit_plan_mode`、`ask_user_question` 与只读工具（`read`/`grep`/`glob`/
+`web_search` 等），`write`/`edit`/`bash`/子代理以及未知的 MCP 工具一律拒绝。
+因此模型在用户批准计划之前无法直接修改文件；只有 `exit_plan_mode` 评审通过
+（或 `/plan off`）后才会退出计划模式并恢复之前的权限状态。若自定义 `modes`
+中的计划模式没有声明 `sandbox`/`approval`，则保持"未声明的原子不动"的旧语义。
+
 计划模式下模型调用 `exit_plan_mode` 时，计划全文以 markdown 渲染在评审面板中
 （`intent: plan-review` 的专用决策布局）：
 

--- a/scripts/verify-effort-mode.mjs
+++ b/scripts/verify-effort-mode.mjs
@@ -34,12 +34,13 @@ function check(name, ok, extra = '') {
  * and an agent whose session append both joins the log and replays through
  * the captured session/event handler (exactly what dsh-session + cordis do).
  */
-function makeEnv({ withCommands = true, withApproval = true } = {}) {
+function makeEnv({ withCommands = true, withApproval = true, withSandboxPolicy = true, withTools = true } = {}) {
   const commands = []
   const approvalPolicies = []
   const appended = []
   const handlers = new Map()
   const events = []
+  const guards = []
   const llm = {
     resolveModelInfo: async () => ({
       reasoning: {
@@ -54,10 +55,24 @@ function makeEnv({ withCommands = true, withApproval = true } = {}) {
   }
   const services = {
     llm,
+    ...(withTools
+      ? {
+          tools: {
+            guard(guard) {
+              guards.push(guard)
+              return () => {}
+            },
+          },
+        }
+      : {}),
+    ...(withSandboxPolicy
+      ? { sandboxPolicy: { defaultMode: 'workspace-write' } }
+      : {}),
     ...(withCommands
       ? {
           commands: {
             list: () => [],
+            find: (_agent, name) => (name === 'plan' ? { name: 'plan', handler() {} } : undefined),
             execute: async (agent, line, _signal) => {
               commands.push(line)
               if (line.startsWith('/plan')) {
@@ -72,7 +87,12 @@ function makeEnv({ withCommands = true, withApproval = true } = {}) {
         }
       : {}),
     ...(withApproval
-      ? { approval: { setPolicy: (agent, policy) => { approvalPolicies.push(policy); agent.session.append('approval/policy', { policy }) } } }
+      ? {
+          approval: {
+            config: { policy: 'ask' },
+            setPolicy: (agent, policy) => { approvalPolicies.push(policy); agent.session.append('approval/policy', { policy }) },
+          },
+        }
       : {}),
   }
   const ctx = {
@@ -101,7 +121,7 @@ function makeEnv({ withCommands = true, withApproval = true } = {}) {
     },
     ctx: { on: () => () => {} },
   }
-  return { ctx, agent, commands, approvalPolicies, appended, events }
+  return { ctx, agent, commands, approvalPolicies, appended, events, guards }
 }
 
 const baseOptions = {
@@ -249,6 +269,141 @@ const baseOptions = {
   check(
     'abort warned',
     channel.notifications.some(n => n.text.includes('/plan')),
+    JSON.stringify(channel.notifications.map(n => n.text)),
+  )
+}
+
+// ---- bare /plan runs the same guard as Shift+Tab ---------------------------
+{
+  const { ctx, agent, approvalPolicies, appended } = makeEnv()
+  const channel = createChannel(ctx, agent, baseOptions)
+  // Simulate a non-default pre-plan state so the restore target is visible.
+  agent.session.append('sandbox/mode', { mode: 'danger-full-access' })
+  agent.session.append('approval/policy', { policy: 'never' })
+  await channel.runExternalCommand('plan', '')
+  check(
+    'bare /plan locks sandbox read-only',
+    appended.some(e => e.type === 'sandbox/mode' && e.data.mode === 'read-only'),
+    JSON.stringify(appended.filter(e => e.type === 'sandbox/mode')),
+  )
+  check(
+    'bare /plan switches approval to ask',
+    approvalPolicies.at(-1) === 'ask',
+    JSON.stringify(approvalPolicies),
+  )
+  check('bare /plan lands mode indicator on plan', channel.mode.id === 'plan' && channel.modeIndex === 1, `${channel.mode.id}/${channel.modeIndex}`)
+  check(
+    'bare /plan posts the plan-lock notification',
+    channel.notifications.some(n => n.text.includes('计划') || n.text.includes('Plan mode locked')),
+    JSON.stringify(channel.notifications.map(n => n.text)),
+  )
+
+  await channel.runExternalCommand('plan', ' off')
+  check(
+    'bare /plan off restores pre-plan sandbox',
+    appended.at(-2)?.type === 'sandbox/mode' && appended.at(-2)?.data.mode === 'danger-full-access',
+    JSON.stringify(appended.filter(e => e.type === 'sandbox/mode')),
+  )
+  check(
+    'bare /plan off restores pre-plan approval',
+    approvalPolicies.at(-1) === 'never',
+    JSON.stringify(approvalPolicies),
+  )
+  check('bare /plan off restores the pre-plan mode indicator', channel.mode.id === 'full' && channel.modeIndex === 2, `${channel.mode.id}/${channel.modeIndex}`)
+}
+
+// ---- plan-mode tool gate: mutations fail closed until approval -------------
+{
+  const { ctx, agent, guards } = makeEnv()
+  const channel = createChannel(ctx, agent, baseOptions)
+  check('tool guard registered', guards.length === 1, String(guards.length))
+  const guard = guards[0]
+  check('tool guard idle before plan mode', guard({ name: 'write', agent }) === undefined, String(guard({ name: 'write', agent })))
+  await channel.runExternalCommand('plan', '')
+  check(
+    'tool guard blocks write in plan mode',
+    typeof guard({ name: 'write', agent }) === 'string',
+    String(guard({ name: 'write', agent })),
+  )
+  check(
+    'tool guard blocks bash in plan mode',
+    typeof guard({ name: 'bash', agent }) === 'string',
+    String(guard({ name: 'bash', agent })),
+  )
+  check(
+    'tool guard blocks unknown/MCP tools in plan mode',
+    typeof guard({ name: 'mcp__example_mutate', agent }) === 'string',
+    String(guard({ name: 'mcp__example_mutate', agent })),
+  )
+  check('tool guard allows read in plan mode', guard({ name: 'read', agent }) === undefined, String(guard({ name: 'read', agent })))
+  check('tool guard allows exit_plan_mode', guard({ name: 'exit_plan_mode', agent }) === undefined, String(guard({ name: 'exit_plan_mode', agent })))
+  check('tool guard allows ask_user_question', guard({ name: 'ask_user_question', agent }) === undefined, String(guard({ name: 'ask_user_question', agent })))
+  await channel.runExternalCommand('plan', ' off')
+  check('tool guard released after plan exit', guard({ name: 'write', agent }) === undefined, String(guard({ name: 'write', agent })))
+}
+
+// ---- resumed plan-active session re-asserts the lock, then restores --------
+{
+  const { ctx, agent, appended, approvalPolicies } = makeEnv()
+  // Simulate a persisted session that entered plan mode before this boot.
+  agent.session.events.push(
+    { type: 'plan/mode', seq: 1, time: Date.now(), data: { active: true } },
+  )
+  const channel = createChannel(ctx, agent, baseOptions)
+  check('resumed plan session derives plan mode', channel.mode.id === 'plan' && channel.modeIndex === 1, `${channel.mode.id}/${channel.modeIndex}`)
+  check(
+    'resumed plan session re-asserts sandbox read-only',
+    appended.some(e => e.type === 'sandbox/mode' && e.data.mode === 'read-only'),
+    JSON.stringify(appended),
+  )
+  check(
+    'resumed plan session re-asserts approval ask',
+    approvalPolicies.at(-1) === 'ask',
+    JSON.stringify(approvalPolicies),
+  )
+
+  agent.session.append('plan/mode', { active: false })
+  check(
+    'resumed plan exit restores the base atoms',
+    appended.some(e => e.type === 'sandbox/mode' && e.data.mode === 'workspace-write'),
+    JSON.stringify(appended.filter(e => e.type === 'sandbox/mode')),
+  )
+  check('resumed plan exit lands on default', channel.mode.id === 'default' && channel.modeIndex === 0, `${channel.mode.id}/${channel.modeIndex}`)
+}
+
+// ---- custom plan mode honours only its declared enforcement atoms ----------
+{
+  const { ctx, agent, appended, approvalPolicies } = makeEnv()
+  const channel = createChannel(ctx, agent, {
+    ...baseOptions,
+    modes: [
+      { id: 'base', sandbox: 'workspace-write', approval: 'never' },
+      { id: 'plan-soft-ro', plan: true, sandbox: 'read-only' },
+    ],
+  })
+  await channel.runExternalCommand('plan', '')
+  check(
+    'custom plan mode applies its declared sandbox',
+    appended.some(e => e.type === 'sandbox/mode' && e.data.mode === 'read-only'),
+    JSON.stringify(appended),
+  )
+  check(
+    'custom plan mode leaves undeclared approval untouched',
+    approvalPolicies.length === 0,
+    JSON.stringify(approvalPolicies),
+  )
+  check('custom plan mode derives its configured mode', channel.mode.id === 'plan-soft-ro' && channel.modeIndex === 1, `${channel.mode.id}/${channel.modeIndex}`)
+}
+
+// ---- Shift+Tab path keeps the single mode-switched notification ------------
+{
+  const { ctx, agent, commands } = makeEnv()
+  const channel = createChannel(ctx, agent, baseOptions)
+  await channel.cycleMode()
+  check('Shift+Tab into plan dispatches /plan', commands.length === 1 && commands[0] === '/plan', JSON.stringify(commands))
+  check(
+    'Shift+Tab into plan does not double-notify the plan lock',
+    channel.notifications.filter(n => n.text.includes('→')).length === 1,
     JSON.stringify(channel.notifications.map(n => n.text)),
   )
 }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1744,6 +1744,201 @@ export function createChannel(
     return policy
   }
 
+  // ── Plan-mode guard ──────────────────────────────────────────────────────
+  // dsh-plan-mode itself is soft guidance (it only logs `plan/mode` and shows
+  // the exit_plan_mode review). qwen-code's plan mode is a hard gate: while
+  // planning, every mutation tool is blocked until the user approves the plan
+  // through exit_plan_mode, and approving restores the pre-plan permission
+  // state. The TUI reproduces that with the planes DSH exposes — the first
+  // configured mode declaring `plan: true` supplies the enforcement atoms
+  // (the built-in cycle uses sandbox read-only + approval ask), and the
+  // pre-plan sandbox/approval values are restored when plan mode is left.
+  // This runs for EVERY `plan/mode` transition, so bare `/plan`, Shift+Tab,
+  // and the model's approved exit_plan_mode all pass through the same gate.
+  type SandboxModeValue = NonNullable<SessionModeSpec['sandbox']>
+  type ApprovalPolicyValue = NonNullable<SessionModeSpec['approval']>
+  const isSandboxModeValue = (value: unknown): value is SandboxModeValue =>
+    value === 'read-only' || value === 'workspace-write' || value === 'danger-full-access'
+  const isApprovalPolicyValue = (value: unknown): value is ApprovalPolicyValue =>
+    value === 'ask' || value === 'never'
+
+  /** Optional service seams: sandboxPolicy exposes the deployment default,
+   *  approval owns the policy switch with model narration. Both are mounted
+   *  by the official profile; bare leaves degrade to raw durable events. */
+  const sandboxPolicyService = ctx.get('sandboxPolicy') as
+    | { readonly defaultMode?: unknown }
+    | undefined
+  const approvalService = ctx.get('approval') as
+    | {
+        readonly config?: { readonly policy?: unknown }
+        setPolicy(agent: Agent, policy: ApprovalPolicyValue): void
+      }
+    | undefined
+
+  /** Fallbacks when neither the log nor the services pin a value. Index 0 is
+   *  the unmarked base mode; built-in default is workspace-write + ask. */
+  const fallbackSandboxMode: SandboxModeValue = sessionModes[0]?.sandbox ?? 'workspace-write'
+  const fallbackApprovalPolicy: ApprovalPolicyValue = sessionModes[0]?.approval ?? 'ask'
+
+  const resolvedSandboxMode = (events: readonly SessionEvent[]): SandboxModeValue => {
+    const folded = foldSandboxMode(events)
+    if (isSandboxModeValue(folded)) return folded
+    if (isSandboxModeValue(sandboxPolicyService?.defaultMode)) return sandboxPolicyService.defaultMode
+    return fallbackSandboxMode
+  }
+  const resolvedApprovalPolicy = (events: readonly SessionEvent[]): ApprovalPolicyValue => {
+    const folded = foldApprovalPolicy(events)
+    if (isApprovalPolicyValue(folded)) return folded
+    if (isApprovalPolicyValue(approvalService?.config?.policy)) return approvalService.config.policy
+    return fallbackApprovalPolicy
+  }
+
+  /** The configured mode that defines what "plan" means for enforcement.
+   *  Undefined when the user configured a cycle with no plan:true mode —
+   *  then DSH's soft guidance remains untouched, matching the documented
+   *  "undeclared atoms are not touched" contract. */
+  const planModeSpec = sessionModes.find(spec => spec.plan === true)
+
+  const setSandboxMode = (mode: SandboxModeValue): void => {
+    if (foldSandboxMode(agent.session.events) === mode) return
+    ;(agent.session as unknown as { append(type: string, data: Record<string, unknown>): unknown }).append(
+      'sandbox/mode',
+      { mode },
+    )
+  }
+  const setApprovalPolicy = (policy: ApprovalPolicyValue): void => {
+    if (foldApprovalPolicy(agent.session.events) === policy) return
+    if (approvalService) {
+      approvalService.setPolicy(agent, policy)
+    } else {
+      ;(agent.session as unknown as { append(type: string, data: Record<string, unknown>): unknown }).append(
+        'approval/policy',
+        { policy },
+      )
+    }
+  }
+
+  /** Values in force just before plan mode was entered. Derived from the
+   *  durable log so resume/fork recover the restore target without a live
+   *  mirror; falls back to the resolved defaults for sessions whose log
+   *  never recorded a sandbox/approval switch before entering plan mode. */
+  const planGuardFromLog = (
+    events: readonly SessionEvent[],
+  ): { sandbox: SandboxModeValue; approval: ApprovalPolicyValue } | undefined => {
+    let active = false
+    let sandbox: SandboxModeValue = isSandboxModeValue(sandboxPolicyService?.defaultMode)
+      ? sandboxPolicyService.defaultMode
+      : fallbackSandboxMode
+    let approval: ApprovalPolicyValue = isApprovalPolicyValue(approvalService?.config?.policy)
+      ? approvalService.config.policy
+      : fallbackApprovalPolicy
+    let snapshot: { sandbox: SandboxModeValue; approval: ApprovalPolicyValue } | undefined
+    for (const event of events) {
+      const type = (event as { type: string }).type
+      if (type === 'sandbox/mode') {
+        const value = (event.data as unknown as { mode?: unknown }).mode
+        if (isSandboxModeValue(value)) sandbox = value
+        continue
+      }
+      if (type === 'approval/policy') {
+        const value = (event.data as unknown as { policy?: unknown }).policy
+        if (isApprovalPolicyValue(value)) approval = value
+        continue
+      }
+      if (type === 'plan/mode') {
+        const next = (event.data as unknown as { active?: boolean }).active === true
+        if (next && !active) snapshot = { sandbox, approval }
+        active = next
+      }
+    }
+    return active ? snapshot : undefined
+  }
+
+  /** qwen-code-style enforcement: apply the configured plan mode's
+   *  sandbox/approval atoms while plan mode is active. With the built-in
+   *  cycle this is read-only + ask, so mutation tools fail or prompt until
+   *  the user approves the plan via exit_plan_mode. */
+  const enforcePlanRestrictions = (): void => {
+    if (planModeSpec?.sandbox !== undefined) setSandboxMode(planModeSpec.sandbox)
+    if (planModeSpec?.approval !== undefined) setApprovalPolicy(planModeSpec.approval)
+  }
+
+  const restorePlanState = (): void => {
+    const snapshot = planGuard
+    planGuard = undefined
+    if (snapshot === undefined) return
+    setSandboxMode(snapshot.sandbox)
+    setApprovalPolicy(snapshot.approval)
+  }
+
+  /** Live `plan/mode` tracking (re-derived from the log on every event).
+   *  Entering plan mode snapshots the current state, then locks it; leaving
+   *  plan mode restores the snapshot. Initialization below seeds these two
+   *  variables from the resumed log before any live event arrives. */
+  let planGuard = planGuardFromLog(agent.session.events)
+  let planWasActive = foldPlanActive(agent.session.events)
+  /** True while applyMode is in flight: its own mode-switched notification
+   *  is enough, so the guard's extra plan-lock notification is skipped. */
+  let applyingSessionMode = false
+
+  /** Hard tool gate while the configured plan mode locks the sandbox to
+   *  read-only: only plan-lifecycle, clarification, and read-only tools run.
+   *  Mirrors qwen-code's `isPlanModeBlocked` (everything except exit_plan_mode
+   *  / ask_user_question / read-only info tools). */
+  let planMutationLocked = false
+  const handlePlanModeChange = (): void => {
+    const active = foldPlanActive(agent.session.events)
+    if (active && !planWasActive) {
+      planGuard = {
+        sandbox: resolvedSandboxMode(agent.session.events),
+        approval: resolvedApprovalPolicy(agent.session.events),
+      }
+      enforcePlanRestrictions()
+      planMutationLocked = planModeSpec?.sandbox === 'read-only'
+      if (!applyingSessionMode && (planModeSpec?.sandbox !== undefined || planModeSpec?.approval !== undefined)) {
+        state.notify(t('plan-guard-engaged'), { color: 'success', timeoutMs: 5000 })
+      }
+    } else if (!active && planWasActive) {
+      restorePlanState()
+      planMutationLocked = false
+    }
+    planWasActive = active
+    refreshMode()
+  }
+
+  /** Tool names allowed while `planMutationLocked` is on. Unknown names
+   *  (including MCP tools) fail closed — a plan-mode gate must not let a
+   *  third-party mutation tool through on a name miss. */
+  const PLAN_MODE_ALLOWED_TOOLS = new Set([
+    'exit_plan_mode',
+    'ask_user_question',
+    'read',
+    'read_image',
+    'grep',
+    'glob',
+    'web_search',
+    'web_fetch',
+    'skill',
+    'skill_search',
+    'skill_load',
+    'get_goal',
+    'job_list',
+    'job_output',
+  ])
+
+  const toolRuntime = ctx.get('tools') as
+    | { guard(guard: (execution: Readonly<{ name: string; agent?: unknown }>) => string | undefined): () => void }
+    | undefined
+  let disposePlanToolGuard: (() => void) | undefined
+  if (toolRuntime) {
+    disposePlanToolGuard = toolRuntime.guard(execution => {
+      if (!planMutationLocked) return undefined
+      if (execution.agent !== agent) return undefined
+      if (PLAN_MODE_ALLOWED_TOOLS.has(execution.name)) return undefined
+      return t('plan-guard-tool-blocked', { tool: execution.name })
+    })
+  }
+
   /** First configured mode whose declared atoms all match the folds;
    *  undeclared atoms are wildcards; no match → index 0 (the base mode).
    *  Matching is exact: a fresh session has no `approval/policy` event, so
@@ -1770,40 +1965,24 @@ export function createChannel(
    *  durable session-log override events). A failing plan toggle aborts the
    *  whole switch so the session never lands in a half-applied mode. */
   const applyMode = async (spec: SessionModeSpec): Promise<void> => {
-    if (spec.plan !== undefined && foldPlanActive(agent.session.events) !== spec.plan) {
-      const text = await executeRegistryCommand('plan', spec.plan ? '' : ' off')
-      if (text === undefined) {
-        // The active preset registers no /plan.
-        state.notify(t('mode-plan-unavailable'), { color: 'warning' })
-        return
+    applyingSessionMode = true
+    try {
+      if (spec.plan !== undefined && foldPlanActive(agent.session.events) !== spec.plan) {
+        const text = await executeRegistryCommand('plan', spec.plan ? '' : ' off')
+        if (text === undefined) {
+          // The active preset registers no /plan.
+          state.notify(t('mode-plan-unavailable'), { color: 'warning' })
+          return
+        }
       }
+      if (spec.sandbox !== undefined) setSandboxMode(spec.sandbox)
+      if (spec.approval !== undefined) setApprovalPolicy(spec.approval)
+      refreshMode()
+      state.notify(t('mode-switched', { name: modeDisplayName(state.mode) }))
+      state.emit()
+    } finally {
+      applyingSessionMode = false
     }
-    // The durable sandbox override is one session event (dsh-sandbox-policy's
-    // own write path); the session/event arm picks it up immediately.
-    if (spec.sandbox !== undefined && foldSandboxMode(agent.session.events) !== spec.sandbox) {
-      ;(agent.session as unknown as { append(type: string, data: Record<string, unknown>): unknown }).append(
-        'sandbox/mode',
-        { mode: spec.sandbox },
-      )
-    }
-    // Prefer the approval service (it narrates the switch to the model);
-    // the raw durable event is the fallback when it is unmounted.
-    if (spec.approval !== undefined && foldApprovalPolicy(agent.session.events) !== spec.approval) {
-      const approval = ctx.get('approval') as
-        | { setPolicy(a: Agent, policy: 'ask' | 'never'): void }
-        | undefined
-      if (approval) {
-        approval.setPolicy(agent, spec.approval)
-      } else {
-        ;(agent.session as unknown as { append(type: string, data: Record<string, unknown>): unknown }).append(
-          'approval/policy',
-          { policy: spec.approval },
-        )
-      }
-    }
-    refreshMode()
-    state.notify(t('mode-switched', { name: modeDisplayName(state.mode) }))
-    state.emit()
   }
 
   /** Shift+Tab: advance to the next configured session mode. Cycling starts
@@ -4592,6 +4771,19 @@ ${output}
       selection.current = { provider: state.provider, model: state.model }
     }
     void applyPreferredEffort()
+    // Re-seed the plan-mode guard from the (possibly replacement) agent's
+    // durable log before any live event: a resumed session that is already
+    // in plan mode keeps its pre-plan restore target, and if the log says
+    // plan mode is active the configured restrictions are re-asserted even
+    // when the profile that wrote the log did not enforce them.
+    planGuard = planGuardFromLog(agent.session.events)
+    planWasActive = foldPlanActive(agent.session.events)
+    if (planWasActive) {
+      enforcePlanRestrictions()
+      planMutationLocked = planModeSpec?.sandbox === 'read-only'
+    } else {
+      planMutationLocked = false
+    }
     refreshMode()
     agentSubscriptions = [
       installModelSelection(agent.ctx, selection),
@@ -4641,9 +4833,14 @@ ${output}
         activityTracker.onSessionEvent(event)
         renderWorkingActivity()
         // Mode-affecting atoms fold into the Shift+Tab mode indicator the
-        // moment they land (whether appended by cycleMode or by hand).
+        // moment they land (whether appended by cycleMode or by hand). A
+        // `plan/mode` transition also runs the plan guard: entering plan
+        // mode locks sandbox/approval until the plan is approved, leaving
+        // it restores the pre-plan values (qwen-code plan-mode semantics).
         const eventType = (event as { type: string }).type
-        if (eventType === 'plan/mode' || eventType === 'sandbox/mode' || eventType === 'approval/policy') {
+        if (eventType === 'plan/mode') {
+          handlePlanModeChange()
+        } else if (eventType === 'sandbox/mode' || eventType === 'approval/policy') {
           refreshMode()
         }
         renderEvent(event)
@@ -4679,7 +4876,10 @@ ${output}
   const effect = (ctx as Context & {
     effect?: (setup: () => () => void, label?: string) => void
   }).effect
-  effect?.call(ctx, () => () => { stopActivityTick() }, 'dsh-tui activity timer')
+  effect?.call(ctx, () => () => {
+    stopActivityTick()
+    disposePlanToolGuard?.()
+  }, 'dsh-tui activity timer')
   // Statusline breadcrumb: current git branch of the session cwd (best-effort).
   // Re-run when an agent swap adopts a different persisted cwd (/resume,
   // issue #96) so the breadcrumb never shows the previous workspace's branch.

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -285,6 +285,8 @@ const dict = {
   'mode-plan': { zh: '计划模式', en: 'plan mode' },
   'mode-full': { zh: '完全访问', en: 'full access' },
   'mode-plan-unavailable': { zh: '当前 preset 未注册 /plan 命令，无法切换计划模式', en: 'The active preset does not register /plan; cannot toggle plan mode' },
+  'plan-guard-engaged': { zh: '已锁定计划模式：确认计划前修改类工具一律拒绝（只读沙箱 + 审批询问 + 工具门禁）', en: 'Plan mode locked: mutation tools are rejected until you approve the plan (read-only sandbox + approval ask + tool gate)' },
+  'plan-guard-tool-blocked': { zh: '计划模式已锁定：工具 {{tool}} 被拦截。先通过 exit_plan_mode 提交计划并等待批准，再执行修改。', en: 'Plan mode is locked: tool {{tool}} was blocked. Submit the plan through exit_plan_mode and wait for approval before making changes.' },
 
   // ── components/LogoV2.tsx ───────────────────────────────────────────
   'logo-tagline': { zh: '探索未至之境！', en: 'Explore the uncharted!' },


### PR DESCRIPTION
https://github.com/ccch1mneyyy/dsh-TUI/issues/290 修复这个问题，现在plan mode 打完之后会停下来等待审核，选择执行/维持plan mode/继续追加对话
<img width="538" height="130" alt="image" src="https://github.com/user-attachments/assets/a25eb895-b810-41ab-acca-46dd5d0dabfd" />
