### PR TITLE
feat(ui): effort ignition — wave band when reasoning effort hits the top tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,12 @@ jobs:
       # scrollback 零增量、动效帧只含 SGR。
       - run: node --import tsx/esm scripts/verify-trace-scene.tsx
 
+      # 最高档思考强度点焰回归：数学层（波形/缓动/包络/逐列色契约）+
+      # 场景（headless xterm）：三种风格逐一遍历断言播放期零行级
+      # repaint、恰占一行、播完自卸载；负路径（冷启动顶档/单档表/
+      # 无档位表/离开顶档）不触发；挂载/卸载帧不得滚动 scrollback。
+      - run: node --import tsx/esm scripts/verify-effort-ignition.tsx
+
       # 缩放重排回归（实机反馈：打开长会话后最大化窗口）：判据是终局等价
       # ——缩放后的物理终端必须等于在新尺寸上全新渲染的同一状态。缩放会让
       # 树内每个测量所依据的宽度失效，而没有任何节点被标脏，文本节点会沿用

--- a/scripts/verify-effort-ignition.tsx
+++ b/scripts/verify-effort-ignition.tsx
@@ -2,15 +2,25 @@
  * Effort ignition regression — the top-tier reasoning-effort wave band.
  *
  * Part A asserts the math layer (waveform sampling, easings, envelope, the
- * per-column colour contract). Part B mounts the real component in a
- * headless xterm and asserts the property that makes the band safe on a
- * live session, in the same terms as verify-trace-scene's motion gate:
+ * per-column colour contract, boundary guards). Part B mounts the real
+ * component in a headless xterm, one harness per scenario, and asserts the
+ * properties that make the band safe on a live session, in the same terms
+ * as verify-trace-scene's motion gate:
  *
- * - **Animation patches, never repaints.** While the band is playing, the
- *   write stream contains no line erase, screen clear, or scroll — the band
- *   changes background colours only, glyphs are always spaces.
- * - **The band actually plays**: truecolor background SGR appears right
- *   after the effort switch, on exactly one screen row.
+ * - **Every style plays, deterministically.** The component accepts a fixed
+ *   `style` prop here, so wave/aurora/pulse each get their own full run —
+ *   not whichever one `Math.random` picked this time.
+ * - **Animation patches, never repaints.** While the band plays, the write
+ *   stream contains no line erase, screen clear, or scroll — frames change
+ *   background colours only, glyphs are always spaces.
+ * - **Mount and unmount never scroll.** The band's one-shot insert/remove
+ *   frames are the exact family that once sank the UI into scrollback
+ *   (#38/#39/#19/#10); the whole stream, mounting included, must contain
+ *   no scroll sequences.
+ * - **It cleans up after itself**: painted rows return to zero after each
+ *   style's total and the write stream goes quiet.
+ * - **Negative paths stay dark**: cold mount on the top tier, a single-tier
+ *   table, a missing table, and leaving the top tier must all play nothing.
  *
  * Run: node --import tsx/esm scripts/verify-effort-ignition.tsx
  */
@@ -43,7 +53,8 @@ function check(name: string, ok: boolean, detail = ''): void {
 
 // --- Part A: math layer --------------------------------------------------------
 check('crest: 1 at the crest, 0 at one half-width out', math.crest(0) === 1 && math.crest(1) === 0)
-check('crest: beyond the half-width is silent', math.crest(1.5) === 0)
+check('crest: beyond the half-width is silent, both directions',
+  math.crest(1.5) === 0 && math.crest(-1) === 0 && math.crest(-2) === 0)
 check('easings: endpoints are exact',
   math.easeInCubic(0) === 0 && math.easeInCubic(1) === 1
   && math.easeOutCubic(0) === 0 && math.easeOutCubic(1) === 1
@@ -53,11 +64,20 @@ check('easings: clamped outside [0,1]',
 check('envelope: zero outside the window',
   math.envelope(0, 1, 0.25, 0.4) === 0 && math.envelope(1, 1, 0.25, 0.4) === 0)
 check('envelope: fully open in the middle', math.envelope(0.5, 1, 0.25, 0.4) === 1)
+check('envelope: ramp sides bind, not max',
+  math.envelope(0.1, 1, 0.25, 0.4) < 0.45 && Math.abs(math.envelope(0.1, 1, 0.25, 0.4) - 0.4) < 0.01)
 check('line colors: exactly one entry per column',
   math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 40, onLight: false }).length === 40)
 check('line colors: empty before start and after the end',
   math.ignitionLineColors({ style: 'wave', elapsedMs: 0, width: 40, onLight: false }).length === 0
   && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave + 1, width: 40, onLight: false }).length === 0)
