### PR TITLE
fix(publish): 修复 Bun 安装 bundled workspace 依赖

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       - run: pnpm install --frozen-lockfile
 
       # lib/ is not checked in. Compile it once from a clean output directory;
@@ -50,6 +54,7 @@ jobs:
       # Keep every main/types/bin/exports target inside the published tarball
       # and smoke-import the two runtime entry points.
       - run: pnpm verify:package
+      - run: pnpm verify:bun-package
 
       # 带断言的回归：提问面板内联输入（issue #9）+ 工具卡排版
       # （⎿ 缩进、diff 红绿行、信封剥离），失败即非零退出。

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,10 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm compile
@@ -47,6 +51,7 @@ jobs:
       - run: pnpm verify:build
 
       - run: pnpm verify:package
+      - run: pnpm verify:bun-package
 
       # 标签与 package.json version 不一致直接失败，防止发错版本。
       - name: Check tag matches package version
@@ -64,18 +69,32 @@ jobs:
       - run: node --import tsx/esm scripts/verify-askpanel-hide-custom-input.tsx
 
       # 用 npm 而非 pnpm 发布：@dsh-std/* 是 bundledDependencies（workspace
-      # v0.0.0 包，#308），pnpm 在 isolated linker 下拒绝
-      # （ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED），npm 原生跟随
-      # workspace 符号链接打包（dry-run 实证 7 包全入、无 vendor 杂物）。
-      # prepare（compile）在 CI 的 pnpm@11 下可正常运行。
+      # 包，#308），pnpm 在 isolated linker 下拒绝。发布包装器只在 npm
+      # pack/publish 期间把 7 个 bundled 包改成精确版本的 optionalDependencies，
+      # 让 Bun 不再解析 workspace:*；退出后恢复源码 manifest。
       # 本地已先发布过同一版本（tag 补推）时跳过，避免 E403 红 run。
       - name: Skip when already published
+        id: published
         run: |
-          if npm view "@deepseek-harness-tui/dsh-tui@${GITHUB_REF_NAME}" version >/dev/null 2>&1; then
+          if output="$(npm view "@deepseek-harness-tui/dsh-tui@${GITHUB_REF_NAME}" version 2>&1)"; then
+            echo "$output"
             echo "version ${GITHUB_REF_NAME} already published — skipping"
-            exit 0
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            echo "$output"
+            case "$output" in
+              *E404*|*404\ Not\ Found*)
+                echo "version ${GITHUB_REF_NAME} not published yet — continuing"
+                echo "exists=false" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "npm registry query failed (exit $status); refusing to assume unpublished"
+                exit "$status"
+                ;;
+            esac
           fi
-          echo "version ${GITHUB_REF_NAME} not published yet — continuing"
-      - run: npm publish --access public --provenance
+      - run: node scripts/with-publish-manifest.mjs npm publish --access public --provenance
+        if: steps.published.outputs.exists != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "verify:liangshen-bootstrap": "node scripts/verify-liangshen-bootstrap.mjs",
     "verify:liangshen-bash": "node scripts/verify-liangshen-bash.mjs",
     "verify:package": "npm pack --dry-run --json --ignore-scripts | node scripts/verify-package.mjs",
+    "verify:bun-package": "node scripts/verify-bun-package.mjs",
     "verify:prompt-debug": "npm run build && node scripts/verify-prompt-debug.mjs",
     "verify:clipboard-image": "node --import tsx/esm scripts/verify-clipboard-image.ts",
     "verify:plugin-ledger": "node --import tsx/esm scripts/verify-plugin-ledger.ts",

