### PR TITLE
fix(input): 修复 Windows 粘贴时 Win32 记录泄漏

### DIFF
--- a/scripts/verify-win32-input.tsx
+++ b/scripts/verify-win32-input.tsx
@@ -273,6 +273,26 @@ check('IME-composed CJK arrives via Uc', new Feeder().feed(`${CSI}65;30;20320;1;
   wchar('你'),
 ])
 
+// A native Windows paste can split a win32-input-mode record after ESC.
+// When the 50ms escape timer fires before the tail arrives, the tokenizer
+// has already emitted Escape; the later `[Vk;Sc;Uc;Kd;Cs;Rc_` tail must
+// still be recognized instead of leaking the protocol bytes into the input.
+{
+  const f = new Feeder()
+  check('split win32 record: ESC waits for its tail', f.feed('\x1b'), [])
+  check('split win32 record: timeout releases Escape', f.feed(null), [
+    wkey('escape', {}, '\x1b'),
+  ])
+  check('split win32 record: late CJK tail is recovered', f.feed('[0;0;36825;1;0;1_'), [
+    wchar('这'),
+  ])
+}
+check(
+  'split win32 records: adjacent late tails are all recovered',
+  new Feeder().feed('[0;0;36825;1;0;1_[0;0;26679;1;0;1_'),
+  [wchar('这'), wchar('样')],
+)
+
 // --- 7. orphaned low surrogates never reach the Vk table ----------------------
 
 check('orphaned low surrogate with Vk=32 is swallowed (not Space)', new Feeder().feed(`${CSI}32;57;56832;1;0;1_`), [])

--- a/src/ink/parse-keypress.ts
+++ b/src/ink/parse-keypress.ts
@@ -47,6 +47,8 @@ const MODIFY_OTHER_KEYS_RE = /^\x1b\[27;(\d+);(\d+)~/
 // win32 instead of kitty/modifyOtherKeys.
 // eslint-disable-next-line no-control-regex
 const WIN32_INPUT_RE = /^\x1b\[([\d;]*)_$/
+const WIN32_INPUT_TAIL_RE = /\[\d*;\d*;\d*;[01](?:;\d*){0,2}_/g
+const WIN32_INPUT_TAILS_RE = /^(?:\[\d*;\d*;\d*;[01](?:;\d*){0,2}_)+$/
 
 // dwControlKeyState modifier bits (others — NUMLOCK_ON 0x20, CAPSLOCK_ON
 // 0x80, ENHANCED_KEY 0x100 — are state indicators, not pressed modifiers)
@@ -736,6 +738,18 @@ export function parseMultipleKeypresses(
     } else if (token.type === 'text') {
       if (inPaste) {
         pasteBuffer += token.value
+      } else if (WIN32_INPUT_TAILS_RE.test(token.value)) {
+        // A delayed win32-input-mode continuation can arrive after App's
+        // escape timer has already flushed its ESC prefix. Recover complete
+        // record tails so their protocol bytes do not leak into the prompt.
+        for (const tail of token.value.match(WIN32_INPUT_TAIL_RE) ?? []) {
+          const win32 = parseWin32KeyEvent('\x1b' + tail, win32Ctx)
+          if (win32 !== undefined && win32 !== null) {
+            for (let i = 0; i < win32.repeat; i++) {
+              keys.push(...feedWin32Paste(win32Paste, win32.key))
+            }
+          }
+        }
       } else if (
         /^\[<\d+;\d+;\d+[Mm]$/.test(token.value) ||
         /^\[M[\x60-\x7f][\x20-\uffff]{2}$/.test(token.value)


### PR DESCRIPTION
## 问题

Windows 原生终端粘贴文本时，Win32 input-mode 的一条记录可能在 ESC 后被拆成两次 stdin 读取。若 50ms ESC 定时器先触发，后到的 `[Vk;Sc;Uc;Kd;Cs;Rc_` 会被 tokenizer 当作普通文本，导致 issue 截图中的 `[0;0;36825;1;0;1_` 直接出现在输入框。

原始复现截图：

![Windows 粘贴乱码复现](https://github.com/user-attachments/assets/e1db04e6-1251-485e-9dc0-7d395a1a937b)

## 修复

- 只在整个 text token 完全由一个或多个合法 Win32 记录尾部组成时恢复，避免吞掉普通输入
- 为尾部补回 ESC，复用现有 `parseWin32KeyEvent` 解析
- 继续复用 `feedWin32Paste`，保留 repeat、keyup、代理对和 bracketed paste 的既有语义
- 不延长全局 ESC 等待时间，避免降低 Escape 键响应速度

## 复现与验证

修复前新增回归用例稳定失败：

```text
FAIL split win32 record: late CJK tail is recovered
expected: 这
actual:   [0;0;36825;1;0;1_
```

修复后通过：

- `node --import tsx/esm scripts/verify-win32-input.tsx`
- `node scripts/verify-batched-prompt-input.mjs`
- `node --import tsx/esm scripts/verify-keys.tsx`
- `pnpm exec tsc -p tsconfig.json`
- `pnpm build`
- `pnpm verify:package`
- `git diff --check`

原始分块序列也已重新执行，后到记录现在解析为中文“这”。

Closes #365