### PR TITLE
fix(input): 修复插话中断后的重投递卡死

### DIFF
--- a/scripts/verify-submit.mjs
+++ b/scripts/verify-submit.mjs
@@ -121,12 +121,7 @@ check('refused pull-back keeps pending', channel.removePending(channel.pending[0
 inboxRemoveResult = true
 check('pull-back succeeds once unclaimed', channel.removePending(channel.pending[0]?.id ?? '') === true && channel.pending.length === 0)
 
-// ---- interruptAndDeliver: cancel + re-queue once the abort settles ----
-// The harness parks kept inbox work until an unrelated wake (official
-// cancel.spec: "keepInbox parks queued work after an active turn aborts"),
-// and a wake issued while the driver still runs is ignored — so delivery
-// is deferred to `whenIdle`, whose re-queue IS the wake that starts the
-// new turn.
+// ---- interruptAndDeliver: cancel + re-queue through the convergence latch ----
 const interruptCalls = []
 const interruptFollowups = []
 let resolveIdle
@@ -153,11 +148,10 @@ const interruptChannel = createChannel(ctx, interruptAgent, {
 })
 check('interruptAndDeliver trims and counts', interruptChannel.interruptAndDeliver(['插话一', '   ', '插话二']) === 2)
 check('interruptAndDeliver cancels without keepInbox', interruptCalls.length === 1 && interruptCalls[0].options === undefined, JSON.stringify(interruptCalls))
-check('delivery waits for the abort to settle', interruptFollowups.length === 0 && interruptChannel.pending.length === 0, JSON.stringify(interruptFollowups))
-resolveIdle()
 await sleep(10)
-check('re-queued after idle (all texts)', interruptFollowups.length === 2 && interruptChannel.pending.length === 2, JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
+check('re-queued without waiting for idle (all texts)', interruptFollowups.length === 2 && interruptChannel.pending.length === 2, JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
 check('re-queued as followup', interruptChannel.pending.every(p => p.placement === 'followup'))
+resolveIdle?.()
 
 // A second interrupt while the first abort is still settling must not
 // double-deliver: only the latest request's re-queue runs (both share the
@@ -189,7 +183,35 @@ resolveIdle2()
 await sleep(10)
 check('double interrupt does not double-deliver', interruptFollowups.filter(m => m.content?.[0]?.text === 'x').length === 0 && interruptFollowups.filter(m => m.content?.[0]?.text === 'y').length === 1, JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
 
-// No whenIdle (defensive): the re-queue waits a beat for the abort.
+// dsh-agent's cancel-convergence wake latch accepts a followup submitted
+// immediately after cancel. Waiting for whenIdle is unsafe: the promise can
+// cover replacement work (or never settle), leaving the user's requeued text
+// undispatched and the TUI stuck in the working state.
+const convergenceFollowups = []
+const convergenceAgent = {
+  id: 'a1',
+  status: 'running',
+  session: { id: 's1', seq: 0, events: [] },
+  ctx: stubAgentCtx,
+  cancel() {},
+  whenIdle() {
+    return new Promise(() => {})
+  },
+  followup(message) {
+    convergenceFollowups.push(message)
+  },
+}
+const convergenceChannel = createChannel(ctx, convergenceAgent, {
+  model: 'deepseek-chat',
+  cwd: '/tmp',
+  provider: 'deepseek',
+  activity: false,
+})
+convergenceChannel.interruptAndDeliver(['取消后立即恢复'])
+await sleep(10)
+check('cancel convergence does not depend on whenIdle', convergenceFollowups.length === 1 && convergenceChannel.pending.length === 1, JSON.stringify(convergenceFollowups))
+
+// No whenIdle observer: delivery still uses the same convergence wake.
 const fallbackCalls = []
 const fallbackAgent = {
   id: 'a1',
@@ -208,7 +230,7 @@ const fallbackChannel = createChannel(ctx, fallbackAgent, {
   activity: false,
 })
 fallbackChannel.interruptAndDeliver(['兜底投递'])
-await sleep(300)
-check('no-whenIdle fallback delivers after a beat', fallbackCalls.length === 1 && fallbackChannel.pending.length === 1, JSON.stringify(fallbackCalls))
+await sleep(10)
+check('no-whenIdle agent still receives the wake', fallbackCalls.length === 1 && fallbackChannel.pending.length === 1, JSON.stringify(fallbackCalls))
 
 process.exit(failed)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -2045,14 +2045,12 @@ export function createChannel(
       if (queued.length === 0) return 0
       // No keepInbox: the parked copies are dropped (their discard events
       // retire the preview), then each text is re-queued as a fresh
-      // followup. The harness parks kept inbox work until an unrelated wake
-      // (official cancel.spec: "keepInbox parks queued work after an active
-      // turn aborts"), and a wake issued while the driver is still aborting
-      // is ignored — so the re-queue happens on `whenIdle`, whose own wake
-      // starts the new turn.
+      // followup. dsh-agent's cancel-convergence wake latch accepts this
+      // wake immediately after cancel and starts it once the aborted turn
+      // retires; waiting for whenIdle is unsafe because it also follows
+      // replacement work and may never settle.
       agent.cancel({ kind: 'user' })
       const token = ++interruptSeq
-      const whenIdle = (agent as { whenIdle?(): Promise<void> }).whenIdle
       const deliver = (): void => {
         // A second interrupt while the abort is still settling must not
         // double-deliver: only the latest request's re-queue runs.
@@ -2065,13 +2063,10 @@ export function createChannel(
           dispatchUserText(text, 'followup')
         }
       }
-      if (typeof whenIdle === 'function') {
-        void whenIdle.call(agent).then(deliver)
-      } else {
-        // Defensive: a wake while the driver still runs is ignored, so wait
-        // for the abort to settle before re-queueing.
-        setTimeout(deliver, 200)
-      }
+      // Let cancel finish its synchronous inbox bookkeeping before waking.
+      // A microtask also coalesces two same-tick interrupts: only the latest
+      // token survives, so the user's text is never sent twice.
+      queueMicrotask(deliver)
       return queued.length
     },
     /**


### PR DESCRIPTION
## 动机

Closes #318。

插话（Esc）会先取消当前回合，再把文本重新排队。如果等待 `agent.whenIdle()`，该 promise 可能跟随后续替代工作或永不 resolve，导致 followup 永远不调用，用户看到工作状态持续为“进行中”。

本 PR 聚焦修复 issue #318 的异常②；Esc 的“打断并立即发送”交互语义属于现有产品约定，不在本次范围内。

## 复现（RED）

在 channel-level fake agent 中让 `whenIdle()` 永不 resolve：旧实现取消后不会调用 `followup()`，回归断言稳定失败。

## 修改

- `cancel()` 后使用 dsh-agent rc.7 的 cancel-convergence wake latch，在微任务中直接重新排队。
- 保留 `interruptSeq`，同一 tick 连续中断时只投递最新请求，避免重复发送。
- 不再依赖 `whenIdle()`，也不再使用固定 200ms 兜底。

## 验证（GREEN）

- `node scripts/verify-submit.mjs`
- `pnpm exec tsc -p tsconfig.json`
- `pnpm build`
- `pnpm verify:package`
- `git diff --check`

回归覆盖：`whenIdle()` 永不 resolve、无 `whenIdle` 观察器、同一 tick 连续中断。

## 平台限制

当前环境为 Windows，无法连接 issue 报告中的 WSL2 + 真实模型运行时；本次使用真实 `createChannel` 与最小 fake agent 锁定取消/重投递竞态，验证的是同一 channel seam 和 dsh-agent rc.7 合约。