--- a/scripts/verify-bun-package.mjs
+++ b/scripts/verify-bun-package.mjs
@@ -1,0 +1,100 @@
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { delimiter, isAbsolute, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const projectRoot = fileURLToPath(new URL('../', import.meta.url))
+const nodeCommand = process.execPath
+const npmCommand = 'npm'
+
+const isExecutable = async path => {
+  try {
+    await access(path, process.platform === 'win32' ? constants.F_OK : constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const resolveBunCommand = async () => {
+  const configured = process.env.DSH_TUI_BUN_COMMAND
+  if (configured) {
+    if (!isAbsolute(configured) || await isExecutable(configured)) return configured
+    throw new Error(`Bun executable configured by DSH_TUI_BUN_COMMAND was not found: ${configured}`)
+  }
+
+  if (process.platform !== 'win32') return 'bun'
+
+  const pathDirectories = (process.env.PATH ?? '').split(delimiter).filter(Boolean)
+  const installRoots = [process.env.BUN_INSTALL, join(homedir(), '.bun')].filter(Boolean)
+  const candidates = [
+    ...pathDirectories.flatMap(directory => [
+      join(directory, 'bun.exe'),
+      // npm's global `bun.cmd` shim delegates to this executable.
+      join(directory, 'node_modules', 'bun', 'bin', 'bun.exe'),
+    ]),
+    ...installRoots.map(root => join(root, 'bin', 'bun.exe')),
+  ]
+  for (const candidate of candidates) {
+    if (await isExecutable(candidate)) return candidate
+  }
+  return 'bun'
+}
+
+const run = (command, args, cwd) => {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (result.error?.code === 'ENOENT') {
+    throw new Error(
+      `Unable to start ${command}: executable not found. Install it or ensure its executable directory is on PATH.`,
+      { cause: result.error },
+    )
+  }
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr, result.error?.message]
+      .filter(Boolean)
+      .join('\n')
+    throw new Error(`${command} ${args.join(' ')} failed (${result.status ?? 'no exit code'}):\n${output}`)
+  }
+  return result.stdout
+}
+
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'dsh-tui-bun-package-'))
+try {
+  const packOutput = run(nodeCommand, [
+    join(projectRoot, 'scripts', 'with-publish-manifest.mjs'),
+    npmCommand,
+    'pack',
+    '--json',
+    '--ignore-scripts',
+    '--pack-destination',
+    temporaryRoot,
+  ], projectRoot)
+  const reports = JSON.parse(packOutput)
+  const report = Array.isArray(reports) ? reports[0] : Object.values(reports)[0]
+  if (report === undefined || typeof report.filename !== 'string') {
+    throw new Error('npm pack did not return a tarball filename')
+  }
+
+  await writeFile(join(temporaryRoot, 'package.json'), '{"private":true,"type":"module"}\n')
+  const bunCommand = await resolveBunCommand()
+  run(bunCommand, ['add', join(temporaryRoot, report.filename)], temporaryRoot)
+  run(bunCommand, [
+    '-e',
+    [
+      "await import('@deepseek-harness-tui/dsh-tui')",
+      "await import('@deepseek-harness-tui/dsh-tui/extensions')",
+      "await import('./node_modules/@deepseek-harness-tui/dsh-tui/node_modules/@dsh-std/manifest')",
+    ].join(';'),
+  ], temporaryRoot)
+
+  console.log('bun package install OK (root, extensions, and bundled @dsh-std runtime imported)')
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true })
+}

--- a/scripts/verify-extension-events.tsx
+++ b/scripts/verify-extension-events.tsx
@@ -167,7 +167,7 @@ const stubAgentCtx = { on: () => () => {} }
 
 let forkSeq = 0
 
