### PR TITLE
fix(bin): detect ERR_PNPM_ADDING_TO_ROOT on stdout and verify install landed

### DIFF
--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -63,6 +63,24 @@ const MSG = {
     en: `[dsh-tui] Plugin install failed. Retry manually later:\n  dsh plugin --profile ${PROFILE} add -w ${PACKAGE}@${ownVersion}`,
     zh: `[dsh-tui] 插件安装失败。可稍后手工重试：\n  dsh plugin --profile ${PROFILE} add -w ${PACKAGE}@${ownVersion}`,
   },
+  // no-op 假成功（自举后复查发现判定文件依旧缺失）：pnpm 把包文件残缺的
+  // profile 视为 already up to date，重装什么都不做却报告成功；继续启动
+  // 只会以 cannot resolve profile bundle 崩溃，而崩溃提示的 `plugin
+  // install` 同样 no-op——用户会陷入「每步都成功、每次都崩」的循环。
+  bootstrapUnreadable: {
+    en: dir =>
+      `[dsh-tui] install reported success but the plugin package is still unreadable under:\n` +
+      `  ${dir}\n` +
+      `  pnpm treats this half-installed profile as already up to date, so every retry\n` +
+      `  reports success while boot keeps failing. Recovery:\n` +
+      `  rm -rf ${dir} && dsh-tui`,
+    zh: dir =>
+      `[dsh-tui] 安装报告成功，但插件包仍不可读：\n` +
+      `  ${dir}\n` +
+      `  pnpm 把半残的 profile 视为已装好，重试永远「成功」而启动照旧崩溃。\n` +
+      `  恢复方法：\n` +
+      `  rm -rf ${dir} 后重新运行 dsh-tui`,
+  },
   versionMismatch: {
     en: (installed, own) =>
       `[dsh-tui] note: the profile is running v${installed} but this launcher is v${own}.\n` +
@@ -140,11 +158,12 @@ const dshHome = process.env.DSH_HOME || join(homedir(), '.dsh')
 const profileDir = join(dshHome, 'profiles', PROFILE)
 // 以已装包的 package.json 可读为准（而非目录存在）：安装中途失败留下的
 // 残骸目录会触发重新安装，而不是以坏 profile 直接启动。
+// 包可读判定文件：installedVersion 读取与自举后的复查共用（残缺 profile
+// 的 no-op 假成功靠它识别——见 bootstrapUnreadable）。
+const installedPkgPath = join(profileDir, 'node_modules', '@deepseek-harness-tui', 'dsh-tui', 'package.json')
 let installedVersion
 try {
-  installedVersion = JSON.parse(
-    readFileSync(join(profileDir, 'node_modules', '@deepseek-harness-tui', 'dsh-tui', 'package.json'), 'utf8'),
-  ).version
+  installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf8')).version
 } catch {
   installedVersion = undefined
 }
@@ -157,20 +176,40 @@ if (installedVersion === undefined) {
   console.log(msg('bootstrapStart'))
   // pnpm ≥11 在带 pnpm-workspace.yaml 的 profile 目录里可能拒绝向
   // workspace root 写依赖（ERR_PNPM_ADDING_TO_ROOT，issue #239）：识别该
-  // 错误时带 -w 重试一次。stderr 走 pipe 捕获供识别，stdout 保持
-  // inherit 让用户实时看到安装进度；手工重试提示同步带 -w。
-  const runAdd = extraArgs => spawnSync(
+  // 错误时带 -w 重试一次。签名在 stdout——pnpm 的错误报告写 stdout（经
+  // dsh 原样转发），stderr 上只有 dsh 自己的失败说明，识别 stderr 永远
+  // 匹配不到（PR #241 的回归）。因此首次 add 的 stdout/stderr 都走 pipe
+  // 捕获，结束后回放（失败回 stderr 保诊断，成功回 stdout 保进度，代价
+  // 是不再实时）；-w 重试大概率成功，恢复 inherit 让进度实时可见。手工
+  // 重试提示同步带 -w。
+  const runAdd = (extraArgs, capture) => spawnSync(
     ...cmd('dsh', ['plugin', '--profile', PROFILE, 'add', ...extraArgs, `${PACKAGE}@${ownVersion}`]),
-    { stdio: ['inherit', 'inherit', 'pipe'], ...shellOpt },
+    { stdio: capture ? ['inherit', 'pipe', 'pipe'] : 'inherit', ...shellOpt },
   )
-  let add = runAdd([])
-  if (add.status !== 0 && String(add.stderr).includes('ERR_PNPM_ADDING_TO_ROOT')) {
-    console.log(msg('bootstrapRetryW'))
-    add = runAdd(['-w'])
+  let add = runAdd([], true)
+  if (add.status !== 0) {
+    const captured = `${add.stdout ?? ''}${add.stderr ?? ''}`
+    process.stderr.write(captured)
+    if (captured.includes('ERR_PNPM_ADDING_TO_ROOT')) {
+      console.log(msg('bootstrapRetryW'))
+      add = runAdd(['-w'], false)
+    }
+  } else {
+    process.stdout.write(`${add.stdout ?? ''}${add.stderr ?? ''}`)
   }
   if (add.status !== 0) {
     console.error(msg('installFailed'))
     process.exit(add.status ?? 1)
+  }
+  // 自举后复查：pnpm 对包文件残缺的 profile 视为 already up to date，
+  // add 报告成功却什么都没装（no-op 假成功）。此时继续启动只会以 cannot
+  // resolve profile bundle 崩溃，提示的 `plugin install` 又同样 no-op——
+  // fail loud 给出唯一可靠的恢复路径（删 profile 目录重建）。
+  try {
+    readFileSync(installedPkgPath, 'utf8')
+  } catch {
+    console.error(MSG.bootstrapUnreadable[lang](profileDir))
+    process.exit(1)
   }
 } else if (installedVersion !== ownVersion) {
   // Reverse skew is fatal (see MSG.profileOlderThanLauncher): compare

--- a/scripts/verify-launcher.mjs
+++ b/scripts/verify-launcher.mjs
@@ -6,6 +6,10 @@
  *   - 参数原样透传给 `dsh --profile dsh-tui`（含空格参数不拆分）
  *   - 残骸 profile（目录在、package.json 不可读）触发重新自举，且版本号
  *     与本包对齐
+ *   - ERR_PNPM_ADDING_TO_ROOT 签名在 stdout（issue #239 / PR #241 回归）：
+ *     识别后带 -w 恰好重试一次；无签名失败不盲重试
+ *   - no-op 假成功（add 成功但判定文件缺失）：fail loud 给出删 profile
+ *     重建的恢复路径，而不是继续启动后 opaque 崩溃
  *   - profile 已装版本与启动器不一致时打印提示；前向错位（profile 更新）
  *     不阻塞启动（0.7.2 起 TUI 降级可用），反向错位（profile 更旧，issue
  *     #183）拒绝启动并给出对齐命令——dsh CLI 会从启动器拷贝读 bundle
@@ -43,8 +47,14 @@ const stubLog = join(tmp, 'stub.log')
 const isWin = process.platform === 'win32'
 mkdirSync(stubDir, { recursive: true })
 // argv 逐参数 <angle> 编码，参数被拆分时一目了然；DSH_STUB_EXIT 只让真正
-// 的 profile 子进程失败，`dsh --version` 预检始终成功。
-writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\nfor a in "$@"; do printf \'<%s>\' "$a"; done >> "$DSH_STUB_LOG"\nprintf \'\\n\' >> "$DSH_STUB_LOG"\nif [ "$1" = "--profile" ]; then exit "${DSH_STUB_EXIT:-0}"; fi\nexit 0\n')
+// 的 profile 子进程失败，`dsh --version` 预检始终成功。plugin add 可控：
+// DSH_STUB_ADD_FAILS=N 让前 N 次 add 失败——DSH_STUB_ADD_SIG 写到 stdout、
+// DSH_STUB_ADD_EXIT_CODE 定退出码（签名在 stdout 对齐 pnpm/dsh 真实转发
+// 行为；PR #241 的回归正是把签名当成了 stderr，故必须断言 stdout 路径）；
+// 成功路径模拟真实安装创建判定文件（DSH_STUB_PKG_VERSION），DSH_STUB_ADD_
+// NOCREATE=1 模拟 no-op 假成功（pnpm 对残缺 profile 的 already-up-to-date
+// 行为：报告成功、什么都不装）。
+writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\nfor a in "$@"; do printf \'<%s>\' "$a"; done >> "$DSH_STUB_LOG"\nprintf \'\\n\' >> "$DSH_STUB_LOG"\nif [ "$1" = "plugin" ]; then\n  c="$DSH_STUB_LOG.count"\n  n=$(cat "$c" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "$c"\n  if [ "$n" -le "${DSH_STUB_ADD_FAILS:-0}" ]; then\n    [ -n "$DSH_STUB_ADD_SIG" ] && printf \'%s\\n\' "$DSH_STUB_ADD_SIG"\n    exit "${DSH_STUB_ADD_EXIT_CODE:-1}"\n  fi\n  if [ -z "$DSH_STUB_ADD_NOCREATE" ]; then\n    d="$DSH_HOME/profiles/dsh-tui/node_modules/@deepseek-harness-tui/dsh-tui"\n    mkdir -p "$d" && printf \'{"version":"%s"}\' "${DSH_STUB_PKG_VERSION:-0.0.0-stub}" > "$d/package.json"\n  fi\n  exit 0\nfi\nif [ "$1" = "--profile" ]; then exit "${DSH_STUB_EXIT:-0}"; fi\nexit 0\n')
 writeFileSync(join(stubDir, 'pnpm'), '#!/bin/sh\nexit 0\n')
 chmodSync(join(stubDir, 'dsh'), 0o755)
 chmodSync(join(stubDir, 'pnpm'), 0o755)
@@ -54,7 +64,7 @@ chmodSync(join(stubDir, 'pnpm'), 0o755)
 if (isWin) {
   writeFileSync(
     join(stubDir, 'dsh.cmd'),
-    '@echo off\r\nnode -e "const fs=require(\'fs\');const a=process.argv.slice(1);fs.appendFileSync(process.env.DSH_STUB_LOG,a.map(v=>\'<\'+v+\'>\').join(\'\')+\'\\n\');process.exit(a[0]===\'--profile\'?Number(process.env.DSH_STUB_EXIT||0):0)" -- %*\r\n@exit /b %errorlevel%\r\n',
+    '@echo off\r\nnode -e "const fs=require(\'fs\');const a=process.argv.slice(1);fs.appendFileSync(process.env.DSH_STUB_LOG,a.map(v=>\'<\'+v+\'>\').join(\'\')+\'\\n\');if(a[0]===\'plugin\'){const c=process.env.DSH_STUB_LOG+\'.count\';let n=0;try{n=Number(fs.readFileSync(c,\'utf8\'))||0}catch(e){}n++;fs.writeFileSync(c,String(n));if(n<=Number(process.env.DSH_STUB_ADD_FAILS||0)){if(process.env.DSH_STUB_ADD_SIG)console.log(process.env.DSH_STUB_ADD_SIG);process.exit(Number(process.env.DSH_STUB_ADD_EXIT_CODE||1));}if(!process.env.DSH_STUB_ADD_NOCREATE){const d=process.env.DSH_HOME+\'/profiles/dsh-tui/node_modules/@deepseek-harness-tui/dsh-tui\';fs.mkdirSync(d,{recursive:true});fs.writeFileSync(d+\'/package.json\',JSON.stringify({version:process.env.DSH_STUB_PKG_VERSION||\'0.0.0-stub\'}));}process.exit(0);}process.exit(a[0]===\'--profile\'?Number(process.env.DSH_STUB_EXIT||0):0)" -- %*\r\n@exit /b %errorlevel%\r\n',
     'ascii',
   )
   writeFileSync(join(stubDir, 'pnpm.cmd'), '@echo off\r\n@exit /b 0\r\n', 'ascii')
@@ -77,6 +87,7 @@ function setProfileVersion(version) {
 
 function resetStubLog() {
   writeFileSync(stubLog, '')
+  rmSync(`${stubLog}.count`, { force: true })
 }
 function stubCalls() {
   return readFileSync(stubLog, 'utf8').trim().split('\n').filter(Boolean)
@@ -89,6 +100,9 @@ function runBin(args, extraEnv = {}) {
       HOME: tmp,
       DSH_HOME: home,
       DSH_STUB_LOG: stubLog,
+      // stub 安装创建的判定文件版本默认与启动器对齐——否则自举后的版本
+      // 比较会以错位提示污染「静默启动」类断言。
+      DSH_STUB_PKG_VERSION: ownVersion,
       // 启动器 spawn(shell:true) 在 Windows 触 DEP0190 弃用警告，
       // 会污染「静默启动」类断言的 stderr——测试环境下关掉。
       NODE_OPTIONS: '--no-deprecation',
@@ -106,6 +120,44 @@ check('bootstrap: broken profile triggers reinstall', stubCalls().some(c => c.in
 check('bootstrap: pinned to the launcher version', stubCalls().some(c => c.includes(`<@deepseek-harness-tui/dsh-tui@${ownVersion}>`)))
 check('bootstrap: launches after reinstall', stubCalls().at(-1) === '<--profile><dsh-tui>')
 check('bootstrap: exits 0', r.status === 0)
+
+// --- 1.5 ERR_PNPM_ADDING_TO_ROOT 签名在 stdout（issue #239 / PR #241 回归）：
+// 签名经 dsh 的 stdout 转发（pnpm 错误报告写 stdout），#241 只查 stderr 导致
+// 识别永不触发、全新自举仍必败——识别必须覆盖捕获的 stdout，重试后安装成功。
+setProfileVersion(undefined)
+resetStubLog()
+r = runBin([], {
+  DSH_STUB_ADD_FAILS: '1',
+  DSH_STUB_ADD_SIG: 'ERR_PNPM_ADDING_TO_ROOT Running this command will add the dependency to the workspace root',
+  DSH_TUI_LANG: 'en',
+})
+const addCalls = () => stubCalls().filter(c => c.includes('<plugin>') && c.includes('<add>'))
+const launchCalls = () => stubCalls().filter(c => c.startsWith('<--profile>'))
+check('root-refusal: retries exactly once with -w', addCalls().length === 2 && addCalls()[1].includes('<-w>'))
+check('root-refusal: retry notice printed', r.stdout.includes('retrying with -w'))
+check('root-refusal: captured refusal replayed to the user', r.stderr.includes('ERR_PNPM_ADDING_TO_ROOT'))
+check('root-refusal: launches after the retry', stubCalls().at(-1) === '<--profile><dsh-tui>' && r.status === 0)
+
+// --- 1.6 无签名的失败：不盲目 -w 重试，按普通安装失败处理 -------------
+setProfileVersion(undefined)
+resetStubLog()
+r = runBin([], { DSH_STUB_ADD_FAILS: '9', DSH_STUB_ADD_EXIT_CODE: '3', DSH_TUI_LANG: 'en' })
+check('other failure: no -w retry without the signature', addCalls().length === 1 && !addCalls()[0].includes('<-w>'))
+check('other failure: manual hint kept', r.stderr.includes('Retry manually'))
+check('other failure: exit code preserved', r.status === 3)
+
+// --- 1.7 no-op 假成功（自举后复查）：add 报告成功但判定文件依旧缺失——
+// pnpm 把包文件残缺的 profile 视为 already up to date，重试永远「成功」而
+// 启动必崩（cannot resolve profile bundle），且崩溃提示的 plugin install
+// 同样 no-op。fail loud 给出删 profile 重建的恢复路径，而不是继续启动。
+setProfileVersion(undefined)
+resetStubLog()
+r = runBin([], { DSH_STUB_ADD_NOCREATE: '1', DSH_TUI_LANG: 'en' })
+check('no-op install: fails loud instead of launching', r.status === 1 && launchCalls().length === 0)
+check('no-op install: names the unreadable package', r.stderr.includes('still unreadable'))
+check('no-op install: gives the rm -rf recovery', r.stderr.includes('rm -rf'))
+r = runBin([], { DSH_STUB_ADD_NOCREATE: '1', DSH_TUI_LANG: 'zh' })
+check('no-op install: Chinese message', r.stderr.includes('仍不可读'))
 
 // --- 2. 版本一致：参数原样透传，无提示 ----------------------------------------
 setProfileVersion(ownVersion)


### PR DESCRIPTION
## 背景与根因

#239 报告的「首次运行自举在 pnpm ≥11 下必败」由 #241 修复并关闭，但 **0.8.1 实测（Linux + dsh 0.1.0-rc.6 + pnpm 11.7 + Node 24）全新环境自举仍然必败**——`-w` 重试从未触发：

```console
$ dsh-tui
[dsh-tui] 首次运行，正在初始化 dsh-tui profile（@deepseek-harness-tui/dsh-tui@0.8.1）…
 ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency to the workspace root ...
[dsh-tui] 插件安装失败。可稍后手工重试：…
```

根因：**`ERR_PNPM_ADDING_TO_ROOT` 由 pnpm 写到 stdout**（经 dsh 原样转发），stderr 上只有 dsh 自己的失败说明。#241 的识别只查 `add.stderr`，签名永远匹配不到，重试是死分支。实测验证（同一命令分别重定向两流）：

```console
$ dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui@0.8.1 2>/dev/null | grep -c ERR_PNPM_ADDING_TO_ROOT
1
$ dsh plugin --profile dsh-tui add … 2>err.log >/dev/null; grep -c ERR_PNPM_ADDING_TO_ROOT err.log
0
```

## 两个修复

### 1. 签名识别覆盖 stdout（修 #241 回归）

首次 add 的 stdout/stderr 都走 pipe 捕获：失败时把捕获输出回放到 stderr（保住诊断信息），识别签名（两流拼接 `includes`）后带 `-w` 恰好重试一次，重试恢复 `inherit` 让安装进度实时可见；成功路径把捕获输出一次性回放到 stdout（spawnSync 无法同时透传与捕获，安装通常数秒，代价可接受）。

### 2. 自举后复查判定文件（no-op 假成功死区）

实测发现的相邻死区：包文件残缺的 profile（如安装中断）下，pnpm 视为 already up to date——`add` 与 `install` 都报告成功（`Done in 1s` / `Already up to date`）却什么都不装。启动器继续启动只会以 cannot resolve profile bundle 崩溃，而崩溃提示的 `plugin install` 同样 no-op：用户陷入「每步都成功、每次都崩」的循环，没有任何出口。修复：自举成功后复查判定文件，仍缺失则 fail loud（双语），给出删 profile 目录重建的恢复指引（实测唯一可靠恢复法）。

## 回归覆盖（verify-launcher.mjs）

stub 的 `plugin add` 对齐真实行为——签名写 stdout、成功时真正创建判定文件、可模拟 no-op 假成功（此前 stub 的 add 永远无副作用成功，正是 #241 带伤合入的漏测根源）。新增三组 case：

- 签名在 stdout → 恰好一次 `-w` 重试、捕获输出回放可见、重试后正常启动
- 无签名的失败 → 不盲目 `-w`、保留退出码与手工提示
- no-op 假成功 → fail loud（双语断言）而非继续启动

全部 33 check 通过。

## 端到端验证（真实 dsh/pnpm 链路，隔离沙箱 DSH_HOME）

| 场景 | 结果 |
|---|---|
| 全新环境（dsh 0.1.0-rc.6） | 签名识别 → 带 -w 重试（Done in 7.2s）→ 复查通过 → 启动抵达 TUI（非 TTY 下停在 interactive terminal 检查，预期） |
| 全新环境（dsh 0.1.0-rc.7，npm 最新） | 同上（Done in 8.7s）——rc.7 的 `plugin add` 不带 `-w` 仍被拒，根因在 dsh 侧未修，本修复在两版下均必要且兼容 |
| 半残 profile | add 假成功 → fail loud「安装报告成功，但插件包仍不可读」+ `rm -rf` 指引，拒绝启动 |
| 按指引删除 profile 目录后重跑 | 全新自举成功，闭环恢复 |

Relates to #239、#241（使 #241 的重试路径在真实链路实际生效，并补上它覆盖不到的假成功场景）。
