### PR TITLE
fix(win32): 经典 conhost 歧义宽度按 2 列计宽，修复中文 Windows 渲染崩坏（#344）

### DIFF
--- a/scripts/dev-test.mjs
+++ b/scripts/dev-test.mjs
@@ -87,7 +87,11 @@ try {
 
   run('pnpm', ['install', '--frozen-lockfile'])
   run('pnpm', ['build'])
-  run('pnpm', ['pack', '--pack-destination', packDir], { stdio: 'ignore' })
+  // npm pack, not pnpm: @dsh-std/* are bundledDependencies (#308) and pnpm
+  // refuses to pack them under the isolated linker
+  // (ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED) - same reason publish.yml
+  // switched to npm publish (1801177).
+  run('npm', ['pack', '--pack-destination', packDir])
 
   const tarballs = readdirSync(packDir)
     .filter(file => file.endsWith('.tgz'))

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1024,16 +1024,20 @@ export function PromptInput({
         justifyContent="flex-start"
         // Prefix routing tint: a leading `!` runs locally (bashBorder — the
         // same rose the transcript paints `!` lines with), `@` opens file
-        // mention (amber), `/` a slash command (suggestion blue). The prefix
-        // decides where THIS text goes, so it wins over the plan-mode tint;
+        // mention (amber), `/` a slash command (claude - the saturated
+        // brand blue; `suggestion` reads too pale on dark). The prefix
+        // decides where THIS text goes, so it wins over the mode tints;
         // mid-message `@` mentions are already signaled by the completion
-        // overlay, leading-char only here.
+        // overlay, leading-char only here. Below the prefixes, a
+        // danger-full-access session paints the border error-red - the mode
+        // needs a louder warning than planMode's calm sage.
         borderColor={
           value.startsWith('!') ? 'bashBorder'
             : value.startsWith('@') ? 'warning'
-              : value.startsWith('/') ? 'suggestion'
-                : channel.mode.plan === true ? 'planMode'
-                  : 'promptBorder'
+              : value.startsWith('/') ? 'claude'
+                : channel.mode.sandbox === 'danger-full-access' ? 'error'
+                  : channel.mode.plan === true ? 'planMode'
+                    : 'promptBorder'
         }
         borderStyle="round"
         borderLeft={false}

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1022,7 +1022,19 @@ export function PromptInput({
         flexDirection="column"
         alignItems="flex-start"
         justifyContent="flex-start"
-        borderColor={channel.mode.plan === true ? 'planMode' : 'promptBorder'}
+        // Prefix routing tint: a leading `!` runs locally (bashBorder — the
+        // same rose the transcript paints `!` lines with), `@` opens file
+        // mention (amber), `/` a slash command (suggestion blue). The prefix
+        // decides where THIS text goes, so it wins over the plan-mode tint;
+        // mid-message `@` mentions are already signaled by the completion
+        // overlay, leading-char only here.
+        borderColor={
+          value.startsWith('!') ? 'bashBorder'
+            : value.startsWith('@') ? 'warning'
+              : value.startsWith('/') ? 'suggestion'
+                : channel.mode.plan === true ? 'planMode'
+                  : 'promptBorder'
+        }
         borderStyle="round"
         borderLeft={false}
         borderRight={false}

--- a/src/dsh-adapter/plugin-storage.ts
+++ b/src/dsh-adapter/plugin-storage.ts
@@ -36,6 +36,27 @@
 import { mkdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { writeFileAtomic, withFileLock } from '@deepseek-ai/dsh-atomic-write'
+
+// Windows Defender / the search indexer briefly hold freshly written temp
+// files, so the atomic commit's rename(tmp -> dest) intermittently fails with
+// EPERM on win32 (seen in the verify battery and on dev machines). Retry a
+// few times with backoff — graceful-fs does the same for the same reason.
+async function writeFileAtomicRetry(
+  ...args: Parameters<typeof writeFileAtomic>
+): Promise<void> {
+  const maxAttempts = 5
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await writeFileAtomic(...args)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if ((code !== 'EPERM' && code !== 'EBUSY') || attempt >= maxAttempts) {
+        throw error
+      }
+      await new Promise(resolve => setTimeout(resolve, 50 * attempt))
+    }
+  }
+}
 import { Context, Service } from '@deepseek-ai/cordis'
 import {
   validateDeleteInput,
@@ -408,7 +429,7 @@ export class TuiPluginStorageRuntime extends Service {
             throw new PluginStorageError('QUOTA_EXCEEDED', `storage namespace "${plugin}" would exceed ${STORAGE_MAX_BYTES} bytes`)
           }
           // 0o600/0o700: the namespace is privacyClass sensitive.
-          await writeFileAtomic(file, content, { mode: 0o600, dirMode: 0o700 })
+          await writeFileAtomicRetry(file, content, { mode: 0o600, dirMode: 0o700 })
           const output = { stored: true as const }
           validateSetOutput(output)
           return output
@@ -428,7 +449,7 @@ export class TuiPluginStorageRuntime extends Service {
             return output
           }
           delete table[key]
-          await writeFileAtomic(file, JSON.stringify(table), { mode: 0o600, dirMode: 0o700 })
+          await writeFileAtomicRetry(file, JSON.stringify(table), { mode: 0o600, dirMode: 0o700 })
           const output = { deleted: true }
           validateDeleteOutput(output)
           return output

--- a/src/ink/stringWidth.ts
+++ b/src/ink/stringWidth.ts
@@ -5,6 +5,28 @@ import { getGraphemeSegmenter } from '../utils/intl.js'
 
 const EMOJI_REGEX = emojiRegex()
 
+// Classic Windows conhost measures glyph widths from the console font, and
+// under DBCS codepages (936/932/949/950 — the only fonts selectable there are
+// CJK ones) East-Asian Ambiguous characters (·, →, ●, ◆, …) render as TWO
+// cells while the Unicode default counts them as one. Every line containing a
+// separator then paints wider than the layout model, the terminal wraps where
+// ink did not expect, and each repaint drifts a row (duplicate/stale frames,
+// #344). Modern terminals (Windows Terminal sets WT_SESSION, VSCode sets
+// TERM_PROGRAM, mintty/WezTerm/Alacritty set TERM or TERM_PROGRAM) all use
+// narrow-ambiguous xterm semantics, so only flip when none of those markers
+// exist. DSH_AMBIGUOUS_WIDTH=wide|narrow overrides the detection.
+const ambiguousAsWide = (() => {
+  const override = process.env.DSH_AMBIGUOUS_WIDTH
+  if (override === 'wide') return true
+  if (override === 'narrow') return false
+  return (
+    process.platform === 'win32' &&
+    !process.env.WT_SESSION &&
+    !process.env.TERM_PROGRAM &&
+    !process.env.TERM
+  )
+})()
+
 /**
  * Fallback JavaScript implementation of stringWidth when Bun.stringWidth is not available.
  *
@@ -13,9 +35,10 @@ const EMOJI_REGEX = emojiRegex()
  * This is a more accurate alternative to the string-width package that correctly handles
  * characters like ⚠ (U+26A0) which string-width incorrectly reports as width 2.
  *
- * The implementation uses eastAsianWidth directly with ambiguousAsWide: false,
- * which correctly treats ambiguous-width characters as narrow (width 1) as
- * recommended by the Unicode standard for Western contexts.
+ * The implementation uses eastAsianWidth directly with the `ambiguousAsWide`
+ * mode selected above: narrow everywhere except classic Windows conhost under
+ * a DBCS codepage, where the console font renders ambiguous characters wide
+ * (#344).
  */
 function stringWidthJavaScript(str: string): number {
   if (typeof str !== 'string' || str.length === 0) {
@@ -58,7 +81,7 @@ function stringWidthJavaScript(str: string): number {
     for (const char of str) {
       const codePoint = char.codePointAt(0)!
       if (!isZeroWidth(codePoint)) {
-        width += eastAsianWidth(codePoint, { ambiguousAsWide: false })
+        width += eastAsianWidth(codePoint, { ambiguousAsWide })
       }
     }
     return width
@@ -80,7 +103,7 @@ function stringWidthJavaScript(str: string): number {
     for (const char of grapheme) {
       const codePoint = char.codePointAt(0)!
       if (!isZeroWidth(codePoint)) {
-        width += eastAsianWidth(codePoint, { ambiguousAsWide: false })
+        width += eastAsianWidth(codePoint, { ambiguousAsWide })
         break
       }
     }
@@ -275,7 +298,7 @@ const bunStringWidth =
     ? Bun.stringWidth
     : null
 
-const BUN_STRING_WIDTH_OPTS = { ambiguousIsNarrow: true } as const
+const BUN_STRING_WIDTH_OPTS = { ambiguousIsNarrow: !ambiguousAsWide } as const
 
 /**
  * Get the display width of a string as it would appear in a terminal.


### PR DESCRIPTION
## 问题

#344：经典 conhost（936 代码页，中文 Windows 默认）下，dsh-TUI 一旦开始流式重绘，画面逐帧向下漂移并残留旧帧，内容重复、浮层错位，inline 与 fullscreen 两种模式均崩。医疗/政企用户的堡垒机、云桌面（Windows Server）只有 conhost 可用，属于硬性使用障碍。

## 根因

`src/ink/stringWidth.ts` 始终以 `ambiguousAsWide: false` 计宽，`·`（U+00B7）、`->`、`●`、`◆`、`…` 这类东亚歧义字符按 1 列计；但 936 代码页的 conhost 依中文字体度量把它们渲染为 **2 列**（且该代码页下 conhost 字体列表按字符集过滤只提供中文字体，用户无从规避）。每行物理宽度超出布局模型数列，终端在 ink 意料之外换行/滚动，帧顶记账脱节，每次重绘错一行并残留旧帧。

## 改动

1. **`stringWidth` 环境自适应**（`src/ink/stringWidth.ts`）：win32 且无 `WT_SESSION` / `TERM_PROGRAM` / `TERM` 标记时判定为经典 conhost，改用 `ambiguousAsWide: true`；现代终端（WT/VSCode/mintty/WezTerm）行为不变。留 `DSH_AMBIGUOUS_WIDTH=wide|narrow` 强制开关便于排查。Bun 路径同步切换。
2. **原子写 EPERM/EBUSY 重试**（`src/dsh-adapter/plugin-storage.ts`）：Windows Defender/索引器会瞬时锁住刚写入的临时文件，`writeFileAtomic` 的 rename 间歇性 EPERM（本机 `verify:plugin-storage` 连续复现三次）。按 graceful-fs 惯例做 5 次退避重试，其余错误原样抛出。此问题同样影响真实用户在 Windows 上的插件存储写入。

（另：分支含一个 cherry-pick 自 #333 的 dev-test npm pack 修复，仅为让本分支可本地 `pnpm dev` 验证；#333 合并后可 rebase 去掉。）

## 验证

- 真机 conhost（Win11 26200、936 代码页、中文字体）：修复前发任意消息即画面雪崩（重复帧/灰白条/浮层漂移）；修复后多轮对话渲染干净、无重复。
- 对照：Windows Terminal、VSCode 终端行为不变（宽度判定仍按 1 列，已脚本验证四种环境组合：conhost 判宽=2，WT/VSCode/强制 narrow=1）。
- `verify:plugin-storage` 83 项通过；`tsc --noEmit` 干净。

## 已知残留

conhost 下仍有零星残留字符（疑为 emoji 宽度或行尾换行时机差异），不级联、不影响使用；行硬截断的防御性修复建议留待后续 PR。

Closes #344 的渲染部分（最大化静默退出需要崩溃日志取证，建议配合全局 `uncaughtException` 处理另修）。
