### PR TITLE
docs: 命令清单补充 dsh-tui-vscode.insertAtMention(0.6.2)

### DIFF
--- a/docs/vscode.en.md
+++ b/docs/vscode.en.md
@@ -107,6 +107,7 @@ appears; clicking it starts a new session (`dsh-tui-vscode.open`).
 | `dsh-tui-vscode.kill` | Terminate session / 终止会话 | Send Ctrl+C to the most recent terminal |
 | `dsh-tui-vscode.refreshSessions` | Refresh sessions / 刷新会话列表 | Manually refresh the sidebar |
 | `dsh-tui-vscode.resumeSession` | Resume session / 恢复会话 | Resume a specific session (sidebar click) |
+| `dsh-tui-vscode.insertAtMention` | Insert @-mention / 插入 @文件引用 | With editor focus press `Ctrl+Alt+K` (macOS `Cmd+Alt+K`) or the editor context menu: inserts the current file / selection as `@absolute/path Lstart-end` into the dsh-tui input box (the absolute path is independent of the dsh-tui session cwd; whole file when nothing is selected; falls back to the clipboard with no running session) |
 
 ### Architecture
 

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -91,6 +91,7 @@ npm run package && code --install-extension dsh-tui-vscode-0.5.1.vsix --force
 | `dsh-tui-vscode.kill` | Terminate session / 终止会话 | 向最近终端发送 Ctrl+C |
 | `dsh-tui-vscode.refreshSessions` | Refresh sessions / 刷新会话列表 | 手动刷新侧边栏 |
 | `dsh-tui-vscode.resumeSession` | Resume session / 恢复会话 | 恢复指定会话（侧边栏点击） |
+| `dsh-tui-vscode.insertAtMention` | Insert @-mention / 插入 @文件引用 | 编辑器聚焦时按 `Ctrl+Alt+K`（macOS `Cmd+Alt+K`）或编辑器右键：把当前文件/选中代码以 `@绝对路径 L起-止` 插入 dsh-tui 输入框（绝对路径与 dsh-tui 会话 cwd 无关；未选中引用整个文件；无运行会话回退为复制到剪贴板） |
 
 ### 架构与机制
 


### PR DESCRIPTION
## 内容 / Content

在命令清单补充 dsh-tui-vscode 0.6.2 新增的命令 `dsh-tui-vscode.insertAtMention`
（于 baobaolaodie/dsh-tui-vscode 实现）：`Ctrl/Cmd+Alt+K` 或编辑器右键把当前
文件/选中代码以 `@绝对路径 L起-止` 引用进 dsh-tui 输入框。

## 验证 / Verification

- dsh-tui-vscode v0.6.2 已发布,命令确实存在;
- 中英文档镜像同步(vscode.md / vscode.en.md)。