### PR TITLE
fix(exit): 修复 Ctrl+C 退出时 stdin EIO 崩溃

### DIFF
--- a/scripts/verify-shutdown-stderr.tsx
+++ b/scripts/verify-shutdown-stderr.tsx
@@ -54,6 +54,15 @@ check('Ink installs the stderr guard while the TUI is mounted', patchedStderrWri
 const sigcontListenersBefore = process.listenerCount('SIGCONT')
 const resizeListenersBefore = stdout.listenerCount('resize')
 const stdinListenersBefore = stdin.listenerCount('readable')
+const activeEio = Object.assign(new Error('read EIO'), {code: 'EIO'})
+let activeEioEscaped = false
+try {
+  stdin.emit('error', activeEio)
+} catch (error) {
+  activeEioEscaped = error === activeEio
+}
+check('Ink does not absorb stdin EIO while the TUI is active', activeEioEscaped)
+
 const runtime = instances.get(stdout)
 runtime?.detachForShutdown()
 
@@ -63,6 +72,28 @@ check('shutdown detach removes the SIGCONT listener', process.listenerCount('SIG
 check('shutdown detach removes the stdout resize listener', stdout.listenerCount('resize') < resizeListenersBefore)
 check('Ink owns a stdin reader before shutdown detach', stdinListenersBefore > 0)
 check('shutdown detach removes the stdin reader', stdin.listenerCount('readable') < stdinListenersBefore)
+
+const lateEio = Object.assign(new Error('read EIO'), {
+  code: 'EIO',
+  errno: -5,
+  syscall: 'read',
+})
+let lateEioEscaped = false
+try {
+  stdin.emit('error', lateEio)
+} catch (error) {
+  lateEioEscaped = error === lateEio
+}
+check('shutdown detach absorbs a late stdin EIO', !lateEioEscaped)
+
+const unexpectedStdinError = Object.assign(new Error('read EPERM'), {code: 'EPERM'})
+let unexpectedErrorEscaped = false
+try {
+  stdin.emit('error', unexpectedStdinError)
+} catch (error) {
+  unexpectedErrorEscaped = error === unexpectedStdinError
+}
+check('shutdown detach does not absorb unexpected stdin errors', unexpectedErrorEscaped)
 
 stdin.write('x')
 await new Promise(resolve => setImmediate(resolve))

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -189,8 +189,19 @@ export default class Ink {
     x: number;
     y: number;
   } | null = null;
+  private handleStdinError(error: NodeJS.ErrnoException): void {
+    if (this.isUnmounted && error.code === 'EIO') {
+      return;
+    }
+    throw error;
+  }
   constructor(private readonly options: Options) {
     autoBind(this);
+    if (options.stdin.isTTY) {
+      // Keep this listener through teardown: a pending libuv TTY read can
+      // report EIO only after raw mode and React have already been released.
+      options.stdin.on('error', this.handleStdinError);
+    }
     if (this.options.patchConsole) {
       this.restoreConsole = this.patchConsole();
       this.restoreStderr = this.patchStderr();


### PR DESCRIPTION
## 问题

Ctrl+C 退出 TUI 时，raw mode 关闭后仍可能有一个 libuv TTY read 在途。macOS 会把这个迟到的读取报告为 `EIO`；stdin 没有错误守卫时，Node 会以未处理的 `error` 事件打印堆栈并返回非零退出码。

## 修改

- 在 Ink 生命周期层为 TTY stdin 安装错误守卫，并保留到退出完成，覆盖 raw mode/React 已拆除后才到达的错误。
- 仅当 Ink 已进入卸载状态且错误码为 `EIO` 时忽略该错误；运行中的 `EIO` 和任何其他错误仍会抛出。
- 扩展现有 shutdown 回归，覆盖运行中 EIO、退出后迟到 EIO、非 EIO 及 stdin 读取器释放。

## 复现与验证

修复前运行聚焦回归（RED）：

```text
FAIL: shutdown detach absorbs a late stdin EIO
PASS: shutdown detach does not absorb unexpected stdin errors
exit=1
```

修复后（GREEN）：

```text
PASS: Ink does not absorb stdin EIO while the TUI is active
PASS: shutdown detach absorbs a late stdin EIO
PASS: shutdown detach does not absorb unexpected stdin errors
PASS: detached Ink does not consume input meant for the replacement process
```

已运行：

- `node --import tsx/esm scripts/verify-shutdown-stderr.tsx`
- `npx tsc --noEmit -p tsconfig.json`
- `pnpm build`
- `pnpm verify:package`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/repro-askpanel.tsx`
- `DSH_TUI_LANG=zh node --import tsx/esm scripts/verify-askpanel-layout.tsx`
- `node --import tsx/esm scripts/repro-toolcards.tsx`
- `git diff --check`

以上全部通过。本机为 Windows，无法让 macOS 内核真实返回 TTY `EIO`；回归通过同一 Node ReadStream `error` 事件缝确定性复现退出后的错误时序与错误对象。

Closes #353