### PR TITLE
feat(notify): 回合结束/审批/提问的终端通知与进度上报

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
       # Alt+numpad 两轮合成。
       - run: node --import tsx/esm scripts/verify-win32-input.tsx
 
+      # 回合通知回归：协议按终端选择、只在状态边沿发（挂载进行中的回合
+      # 不发）、unfocused 尊重 DECSET 1004 焦点、off 连进度指示一起关。
+      - run: node scripts/verify-notifications.mjs
+
       # 退出漏斗回归（issue #12）：上下文 teardown 不得走到进程退出。
       - run: node --import tsx/esm scripts/verify-teardown-exit.tsx
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ macOS 自带 Terminal.app 会自行消费 `⌘` 快捷键，请继续使用 `Ctr
   `dark-ansi`），也支持 `~/.dsh-tui/themes/<名字>.json` 自定义主题，选中即热切换
   并持久化；`DSH_TUI_THEME` 环境变量 > 持久化选择 > OSC 11 终端背景自动检测。
   详见[主题系统](docs/themes.md)。
+- **回合通知**：回合结束、工具审批弹出、模型提问时向终端要一次注意力，工作
+  期间还会驱动终端进度指示。默认 `unfocused`——只在窗口失焦时通知，你盯着
+  屏幕看时不打扰；`/settings` 里可改成 `always` 或 `off`。iTerm2 / WezTerm /
+  kitty / Ghostty 走各自的原生通知协议，其余终端退回 BEL（tmux 内会变成窗口
+  活动标记）。详见[配置参考](docs/configuration.md#回合通知)。
 - **MCP**：通过 `@deepseek-ai/dsh-mcp-client` 挂载服务器，工具以
   `mcp__<服务器>__<工具>` 注册；`/mcp` 查看连接状态。
   详见[配置参考](docs/configuration.md#mcp)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -184,6 +184,13 @@ The complete bilingual index is [`docs/README.md`](docs/README.md).
   `~/.dsh-tui/themes/<name>.json` — selecting one hot-swaps and persists it; precedence is
   `DSH_TUI_THEME` env var > persisted selection > OSC 11 terminal-background auto-detection.
   See [Themes](docs/themes.en.md).
+- **Turn notifications**: the terminal is asked for attention when a turn ends, a tool
+  approval parks, or the model asks a question, and the working state drives the terminal
+  progress indicator. The default `unfocused` only notifies while the window is not
+  focused, so watching the stream is never interrupted; `/settings` switches it to
+  `always` or `off`. iTerm2 / WezTerm / kitty / Ghostty use their native notification
+  protocols; every other terminal falls back to BEL (a window activity flag inside tmux).
+  See [Configuration](docs/configuration.en.md#turn-notifications).
 - **MCP**: servers are mounted via `@deepseek-ai/dsh-mcp-client`, with tools registered as
   `mcp__<server>__<tool>`; `/mcp` shows connection status.
   See [Configuration](docs/configuration.en.md#mcp).

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -267,6 +267,10 @@
         # Edit/Write diff 呈现：auto（≥110 列双栏对照，窄屏统一式）/
         # split（强制双栏）/ unified（强制统一式）。/settings 屏可实时改。
         # diffLayout: auto
+        # 回合结束（以及 agent 卡在审批/提问上）时向终端发通知，并驱动终端
+        # 进度指示：unfocused（默认，仅窗口失焦时）/ always / off。
+        # /settings 屏可实时改。
+        # notify: unfocused
         # 每个请求实际生效的推理强度，按当前路由的 adapter 档位校验
         # （deepseek: off/high/max）——不在档位表里的值被忽略，回落 adapter
         # 默认值。优先于持久化的 Shift+Tab 选择（~/.dsh-tui/effort.json）；

--- a/cordis.yml
+++ b/cordis.yml
@@ -57,6 +57,11 @@
     # wl-copy/xclip/xsel 兜底）、滚轮滚动、双击选词/三击选行。false 则退回
     # inline 渲染, 鼠标交给终端模拟器原生选择。
     fullscreen: true
+    # Turn notification: notify the terminal when a turn ends (or the agent
+    # blocks on an approval / question), and drive the terminal progress
+    # indicator. `unfocused` (default) only while the window is not focused,
+    # `always`, or `off`. Editable live from the /settings screen.
+    # notify: unfocused
     # Reasoning effort applied to every request, validated against the live
     # route's adapter levels (deepseek: off/high/max) — an unlisted level is
     # ignored and the adapter default applies. Wins over the persisted

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -39,6 +39,7 @@ A complete common override looks like this:
     activityFrames: claude
     contextBar: true
     fullscreen: false
+    notify: unfocused
     preset: !!js process.env.DSH_TUI_PRESET ?? undefined
     workspace: !!js process.env.DSH_TUI_WORKSPACE_TARGET ?? undefined
     sessionId: !!js process.env.DSH_TUI_RESUME_SESSION ?? undefined
@@ -56,8 +57,33 @@ A complete common override looks like this:
 | `activityFrames` | persisted choice or `claude` | Activity animation preset; `/activity` changes it at runtime |
 | `contextBar` | `true` | Segmented context-usage bar below the input box; `false` hides the row |
 | `fullscreen` | `false` | `true` uses the alternate screen, app scrolling, and mouse selection; `false` uses inline mode |
+| `notify` | `unfocused` | Notify the terminal when a turn ends (or the agent blocks on an approval/question) and drive the terminal progress indicator; `always` notifies every time, `off` disables both. Editable live from `/settings` |
 | `preset` | roster default `standard` | Agent preset for new sessions; explicit configuration wins over persisted preference |
 | `sessionId` | unset | Session to resume, normally injected by the Windows `--resume` launcher |
+
+## Turn notifications
+
+`notify` controls when the TUI asks the terminal for attention: once when a
+turn ends, once when a tool approval parks, and once when the model opens an
+`ask_user_question` — so a long task can run while you look elsewhere.
+
+- `unfocused` (default): only while the terminal window is not focused.
+  Focus comes from DECSET 1004 focus reporting; a terminal that does not
+  report is treated as focused, i.e. left alone.
+- `always`: notify every time.
+- `off`: no notification and no progress reporting.
+
+The notification uses the terminal's own protocol, chosen from environment
+markers: OSC 9 for iTerm2 and WezTerm, OSC 99 for kitty, OSC 777 for
+Ghostty. Anything unrecognized falls back to BEL (``), which tmux turns
+into a window activity flag. Inside tmux/screen the inner `TERM` is
+rewritten and `TERM_PROGRAM` is not always forwarded, so multiplexed
+sessions usually land on BEL.
+
+While a turn runs the terminal progress indicator is driven too (OSC 9;4
+indeterminate), cleared when the turn ends. That sequence is only emitted on
+ConEmu, Ghostty 1.2.0+, and iTerm2 3.6.6+; Windows Terminal reads OSC 9;4 as
+a notification and is excluded explicitly.
 
 ## Live activity row
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ Profile 启动按顺序叠加 `dsh-base`、已安装 bundle、`@deepseek-harness
     activityFrames: claude
     contextBar: true
     fullscreen: false