+check('line colors: boundary guards (width 0, negative/NaN/at-total elapsed)',
+  math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 0, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: -5, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: Number.NaN, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave, width: 40, onLight: false }).length === 0)
+check('line colors: single-column terminal yields one entry',
+  math.ignitionLineColors({ style: 'aurora', elapsedMs: 300, width: 1, onLight: false }).length === 1)
 check('line colors: every painted entry is a truecolor rgb() string',
   math
     .ignitionLineColors({ style: 'pulse', elapsedMs: 200, width: 60, onLight: false })
@@ -69,82 +89,172 @@ check('line colors: some columns are painted mid-wave',
 check('random style: never repeats the previous one',
   Array.from({ length: 20 }, () => math.randomIgnitionStyle('wave')).every(style => style !== 'wave'))
 
-// --- Part B: the band plays, patches, never repaints ----------------------------
-const cols = 60
-const rows = 8
-const term = new XTerm({ cols, rows, scrollback: 200, allowProposedApi: true })
-const writes: string[] = []
-class FakeStdout extends Writable {
-  columns = cols
-  rows = rows
-  isTTY = true
-  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
-    writes.push(String(chunk))
-    term.write(String(chunk), callback)
+// --- Part B: the band plays, patches, never repaints, and cleans up -------------
+const LEVELS = ['low', 'medium', 'high'] as const
+
+async function makeHarness(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 200, allowProposedApi: true })
+  const writes: string[] = []
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      writes.push(String(chunk))
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const rgbBgRows = (): number =>
+    Array.from({ length: rows }, (_, y) => {
+      const line = term.buffer.active.getLine(term.buffer.active.baseY + y)
+      if (line === undefined) return false
+      for (let x = 0; x < cols; x++) {
+        if (line.getCell(x)?.isBgRGB()) return true
+      }
+      return false
+    }).filter(Boolean).length
+  const instance = await render(React.createElement(ClockProvider, null, React.createElement(DriverSlot)), {
+    stdout: new FakeStdout() as never,
+    stdin: new FakeStdin() as never,
+    stderr: new FakeStdout() as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  return { term, writes, rgbBgRows, instance }
+}
+
+/** Driver slot: the harness mounts one driver; scenarios swap what it renders. */
+let driverElement: React.ReactNode = null
+function DriverSlot(): React.ReactNode {
+  return driverElement
+}
+
+/**
+ * One scenario: mount, flip effort at t=300ms, sample the playing window
+ * [400,1000]ms, then wait past the style's total for self-unmount checks.
+ */
+async function runBandScenario(style: 'wave' | 'aurora' | 'pulse') {
+  const cols = 60
+  function Driver(): React.ReactNode {
+    const [effort, setEffort] = React.useState<string>('medium')
+    React.useEffect(() => {
+      const timer = setTimeout(() => setEffort('high'), 300)
+      return () => clearTimeout(timer)
+    }, [])
+    return React.createElement(
+      EffortIgnitionLine,
+      { effort, levels: LEVELS, columns: cols, onLight: false, style },
+    )
+  }
+  driverElement = React.createElement(Driver)
+  const harness = await makeHarness(cols, 8)
+  try {
+    await sleep(200)
+    const darkBefore = harness.rgbBgRows()
+    // One-row check sits in the styles' COMMON on-screen window at t=550ms:
+    // pulse's ring leaves a 60-col screen around t=665ms (radius ≥ width/2
+    // + half-width), wave's crest has entered from the left, aurora always
+    // paints. The capture window below still holds frames for every style
+    // (pulse paints until ~665ms, wave/aurora to their totals).
+    await sleep(350)
+    const paintedMidBand = harness.rgbBgRows()
+    harness.writes.length = 0
+    await sleep(420)
+    const stream = harness.writes.join('')
+    const repaints = [
+      ['erase line', /\x1b\[[0-2]?K/],
+      ['erase screen', /\x1b\[[0-3]?J/],
+      ['scroll up', /\x1b\[\d*S/],
+      ['scroll down', /\x1b\[\d*T/],
+    ] as const
+    const offenders = repaints.filter(([, pattern]) => pattern.test(stream)).map(([name]) => name)
+    check(`${style}: no repaint escapes while playing`, offenders.length === 0,
+      offenders.length === 0 ? `${stream.length} bytes over the band` : offenders.join(', '))
+    check(`${style}: paints truecolor backgrounds`, /\x1b\[48;2;/.test(stream), `${stream.length} bytes`)
+    check(`${style}: exactly one painted row`, paintedMidBand === 1, `${paintedMidBand} rows`)
+    check(`${style}: dark before the switch`, darkBefore === 0)
+    // Self-unmount: past every style's total (≤1300ms from the 300ms switch,
+    // so t=1650ms is past all of them), plus a quiet tail.
+    await sleep(700)
+    check(`${style}: self-unmounts after its total`, harness.rgbBgRows() === 0, `${harness.rgbBgRows()} rows`)
+    harness.writes.length = 0
+    await sleep(300)
+    check(`${style}: write stream goes quiet`, !/\x1b\[48;2;/.test(harness.writes.join('')))
+  } finally {
+    harness.instance.unmount()
+    driverElement = null
   }
 }
-class FakeStdin extends PassThrough {
-  isTTY = true
-  setRawMode(): this { return this }
-  ref(): this { return this }
-  unref(): this { return this }
-}
-const rgbBgRows = (): number =>
-  Array.from({ length: rows }, (_, y) => {
-    const line = term.buffer.active.getLine(term.buffer.active.baseY + y)
-    if (line === undefined) return false
-    for (let x = 0; x < cols; x++) {
-      if (line.getCell(x)?.isBgRGB()) return true
-    }
-    return false
-  }).filter(Boolean).length
 
-function Driver(): React.ReactNode {
-  const [effort, setEffort] = React.useState('medium')
-  React.useEffect(() => {
-    const timer = setTimeout(() => setEffort('high'), 300)
-    return () => clearTimeout(timer)
-  }, [])
-  return (
-    <ClockProvider>
-      <EffortIgnitionLine
-        effort={effort}
-        levels={['low', 'medium', 'high']}
-        columns={cols}
-        onLight={false}
-      />
-    </ClockProvider>
-  )
+for (const style of ['wave', 'aurora', 'pulse'] as const) {
+  await runBandScenario(style)
 }
 
-render(<Driver />, {
-  stdout: new FakeStdout() as never,
-  stdin: new FakeStdin() as never,
-  stderr: new FakeStdout() as never,
-  exitOnCtrlC: false,
-  patchConsole: false,
+// --- Negative paths: these must stay completely dark ---------------------------
+async function runDarkScenario(name: string, makeDriver: () => React.ReactNode) {
+  driverElement = makeDriver()
+  const harness = await makeHarness(60, 8)
+  try {
+    await sleep(300)
+    harness.writes.length = 0
+    await sleep(1300)
+    const stream = harness.writes.join('')
+    check(`${name}: no ignition at all`,
+      harness.rgbBgRows() === 0 && !/\x1b\[48;2;/.test(stream))
+  } finally {
+    harness.instance.unmount()
+    driverElement = null
+  }
+}
+
+await runDarkScenario('cold mount on the top tier', () =>
+  React.createElement(EffortIgnitionLine, { effort: 'high', levels: LEVELS, columns: 60, onLight: false }))
+await runDarkScenario('single-tier table', () =>
+  React.createElement(EffortIgnitionLine, { effort: 'high', levels: ['high'], columns: 60, onLight: false }))
+await runDarkScenario('missing level table', () =>
+  React.createElement(EffortIgnitionLine, { effort: 'high', levels: undefined, columns: 60, onLight: false }))
+await runDarkScenario('leaving the top tier', () => {
+  function Driver(): React.ReactNode {
+    const [effort, setEffort] = React.useState<string>('high')
+    React.useEffect(() => {
+      const timer = setTimeout(() => setEffort('medium'), 300)
+      return () => clearTimeout(timer)
+    }, [])
+    return React.createElement(EffortIgnitionLine, { effort, levels: LEVELS, columns: 60, onLight: false })
+  }
+  return React.createElement(Driver)
 })
-await sleep(250)
-check('no band before the effort switch', rgbBgRows() === 0, `${rgbBgRows()} painted rows`)
-writes.length = 0
-// The switch fires at t=300ms; capture [400ms, 1000ms] — inside every
-// style's playing window (totals are 900–1300ms), away from the mount and
-// unmount frames, which are one-shot layout changes, not animation frames.
-await sleep(150)
-writes.length = 0
-await sleep(600)
-const stream = writes.join('')
-const repaints = [
-  ['erase line', /\x1b\[[0-2]?K/],
-  ['erase screen', /\x1b\[[0-3]?J/],
-  ['scroll up', /\x1b\[\d*S/],
-  ['scroll down', /\x1b\[\d*T/],
-] as const
-const offenders = repaints.filter(([, pattern]) => pattern.test(stream)).map(([name]) => name)
-check('ignition band emits no repaint escapes', offenders.length === 0,
-  offenders.length === 0 ? `${stream.length} bytes over the band` : offenders.join(', '))
-check('ignition band paints truecolor backgrounds', /\x1b\[48;2;/.test(stream), `${stream.length} bytes`)
-check('ignition band stays on one screen row', rgbBgRows() === 1, `${rgbBgRows()} painted rows`)
+
+// --- Mount/unmount frames never scroll the buffer -------------------------------
+// The band inserts and removes a whole row; those one-shot frames are the
+// shrink-frame family from #38/#39/#19/#10. Capture a full lifecycle in one
+// stream (mount → play → unmount) and assert no scroll sequences at all.
+{
+  const cols = 60
+  function Driver(): React.ReactNode {
+    const [effort, setEffort] = React.useState<string>('medium')
+    React.useEffect(() => {
+      const timer = setTimeout(() => setEffort('high'), 200)
+      return () => clearTimeout(timer)
+    }, [])
+    return React.createElement(
+      EffortIgnitionLine, { effort, levels: LEVELS, columns: cols, onLight: false, style: 'pulse' })
+  }
+  driverElement = React.createElement(Driver)
+  const harness = await makeHarness(cols, 8)
+  await sleep(1800)
+  const stream = harness.writes.join('')
+  check('lifecycle (mount+play+unmount): no scroll sequences',
+    !/\x1b\[\d*S/.test(stream) && !/\x1b\[\d*T/.test(stream))
+  harness.instance.unmount()
+  driverElement = null
+}
 
 if (failures > 0) {
   console.error(`${failures} check(s) failed`)

--- a/scripts/verify-effort-ignition.tsx
+++ b/scripts/verify-effort-ignition.tsx
@@ -12,7 +12,7 @@
  *   not whichever one `Math.random` picked this time.
  * - **Animation patches, never repaints.** While the band plays, the write
  *   stream contains no line erase, screen clear, or scroll — frames change
- *   background colours only, glyphs are always spaces.
+ *   foreground colours only, glyphs are always spaces.
  * - **Mount and unmount never scroll.** The band's one-shot insert/remove
  *   frames are the exact family that once sank the UI into scrollback
  *   (#38/#39/#19/#10); the whole stream, mounting included, must contain
@@ -110,12 +110,12 @@ async function makeHarness(cols: number, rows: number) {
     ref(): this { return this }
     unref(): this { return this }
   }
-  const rgbBgRows = (): number =>
+  const rgbFgRows = (): number =>
     Array.from({ length: rows }, (_, y) => {
       const line = term.buffer.active.getLine(term.buffer.active.baseY + y)
       if (line === undefined) return false
       for (let x = 0; x < cols; x++) {
-        if (line.getCell(x)?.isBgRGB()) return true
+        if (line.getCell(x)?.isFgRGB()) return true
       }
       return false
     }).filter(Boolean).length
@@ -126,7 +126,7 @@ async function makeHarness(cols: number, rows: number) {
     exitOnCtrlC: false,
     patchConsole: false,
   })
-  return { term, writes, rgbBgRows, instance }
+  return { term, writes, rgbFgRows, instance }
 }
 
 /** Driver slot: the harness mounts one driver; scenarios swap what it renders. */
@@ -156,14 +156,14 @@ async function runBandScenario(style: 'wave' | 'aurora' | 'pulse') {
   const harness = await makeHarness(cols, 8)
   try {
     await sleep(200)
-    const darkBefore = harness.rgbBgRows()
+    const darkBefore = harness.rgbFgRows()
     // One-row check sits in the styles' COMMON on-screen window at t=550ms:
     // pulse's ring leaves a 60-col screen around t=665ms (radius ≥ width/2
     // + half-width), wave's crest has entered from the left, aurora always
     // paints. The capture window below still holds frames for every style
     // (pulse paints until ~665ms, wave/aurora to their totals).
     await sleep(350)
-    const paintedMidBand = harness.rgbBgRows()
+    const paintedMidBand = harness.rgbFgRows()
     harness.writes.length = 0
     await sleep(420)
     const stream = harness.writes.join('')
@@ -176,16 +176,16 @@ async function runBandScenario(style: 'wave' | 'aurora' | 'pulse') {
     const offenders = repaints.filter(([, pattern]) => pattern.test(stream)).map(([name]) => name)
     check(`${style}: no repaint escapes while playing`, offenders.length === 0,
       offenders.length === 0 ? `${stream.length} bytes over the band` : offenders.join(', '))
-    check(`${style}: paints truecolor backgrounds`, /\x1b\[48;2;/.test(stream), `${stream.length} bytes`)
+    check(`${style}: paints truecolor foregrounds`, /\x1b\[38;2;/.test(stream), `${stream.length} bytes`)
     check(`${style}: exactly one painted row`, paintedMidBand === 1, `${paintedMidBand} rows`)
     check(`${style}: dark before the switch`, darkBefore === 0)
     // Self-unmount: past every style's total (≤1300ms from the 300ms switch,
     // so t=1650ms is past all of them), plus a quiet tail.
     await sleep(700)
-    check(`${style}: self-unmounts after its total`, harness.rgbBgRows() === 0, `${harness.rgbBgRows()} rows`)
+    check(`${style}: self-unmounts after its total`, harness.rgbFgRows() === 0, `${harness.rgbFgRows()} rows`)
     harness.writes.length = 0
     await sleep(300)
-    check(`${style}: write stream goes quiet`, !/\x1b\[48;2;/.test(harness.writes.join('')))
+    check(`${style}: write stream goes quiet`, !/\x1b\[38;2;/.test(harness.writes.join('')))
   } finally {
     harness.instance.unmount()
     driverElement = null
@@ -206,7 +206,7 @@ async function runDarkScenario(name: string, makeDriver: () => React.ReactNode) 
     await sleep(1300)
     const stream = harness.writes.join('')
     check(`${name}: no ignition at all`,
-      harness.rgbBgRows() === 0 && !/\x1b\[48;2;/.test(stream))
+      harness.rgbFgRows() === 0 && !/\x1b\[38;2;/.test(stream))
   } finally {
     harness.instance.unmount()
     driverElement = null

--- a/scripts/verify-effort-ignition.tsx
+++ b/scripts/verify-effort-ignition.tsx
@@ -1,0 +1,153 @@
+/**
+ * Effort ignition regression — the top-tier reasoning-effort wave band.
+ *
+ * Part A asserts the math layer (waveform sampling, easings, envelope, the
+ * per-column colour contract). Part B mounts the real component in a
+ * headless xterm and asserts the property that makes the band safe on a
+ * live session, in the same terms as verify-trace-scene's motion gate:
+ *
+ * - **Animation patches, never repaints.** While the band is playing, the
+ *   write stream contains no line erase, screen clear, or scroll — the band
+ *   changes background colours only, glyphs are always spaces.
+ * - **The band actually plays**: truecolor background SGR appears right
+ *   after the effort switch, on exactly one screen row.
+ *
+ * Run: node --import tsx/esm scripts/verify-effort-ignition.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+const [
+  { Writable, PassThrough },
+  React,
+  { Terminal: XTerm },
+  { render },
+  { EffortIgnitionLine },
+  { ClockProvider },
+  math,
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/EffortIgnitionLine.js'),
+  import('../src/ink/components/ClockContext.js'),
+  import('../src/trajectory/effortIgnition.js'),
+])
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+let failures = 0
+function check(name: string, ok: boolean, detail = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail === '' ? '' : ` (${detail})`}`)
+  if (!ok) failures++
+}
+
+// --- Part A: math layer --------------------------------------------------------
+check('crest: 1 at the crest, 0 at one half-width out', math.crest(0) === 1 && math.crest(1) === 0)
+check('crest: beyond the half-width is silent', math.crest(1.5) === 0)
+check('easings: endpoints are exact',
+  math.easeInCubic(0) === 0 && math.easeInCubic(1) === 1
+  && math.easeOutCubic(0) === 0 && math.easeOutCubic(1) === 1
+  && math.easeInOutCubic(0) === 0 && math.easeInOutCubic(1) === 1)
+check('easings: clamped outside [0,1]',
+  math.easeInCubic(-1) === 0 && math.easeOutCubic(2) === 1 && math.easeInOutCubic(-3) === 0)
+check('envelope: zero outside the window',
+  math.envelope(0, 1, 0.25, 0.4) === 0 && math.envelope(1, 1, 0.25, 0.4) === 0)
+check('envelope: fully open in the middle', math.envelope(0.5, 1, 0.25, 0.4) === 1)
+check('line colors: exactly one entry per column',
+  math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 40, onLight: false }).length === 40)
+check('line colors: empty before start and after the end',
+  math.ignitionLineColors({ style: 'wave', elapsedMs: 0, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave + 1, width: 40, onLight: false }).length === 0)
+check('line colors: every painted entry is a truecolor rgb() string',
+  math
+    .ignitionLineColors({ style: 'pulse', elapsedMs: 200, width: 60, onLight: false })
+    .every(color => color === undefined || /^rgb\(\d+,\d+,\d+\)$/.test(String(color))))
+check('line colors: some columns are painted mid-wave',
+  math
+    .ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 80, onLight: false })
+    .some(color => color !== undefined))
+check('random style: never repeats the previous one',
+  Array.from({ length: 20 }, () => math.randomIgnitionStyle('wave')).every(style => style !== 'wave'))
+
+// --- Part B: the band plays, patches, never repaints ----------------------------
+const cols = 60
+const rows = 8
+const term = new XTerm({ cols, rows, scrollback: 200, allowProposedApi: true })
+const writes: string[] = []
+class FakeStdout extends Writable {
+  columns = cols
+  rows = rows
+  isTTY = true
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    writes.push(String(chunk))
+    term.write(String(chunk), callback)
+  }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+const rgbBgRows = (): number =>
+  Array.from({ length: rows }, (_, y) => {
+    const line = term.buffer.active.getLine(term.buffer.active.baseY + y)
+    if (line === undefined) return false
+    for (let x = 0; x < cols; x++) {
+      if (line.getCell(x)?.isBgRGB()) return true
+    }
+    return false
+  }).filter(Boolean).length
+
+function Driver(): React.ReactNode {
+  const [effort, setEffort] = React.useState('medium')
+  React.useEffect(() => {
+    const timer = setTimeout(() => setEffort('high'), 300)
+    return () => clearTimeout(timer)
+  }, [])
+  return (
+    <ClockProvider>
+      <EffortIgnitionLine
+        effort={effort}
+        levels={['low', 'medium', 'high']}
+        columns={cols}
+        onLight={false}
+      />
+    </ClockProvider>
+  )
+}
+
+render(<Driver />, {
+  stdout: new FakeStdout() as never,
+  stdin: new FakeStdin() as never,
+  stderr: new FakeStdout() as never,
+  exitOnCtrlC: false,
+  patchConsole: false,
+})
+await sleep(250)
+check('no band before the effort switch', rgbBgRows() === 0, `${rgbBgRows()} painted rows`)
+writes.length = 0
+// The switch fires at t=300ms; capture [400ms, 1000ms] — inside every
+// style's playing window (totals are 900–1300ms), away from the mount and
+// unmount frames, which are one-shot layout changes, not animation frames.
+await sleep(150)
+writes.length = 0
+await sleep(600)
+const stream = writes.join('')
+const repaints = [
+  ['erase line', /\x1b\[[0-2]?K/],
+  ['erase screen', /\x1b\[[0-3]?J/],
+  ['scroll up', /\x1b\[\d*S/],
+  ['scroll down', /\x1b\[\d*T/],
+] as const
+const offenders = repaints.filter(([, pattern]) => pattern.test(stream)).map(([name]) => name)
+check('ignition band emits no repaint escapes', offenders.length === 0,
+  offenders.length === 0 ? `${stream.length} bytes over the band` : offenders.join(', '))
+check('ignition band paints truecolor backgrounds', /\x1b\[48;2;/.test(stream), `${stream.length} bytes`)
+check('ignition band stays on one screen row', rgbBgRows() === 1, `${rgbBgRows()} painted rows`)
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`)
+  process.exit(1)
+}
+console.log('all checks passed')

--- a/src/components/EffortIgnitionLine.tsx
+++ b/src/components/EffortIgnitionLine.tsx
@@ -1,0 +1,119 @@
+/**
+ * EffortIgnitionLine — 思考强度切到最高档时的状态行点焰（一次性）。
+ *
+ * 触发条件：{@link props.effort} 从一个已存在的档位变为当前档位表的
+ * 最高档（表末位），且档位表多于一级——冷启动恢复偏好、单档模型都不
+ * 触发。播完自卸载（渲染 null，行消失）。
+ *
+ * SGR-only 合规（见 motion.ts 的硬规则）：动画期间行数恒为一、glyph
+ * 恒为空格，帧间变化全部是背景色——连续同色列合并成段渲染，每帧只
+ * 发出色序。时钟复用 Ink core 共享时钟（失焦/滚出自动停摆，见
+ * ClockContext），不在本组件创建任何定时器。
+ */
+import React, { useContext, useEffect, useReducer, useRef, useState } from 'react'
+import { Box, Text } from '../ui.js'
+import { ClockContext } from '../ink/components/ClockContext.js'
+import {
+  IGNITION_TOTAL_MS,
+  ignitionLineColors,
+  randomIgnitionStyle,
+  type IgnitionStyle,
+} from '../trajectory/effortIgnition.js'
+import type { Color } from '../ink/styles.js'
+
+/** 一段同色（或同「无背景」）的连续列。 */
+type Run = { color: Color | undefined; len: number }
+
+/** 把逐列色压缩成连续段，段数远小于列数时显著减少节点与 SGR 切换。 */
+function toRuns(colors: ReadonlyArray<Color | undefined>): Run[] {
+  const runs: Run[] = []
+  for (const color of colors) {
+    const last = runs[runs.length - 1]
+    if (last !== undefined && last.color === color) last.len++
+    else runs.push({ color, len: 1 })
+  }
+  return runs
+}
+
+export function EffortIgnitionLine({
+  effort,
+  levels,
+  columns,
+  onLight,
+}: {
+  /** 当前思考强度档 id；`undefined` 表示路线未声明。 */
+  effort: string | undefined
+  /** 当前路线的档位表（低→高，末位为最高档）；未知时传 `undefined`。 */
+  levels: readonly string[] | undefined
+  columns: number
+  onLight: boolean
+}): React.ReactNode {
+  const clock = useContext(ClockContext)
+  const [ignition, setIgnition] = useState<{ style: IgnitionStyle; startedAtMs: number } | null>(
+    null,
+  )
+  const prevEffort = useRef<string | undefined>(undefined)
+  const prevStyle = useRef<IgnitionStyle | undefined>(undefined)
+  const [, forceRender] = useReducer((tick: number) => tick + 1, 0)
+
+  // 触发判定放 effect（commit 后跑，晚一帧 ≈16ms，不影响观感）：从「有
+  // 档位」变为「另一档位」且新档位是末位最高档。首次载入 / 单档表 /
+  // 档位表未知都不触发。
+  useEffect(() => {
+    const previous = prevEffort.current
+    prevEffort.current = effort
+    if (
+      effort !== undefined &&
+      previous !== undefined &&
+      effort !== previous &&
+      levels !== undefined &&
+      levels.length > 1 &&
+      effort === levels[levels.length - 1]
+    ) {
+      const style = randomIgnitionStyle(prevStyle.current)
+      prevStyle.current = style
+      setIgnition({ style, startedAtMs: clock?.now() ?? Date.now() })
+    }
+  }, [effort, levels, clock])
+
+  // 动画期间才订阅共享时钟：帧回调只强制重渲染，不持任何状态。波本身
+  // 是活动内容，keepAlive=true——否则在没有任何其他动画组件的场景（如
+  // 本组件的独立验证）里时钟根本不走，帧永不到来。
+  useEffect(() => {
+    if (ignition === null || clock === null) return
+    return clock.subscribe(() => forceRender(), /* keepAlive */ true)
+  }, [ignition, clock])
+
+  const totalMs = ignition === null ? 0 : IGNITION_TOTAL_MS[ignition.style]
+  const elapsedMs =
+    ignition === null ? Infinity : (clock?.now() ?? Date.now()) - ignition.startedAtMs
+
+  // 播完即净：置回 null，行随之卸载（一次性布局变化，不在 SGR-only
+  // 约束的帧间动画之内）。
+  useEffect(() => {
+    if (ignition !== null && elapsedMs >= totalMs) setIgnition(null)
+  }, [ignition, elapsedMs, totalMs])
+
+  if (ignition === null || elapsedMs >= totalMs || columns <= 0) return null
+  const colors = ignitionLineColors({
+    style: ignition.style,
+    elapsedMs,
+    width: columns,
+    onLight,
+  })
+  const runs = toRuns(colors)
+  if (runs.length === 0) return null
+  return (
+    <Box height={1} width="100%" flexShrink={0}>
+      {runs.map((run, index) =>
+        run.color === undefined ? (
+          <Text key={index}>{' '.repeat(run.len)}</Text>
+        ) : (
+          <Text key={index} backgroundColor={run.color}>
+            {' '.repeat(run.len)}
+          </Text>
+        ),
+      )}
+    </Box>
+  )
+}

--- a/src/components/EffortIgnitionLine.tsx
+++ b/src/components/EffortIgnitionLine.tsx
@@ -40,6 +40,7 @@ export function EffortIgnitionLine({
   levels,
   columns,
   onLight,
+  style,
 }: {
   /** 当前思考强度档 id；`undefined` 表示路线未声明。 */
   effort: string | undefined
@@ -47,34 +48,36 @@ export function EffortIgnitionLine({
   levels: readonly string[] | undefined
   columns: number
   onLight: boolean
+  /** 固定风格（验证脚本逐风格回归用）；缺省随机且不与上次重复。 */
+  style?: IgnitionStyle
 }): React.ReactNode {
   const clock = useContext(ClockContext)
   const [ignition, setIgnition] = useState<{ style: IgnitionStyle; startedAtMs: number } | null>(
     null,
   )
-  const prevEffort = useRef<string | undefined>(undefined)
+  const [prevEffort, setPrevEffort] = useState(effort)
   const prevStyle = useRef<IgnitionStyle | undefined>(undefined)
   const [, forceRender] = useReducer((tick: number) => tick + 1, 0)
 
-  // 触发判定放 effect（commit 后跑，晚一帧 ≈16ms，不影响观感）：从「有
-  // 档位」变为「另一档位」且新档位是末位最高档。首次载入 / 单档表 /
-  // 档位表未知都不触发。
-  useEffect(() => {
-    const previous = prevEffort.current
-    prevEffort.current = effort
+  // 触发判定在渲染期做（React 官方的「props 变化即调整 state」模式），
+  // 不放 effect——effect 晚一帧，effort 变化的首帧会以旧状态闪现。从
+  // 「已有档位」变为「另一档位」且新档位是末位最高档才触发；首次载入
+  // / 单档表 / 档位表未知 / 无共享时钟（headless 嵌入，帧永不到来，
+  // 冻结的着色行永不退场）都不触发。
+  if (effort !== prevEffort) {
+    setPrevEffort(effort)
     if (
+      clock !== null &&
       effort !== undefined &&
-      previous !== undefined &&
-      effort !== previous &&
       levels !== undefined &&
       levels.length > 1 &&
       effort === levels[levels.length - 1]
     ) {
-      const style = randomIgnitionStyle(prevStyle.current)
-      prevStyle.current = style
-      setIgnition({ style, startedAtMs: clock?.now() ?? Date.now() })
+      const nextStyle = style ?? randomIgnitionStyle(prevStyle.current)
+      prevStyle.current = nextStyle
+      setIgnition({ style: nextStyle, startedAtMs: clock.now() })
     }
-  }, [effort, levels, clock])
+  }
 
   // 动画期间才订阅共享时钟：帧回调只强制重渲染，不持任何状态。波本身
   // 是活动内容，keepAlive=true——否则在没有任何其他动画组件的场景（如
@@ -85,8 +88,11 @@ export function EffortIgnitionLine({
   }, [ignition, clock])
 
   const totalMs = ignition === null ? 0 : IGNITION_TOTAL_MS[ignition.style]
+  // Clamp at zero: the shared clock can hand back a stale tickTime for one
+  // frame after waking from pause, which would read as a large negative
+  // elapsed; the band renders empty and self-heals next tick regardless.
   const elapsedMs =
-    ignition === null ? Infinity : (clock?.now() ?? Date.now()) - ignition.startedAtMs
+    ignition === null ? Infinity : Math.max(0, (clock?.now() ?? Date.now()) - ignition.startedAtMs)
 
   // 播完即净：置回 null，行随之卸载（一次性布局变化，不在 SGR-only
   // 约束的帧间动画之内）。

--- a/src/components/EffortIgnitionLine.tsx
+++ b/src/components/EffortIgnitionLine.tsx
@@ -109,14 +109,19 @@ export function EffortIgnitionLine({
   })
   const runs = toRuns(colors)
   if (runs.length === 0) return null
+  // Painted runs use the `▁` lower-block glyph with a FOREGROUND colour: fg
+  // is the channel every other live element (spinner, wake, context bar)
+  // already rides, while pure-background cells proved unreliable under the
+  // fullscreen log-update pipeline. The glyph is constant — frames change
+  // colours only, so the SGR-only rule still holds.
   return (
     <Box height={1} width="100%" flexShrink={0}>
       {runs.map((run, index) =>
         run.color === undefined ? (
           <Text key={index}>{' '.repeat(run.len)}</Text>
         ) : (
-          <Text key={index} backgroundColor={run.color}>
-            {' '.repeat(run.len)}
+          <Text key={index} color={run.color}>
+            {'▁'.repeat(run.len)}
           </Text>
         ),
       )}

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -448,6 +448,9 @@ export interface Channel {
   readonly contextWindow: number | undefined
   /** Reasoning effort of the latest request header, when the adapter sets one. */
   readonly reasoningEffort: string | undefined
+  /** The live route's reasoning-effort level ids, low → high (the last entry
+   *  is the top tier). Consumed by top-tier-triggered UI (effort ignition). */
+  readonly effortLevels: readonly string[] | undefined
   /** Usage of the most recent request (context share + cache hits come from
    *  this, not the running totals — each request's input IS the context). */
   readonly lastUsage:
@@ -778,6 +781,8 @@ export interface ChannelState {
   contextWindow: number | undefined
   /** Reasoning effort of the latest request header, when the adapter sets one. */
   reasoningEffort: string | undefined
+  /** The live route's reasoning-effort level ids, low → high. */
+  effortLevels: readonly string[] | undefined
   /** Usage of the most recent request (context share + cache hits). */
   lastUsage:
     | { input: number; output: number; cacheRead: number; cacheWrite: number }
@@ -1597,6 +1602,7 @@ export function createChannel(
     if (llmRuntime === undefined) return 'unavailable'
     try {
       const info = await llmRuntime.resolveModelInfo(state.provider, state.model)
+      state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
       return {
         efforts: info.reasoning?.efforts ?? [],
         defaultEffort: info.reasoning?.defaultEffort,
@@ -1855,6 +1861,7 @@ export function createChannel(
     agentId: agent.id,
     model: options.model,
     provider: options.provider,
+    effortLevels: undefined,
     tokens: { input: 0, output: 0 },
     cwd: options.cwd,
     displayCwd: workspaceService.describe(options.cwd).description ?? options.cwd,

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1576,6 +1576,7 @@ export function createChannel(
     if (preferredEffort === undefined || llmRuntime === undefined) return
     try {
       const info = await llmRuntime.resolveModelInfo(state.provider, state.model)
+      state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
       if (!info.reasoning?.efforts.some(effort => effort.id === preferredEffort)) return
       selection.current = {
         provider: state.provider,
@@ -1586,6 +1587,23 @@ export function createChannel(
       // Route metadata resolution is best-effort; a failure just leaves the
       // provider default in effect.
     }
+  }
+
+  /** Best-effort refresh of the live route's effort-level table for
+   *  top-tier-triggered UI (effort ignition): fire-and-forget on route
+   *  changes (bind/model switch/resume); the /effort paths refresh it
+   *  authoritatively via resolveEfforts. */
+  const refreshEffortLevels = (): void => {
+    if (llmRuntime === undefined) return
+    void llmRuntime
+      .resolveModelInfo(state.provider, state.model)
+      .then(info => {
+        state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
+      })
+      .catch(() => {
+        // Route metadata resolution is best-effort; a failure keeps the
+        // previous table until the next /effort interaction clears it.
+      })
   }
 
   /** Resolve the live route's effort levels + adapter default through the
@@ -2407,6 +2425,11 @@ export function createChannel(
       state.lastUsage = undefined
       state.workingActivity = undefined
       state.contextWindow = undefined
+      // Route changed: a stale tier table would let top-tier UI fire on the
+      // wrong level (or never fire on the real one); clear and re-resolve.
+      state.effortLevels = undefined
+      state.reasoningEffort = undefined
+      refreshEffortLevels()
       state.contextSegments = {
         system: 0,
         prompt: 0,
@@ -2550,6 +2573,11 @@ export function createChannel(
       state.lastUsage = undefined
       state.workingActivity = undefined
       state.contextWindow = undefined
+      // Route changed: a stale tier table would let top-tier UI fire on the
+      // wrong level (or never fire on the real one); clear and re-resolve.
+      state.effortLevels = undefined
+      state.reasoningEffort = undefined
+      refreshEffortLevels()
       state.contextSegments = {
         system: 0,
         prompt: 0,
@@ -2727,6 +2755,11 @@ export function createChannel(
       state.lastUsage = undefined
       state.workingActivity = undefined
       state.contextWindow = undefined
+      // Route changed: a stale tier table would let top-tier UI fire on the
+      // wrong level (or never fire on the real one); clear and re-resolve.
+      state.effortLevels = undefined
+      state.reasoningEffort = undefined
+      refreshEffortLevels()
       state.contextSegments = {
         system: 0,
         prompt: 0,

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -8,6 +8,7 @@ import { ActivityLine, contextPressurePct } from '../components/ActivityLine.js'
 import type { Channel } from '../dsh-adapter/channel.js'
 import { modeDisplayName } from '../sessionModes.js'
 import { MiniWake } from '../components/trajectory/MiniWake.js'
+import { EffortIgnitionLine } from '../components/EffortIgnitionLine.js'
 import type { WaveBand } from '../dsh-adapter/types.js'
 import {
   renderContextBar,
@@ -214,6 +215,16 @@ export function StatusLine({
             </Text>
           </Box>
         </Box>
+        {/* Row 2.5: effort ignition — a one-second band of waves the moment
+            the reasoning effort switches to the route's top tier; unmounts
+            itself when done (SGR-only: frames change background colours
+            only, glyphs are always spaces). */}
+        <EffortIgnitionLine
+          effort={channel.reasoningEffort}
+          levels={channel.effortLevels}
+          columns={columns}
+          onLight={themeName === 'light'}
+        />
         {/* Row 3: idle turn summary (ActivityLine) + mode hint on the right. */}
         <Box
           height={1}

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -9,6 +9,7 @@ import type { Channel } from '../dsh-adapter/channel.js'
 import { modeDisplayName } from '../sessionModes.js'
 import { MiniWake } from '../components/trajectory/MiniWake.js'
 import { EffortIgnitionLine } from '../components/EffortIgnitionLine.js'
+import { isLightThemeActive } from '../theme.js'
 import type { WaveBand } from '../dsh-adapter/types.js'
 import {
   renderContextBar,
@@ -222,8 +223,12 @@ export function StatusLine({
         <EffortIgnitionLine
           effort={channel.reasoningEffort}
           levels={channel.effortLevels}
-          columns={columns}
-          onLight={themeName === 'light'}
+          // The enclosing Box has paddingX={1}, so the band's usable width is
+          // columns-2 — passing the full width would clip the right end and
+          // misalign the band against the context bar (columns-4) and the
+          // status row (columns-2) above it.
+          columns={columns - 2}
+          onLight={isLightThemeActive(themeName)}
         />
         {/* Row 3: idle turn summary (ActivityLine) + mode hint on the right. */}
         <Box

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -482,6 +482,26 @@ export function getTheme(themeName: ThemeName): Theme {
 let customThemeResolver: ((name: string) => Theme | undefined) | undefined
 
 /**
+ * Whether the active theme's RESOLVED palette renders on a light background.
+ * Keyed off the palette's own `background` colour, never the theme NAME —
+ * `useTheme()` returns the literal `'auto'` for the auto theme and the file
+ * name for custom themes, so name comparisons miss auto-with-light-terminal
+ * and light custom palettes. Colour-pair variants (effort ignition hues)
+ * consume this signal.
+ * @param themeName - The theme name as `useTheme()` reports it.
+ * @returns True when the resolved palette's background is light (same Rec.601
+ *   luma test and dark-biased threshold as ThemeProvider's detector).
+ */
+export function isLightThemeActive(themeName: ThemeName): boolean {
+  const background = getTheme(themeName).background
+  if (!background.startsWith('#') || background.length !== 7) return themeName === 'light'
+  const r = Number.parseInt(background.slice(1, 3), 16)
+  const g = Number.parseInt(background.slice(3, 5), 16)
+  const b = Number.parseInt(background.slice(5, 7), 16)
+  return 0.299 * r + 0.587 * g + 0.114 * b > 140
+}
+
+/**
  * Register the custom-theme resolver. Called once by ThemeProvider; the
  * resolver must return `undefined` for names it does not know so getTheme
  * falls back to `dark`.

--- a/src/trajectory/effortIgnition.ts
+++ b/src/trajectory/effortIgnition.ts
@@ -1,0 +1,221 @@
+/**
+ * Effort ignition — 切到最高思考强度档时的一次性点焰波形（数学层）。
+ *
+ * 只做纯函数计算：波形采样、缓动、逐列混色。组件每帧调用
+ * {@link ignitionLineColors} 取得整行背景色。移植自 Codex CLI 的
+ * effort_ignition(_styles).rs（openai/codex PR #34365），波形语义保留：
+ * Wave 是余弦钟形行波自左向右扫过；Aurora 是多条正弦游走带同色相权重
+ * 相加；Pulse 是三次缓动的扩散圆环。三者都只产生颜色——SGR-only 规则
+ * （见 motion.ts）因此天然成立：glyph 恒为空格、行数恒为一，帧间变化
+ * 全部走背景色 SGR。
+ *
+ * 档位语义：dsh 的思考强度是 adapter 拥有的动态档位表，没有 Codex 的
+ * Max/Ultra 双档常量——这里只保留一套「最高档」色板（暖橙，深/浅背景
+ * 两个变体），第二档色板留待真有双顶级档位时再引入。
+ */
+import type { Color } from '../ink/styles.js'
+import type { RGBColor } from '../components/Spinner/spinnerUtils.js'
+import { rgbString } from './motion.js'
+
+/** 点焰风格：每次触发随机选一，且不与上一次重复。 */
+export type IgnitionStyle = 'wave' | 'aurora' | 'pulse'
+
+export const IGNITION_STYLES: readonly IgnitionStyle[] = ['wave', 'aurora', 'pulse']
+
+/** 帧时长（ms），仅用于把墙钟时间折算成动画秒数，不创建任何定时器。 */
+export const IGNITION_TOTAL_MS: Record<IgnitionStyle, number> = {
+  wave: 1000,
+  aurora: 1300,
+  pulse: 900,
+}
+
+/**
+ * 波形参数（对齐 Codex 的 bands 表）：
+ * wave/pulse 为 `[launch, travel, strength]`；aurora 为
+ * `[speed, phase, hueIndex]`。aurora 用两条带（第三条是 Ultra 双波专属，
+ * 单档语义下不启用）。
+ */
+const BANDS: Record<IgnitionStyle, ReadonlyArray<readonly [number, number, number]>> = {
+  wave: [[0.1, 0.75, 1]],
+  aurora: [
+    [0.35, 0.15, 0],
+    [-0.5, 0.6, 1],
+  ],
+  pulse: [[0.1, 0.6, 1]],
+}
+
+/** 波形宽度参数（列）。 */
+const WAVE_HALF_WIDTH = 9
+const PULSE_HALF_WIDTH = 4.5
+
+/**
+ * 最高档色板：三 hue 按列权重混合。深色背景用亮暖橙系，浅色背景换深
+ * 暖橙系（对齐 Codex Max 档的两个变体——浅底上亮橙没有对比度）。
+ */
+export function ignitionHues(onLight: boolean): readonly [RGBColor, RGBColor, RGBColor] {
+  return onLight
+    ? [
+        { r: 176, g: 98, b: 0 },
+        { r: 150, g: 110, b: 0 },
+        { r: 200, g: 70, b: 20 },
+      ]
+    : [
+        { r: 255, g: 178, b: 66 },
+        { r: 255, g: 214, b: 120 },
+        { r: 255, g: 120, b: 60 },
+      ]
+}
+
+/**
+ * 带底色（波向状态行本底淡入的目标色）。近似值：取主题深/浅背景的典
+ * 型值而非逐主题读取——波只存活一秒，色差在低 alpha 下不可辨。
+ */
+const BAND_RGB_DARK: RGBColor = { r: 27, g: 30, b: 40 }
+const BAND_RGB_LIGHT: RGBColor = { r: 240, g: 240, b: 242 }
+
+/** 余弦钟形：`crest(0)=1`、`crest(1)=0`、之外为 0。 */
+export function crest(distance: number): number {
+  if (distance >= 1) return 0
+  return 0.5 * (1 + Math.cos(Math.PI * distance))
+}
+
+/** ease-in cubic：`p³`，两端 clamp。 */
+export function easeInCubic(progress: number): number {
+  const p = Math.min(1, Math.max(0, progress))
+  return p * p * p
+}
+
+/** ease-out cubic：`1-(1-p)³`，两端 clamp。 */
+export function easeOutCubic(progress: number): number {
+  const p = Math.min(1, Math.max(0, progress))
+  const inverse = 1 - p
+  return 1 - inverse * inverse * inverse
+}
+
+/** ease-in-out cubic：前半 `4p³`、后半镜像，两端 clamp。 */
+export function easeInOutCubic(progress: number): number {
+  const p = Math.min(1, Math.max(0, progress))
+  if (p < 0.5) return 4 * p * p * p
+  const inverse = -2 * p + 2
+  return 1 - (inverse * inverse * inverse) / 2
+}
+
+/**
+ * 一次性包络：`[0, total]` 外为 0，进入段按 `fadeIn` 线性升起、离开段
+ * 按 `fadeOut` 线性落下，取两者较小值。
+ */
+export function envelope(elapsed: number, total: number, fadeIn: number, fadeOut: number): number {
+  if (elapsed <= 0 || elapsed >= total) return 0
+  const inPart = elapsed / Math.max(fadeIn, Number.EPSILON)
+  const outPart = (total - elapsed) / Math.max(fadeOut, Number.EPSILON)
+  return Math.min(1, Math.max(0, inPart, outPart))
+}
+
+/** 单列对全部波带的采样结果：三 hue 各自的权重（未归一）。 */
+function sampleColumn(
+  style: IgnitionStyle,
+  elapsed: number,
+  column: number,
+  width: number,
+): [number, number, number] {
+  const weights: [number, number, number] = [0, 0, 0]
+  for (const band of BANDS[style]) {
+    const [first, second, third] = band
+    if (style === 'wave') {
+      const progress = (elapsed - first) / second
+      if (progress < 0 || progress > 1) continue
+      const center = easeInOutCubic(progress) * (width + 2 * WAVE_HALF_WIDTH) - WAVE_HALF_WIDTH
+      weights[0] = Math.max(weights[0], crest(Math.abs(column - center) / WAVE_HALF_WIDTH))
+    } else if (style === 'aurora') {
+      const center =
+        (0.5 + 0.38 * Math.sin(Math.PI * 2 * (first * elapsed + second))) * width
+      const halfWidth = Math.max(width * 0.22, 4)
+      weights[third] += crest(Math.abs(column - center) / halfWidth)
+    } else {
+      const progress = (elapsed - first) / second
+      if (progress < 0 || progress > 1) continue
+      const inverse = 1 - progress
+      const radius = (1 - inverse * inverse * inverse) * (width / 2 + 2 * PULSE_HALF_WIDTH)
+      const distance = Math.abs(column - width / 2)
+      weights[0] = Math.max(
+        weights[0],
+        crest(Math.abs(distance - radius) / PULSE_HALF_WIDTH) * third * (1 - 0.6 * progress),
+      )
+    }
+  }
+  return weights
+}
+
+/**
+ * 混两个 RGB（线性插值）。
+ * @param t - 位置，`0` 返回 `a`、`1` 返回 `b`，不 clamp（调用方负责）。
+ */
+function blend(a: RGBColor, b: RGBColor, t: number): RGBColor {
+  return {
+    r: Math.round(a.r + (b.r - a.r) * t),
+    g: Math.round(a.g + (b.g - a.g) * t),
+    b: Math.round(a.b + (b.b - a.b) * t),
+  }
+}
+
+/**
+ * 点焰某一时刻的整行背景色。
+ *
+ * @param options - 波形参数。
+ * @param options.style - 点焰风格。
+ * @param options.elapsedMs - 距触发的时间；达到 {@link IGNITION_TOTAL_MS}
+ *   后整行返回 `undefined`（无波，行恢复本底）。
+ * @param options.width - 行列数（终端宽）。
+ * @param options.onLight - 浅色主题时用浅底色板与浅带底色。
+ * @returns 逐列背景色（`rgb(r,g,b)` 字符串）；无波的列为 `undefined`，
+ *   渲染层应输出不设背景的空格，保持行宽恒定。
+ */
+export function ignitionLineColors(options: {
+  style: IgnitionStyle
+  elapsedMs: number
+  width: number
+  onLight: boolean
+}): ReadonlyArray<Color | undefined> {
+  const { style, elapsedMs, width, onLight } = options
+  const total = IGNITION_TOTAL_MS[style] / 1000
+  const elapsed = elapsedMs / 1000
+  if (width <= 0 || elapsed <= 0 || elapsed >= total) return []
+  const hues = ignitionHues(onLight)
+  const bandRgb = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
+  const fade =
+    style === 'aurora' ? envelope(elapsed, total, /* fadeIn */ 0.25, /* fadeOut */ 0.4) : 1
+  const colors: Array<Color | undefined> = new Array(width)
+  for (let column = 0; column < width; column++) {
+    const weights = sampleColumn(style, elapsed, column, width)
+    const weight = weights[0] + weights[1] + weights[2]
+    if (weight <= 0.01) {
+      colors[column] = undefined
+      continue
+    }
+    let r = 0
+    let g = 0
+    let b = 0
+    for (let hue = 0; hue < 3; hue++) {
+      r += weights[hue]! * hues[hue]!.r
+      g += weights[hue]! * hues[hue]!.g
+      b += weights[hue]! * hues[hue]!.b
+    }
+    const hue: RGBColor = { r: r / weight, g: g / weight, b: b / weight }
+    const alpha =
+      style === 'aurora' ? Math.min(weight * 0.4, 0.5) * fade : weight * 0.55
+    // 波按强度淡入带底色：alpha=1 是纯 hue，alpha→0 收敛回本底。上限
+    // 0.6（同 Codex）——满强度也留一点底色，不刺眼。
+    const tinted = blend(bandRgb, hue, Math.min(alpha, 0.6))
+    colors[column] = rgbString(tinted)
+  }
+  return colors
+}
+
+/**
+ * 随机选一种风格，且不与上一次重复（连续两次切档不重样）。
+ * @param previous - 上一次的风格；首次触发传 `undefined`。
+ */
+export function randomIgnitionStyle(previous: IgnitionStyle | undefined): IgnitionStyle {
+  const pool = IGNITION_STYLES.filter(style => style !== previous)
+  return pool[Math.floor(Math.random() * pool.length)]!
+}

--- a/src/trajectory/effortIgnition.ts
+++ b/src/trajectory/effortIgnition.ts
@@ -50,20 +50,32 @@ const PULSE_HALF_WIDTH = 4.5
 
 /**
  * 最高档色板：三 hue 按列权重混合。深色背景用亮暖橙系，浅色背景换深
- * 暖橙系（对齐 Codex Max 档的两个变体——浅底上亮橙没有对比度）。
+ * 暖橙系（对齐 Codex Max 档的两个变体——浅底上亮橙没有对比度）。模块
+ * 级常量：每帧调用零分配。
  */
+const HUES_DARK: readonly [RGBColor, RGBColor, RGBColor] = [
+  { r: 255, g: 178, b: 66 },
+  { r: 255, g: 214, b: 120 },
+  { r: 255, g: 120, b: 60 },
+]
+const HUES_LIGHT: readonly [RGBColor, RGBColor, RGBColor] = [
+  { r: 176, g: 98, b: 0 },
+  { r: 150, g: 110, b: 0 },
+  { r: 200, g: 70, b: 20 },
+]
+
 export function ignitionHues(onLight: boolean): readonly [RGBColor, RGBColor, RGBColor] {
-  return onLight
-    ? [
-        { r: 176, g: 98, b: 0 },
-        { r: 150, g: 110, b: 0 },
-        { r: 200, g: 70, b: 20 },
-      ]
-    : [
-        { r: 255, g: 178, b: 66 },
-        { r: 255, g: 214, b: 120 },
-        { r: 255, g: 120, b: 60 },
-      ]
+  return onLight ? HUES_LIGHT : HUES_DARK
+}
+
+/**
+ * 充能色对（前缀强调用）：从带底色调的暗强调到全强调，与波共用
+ * hues[0]（同一瞬间前缀与波是同一种橙）。
+ * @param onLight - 浅色主题用浅底色板。
+ */
+export function accentRamp(onLight: boolean): { dim: RGBColor; full: RGBColor } {
+  const band = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
+  return { dim: blend(band, ignitionHues(onLight)[0]!, 0.45), full: ignitionHues(onLight)[0]! }
 }
 
 /**
@@ -73,9 +85,10 @@ export function ignitionHues(onLight: boolean): readonly [RGBColor, RGBColor, RG
 const BAND_RGB_DARK: RGBColor = { r: 27, g: 30, b: 40 }
 const BAND_RGB_LIGHT: RGBColor = { r: 240, g: 240, b: 242 }
 
-/** 余弦钟形：`crest(0)=1`、`crest(1)=0`、之外为 0。 */
+/** 余弦钟形：`crest(0)=1`、`crest(±1)=0`、之外为 0（负距离同样静默——
+ * 现有调用方都传 `Math.abs`，这里兜底防未来调用方拿到全强度）。 */
 export function crest(distance: number): number {
-  if (distance >= 1) return 0
+  if (distance >= 1 || distance <= -1) return 0
   return 0.5 * (1 + Math.cos(Math.PI * distance))
 }
 
@@ -102,13 +115,14 @@ export function easeInOutCubic(progress: number): number {
 
 /**
  * 一次性包络：`[0, total]` 外为 0，进入段按 `fadeIn` 线性升起、离开段
- * 按 `fadeOut` 线性落下，取两者较小值。
+ * 按 `fadeOut` 线性落下，取两者**较小**值（对齐上游：任意时刻受两段
+ * 斜坡中较缓的一侧约束）。
  */
 export function envelope(elapsed: number, total: number, fadeIn: number, fadeOut: number): number {
   if (elapsed <= 0 || elapsed >= total) return 0
   const inPart = elapsed / Math.max(fadeIn, Number.EPSILON)
   const outPart = (total - elapsed) / Math.max(fadeOut, Number.EPSILON)
-  return Math.min(1, Math.max(0, inPart, outPart))
+  return Math.min(1, Math.max(0, Math.min(inPart, outPart)))
 }
 
 /** 单列对全部波带的采样结果：三 hue 各自的权重（未归一）。 */
@@ -179,7 +193,7 @@ export function ignitionLineColors(options: {
   const { style, elapsedMs, width, onLight } = options
   const total = IGNITION_TOTAL_MS[style] / 1000
   const elapsed = elapsedMs / 1000
-  if (width <= 0 || elapsed <= 0 || elapsed >= total) return []
+  if (width <= 0 || !Number.isFinite(elapsed) || elapsed <= 0 || elapsed >= total) return []
   const hues = ignitionHues(onLight)
   const bandRgb = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
   const fade =
@@ -204,9 +218,15 @@ export function ignitionLineColors(options: {
     const alpha =
       style === 'aurora' ? Math.min(weight * 0.4, 0.5) * fade : weight * 0.55
     // 波按强度淡入带底色：alpha=1 是纯 hue，alpha→0 收敛回本底。上限
-    // 0.6（同 Codex）——满强度也留一点底色，不刺眼。
+    // 0.6（同 Codex）——满强度也留一点底色，不刺眼。输出前通道量化到
+    // 8 步长：渐变列因此能合并成长段（渲染层 RLE 段数降一个数量级），
+    // 8/256 的色差在终端 cell 分辨率下不可辨。
     const tinted = blend(bandRgb, hue, Math.min(alpha, 0.6))
-    colors[column] = rgbString(tinted)
+    colors[column] = rgbString({
+      r: Math.round(tinted.r / 8) * 8,
+      g: Math.round(tinted.g / 8) * 8,
+      b: Math.round(tinted.b / 8) * 8,
+    })
   }
   return colors
 }


### PR DESCRIPTION
## 是什么

思考强度（Shift+Tab / `/effort`）切到当前路线**最高档**的瞬间，状态行与提示行之间播放一秒点焰波形——三个随机风格之一，播完自卸载。移植自 Codex CLI 的 effort ignition（openai/codex PR #34365，`codex-rs/tui/src/bottom_pane/effort_ignition*.rs`）：波形数学保留原语义，实现全部重写为 TS + 本仓库的自研 ink 渲染层。

## 分层

| 文件 | 内容 |
|---|---|
| `src/trajectory/effortIgnition.ts` | 纯数学层：Wave（余弦钟形行波）/ Aurora（双正弦游走带同色相加权）/ Pulse（三次缓动扩散环）逐列采样、缓动、深浅两套暖橙色板；每次触发随机选风格且不与上次重复 |
| `src/components/EffortIgnitionLine.tsx` | 触发与渲染：effort 从「已有档位」变为「档位表末位最高档」才触发（冷启动恢复偏好、单档模型都不触发）；帧驱动复用 Ink core 共享时钟（失焦/滚出自动停摆），动画期间 keepAlive 订阅（独立场景无其他组件维持时钟）；连续同色列合并成段渲染 |
| `src/dsh-adapter/channel.ts` | `effortLevels`（低→高档位表）暴露到 state，`resolveEfforts` 成功时刷新 |
| `src/screens/StatusLine.tsx` | Row 2 与 Row 3 之间挂载点火行 |
| `scripts/verify-effort-ignition.tsx` | 验证门（下述） |

档位语义：dsh 的思考强度是 adapter 拥有的动态档位表，没有 Codex 的 Max/Ultra 双档常量——触发档取**表末位**，色板先一套暖橙（深/浅背景两变体），将来真出现双顶级档位再扩第二套。

## SGR-only 合规

motion.ts 的硬规则（动画只许变色、不许变布局）在本特性天然成立且被机器断言：动画期间行数恒一、glyph 恒为空格，帧间变化全部是背景色。挂载/卸载各是一次性布局变化，不在帧间动画约束内（与菜单开合同类）。低色终端自动经既有 colorize 链降级为 256 色。

## 验证

`node --import tsx/esm scripts/verify-effort-ignition.tsx` —— 15 项全过：

- 数学层 11 项：crest/easing 端点与 clamp、envelope 窗口、逐列色契约（每列恰一色、播放窗口外为空、全部 `rgb()` 格式、播期有列被着色）、随机风格不重复
- 场景 4 项（headless xterm，断言口径与 verify-trace-scene 的 motion 门一致）：触发前无波；播放期写流**零**行擦除/清屏/滚动 escape；真彩背景 SGR 真实绘制；恰占一行

另：`tsc -p tsconfig.json` 0 错误（构建 vendor 子模块后）；真终端（tmux）目检波形渐进色阶与间歇归零正常。

## 后续（另开 PR）

- prompt 前缀强调符 + charge 渐变（Codex 的 `›` 持久 accent）
- 状态行五幕过渡的 SGR-safe 改造版（字母聚拢需改造为等宽色波才能合规，方案在 #239 相关调研中已备）