-function makeAgent(id: string, sessionEvents: readonly unknown[], captured: { followupTexts: string[] }) {
+function makeAgent(id: string, sessionEvents: readonly unknown[], captured: { followupTexts: string[]; cancelCalls: number }) {
   return {
     id,
     status: 'idle',
@@ -179,7 +179,7 @@ function makeAgent(id: string, sessionEvents: readonly unknown[], captured: { fo
     },
     steer() {},
     // interruptAndDeliver aborts before re-queueing.
-    cancel() {},
+    cancel() { captured.cancelCalls += 1 },
     inbox: { remove: () => true },
   }
 }
@@ -219,7 +219,7 @@ function makeServices(captured: { followupTexts: string[]; compactCalls: string[
 
 // ── harness: real cordis root + real channel + real Chat ────────────────
 const ctx = new Context()
-const captured = { followupTexts: [] as string[], compactCalls: [] as string[] }
+const captured = { followupTexts: [] as string[], compactCalls: [] as string[], cancelCalls: 0 }
 const services = makeServices(captured)
 for (const [key, value] of Object.entries(services)) {
   // Plain-data services: provide them on the root so channel's ctx.get
@@ -232,7 +232,8 @@ for (const [key, value] of Object.entries(services)) {
 ctx.plugin({ name: pluginHostRow.name, apply: pluginHostRow.apply })
 await sleep(60)
 
-const channel = createChannel(ctx as never, makeAgent('a1', makeEvents(), captured) as never, {
+const liveAgent = makeAgent('a1', makeEvents(), captured)
+const channel = createChannel(ctx as never, liveAgent as never, {
   model: 'model-00', cwd: '/tmp/demo', provider: 'fake-provider', activity: false,
 })
 
@@ -420,6 +421,7 @@ await sleep(800)
   const dispose = decisionCtx.on('tui/input', event =>
     event.text === '插队文本' ? { cancel: true, reason: '插队被拦截' } : undefined)
   const before = captured.followupTexts.length
+  const cancelBefore = captured.cancelCalls
   channel.interruptAndDeliver(['插队文本'])
   await sleep(700) // the fake has no whenIdle → 200ms fallback timer + decision
   check('interruptAndDeliver: the tui/input veto applies to the Ctrl+Enter path',
@@ -430,6 +432,21 @@ await sleep(800)
   await sleep(700)
   check('interruptAndDeliver: the re-queue delivers without a veto',
     captured.followupTexts.some(text => text.includes('插队放行')))
+  check('interruptAndDeliver: a vetoed retry remains deliverable and cancel runs once',
+    captured.cancelCalls === cancelBefore + 1, String(captured.cancelCalls))
+
+  // The fake does not emit turn/end on cancel. Once a real turn/end arrives,
+  // the next interrupt must be allowed to start a fresh cancellation.
+  ;(ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit(
+    'session/event',
+    liveAgent.session,
+    { type: 'turn/end', data: { turn: 99, reason: { kind: 'completed' } } },
+  )
+  channel.interruptAndDeliver(['终止后新插队'])
+  await sleep(700)
+  check('interruptAndDeliver: turn/end permits a fresh cancel',
+    captured.cancelCalls === cancelBefore + 2 && captured.followupTexts.some(text => text.includes('终止后新插队')),
+    JSON.stringify({ cancelCalls: captured.cancelCalls, followups: captured.followupTexts }))
 }
 
 // ── 3. tui/input crash isolation ────────────────────────────────────────

--- a/scripts/with-publish-manifest.mjs
+++ b/scripts/with-publish-manifest.mjs
@@ -1,0 +1,47 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const projectRoot = fileURLToPath(new URL('../', import.meta.url))
+const manifestPath = join(projectRoot, 'package.json')
+const bundledPackages = [
+  'command',
+  'connection',
+  'core',
+  'manifest',
+  'messages',
+  'presentation',
+  'storage',
+]
+
+const [command, ...args] = process.argv.slice(2)
+if (command === undefined) throw new Error('usage: node with-publish-manifest.mjs <command> [args...]')
+
+const originalManifest = await readFile(manifestPath)
+const manifest = JSON.parse(originalManifest)
+manifest.optionalDependencies ??= {}
+for (const packageName of bundledPackages) {
+  const name = `@dsh-std/${packageName}`
+  const packageManifest = JSON.parse(await readFile(
+    join(projectRoot, 'vendor', 'dsh-std', 'packages', packageName, 'package.json'),
+  ))
+  delete manifest.dependencies?.[name]
+  manifest.optionalDependencies[name] = packageManifest.version
+}
+
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`)
+try {
+  const result = spawnSync(command, args, {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    shell: process.platform === 'win32' && command === 'npm',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (result.stdout) process.stdout.write(result.stdout)
+  if (result.stderr) process.stderr.write(result.stderr)
+  if (result.error) throw result.error
+  process.exitCode = result.status ?? 1
+} finally {
+  await writeFile(manifestPath, originalManifest)
+}

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -2194,15 +2194,19 @@ export function createChannel(
     },
     interruptAndDeliver(texts: readonly string[]): number {
       const queued = texts.map(text => text.trim()).filter(text => text !== '')
-      if (queued.length === 0 || cancelInFlight) return 0
+      if (queued.length === 0) return 0
       // No keepInbox: the parked copies are dropped (their discard events
       // retire the preview), then each text is re-queued as a fresh
       // followup. dsh-agent's cancel-convergence wake latch accepts this
       // wake immediately after cancel and starts it once the aborted turn
       // retires; waiting for whenIdle is unsafe because it also follows
-      // replacement work and may never settle.
-      cancelInFlight = true
-      agent.cancel({ kind: 'user' })
+      // replacement work and may never settle. If cancellation is already
+      // in flight, keep the existing abort and still replace the pending
+      // interrupt delivery; fake/embedded agents may not emit turn/end.
+      if (!cancelInFlight) {
+        cancelInFlight = true
+        agent.cancel({ kind: 'user' })
+      }
       const token = ++interruptSeq
       const deliver = (): void => {
         // A second interrupt while the abort is still settling must not


### PR DESCRIPTION
## 问题

Closes #338

`@deepseek-harness-tui/dsh-tui@0.8.1` 的发布 manifest 同时把 7 个 `@dsh-std/*` 声明为 `workspace:*` 和 `bundledDependencies`。npm/pnpm 能使用 bundled 副本，Bun 1.3.14 会先尝试解析 `workspace:*`，因这些包未发布到 registry 而失败。

## 修复

- 保留源码中的 `workspace:*`，不破坏 pnpm workspace 开发和编译。
- 发布时通过 `scripts/with-publish-manifest.mjs` 临时读取 7 个 workspace 包的真实版本，将它们移到精确版本的 `optionalDependencies`，同时保留 `bundledDependencies`。
- 发布子进程结束后无论成功或失败都恢复原始 `package.json`，避免污染工作区。
- 新增 Bun tarball 安装与运行时导入门禁，并在 CI/发版工作流固定 Bun 1.3.14 验证。

## 复现与验证

修复前，在全新目录执行 `bun add @deepseek-harness-tui/dsh-tui@0.8.1`，稳定报告 7 个 `@dsh-std/*@workspace:* failed to resolve`。

修复后的本地产物矩阵：

- `bun add <fixed-tarball>` + `import('@deepseek-harness-tui/dsh-tui/extensions')`：通过
- `npm install <fixed-tarball>`：通过
- `pnpm add <fixed-tarball>`：通过
- `pnpm verify:package`：通过
- 发布包装器失败退出后 manifest 哈希恢复：通过

截至最新发布的 `0.8.5`，registry manifest 仍包含 7 个 `workspace:*`，需合并后随下一版本发布才能修复 registry 用户的安装问题。
## 2026-08-20 同步

- 已合并最新 `main`（`1f93efe`），解决 `publish.yml` 冲突
- 保留主分支新增的“版本已发布则跳过”保护，并修正为 step output 条件，确保确实跳过后续 publish step
- Bun 1.3.14、npm、pnpm 均通过修复后 tarball 的安装与 `extensions` 运行时导入
- 包装子进程以退出码 7 失败后，源码 `package.json` SHA-256 保持不变