+    notify: unfocused
     preset: !!js process.env.DSH_TUI_PRESET ?? undefined
     workspace: !!js process.env.DSH_TUI_WORKSPACE_TARGET ?? undefined
     sessionId: !!js process.env.DSH_TUI_RESUME_SESSION ?? undefined
@@ -54,8 +55,28 @@ Profile 启动按顺序叠加 `dsh-base`、已安装 bundle、`@deepseek-harness
 | `activityFrames` | 持久化选择或 `claude` | 工作状态动画预设；也可通过 `/activity` 修改 |
 | `contextBar` | `true` | 输入框下方的分段上下文进度条；`false` 隐藏该行 |
 | `fullscreen` | `false` | `true` 使用 alternate screen、应用内滚动和鼠标选区；`false` 使用 inline 模式 |
+| `notify` | `unfocused` | 回合结束（以及卡在审批/提问上）时向终端发通知，并驱动终端进度指示；`always` 每次都通知，`off` 全部关闭。`/settings` 可实时改 |
 | `preset` | 名册默认 `standard` | 新会话 Agent preset；显式配置优先于持久化偏好 |
 | `sessionId` | 未设置 | 要恢复的会话 ID，通常由 Windows `--resume` 启动器注入 |
+
+## 回合通知
+
+`notify` 控制 TUI 什么时候向终端"要注意力"：回合结束、工具审批弹出、模型
+发起 `ask_user_question` 这三个时刻各发一次，长任务跑着时你可以切去干别的。
+
+- `unfocused`（默认）：仅在终端窗口失焦时通知。焦点状态来自 DECSET 1004
+  焦点上报——终端不支持时按"已聚焦"处理，也就是不打扰。
+- `always`：每次都通知。
+- `off`：通知与进度指示全部关闭。
+
+通知走终端原生协议，按环境变量选择：iTerm2 与 WezTerm 用 OSC 9，kitty 用
+OSC 99，Ghostty 用 OSC 777；识别不出的终端退回 BEL（``）——在 tmux 里
+BEL 会变成窗口活动标记。tmux/screen 内层 `TERM` 被改写、`TERM_PROGRAM`
+不一定透传，所以复用会话通常落在 BEL 分支。
+
+工作期间还会打终端进度指示（OSC 9;4 indeterminate），回合结束清除。该序列
+只在 ConEmu、Ghostty 1.2.0+、iTerm2 3.6.6+ 上发出；Windows Terminal 把
+OSC 9;4 当通知解释，因此被显式排除。
 
 ## 工作状态行
 

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -212,6 +212,7 @@ change, also run the closest focused script:
 | Theme loading and persistence | `node --import tsx/esm scripts/verify-themes.mjs` |
 | Scrolling/sticky-bottom behavior | `node scripts/verify-scroll.mjs`, `node scripts/verify-resticky.mjs`, and the matching `repro-*` harness |
 | Fullscreen copy-on-select | `node scripts/verify-copy-on-select.mjs` |
+| Turn notifications and terminal progress | `node scripts/verify-notifications.mjs` |
 
 Most focused scripts invoked with plain `node` import `lib/types/`; run
 `pnpm build` first. Scripts that import TypeScript sources declare the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -165,6 +165,7 @@ CI 回归都要跑。窄改动还要跑最近的聚焦脚本：
 | 主题加载与持久化 | `node --import tsx/esm scripts/verify-themes.mjs` |
 | 滚动/粘底行为 | `node scripts/verify-scroll.mjs`、`node scripts/verify-resticky.mjs` 及对应 `repro-*` 环境 |
 | 全屏复制即选区 | `node scripts/verify-copy-on-select.mjs` |
+| 回合通知与终端进度 | `node scripts/verify-notifications.mjs` |
 
 多数用普通 `node` 调用的脚本 import `lib/types/`——先跑 `pnpm build`。import
 TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式。不要凭

--- a/scripts/verify-notifications.mjs
+++ b/scripts/verify-notifications.mjs
@@ -1,0 +1,196 @@
+/**
+ * Headless verification of turn notifications (hooks/useTurnNotification.ts):
+ * the terminal is asked for attention on the *edges* the user cares about —
+ * a turn ending, an approval parking, a questionnaire opening — and the
+ * working flag drives the terminal's progress indicator.
+ *
+ * Covers the three ways this feature can go wrong in a way no type check
+ * sees: firing on mount (alerting about work the user did not start),
+ * firing while the user is already watching (`unfocused` must respect DECSET
+ * 1004 focus), and firing at all when the mode is `off`.
+ *
+ * Run against the compiled lib: `node scripts/verify-notifications.mjs`
+ */
+import { PassThrough, Writable } from 'node:stream'
+import React from 'react'
+import { render, Text } from '../lib/types/ui.js'
+import { useTurnNotification } from '../lib/types/hooks/useTurnNotification.js'
+import { pickNotifyChannel } from '../lib/types/notifications.js'
+import { setTerminalFocused } from '../lib/types/ink/terminal-focus-state.js'
+
+// The progress helper gates on a real TTY and rejects Windows Terminal
+// (which reads OSC 9;4 as a notification). Force the ConEmu branch so the
+// assertions below do not depend on how the suite was launched.
+process.stdout.isTTY = true
+delete process.env.WT_SESSION
+delete process.env.TMUX
+delete process.env.STY
+process.env.ConEmuANSI = 'ON'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+// ── 1. Protocol selection (pure) ──────────────────────────────────────────
+
+check('ghostty by TERM_PROGRAM', pickNotifyChannel({ TERM_PROGRAM: 'ghostty' }) === 'ghostty')
+check('ghostty by resources dir', pickNotifyChannel({ GHOSTTY_RESOURCES_DIR: '/x' }) === 'ghostty')
+check('kitty by TERM', pickNotifyChannel({ TERM: 'xterm-kitty' }) === 'kitty')
+check('kitty by window id', pickNotifyChannel({ KITTY_WINDOW_ID: '1' }) === 'kitty')
+check('iTerm2 by TERM_PROGRAM', pickNotifyChannel({ TERM_PROGRAM: 'iTerm.app' }) === 'iterm2')
+check('WezTerm rides the iTerm2 payload', pickNotifyChannel({ TERM_PROGRAM: 'WezTerm' }) === 'iterm2')
+check('unknown terminal falls back to BEL', pickNotifyChannel({ TERM: 'xterm-256color' }) === 'bell')
+check('empty environment falls back to BEL', pickNotifyChannel({}) === 'bell')
+
+// ── 2. Emission edges (mounted) ───────────────────────────────────────────
+
+function makeStreams() {
+  const stdout = new Writable({
+    write(chunk, _enc, cb) {
+      stdout.frames.push(String(chunk))
+      cb()
+    },
+  })
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.frames = []
+  const stderr = new Writable({ write(_c, _e, cb) { cb() } })
+  stderr.isTTY = true
+  const stdin = new PassThrough()
+  stdin.isTTY = true
+  stdin.setRawMode = () => stdin
+  stdin.setEncoding = () => stdin
+  stdin.ref = () => stdin
+  stdin.unref = () => stdin
+  return { stdout, stderr, stdin }
+}
+
+function Harness({ mode, working, awaitingApproval, awaitingQuestion }) {
+  useTurnNotification(mode, {
+    working,
+    awaitingApproval,
+    awaitingQuestion,
+    title: 'demo session',
+  })
+  return React.createElement(Text, null, 'harness')
+}
+
+/** Mount the harness and return a driver that re-renders it with new state. */
+async function mount(initial) {
+  const { stdout, stderr, stdin } = makeStreams()
+  let state = { mode: 'always', working: false, awaitingApproval: false, awaitingQuestion: false, ...initial }
+  const instance = await render(React.createElement(Harness, state), {
+    stdout,
+    stderr,
+    stdin,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  await sleep(80)
+  return {
+    /** stdout since the last `clear()`. */
+    out: () => stdout.frames.join(''),
+    clear: () => { stdout.frames.length = 0 },
+    async set(next) {
+      state = { ...state, ...next }
+      instance.rerender(React.createElement(Harness, state))
+      await sleep(120)
+    },
+    unmount: () => { instance.unmount() },
+  }
+}
+
+/** OSC 9 notification payload (iTerm2/WezTerm), independent of terminator. */
+const ITERM2_NOTIFY = '\x1b]9;\n\n'
+/** OSC 9;4 progress: `3` indeterminate, `0` clear. */
+const PROGRESS_BUSY = '\x1b]9;4;3;'
+const PROGRESS_CLEAR = '\x1b]9;4;0;'
+
+process.env.TERM_PROGRAM = 'iTerm.app'
+setTerminalFocused(false)
+
+// Mounting mid-turn must stay silent: the refs seed from the first render,
+// so `--resume` onto a live agent does not alert about a turn the user did
+// not start here.
+{
+  const ui = await mount({ working: true })
+  check('no alert on mount into a running turn', !ui.out().includes(ITERM2_NOTIFY))
+  ui.clear()
+  await ui.set({ working: false })
+  check('turn end alerts (iTerm2 OSC 9)', ui.out().includes(ITERM2_NOTIFY))
+  ui.unmount()
+}
+
+{
+  const ui = await mount({ working: false })
+  ui.clear()
+  await ui.set({ working: true })
+  check('turn start does not alert', !ui.out().includes(ITERM2_NOTIFY))
+  check('turn start raises progress', ui.out().includes(PROGRESS_BUSY))
+  ui.clear()
+  await ui.set({ working: false })
+  check('turn end clears progress', ui.out().includes(PROGRESS_CLEAR))
+  ui.unmount()
+}
+
+{
+  const ui = await mount({ mode: 'off', working: true })
+  ui.clear()
+  await ui.set({ working: false })
+  check('mode off stays silent', !ui.out().includes(ITERM2_NOTIFY))
+  check('mode off reports no progress', !ui.out().includes(PROGRESS_BUSY))
+  ui.unmount()
+}
+
+{
+  const ui = await mount({ mode: 'unfocused', working: true })
+  setTerminalFocused(true)
+  await sleep(50)
+  ui.clear()
+  await ui.set({ working: false })
+  check('unfocused mode stays silent while focused', !ui.out().includes(ITERM2_NOTIFY))
+  ui.unmount()
+}
+
+{
+  setTerminalFocused(false)
+  const ui = await mount({ mode: 'unfocused', working: true })
+  ui.clear()
+  await ui.set({ working: false })
+  check('unfocused mode alerts while blurred', ui.out().includes(ITERM2_NOTIFY))
+  ui.unmount()
+}
+
+{
+  const ui = await mount({})
+  ui.clear()
+  await ui.set({ awaitingApproval: true })
+  check('parked approval alerts', ui.out().includes(ITERM2_NOTIFY))
+  ui.clear()
+  await ui.set({ awaitingApproval: false })
+  check('settled approval does not alert', !ui.out().includes(ITERM2_NOTIFY))
+  ui.clear()
+  await ui.set({ awaitingQuestion: true })
+  check('parked questionnaire alerts', ui.out().includes(ITERM2_NOTIFY))
+  ui.unmount()
+}
+
+// BEL fallback: an unrecognized terminal rings instead of writing OSC 9.
+{
+  delete process.env.TERM_PROGRAM
+  const ui = await mount({ working: true })
+  ui.clear()
+  await ui.set({ working: false })
+  const out = ui.out()
+  check('unknown terminal rings the bell', out.includes('\x07'))
+  check('unknown terminal writes no OSC 9 notification', !out.includes(ITERM2_NOTIFY))
+  ui.unmount()
+}
+
+console.log(failed === 0 ? '\nverify-notifications: OK' : `\nverify-notifications: ${failed} failure(s)`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -48,6 +48,7 @@ import { homeDir, LEGACY_DATA_DIR } from '../utils/paths.js'
 import { extractMentions } from '../utils/mentions.js'
 import { t } from '../i18n.js'
 import { modeDisplayName, resolveSessionModes, type SessionModeSpec } from '../sessionModes.js'
+import { DEFAULT_NOTIFY_MODE, type NotifyMode } from '../notifications.js'
 import type { SpinnerMode } from '../components/Spinner/spinnerMode.js'
 import { ActivityTracker, type ActivityState } from 'dsh-working-activity/status'
 import { attachSessionToWorkspace } from './workspace.js'
@@ -462,6 +463,8 @@ export interface Channel {
   readonly activityFrames: string | undefined
   /** Edit/Write diff presentation preference (`auto`/`split`/`unified`). */
   readonly diffLayout: 'auto' | 'split' | 'unified'
+  /** When a finished turn (or a blocked agent) notifies the terminal. */
+  readonly notifyMode: NotifyMode
   /** Whether the in-process working-activity line is shown (config.activity). */
   readonly activityEnabled: boolean
   /** Whether the segmented context bar row shows in the status footer
@@ -793,6 +796,10 @@ export interface ChannelState {
   diffLayout: 'auto' | 'split' | 'unified'
   /** Apply a diff-layout change (see the public Channel type). */
   setDiffLayout(layout: 'auto' | 'split' | 'unified'): void
+  /** Notification preference (see the public Channel type). */
+  notifyMode: NotifyMode
+  /** Apply a notification-mode change (see the public Channel type). */
+  setNotifyMode(mode: NotifyMode): void
   /** Working-activity display switch (see the public Channel type). */
   activityEnabled: boolean
   /** Context bar row switch (see the public Channel type). */
@@ -1219,6 +1226,8 @@ export function createChannel(
     /** Edit/Write diff presentation; default `auto` (side-by-side ≥110
      *  columns, unified below). */
     diffLayout?: 'auto' | 'split' | 'unified'
+    /** When a finished turn notifies the terminal; default `unfocused`. */
+    notifyMode?: NotifyMode
     /** Show the segmented context bar row in the status footer; default on
      *  (cordis.yml `contextBar: false` hides it, issue #29). */
     contextBar?: boolean
@@ -1871,6 +1880,7 @@ export function createChannel(
     workingActivity: undefined,
     activityFrames: options.activityFrames,
     diffLayout: options.diffLayout ?? 'auto',
+    notifyMode: options.notifyMode ?? DEFAULT_NOTIFY_MODE,
     activityEnabled: options.activity !== false,
     contextBarEnabled: options.contextBar !== false,
     agentPreset: options.agentPreset,
@@ -2793,6 +2803,11 @@ export function createChannel(
     setDiffLayout(layout) {
       if (layout === state.diffLayout) return
       state.diffLayout = layout
+      state.emit()
+    },
+    setNotifyMode(mode) {
+      if (mode === state.notifyMode) return
+      state.notifyMode = mode
       state.emit()
     },
     setActivityFrames(name) {

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -8,6 +8,7 @@
  */
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
+import type { NotifyMode } from '../notifications.js'
 import type { SessionModeSpec } from '../sessionModes.js'
 
 export const name = 'dsh-tui'
@@ -77,6 +78,12 @@ export interface Config {
    *  terminals (≥110 cols) and unified below; `split`/`unified` force one
    *  layout. Editable live from the `/settings` screen. */
   diffLayout?: 'auto' | 'split' | 'unified'
+  /** When a finished turn — or an agent blocked on an approval or an
+   *  `ask_user_question` — asks the terminal for attention: `unfocused`
+   *  (default) only while the window is not focused, `always` every time,
+   *  `off` never (progress reporting included). Editable live from the
+   *  `/settings` screen. */
+  notify?: NotifyMode
   /** Shift+Tab session-mode cycle (array order IS the cycle order; index 0
    *  is the unmarked base mode). Each entry bundles any subset of the
    *  `plan`/`sandbox`/`approval` atoms; absent → the built-in
@@ -102,6 +109,7 @@ export const Config: Schema<Config> = Schema.object({
   lang: Schema.string().required(false),
   preset: Schema.string().required(false),
   diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
+  notify: Schema.union(['off', 'unfocused', 'always']).default('unfocused'),
   modes: Schema.array(
     Schema.object({
       id: Schema.string(),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -17,6 +17,7 @@ import { registerPackagedSkills } from './packaged-skills.js'
 import { registerPromptDebug } from './promptDebug.js'
 import { readActivityFrames } from '../activityPrefs.js'
 import { readModelPref } from '../modelPrefs.js'
+import { DEFAULT_NOTIFY_MODE, type NotifyMode } from '../notifications.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ModelRoute } from '../modelRoute.js'
 import { readPresetPref } from '../presetPrefs.js'
@@ -341,6 +342,9 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     // Edit/Write diff presentation (schema default 'auto'); the /settings
     // screen edits this key live through the dsh-tui namespace.
     diffLayout: config.diffLayout,
+    // Turn-notification mode (schema default 'unfocused'); edited live from
+    // the same namespace.
+    notifyMode: config.notify,
     handle,
   })
   // Register the dsh-tui settings namespace so the /settings screen can
@@ -352,6 +356,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       settingsNamespace('dsh-tui'),
       Schema.object({
         diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
+        notify: Schema.union(['off', 'unfocused', 'always']).default('unfocused'),
         // No default on purpose: an unset `lang` keeps the field showing
         // the effective language (see the section's format below) and lets
         // cordis.yml / lang.json keep their precedence.
@@ -360,6 +365,9 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     )
     const applyLayout = (value: { diffLayout?: 'auto' | 'split' | 'unified' }): void => {
       channel.setDiffLayout(value.diffLayout ?? config.diffLayout ?? 'auto')
+    }
+    const applyNotify = (value: { notify?: NotifyMode }): void => {
+      channel.setNotifyMode(value.notify ?? config.notify ?? DEFAULT_NOTIFY_MODE)
     }
     // The /settings language field writes `lang` through the settings
     // service (user layer): apply it live and mirror it to lang.json so
@@ -372,8 +380,13 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
         writeLangPref(value.lang)
       }
     }
-    const apply = (next: { diffLayout?: 'auto' | 'split' | 'unified'; lang?: 'zh' | 'en' }): void => {
+    const apply = (next: {
+      diffLayout?: 'auto' | 'split' | 'unified'
+      notify?: NotifyMode
+      lang?: 'zh' | 'en'
+    }): void => {
       applyLayout(next)
+      applyNotify(next)
       applyLang(next)
     }
     apply(scope.get())
@@ -427,6 +440,19 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
             { value: 'auto', label: 'Auto (by width)', descriptions: { zh: '自动（按宽度）' } },
             { value: 'split', label: 'Side-by-side', descriptions: { zh: '双栏对照' } },
             { value: 'unified', label: 'Unified', descriptions: { zh: '统一式' } },
+          ],
+        },
+        {
+          path: ['notify'],
+          label: 'Turn notification',
+          descriptions: { zh: '回合通知' },
+          hint: 'Notify the terminal when a turn ends or the agent needs you; also drives the terminal progress indicator.',
+          hintDescriptions: { zh: '回合结束或 agent 需要你时通知终端；同时驱动终端进度指示。' },
+          kind: 'select',
+          options: [
+            { value: 'unfocused', label: 'When unfocused', descriptions: { zh: '仅窗口失焦时' } },
+            { value: 'always', label: 'Always', descriptions: { zh: '总是' } },
+            { value: 'off', label: 'Off', descriptions: { zh: '关闭' } },
           ],
         },
       ],

--- a/src/hooks/useTurnNotification.ts
+++ b/src/hooks/useTurnNotification.ts
@@ -1,0 +1,111 @@
+import React from 'react'
+import { t } from '../i18n.js'
+import { useTerminalFocus } from '../ink/hooks/use-terminal-focus.js'
+import { useTerminalNotification } from '../ink/useTerminalNotification.js'
+import { pickNotifyChannel, type NotifyMode } from '../notifications.js'
+
+/** What the TUI is waiting on, as far as the notifier is concerned. */
+export interface TurnNotificationState {
+  /** True between turn/start and turn/end (the working spinner's own flag). */
+  working: boolean
+  /** True while a tool approval is parked on the panel. */
+  awaitingApproval: boolean
+  /** True while an `ask_user_question` batch is parked on the panel. */
+  awaitingQuestion: boolean
+  /** Session title, used as the notification body so a user with several
+   *  windows open can tell which one finished. */
+  title: string
+}
+
+/** Which of the three moments an alert is being raised for. */
+type Alert = 'done' | 'approval' | 'question'
+
+/**
+ * Ask the terminal for the user's attention when a turn ends or the agent
+ * blocks on the user, and mirror the working state into the terminal's
+ * progress indicator.
+ *
+ * Alerts fire on state *edges* only, and the refs seed from the first
+ * render's state so mounting into an already-running turn (`--resume` onto a
+ * live agent) never opens with a notification for work the user did not
+ * start. `unfocused` — the default — reads the DECSET 1004 focus state the
+ * renderer already tracks, so a user watching the stream is never alerted
+ * about something already on screen.
+ *
+ * Progress reporting is ambient rather than an alert, but `off` means off:
+ * it is gated on the same mode and cleared on unmount, in addition to the
+ * teardown sequence's own clear.
+ *
+ * @param mode - The user's notification preference.
+ * @param state - What the TUI is currently waiting on.
+ */
+export function useTurnNotification(mode: NotifyMode, state: TurnNotificationState): void {
+  const { working, awaitingApproval, awaitingQuestion, title } = state
+  const focused = useTerminalFocus()
+  const { notifyITerm2, notifyKitty, notifyGhostty, notifyBell, progress } = useTerminalNotification()
+
+  // Read through refs inside the effects: `focused` and `title` must not
+  // re-run an edge effect (a window regaining focus is not a turn ending),
+  // and the notification id counter has to survive re-renders.
+  const focusedRef = React.useRef(focused)
+  focusedRef.current = focused
+  const titleRef = React.useRef(title)
+  titleRef.current = title
+  const notifyIdRef = React.useRef(0)
+
+  const alert = React.useCallback((kind: Alert) => {
+    if (mode === 'off') return
+    if (mode === 'unfocused' && focusedRef.current) return
+    const message = t(
+      kind === 'done'
+        ? 'notify-turn-done'
+        : kind === 'approval'
+          ? 'notify-approval'
+          : 'notify-question',
+    )
+    const body = titleRef.current.trim() === '' ? message : `${message} · ${titleRef.current}`
+    switch (pickNotifyChannel()) {
+      case 'iterm2':
+        notifyITerm2({ message: body, title: 'dsh-tui' })
+        break
+      case 'kitty':
+        notifyKitty({ message: body, title: 'dsh-tui', id: ++notifyIdRef.current })
+        break
+      case 'ghostty':
+        notifyGhostty({ message: body, title: 'dsh-tui' })
+        break
+      case 'bell':
+        notifyBell()
+        break
+    }
+  }, [mode, notifyITerm2, notifyKitty, notifyGhostty, notifyBell])
+
+  const wasWorking = React.useRef(working)
+  React.useEffect(() => {
+    const ended = wasWorking.current && !working
+    wasWorking.current = working
+    if (ended) alert('done')
+  }, [working, alert])
+
+  const wasAwaitingApproval = React.useRef(awaitingApproval)
+  React.useEffect(() => {
+    const opened = !wasAwaitingApproval.current && awaitingApproval
+    wasAwaitingApproval.current = awaitingApproval
+    if (opened) alert('approval')
+  }, [awaitingApproval, alert])
+
+  const wasAwaitingQuestion = React.useRef(awaitingQuestion)
+  React.useEffect(() => {
+    const opened = !wasAwaitingQuestion.current && awaitingQuestion
+    wasAwaitingQuestion.current = awaitingQuestion
+    if (opened) alert('question')
+  }, [awaitingQuestion, alert])
+
+  React.useEffect(() => {
+    if (mode === 'off') return
+    progress(working ? 'indeterminate' : null)
+    return () => {
+      progress(null)
+    }
+  }, [mode, working, progress])
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -262,6 +262,11 @@ const dict = {
   // ── plugin.ts — /update flow ───────────────────────────────────────
   'update-aborted-no-profile': { zh: 'dsh-tui 更新中止：未解析到 dsh profile。', en: 'dsh-tui update aborted: no dsh profile resolved.' },
 
+  // ── hooks/useTurnNotification.ts ─────────────────────────────────────
+  'notify-turn-done': { zh: '本回合已完成', en: 'Turn complete' },
+  'notify-approval': { zh: '等待工具审批', en: 'Waiting for tool approval' },
+  'notify-question': { zh: '模型正在提问', en: 'The model is asking a question' },
+
   // ── components/ActivityLine.tsx ──────────────────────────────────────
   'activity-ctx-warn': { zh: '⚠ 上下文', en: '⚠ ctx ' },
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,64 @@
+/**
+ * Turn-notification domain: when the TUI asks the terminal for attention,
+ * and which escape sequence it uses to ask.
+ *
+ * The preference itself is a plain display setting — it lives in the
+ * `dsh-tui` settings namespace next to `diffLayout` (cordis.yml key +
+ * `/settings` field), not in a `~/.dsh-tui` preference file.
+ */
+
+/**
+ * When the TUI raises a notification.
+ *
+ * - `off` — never; no notification and no progress reporting.
+ * - `unfocused` — only while the terminal window does not have focus.
+ * - `always` — on every completed turn, focused or not.
+ */
+export type NotifyMode = 'off' | 'unfocused' | 'always'
+
+/** The notification modes, in `/settings` display order. */
+export const NOTIFY_MODES = ['off', 'unfocused', 'always'] as const
+
+/**
+ * The mode used when nothing is configured. Attention is only worth taking
+ * when the user is looking somewhere else, so the default stays quiet for
+ * anyone already watching the turn stream.
+ */
+export const DEFAULT_NOTIFY_MODE: NotifyMode = 'unfocused'
+
+/**
+ * Whether a value names a shipped notification mode.
+ * @param value - Candidate mode.
+ */
+export function isNotifyMode(value: unknown): value is NotifyMode {
+  return typeof value === 'string' && (NOTIFY_MODES as readonly string[]).includes(value)
+}
+
+/** The attention protocol used for one notification. */
+export type NotifyChannel = 'iterm2' | 'kitty' | 'ghostty' | 'bell'
+
+/**
+ * Pick the notification protocol for an environment.
+ *
+ * Desktop-notification escape sequences are terminal-specific and there is
+ * no capability query for them, so the emitter is chosen from the same
+ * environment markers the renderer already trusts for terminal detection
+ * (see ink/terminal.ts). WezTerm rides the iTerm2 branch: it implements the
+ * same OSC 9 payload and reports no marker the other branches claim first.
+ *
+ * Anything unrecognized falls back to BEL, which every emulator understands
+ * and which tmux turns into a window activity flag. Inside tmux/screen the
+ * inner TERM is rewritten and TERM_PROGRAM is not always forwarded, so a
+ * multiplexed session usually lands there — the multiplexer's own activity
+ * flag is the honest signal in that case anyway.
+ *
+ * @param env - Environment to inspect (injectable for tests).
+ * @returns The protocol to emit.
+ */
+export function pickNotifyChannel(env: NodeJS.ProcessEnv = process.env): NotifyChannel {
+  const program = env.TERM_PROGRAM ?? ''
+  if (program === 'ghostty' || env.GHOSTTY_RESOURCES_DIR !== undefined) return 'ghostty'
+  if (env.TERM === 'xterm-kitty' || env.KITTY_WINDOW_ID !== undefined) return 'kitty'
+  if (program === 'iTerm.app' || program === 'WezTerm') return 'iterm2'
+  return 'bell'
+}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -22,6 +22,7 @@ import type { DOMElement } from '../ink/dom.js'
 import { useSearchHighlight } from '../ink/hooks/use-search-highlight.js'
 import { useTerminalTitle } from '../ink/hooks/use-terminal-title.js'
 import { useTerminalFocus } from '../ink/hooks/use-terminal-focus.js'
+import { useTurnNotification } from '../hooks/useTurnNotification.js'
 import { useCopyOnSelect } from '../ink/hooks/use-copy-on-select.js'
 import { useSelection } from '../ink/hooks/use-selection.js'
 import { NoSelect } from '../ink/components/NoSelect.js'
@@ -490,6 +491,17 @@ export function Chat({
   useTerminalTitle(
     `${titlePrefix} 🐋 ${channel.sessionTitle}`,
   )
+  // Attention outside the viewport: a finished turn (or an agent blocked on
+  // an approval/questionnaire) notifies the terminal, and the working state
+  // drives the terminal's own progress indicator. Both are gated on
+  // `notifyMode` — `unfocused` by default, so nothing fires while the user
+  // is watching the stream.
+  useTurnNotification(channel.notifyMode, {
+    working: channel.working,
+    awaitingApproval: approvalSnapshot !== null,
+    awaitingQuestion: questionSnapshot !== null,
+    title: channel.sessionTitle,
+  })
 
   const handleWorkspaceResult = (result: TuiWorkspaceCommandResult): void => {
     workspaceFlowAbortRef.current = null


### PR DESCRIPTION
feat: 接上长任务终端通知

问题背景
用户在执行长任务时经常会切到其他窗口，等切回来才发现回合几分钟前就已经结束，体验不佳。项目中此前已有一个从 Claude Code 移植过来的 useTerminalNotification（支持 iTerm2 OSC 9、kitty OSC 99、Ghostty OSC 777、BEL、OSC 9;4 进度），但一直未接线；useTerminalFocus 也仅用于暂停标题动画。本次改动将两者串联，让终端在关键节点主动提醒用户。

解决方案
在三个时刻分别发送一次终端通知：

turn/end（回合结束）

工具审批面板弹出时

模型发起 ask_user_question 时

任务运行期间显示一个不确定进度指示（indeterminate），回合结束后自动清除。

实现细节
src/notifications.ts：定义 NotifyMode，新增 pickNotifyChannel，根据环境变量选择通知协议：

iTerm2 / WezTerm → OSC 9

kitty → OSC 99

Ghostty → OSC 777

其余 → BEL（在 tmux 中也可作为窗口活动标记）

src/hooks/useTurnNotification.ts：通知仅在状态边沿触发。使用 ref 保存首帧状态做“播种”，确保挂载时若回合已在运行（如 --resume 接上活跃 agent），不会在开局误发通知。focused / title 均通过 ref 读取，窗口重新获得焦点不会被误判为回合结束。

默认模式为 unfocused：依赖 DECSET 1004 获取焦点事件；若终端不上报焦点状态，则按“已聚焦”处理，避免无谓打扰。off 模式会连进度指示一起关闭。

配置统一走 dsh-tui 命名空间的 notify 键，与 diffLayout 一样支持 /settings 实时修改；并在 cordis.yml / cordis.patch.yml 中添加注释示例。

测试
新增 verify-notifications.mjs，覆盖：

协议选择逻辑

边沿语义（挂载不发、开始不发、结束发）

unfocused 模式对焦点状态的尊重

off 模式全关

BEL 兜底

测试已挂入 CI。

影响范围
无破坏性变更，默认行为不打扰用户，所有功能均通过配置主动开启。