### PR TITLE
feat: 思考折叠体验 + 长会话性能与渲染修复套件（thinkingFold/恒高预览/11ms 流式/锚定重绘/审计修复）

### DIFF
--- a/docs/project-documentation/session-context.md
+++ b/docs/project-documentation/session-context.md
@@ -143,12 +143,14 @@ refreshLoadedContext（src/channel.ts:2165-2218）：
 触发点：createChannel 末尾（src/channel.ts:2244）+ rewindTo(1342) / resumeTo(1447) /
 newSession(1567) / switchModel(1672) 四个 agent 交换路径。
 
-### 启动摘要与 `/context`
+### 启动面板与 `/context`
 
-- 启动摘要仅在 `channel.rows.length === 0 && channel.loadedContext !==
-  undefined` 时显示；首条转录行接管后消失，并提示用 `/context` 查看明细。
+- 启动面板仅在 `channel.rows.length === 0 && channel.loadedContext !==
+  undefined` 时显示；默认折叠为一行摘要，Ctrl+P 展开/收起分组明细，
+  首条转录行接管后整个面板消失。
 - `/context` 每次执行都通过 `channel.pushLocal` 向当前转录输出一次本地报告；它不切换
-  常驻状态，也不进入模型上下文或会话事件。Ctrl+T 始终只打开会话轨迹。
+  常驻状态，也不进入模型上下文或会话事件。Ctrl+T 始终只打开会话轨迹，Ctrl+P 只在
+  启动面板在屏时生效。
 - 单条文本上限 800 字符（src/utils/loaded-context.ts:5，CONTEXT_ENTRY_MAX_CHARS）；
   truncateContextText 只保留头部并追加截断标记，注释明确 "model-visible
   text is the source of truth"，本地报告只约束自身渲染，模型实际收到的内容不受影响；

--- a/scripts/smoke.tsx
+++ b/scripts/smoke.tsx
@@ -517,8 +517,8 @@ console.log('--- has interrupted?', plain.includes('Interrupted') && plain.inclu
 console.log('--- has notification?', plain.includes('Test notification'))
 console.log('--- has help menu?', plain.includes('/ for commands') || true)
 
-// Startup loaded-context summary: details live behind the one-shot `/context`
-// command; Ctrl+T remains exclusively owned by the trajectory scene.
+// Startup loaded-context panel: collapsed summary, expandable with Ctrl+P;
+// the one-shot `/context` command still prints the same details as a report.
 const panelChannel = {
   ...channel,
   version: 1,
@@ -547,7 +547,7 @@ const panelInstance = await render(
 await new Promise(resolve => setTimeout(resolve, 600))
 const collapsed = plainText(panelStdout.frames)
 const hasContextSummary = collapsed.includes('已加载上下文') || collapsed.includes('Context loaded')
-console.log('--- context summary?', hasContextSummary, collapsed.includes('/context'), !collapsed.includes('Ctrl+T'))
+console.log('--- context summary?', hasContextSummary, collapsed.includes('Ctrl+P'))
 // ── Interaction panels: plan review + approval ─────────────────────────
 // Drives a third Chat with real QuestionStore/ApprovalStore instances. The
 // fake channel needs pushLocal: resolving a question folds a Q&A summary

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -148,13 +148,15 @@ function makeHarness(cols: number, rows: number) {
   }
   const stdin = new FakeStdin()
   const screen = (): string => {
-    // getLine() indexes the WHOLE buffer, scrollback included; the viewport
-    // starts at baseY. Reading from 0 after a frame taller than the terminal
-    // returns the PREVIOUS, larger frame's rows — which reads exactly like a
-    // repaint bug and is not one.
+    // Read the WHOLE buffer (scrollback + viewport), filtered of blank
+    // lines. Content-presence checks must see rows the anchored shrink
+    // repaint legitimately left to their scrollback copies (a frame that
+    // collapsed below the viewport anchors its tail at the bottom and the
+    // viewport's top region goes blank); a viewport-only read mistakes
+    // that correct presentation for a lost panel.
     const buffer = term.buffer.active
-    return Array.from({ length: rows }, (_, y) =>
-      (buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+    return Array.from({ length: buffer.length }, (_, y) =>
+      (buffer.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
       .filter(line => line !== '')
       .join('\n')
   }

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -1,11 +1,14 @@
 /**
  * Ctrl+T ownership regression.
  *
- * Loaded-context details use the one-shot `/context` command. Ctrl+T has one
- * stable meaning throughout the session: open the trajectory scene.
+ * Ctrl+T has one stable meaning throughout the session: open the trajectory
+ * scene. The startup loaded-context panel (visible only while the transcript
+ * is still empty) owns Ctrl+P instead: the key toggles the collapsed summary
+ * between the one-liner and the grouped details. The one-shot `/context`
+ * command stays available in both states.
  *
- * These checks pin both empty- and non-empty-transcript states so another
- * context-sensitive shortcut does not creep back in.
+ * These checks pin both empty- and non-empty-transcript states so a
+ * context-sensitive shortcut does not creep in the wrong direction.
  *
  * Run: node --import tsx/esm scripts/verify-ctrl-t-scope.tsx
  */
@@ -182,11 +185,13 @@ async function mount(harness: ReturnType<typeof makeHarness>, channel: Record<st
 }
 
 const CTRL_T = '\x14'
+const CTRL_P = '\x10'
 const isScene = (text: string): boolean => /✦\s*轨迹/.test(text)
 const panelHeader = (text: string): string =>
   text.split('\n').find(line => line.includes('已加载上下文')) ?? ''
 
-// ── empty transcript: summary is informational; Ctrl+T still means trace ───
+// ── empty transcript: the panel is collapsed; Ctrl+P toggles it, Ctrl+T
+//    still opens the trajectory ────────────────────────────────────────────
 {
   const harness = makeHarness(100, 30)
   const localReports: Array<{ title: string; lines: readonly string[] }> = []
@@ -197,9 +202,21 @@ const panelHeader = (text: string): string =>
   await sleep(500)
 
   const summary = harness.screen()
-  check('the startup context summary is on screen', /已加载上下文/.test(summary))
-  check('the summary points to /context', panelHeader(summary).includes('/context'), panelHeader(summary).trim())
-  check('the summary does not claim Ctrl+T', !panelHeader(summary).includes('Ctrl+T'), panelHeader(summary).trim())
+  check('the startup context panel is on screen', /已加载上下文/.test(summary))
+  check('the collapsed panel claims Ctrl+P', panelHeader(summary).includes('Ctrl+P'), panelHeader(summary).trim())
+
+  harness.stdin.write(CTRL_P)
+  await sleep(500)
+  const expanded = harness.screen()
+  check('Ctrl+P expands the panel before the first message', expanded.includes('你是 dsh'),
+    expanded.split('\n')[0]?.trim() ?? '')
+  check('the expanded details still point to /context', expanded.includes('/context'),
+    expanded.split('\n').filter(line => line.includes('/context')).join(' | '))
+
+  harness.stdin.write(CTRL_P)
+  await sleep(500)
+  check('Ctrl+P collapses the panel again', !harness.screen().includes('你是 dsh'),
+    panelHeader(harness.screen()).trim())
 
   harness.stdin.write(CTRL_T)
   await sleep(500)

--- a/scripts/verify-loaded-context-width.tsx
+++ b/scripts/verify-loaded-context-width.tsx
@@ -51,7 +51,7 @@ const context = {
 
 const app = await render(
   <ThemeProvider theme="dark">
-    <LoadedContextPanel context={context} />
+    <LoadedContextPanel context={context} open={false} onToggle={() => {}} />
   </ThemeProvider>,
   {
     stdout: new FakeStdout() as NodeJS.WriteStream,
@@ -78,8 +78,8 @@ if (contentLines.length !== 1) {
 if (!contentLines[0]?.includes('Context loaded')) {
   throw new Error(`Collapsed context summary was not rendered: ${contentLines[0] ?? ''}`)
 }
-if (contentLines[0]?.includes('Ctrl+T')) {
-  throw new Error(`Context summary still claims the trajectory shortcut: ${contentLines[0] ?? ''}`)
+if (!contentLines[0]?.includes('Ctrl+P')) {
+  throw new Error(`Collapsed context summary lost the expand hint: ${contentLines[0] ?? ''}`)
 }
 
 process.stdout.write('loaded context narrow-width regression passed\n')

--- a/scripts/verify-trace-scene.tsx
+++ b/scripts/verify-trace-scene.tsx
@@ -88,9 +88,16 @@ function makeHarness(cols: number, rows: number, scrollback = 200) {
    * here and nowhere else. The alternate screen has no scrollback, so reading
    * from 0 is what that part is actually about.
    */
-  const screenFromTop = (): string =>
-    Array.from({ length: rows }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '')
+  // Read the WHOLE buffer (frame + any scroll history): the scene's frame
+  // legitimately grows past the terminal (ledger of 20 steps), and the
+  // checks assert content presence — title at the head, hotspot rows
+  // wherever the layout put them. A 30-row window (head OR viewport)
+  // loses one end or the other.
+  const screenFromTop = (): string => {
+    const buf = term.buffer.active
+    return Array.from({ length: buf.length }, (_, y) => buf.getLine(y)?.translateToString(true) ?? '')
       .join('\n')
+  }
   return { term, stdout: new FakeStdout(), stdin, screen, screenFromTop, writes }
 }
 
@@ -270,16 +277,31 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   await sleep(140)
   check('esc clears the query', screen().includes('grep_repo'))
 
-  // View switching.
+  // View switching. The hotspot rows animate in (motion arrive); a fixed
+  // sleep races the animation — poll until the view materializes.
   stdin.write('\x1b[C')
-  await sleep(180)
-  const hotspot = screen()
+  let hotspot = ''
+  for (let i = 0; i < 40 && !(hotspot.includes('工具') || hotspot.includes('Tools')); i++) {
+    await sleep(80)
+    hotspot = screen()
+  }
+  {
+    const buf = term.buffer.active
+    const all: string[] = []
+    for (let y = 0; y < buf.length; y++) all.push(`${y}|${buf.getLine(y)?.translateToString(true)?.slice(0, 70) ?? ''}`)
+    console.error('--- FULL BUFFER (len=' + buf.length + ' vy=' + buf.viewportY + ') ---')
+    console.error(all.join(String.fromCharCode(10)))
+  }
   check('→ switches to the hotspot view', hotspot.includes('工具') || hotspot.includes('Tools'))
   check('hotspot ranks tools by cost', /web_search|read_file/.test(hotspot))
   check('hotspot draws bars', /[█▌]/.test(hotspot))
   stdin.write('\x1b[D')
-  await sleep(180)
-  check('← returns to the timeline', screen().includes('read_file'))
+  let backToTimeline = ''
+  for (let i = 0; i < 40 && !backToTimeline.includes('read_file'); i++) {
+    await sleep(80)
+    backToTimeline = screen()
+  }
+  check('← returns to the timeline', backToTimeline.includes('read_file'))
 
   instance.unmount()
   term.dispose()
@@ -491,11 +513,18 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   })
   await sleep(400)
 
-  const buffer = term.buffer.active
-  const lines = Array.from({ length: buffer.length }, (_, row) =>
-    buffer.getLine(row)?.translateToString(true) ?? '',
-  )
-  const secondIndex = lines.findLastIndex(line => line.includes('SECOND RESPONSE SECTION'))
+  // The settle paint is throttled behind the ink frame clock — poll for the
+  // markers instead of racing a fixed sleep.
+  let lines: string[] = []
+  let secondIndex = -1
+  for (let attempt = 0; attempt < 25 && secondIndex < 0; attempt++) {
+    await sleep(80)
+    const buffer = term.buffer.active
+    lines = Array.from({ length: buffer.length }, (_, row) =>
+      buffer.getLine(row)?.translateToString(true) ?? '',
+    )
+    secondIndex = lines.findLastIndex(line => line.includes('SECOND RESPONSE SECTION'))
+  }
   let firstIndex = -1
   for (let index = secondIndex - 1; index >= 0; index--) {
     if (lines[index]?.includes('FIRST RESPONSE SECTION')) {
@@ -509,7 +538,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   check(
     'reasoning that settles in the trajectory leaves no blank answer gap',
     firstIndex >= 0 && secondIndex >= 0 && gap <= 1,
-    `first=${firstIndex}, second=${secondIndex}, blank=${gap}, buffer=${buffer.length}`,
+    `first=${firstIndex}, second=${secondIndex}, blank=${gap}, buffer=${lines.length}`,
   )
 
   stdin.write('\x0f') // Ctrl+O

--- a/src/components/LoadedContextPanel.tsx
+++ b/src/components/LoadedContextPanel.tsx
@@ -1,27 +1,123 @@
 import React from 'react'
 import { t } from '../i18n.js'
 import { Box, Text } from '../ui.js'
-import type { LoadedContext } from '../dsh-adapter/channel.js'
-import { summarizeLoadedContext } from '../utils/loaded-context.js'
+import type { LoadedContext, LoadedContextEntry } from '../dsh-adapter/channel.js'
+import { summarizeLoadedContext, truncateContextText } from '../utils/loaded-context.js'
+
+/** One named entry (section or dynamic context) with its full text. */
+function Entry({ entry }: { entry: LoadedContextEntry }): React.ReactNode {
+  return (
+    <Box flexDirection="column">
+      <Text bold dimColor>
+        {entry.name}
+      </Text>
+      <Text dimColor wrap="wrap">
+        {truncateContextText(entry.text)}
+      </Text>
+    </Box>
+  )
+}
+
+/** A titled group of rows inside the expanded panel. */
+function Group({ title, children }: { title: string; children: React.ReactNode }): React.ReactNode {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold color="subtle">
+        {title}
+      </Text>
+      <Box flexDirection="column" paddingLeft={2}>
+        {children}
+      </Box>
+    </Box>
+  )
+}
 
 /**
- * The startup context summary: a one-line inventory of what a
+ * The startup context panel: a collapsed one-line summary of what a
  * fresh conversation will load for the current agent (system prompt
  * sections, workspace instruction files, dynamic context, skill catalog,
- * tools). `/context` renders the existing details as a local report; the
- * summary itself disappears once the transcript has rows. Renders nothing
- * for an empty snapshot.
+ * tools), expandable to the grouped details with Ctrl+P. The `/context`
+ * local command still prints the same details as a transcript report.
+ * The panel renders only while the transcript is still empty — the first
+ * message's rows take over. Renders nothing for an empty snapshot.
  * @param context - the channel's loaded-context snapshot.
+ * @param open - whether the grouped details are shown.
+ * @param onToggle - flips `open`; fired by the Ctrl+P keybinding.
  */
-export function LoadedContextPanel({ context }: { context: LoadedContext }): React.ReactNode {
+export function LoadedContextPanel({
+  context,
+  open,
+  onToggle,
+}: {
+  context: LoadedContext
+  open: boolean
+  onToggle: () => void
+}): React.ReactNode {
   const summary = summarizeLoadedContext(context)
   if (summary === '') return null
   return (
-    <Box marginTop={1} marginBottom={1} paddingX={1}>
-      <Text wrap="truncate">
-        {t('context-loaded')} · {summary}
-        <Text dimColor> · /context</Text>
-      </Text>
+    <Box flexDirection="column" marginTop={1} marginBottom={1}>
+      <Box paddingX={1} backgroundColor={open ? 'userMessageBackground' : undefined}>
+        <Text bold={open} wrap="truncate">
+          {open ? '▼' : '▶'} <Text dimColor>（Ctrl+P{open ? t('context-panel-collapse') : t('context-panel-expand')}）</Text> {t('context-loaded')} · {summary}
+        </Text>
+      </Box>
+      {open && (
+        <Box flexDirection="column" paddingX={1} paddingTop={1}>
+          {context.sections.length > 0 && (
+            <Group title={t('context-panel-sections', { n: context.sections.length })}>
+              {context.sections.map(section => (
+                <Entry key={section.name} entry={section} />
+              ))}
+            </Group>
+          )}
+          {context.files.length > 0 && (
+            <Group title={t('context-panel-files', { n: context.files.length })}>
+              {context.files.map(file => (
+                <Text key={file.displayPath} dimColor>
+                  {file.displayPath}
+                </Text>
+              ))}
+            </Group>
+          )}
+          {context.contexts.length > 0 && (
+            <Group title={t('context-panel-runtime', { n: context.contexts.length })}>
+              {context.contexts.map(entry => (
+                <Entry key={entry.name} entry={entry} />
+              ))}
+            </Group>
+          )}
+          {context.skills.length > 0 && (
+            <Group title={t('context-panel-skills', { n: context.skills.length })}>
+              {context.skills.map(skill => (
+                <Box key={skill.name} flexDirection="column">
+                  <Text bold dimColor>
+                    {skill.name}
+                  </Text>
+                  <Text dimColor wrap="wrap">
+                    {skill.description}
+                  </Text>
+                </Box>
+              ))}
+            </Group>
+          )}
+          {context.tools.length > 0 && (
+            <Group title={t('context-panel-tools', { n: context.tools.length })}>
+              {context.tools.map(tool => (
+                <Box key={tool.name} flexDirection="column">
+                  <Text bold dimColor>
+                    {tool.name}
+                  </Text>
+                  <Text dimColor wrap="wrap">
+                    {truncateContextText(tool.description, 160)}
+                  </Text>
+                </Box>
+              ))}
+            </Group>
+          )}
+          <Text dimColor>· /context</Text>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -276,6 +276,14 @@ export function MessageList({
       end = Math.max(end, idx + 1)
     }
   }
+  // The newest failed tool call carries the trajectory footnote
+  // (failureHint). Virtualization must not unmount it: before the window
+  // clamp the row was always mounted, now keep mounting it explicitly while
+  // the hint is live (verify-trace-scene's footnote check).
+  if (failureHintRowId !== undefined && failureHintRowId !== null) {
+    const idx = visibleRows.findIndex(row => row.id === failureHintRowId)
+    if (idx !== -1) start = Math.min(start, idx)
+  }
   const topPad = offsets[start] ?? 0
   const mountedBottom = end < visibleRows.length ? offsets[end] : total
   const bottomPad = total - mountedBottom

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -135,6 +135,30 @@ export function MessageList({
   const HEIGHTS_CACHE_MAX = 5000
   const heightsRef = React.useRef(new Map<number, number>())
   const localRefs = React.useRef(new Map<number, DOMElement>())
+  /** Row ids that have been mounted (and therefore painted into the
+   *  terminal) at least once. The sticky window may skip a row ONLY after
+   *  this: an unpainted row above the window has no scrollback copy, so
+   *  skipping it would erase it from the user's history entirely — preset
+   *  history at boot (session resume) landed exactly there. Cleared when
+   *  the list head changes identity (rewind / new session / loadOlder
+   *  prepends restored rows that must paint again). */
+  const paintedOnceRef = React.useRef<Set<number>>(new Set())
+  const paintedBaseRef = React.useRef<number | undefined>(undefined)
+  /** Window-expansion hold: after the window WIDENS (new rows mounted),
+   *  refuse to tighten for a short hold so the mounted rows actually reach
+   *  the terminal. React commits within one ink frame coalesce — a render
+   *  that mounts rows followed by the measure-tick re-render that drops
+   *  them paints only the DROPPED layout, and never-mounted rows have no
+   *  scrollback copy (preset history at boot vanished — CI
+   *  repro-inline-scrollback). After the hold, tightening is visually
+   *  free: those rows sit in scrollback and the diff skips them. */
+  const lastStartRef = React.useRef<number>(-1)
+  const holdUntilRef = React.useRef<number>(0)
+  const listHeadId = visibleRows[0]?.id
+  if (listHeadId !== undefined && paintedBaseRef.current !== undefined && listHeadId !== paintedBaseRef.current) {
+    paintedOnceRef.current = new Set()
+  }
+  if (listHeadId !== undefined) paintedBaseRef.current = listHeadId
   /** Content-space offset of visibleRows[0] (header + dividers), measured. */
   const baseRef = React.useRef<number | null>(null)
   const measureQueuedRef = React.useRef(false)
@@ -214,7 +238,36 @@ export function MessageList({
       covered -= heightOf(visibleRows[floor])
       floor--
     }
-    start = floor + 1
+    // The walk exhausted the whole list: every row is within coverage —
+    // floor+1 here would drop row 0 (its content then has no terminal copy
+    // anywhere; preset history lost its head — CI repro-inline-scrollback).
+    start = floor === 0 && covered > 0 ? 0 : floor + 1
+    // Paint-at-least-once: extend the window over any row that has never
+    // been mounted. A row the window skips keeps only its terminal/scrollback
+    // copy — a row that was never painted has NO copy anywhere, so preset
+    // history (session resume, repro-inline-scrollback's #39 family) would
+    // vanish from the user's scrollback. Extending mounts everything above
+    // on the first frame (topPad 0, full paint), then the set fills and the
+    // window tightens to the tail.
+    const paintedOnce = paintedOnceRef.current
+    for (let i = 0; i < start; i++) {
+      if (!paintedOnce.has(visibleRows[i]!.id)) {
+        start = i
+        break
+      }
+    }
+    // Expansion hold — AFTER the extension so it tracks the FINAL window:
+    // never tighten within the hold window after a widen. React commits
+    // inside one ink frame coalesce; a mount followed by the measure-tick
+    // re-render that drops the row paints only the DROPPED layout, and the
+    // row's painted-once mark (set at the first commit) is a lie.
+    if (lastStartRef.current >= 0 && start > lastStartRef.current && performance.now() < holdUntilRef.current) {
+      start = lastStartRef.current
+    }
+    if (lastStartRef.current < 0 || start < lastStartRef.current) {
+      holdUntilRef.current = performance.now() + 120
+    }
+    lastStartRef.current = start
   }
   if (forceMountRowId !== undefined && forceMountRowId !== null) {
     const idx = visibleRows.findIndex(row => row.id === forceMountRowId)
@@ -257,6 +310,11 @@ export function MessageList({
   // mounted coverage so burst scrolls never show blank spacer.
   React.useLayoutEffect(() => {
     let changed = false
+    // Mounted ⇒ painted: record rows eligible for window skipping.
+    const paintedOnce = paintedOnceRef.current
+    for (const id of localRefs.current.keys()) {
+      if (!paintedOnce.has(id)) paintedOnce.add(id)
+    }
     for (const [id, el] of localRefs.current) {
       const h = el.yogaNode?.getComputedHeight()
       if (h !== undefined && h > 0 && heightsRef.current.get(id) !== h) {

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -125,7 +125,7 @@ export function MessageList({
   }
 
   // --- layout virtualization ---------------------------------------------
-  const { columns } = useTerminalSize()
+  const { columns, rows: termRows } = useTerminalSize()
   // Measured row heights, remembered after a row unmounts so virtualization
   // can compute total content height. Bounded: row ids grow monotonically
   // and rows are never removed from the transcript (foldRows keeps the
@@ -190,6 +190,15 @@ export function MessageList({
   // back to the real bottom: a self-sustaining ping-pong that blanks the
   // transcript mid-stream.
   if (sticky && visibleRows.length > 0) {
+    // Sticky (follow-bottom): the viewport shows the TAIL of the content —
+    // mount exactly the tail window the floor walk covers, not everything
+    // from the scrollTop scan. Main-screen ScrollBox reports its viewport
+    // as the CONTENT height (the terminal itself is the scroller), so both
+    // the scan and an unclamped floor walk mount EVERY row in long
+    // sessions — and React's commit traverses every fiber of every mounted
+    // row per frame (measured as the dominant long-session stall). The
+    // user only ever sees terminal rows: clamp the walk-back coverage to
+    // the TERMINAL viewport plus overscan.
     start = Math.min(start, visibleRows.length - 1)
     // Blank-band guard: sticky scrollTop tracks the renderer's FRESH Yoga
     // scrollHeight, while these offsets use per-row heights measured one to
@@ -197,15 +206,15 @@ export function MessageList({
     // deeper through the underestimated offsets than the real viewport does,
     // unmounting rows that are still on screen (visible spacer band). Walk
     // backwards from the tail with the known heights and mount at least one
-    // viewport plus overscan of content above it, so the window can never
-    // open a gap inside what the user is looking at.
-    let covered = viewport + OVERSCAN_LINES
+    // terminal viewport plus overscan of content above it, so the window
+    // can never open a gap inside what the user is looking at.
+    let covered = Math.min(viewport, termRows) + OVERSCAN_LINES
     let floor = visibleRows.length - 1
     while (floor > 0 && covered > 0) {
       covered -= heightOf(visibleRows[floor])
       floor--
     }
-    start = Math.min(start, floor + 1)
+    start = floor + 1
   }
   if (forceMountRowId !== undefined && forceMountRowId !== null) {
     const idx = visibleRows.findIndex(row => row.id === forceMountRowId)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -49,6 +49,7 @@ export function MessageList({
   onToggleRow,
   model,
   diffLayout = 'auto',
+  thinkingFold = 'preview',
   showAll,
   onToggleAll,
   onLoadOlder,
@@ -69,6 +70,8 @@ export function MessageList({
   model: string
   /** Edit/Write diff presentation preference (forwarded to tool cards). */
   diffLayout?: 'auto' | 'split' | 'unified'
+  /** Thinking-block display mode from channel (`preview`/`full`). */
+  thinkingFold?: 'preview' | 'full'
   showAll: boolean
   onToggleAll: () => void
   /** Restore folded-away older rows from the session log (CC-style "load
@@ -344,6 +347,7 @@ export function MessageList({
               expanded={expanded}
               model={model}
               diffLayout={diffLayout}
+              thinkingFold={thinkingFold}
               background={rowBackground(row.id)}
               toolCallId={tool?.callId}
               toolName={tool?.name}
@@ -393,6 +397,7 @@ type MemoRowProps = {
   model: string
   /** Edit/Write diff presentation preference (forwarded to tool cards). */
   diffLayout: 'auto' | 'split' | 'unified'
+  thinkingFold: 'preview' | 'full'
   background: 'messageActionsBackground' | 'userMessageBackgroundHover' | undefined
   // ToolRow, flattened: the channel writes status/result fields in place,
   // so passing the object itself would make mutations invisible to memo.
@@ -433,6 +438,7 @@ function TranscriptRow({
   expanded,
   model,
   diffLayout,
+  thinkingFold,
   background,
   toolCallId,
   toolName,
@@ -524,6 +530,12 @@ function TranscriptRow({
           <AssistantThinkingMessage
             thinking={text}
             addMargin={addMargin}
+            preview={
+              streaming &&
+              thinkingFold === 'preview' &&
+              !expanded &&
+              !isExpanded
+            }
             // Streaming reasoning shows expanded live, then folds
             // automatically once the turn settles (unless Ctrl+O or a
             // single-row expansion keeps it open).

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -51,8 +51,10 @@ function clipSuffixTail(suffix: string, cut: { current: number }): string {
 
 export function StreamingMarkdown({
   children,
+  dimColor = false,
 }: {
   children: string
+  dimColor?: boolean
 }): React.ReactNode {
   // The stable prefix is kept as ONE string identity across renders: a
   // fresh substring per render would break Markdown's React.memo and
@@ -91,8 +93,8 @@ export function StreamingMarkdown({
 
   return (
     <Box flexDirection="column" gap={1}>
-      {stablePrefix && <Markdown>{stablePrefix}</Markdown>}
-      {unstableSuffix && <Markdown cacheTokens={false}>{unstableSuffix}</Markdown>}
+      {stablePrefix && <Markdown dimColor={dimColor}>{stablePrefix}</Markdown>}
+      {unstableSuffix && <Markdown dimColor={dimColor} cacheTokens={false}>{unstableSuffix}</Markdown>}
     </Box>
   )
 }

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -56,16 +56,10 @@ export function StreamingMarkdown({
   children: string
   dimColor?: boolean
 }): React.ReactNode {
-  // The stable prefix is kept per-BLOCK: each finalized markdown block
-  // renders through its own memoized <Markdown>, so a prefix advance
-  // (block completed) re-renders only the NEW block — not the whole
-  // finished prefix (marked re-parse + re-wrap of everything before it;
-  // the long-message streaming stall). Block strings keep their identity
-  // across renders; only the active/growing block re-renders, in the
-  // suffix below.
-  const blocksRef = React.useRef<string[]>([])
-  // Joined copy kept ONLY as the reset validator (text replaced?) — the
-  // render path uses blocksRef so per-block memoization holds.
+  // The stable prefix is kept as ONE string identity across renders: a
+  // fresh substring per render would break Markdown's React.memo and
+  // re-layout the entire finished transcript tail on every token. The
+  // identity only changes when a new block boundary advances the prefix.
   const prefixRef = React.useRef('')
   const cutRef = React.useRef(0)
 
@@ -73,7 +67,6 @@ export function StreamingMarkdown({
 
   // Reset if text was replaced (defensive; normally unmount handles this)
   if (!stripped.startsWith(prefixRef.current)) {
-    blocksRef.current = []
     prefixRef.current = ''
     cutRef.current = 0
   }
@@ -89,30 +82,18 @@ export function StreamingMarkdown({
   }
   let advance = 0
   for (let i = 0; i < lastContentIdx; i++) {
-    // Merge a following space token into its block so per-block rendering
-    // reproduces the single-Markdown flow (the blank separator belongs to
-    // the block before it, not the layout).
-    let raw = tokens[i]!.raw
-    const next = tokens[i + 1]
-    if (next !== undefined && next.type === 'space' && i + 1 < lastContentIdx) {
-      raw += next.raw
-      i++
-    }
-    advance += raw.length
-    blocksRef.current.push(raw)
+    advance += tokens[i].raw.length
   }
   if (advance > 0) {
     prefixRef.current = stripped.substring(0, boundary + advance)
   }
 
-  const stableBlocks = blocksRef.current
-  const unstableSuffix = clipSuffixTail(stripped.substring(prefixRef.current.length), cutRef)
+  const stablePrefix = prefixRef.current
+  const unstableSuffix = clipSuffixTail(stripped.substring(stablePrefix.length), cutRef)
 
   return (
-    <Box flexDirection="column">
-      {stableBlocks.map((block, i) => (
-        <Markdown key={i} dimColor={dimColor}>{block}</Markdown>
-      ))}
+    <Box flexDirection="column" gap={1}>
+      {stablePrefix && <Markdown dimColor={dimColor}>{stablePrefix}</Markdown>}
       {unstableSuffix && <Markdown dimColor={dimColor} cacheTokens={false}>{unstableSuffix}</Markdown>}
     </Box>
   )

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -56,10 +56,16 @@ export function StreamingMarkdown({
   children: string
   dimColor?: boolean
 }): React.ReactNode {
-  // The stable prefix is kept as ONE string identity across renders: a
-  // fresh substring per render would break Markdown's React.memo and
-  // re-layout the entire finished transcript tail on every token. The
-  // identity only changes when a new block boundary advances the prefix.
+  // The stable prefix is kept per-BLOCK: each finalized markdown block
+  // renders through its own memoized <Markdown>, so a prefix advance
+  // (block completed) re-renders only the NEW block — not the whole
+  // finished prefix (marked re-parse + re-wrap of everything before it;
+  // the long-message streaming stall). Block strings keep their identity
+  // across renders; only the active/growing block re-renders, in the
+  // suffix below.
+  const blocksRef = React.useRef<string[]>([])
+  // Joined copy kept ONLY as the reset validator (text replaced?) — the
+  // render path uses blocksRef so per-block memoization holds.
   const prefixRef = React.useRef('')
   const cutRef = React.useRef(0)
 
@@ -67,6 +73,7 @@ export function StreamingMarkdown({
 
   // Reset if text was replaced (defensive; normally unmount handles this)
   if (!stripped.startsWith(prefixRef.current)) {
+    blocksRef.current = []
     prefixRef.current = ''
     cutRef.current = 0
   }
@@ -82,18 +89,30 @@ export function StreamingMarkdown({
   }
   let advance = 0
   for (let i = 0; i < lastContentIdx; i++) {
-    advance += tokens[i].raw.length
+    // Merge a following space token into its block so per-block rendering
+    // reproduces the single-Markdown flow (the blank separator belongs to
+    // the block before it, not the layout).
+    let raw = tokens[i]!.raw
+    const next = tokens[i + 1]
+    if (next !== undefined && next.type === 'space' && i + 1 < lastContentIdx) {
+      raw += next.raw
+      i++
+    }
+    advance += raw.length
+    blocksRef.current.push(raw)
   }
   if (advance > 0) {
     prefixRef.current = stripped.substring(0, boundary + advance)
   }
 
-  const stablePrefix = prefixRef.current
-  const unstableSuffix = clipSuffixTail(stripped.substring(stablePrefix.length), cutRef)
+  const stableBlocks = blocksRef.current
+  const unstableSuffix = clipSuffixTail(stripped.substring(prefixRef.current.length), cutRef)
 
   return (
-    <Box flexDirection="column" gap={1}>
-      {stablePrefix && <Markdown dimColor={dimColor}>{stablePrefix}</Markdown>}
+    <Box flexDirection="column">
+      {stableBlocks.map((block, i) => (
+        <Markdown key={i} dimColor={dimColor}>{block}</Markdown>
+      ))}
       {unstableSuffix && <Markdown dimColor={dimColor} cacheTokens={false}>{unstableSuffix}</Markdown>}
     </Box>
   )

--- a/src/components/messages/AssistantThinkingMessage.tsx
+++ b/src/components/messages/AssistantThinkingMessage.tsx
@@ -10,6 +10,11 @@ type Props = {
   addMargin: boolean
   /** True when Ctrl+O transcript/verbose mode is on — show the full text. */
   verbose: boolean
+  /** Streaming compact mode (thinkingFold=preview): a 2-3 line live ticker
+   *  of the model's latest reasoning lines instead of the full block —
+   *  kimicode-style. Each source line truncates to the width so the block
+   *  is at most 3 screen rows tall. */
+  preview?: boolean
   /** Thinking wall-clock duration once the reasoning block settled (ms). */
   durationMs?: number
   /** Message-selection mode highlight. */
@@ -28,6 +33,7 @@ export function AssistantThinkingMessage({
   thinking,
   addMargin,
   verbose,
+  preview = false,
   durationMs,
   isSelected = false,
   onClick,
@@ -38,6 +44,32 @@ export function AssistantThinkingMessage({
     durationMs !== undefined && durationMs >= 1000
       ? ` · ${formatDuration(durationMs)}`
       : ''
+
+  if (preview) {
+    // Live ticker: the model's last few reasoning lines, dimmed, each
+    // truncated to the width — a bounded 2-3 row block that follows the
+    // stream. The folded summary takes over when the step settles.
+    const lines = thinking.split('\n')
+    const visible = lines.slice(-3)
+    const clipped = lines.length > visible.length
+    return (
+      <Box
+        flexDirection="column"
+        marginTop={addMargin ? 1 : 0}
+        backgroundColor={isSelected ? 'messageActionsBackground' : undefined}
+        onClick={onClick}
+      >
+        <Text dimColor italic>
+          ∴ {t('thinking-label')}{duration}…
+        </Text>
+        <Box paddingLeft={2}>
+          <Text dimColor italic wrap="truncate">
+            {clipped ? `…${visible.join('\n')}` : visible.join('\n')}
+          </Text>
+        </Box>
+      </Box>
+    )
+  }
 
   if (!verbose) {
     return (

--- a/src/components/messages/AssistantThinkingMessage.tsx
+++ b/src/components/messages/AssistantThinkingMessage.tsx
@@ -4,16 +4,23 @@ import { t } from '../../i18n.js'
 import { StreamingMarkdown } from '../StreamingMarkdown.js'
 import { formatDuration } from '../../cc/format.js'
 
+/** Preview body rows — a FIXED row count (kimicode-style constant-height
+ *  ticker). Ink's truncate slices the whole string across newlines as one
+ *  logical line, so a single joined Text collapses to 1-2 rows whenever
+ *  the combined width passes the terminal width, then bounces back as
+ *  lines shift. One Text per row, each truncated to the width and padded
+ *  to exactly this many rows, keeps the block height stream-independent. */
+const PREVIEW_ROWS = 3
+
 type Props = {
   thinking: string
   /** Adds the top margin between messages (CC: addMargin). */
   addMargin: boolean
   /** True when Ctrl+O transcript/verbose mode is on — show the full text. */
   verbose: boolean
-  /** Streaming compact mode (thinkingFold=preview): a 2-3 line live ticker
-   *  of the model's latest reasoning lines instead of the full block —
-   *  kimicode-style. Each source line truncates to the width so the block
-   *  is at most 3 screen rows tall. */
+  /** Streaming compact mode (thinkingFold=preview): a 3-row live ticker of
+   *  the model's latest reasoning lines instead of the full block —
+   *  kimicode-style constant height; the block never resizes mid-stream. */
   preview?: boolean
   /** Thinking wall-clock duration once the reasoning block settled (ms). */
   durationMs?: number
@@ -46,12 +53,22 @@ export function AssistantThinkingMessage({
       : ''
 
   if (preview) {
-    // Live ticker: the model's last few reasoning lines, dimmed, each
-    // truncated to the width — a bounded 2-3 row block that follows the
-    // stream. The folded summary takes over when the step settles.
+    // Live ticker: the model's last few reasoning lines, dimmed, one Text
+    // per row so each truncates to the width independently, padded to a
+    // constant PREVIEW_ROWS-tall block that follows the stream. The folded
+    // summary takes over when the step settles. The LAST row truncates
+    // from the start (leading ellipsis) so the newest tokens — which grow
+    // at the line's end — stay visible while the line is longer than the
+    // width.
     const lines = thinking.split('\n')
-    const visible = lines.slice(-3)
+    const visible = lines.slice(-PREVIEW_ROWS)
     const clipped = lines.length > visible.length
+    // Pad with single spaces — an empty-string Text renders with zero
+    // height in ink, so '' padding would not hold the row open.
+    const rows = Array.from(
+      { length: PREVIEW_ROWS },
+      (_, i) => visible[i] ?? ' ',
+    )
     return (
       <Box
         flexDirection="column"
@@ -62,10 +79,17 @@ export function AssistantThinkingMessage({
         <Text dimColor italic>
           ∴ {t('thinking-label')}{duration}…
         </Text>
-        <Box paddingLeft={2}>
-          <Text dimColor italic wrap="truncate">
-            {clipped ? `…${visible.join('\n')}` : visible.join('\n')}
-          </Text>
+        <Box flexDirection="column" paddingLeft={2}>
+          {rows.map((line, i) => (
+            <Text
+              key={i}
+              dimColor
+              italic
+              wrap={i === rows.length - 1 ? 'truncate-start' : 'truncate'}
+            >
+              {i === 0 && clipped ? `…${line}` : line}
+            </Text>
+          ))}
         </Box>
       </Box>
     )

--- a/src/components/messages/AssistantThinkingMessage.tsx
+++ b/src/components/messages/AssistantThinkingMessage.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Box, Text } from '../../ui.js'
 import { t } from '../../i18n.js'
-import { Markdown } from '../Markdown.js'
+import { StreamingMarkdown } from '../StreamingMarkdown.js'
 import { formatDuration } from '../../cc/format.js'
 
 type Props = {
@@ -66,7 +66,10 @@ export function AssistantThinkingMessage({
         ∴ {t('thinking-label')}{duration}…
       </Text>
       <Box paddingLeft={2}>
-        <Markdown dimColor>{thinking}</Markdown>
+        {/* StreamingMarkdown: the live thinking text grows per token — the
+          incremental stable-prefix + tail budget keeps the per-frame layout
+          cost at O(new content) instead of re-laying out the whole block. */}
+        <StreamingMarkdown dimColor>{thinking}</StreamingMarkdown>
       </Box>
     </Box>
   )

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -4260,10 +4260,14 @@ ${output}
         }
         streaming = undefined
         if (reasoning !== undefined) {
-          // Seal, don't fold: the per-step duration settles here, but the
-          // row keeps streaming=true (expanded) until turn/end — WebUI
-          // keepOpen parity. The next step's reasoning opens a fresh row.
+          // Seal AND fold: the per-step duration settles here and the row
+          // folds to its `∴ Thinking · 12s` summary immediately — holding
+          // every finished step's reasoning expanded until turn/end meant a
+          // 35-step turn laid out 34 full thinking blocks live (the
+          // dominant cost of long multi-step turns; CC folds per step too).
+          // The next step's reasoning opens a fresh, expanded row.
           reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
+          reasoning.streaming = false
           sealedReasoning.push(reasoning)
           logForDebugging(`thinking: step sealed (${reasoning.durationMs}ms), expanded until turn/end`)
         }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -2204,6 +2204,10 @@ export function createChannel(
       // counters land back at the rewind point, matching the fork).
       streaming = undefined
       reasoning = undefined
+      // Stale sealed/thinking bookkeeping belongs to the OLD agent's rows;
+      // keep it out of the next turn's settle logs and revive cache.
+      sealedReasoning.length = 0
+      lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
       state.rows.length = 0
@@ -2237,7 +2241,13 @@ export function createChannel(
         thinking: 0,
         tools: 0,
       }
-      for (const event of prepareReplayEvents(seed)) renderEvent(event)
+      replayEvents(seed)
+      settleStreaming()
+      // A seed ending mid-turn replays a turn/start that set working=true;
+      // the boot path resets this after replay — mirror it here so an idle
+      // rewound agent doesn't sit with a live spinner (a still-running
+      // agent re-asserts on its next event).
+      state.working = handle.agent.status === 'running'
       // Rebind subscriptions to the new agent, then free the old one.
       const oldHandle = currentHandle
       const sourceSessionId = String(agent.session.id)
@@ -2362,6 +2372,10 @@ export function createChannel(
       // rewindTo, plus the context window which the replay re-derives).
       streaming = undefined
       reasoning = undefined
+      // Stale sealed/thinking bookkeeping belongs to the OLD agent's rows;
+      // keep it out of the next turn's settle logs and revive cache.
+      sealedReasoning.length = 0
+      lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
       state.rows.length = 0
@@ -2414,8 +2428,12 @@ export function createChannel(
         thinking: 0,
         tools: 0,
       }
-      for (const event of prepareReplayEvents(handle.agent.session.events)) renderEvent(event)
+      replayEvents(handle.agent.session.events)
       settleStreaming()
+      // A log ending mid-turn replays a turn/start that set working=true;
+      // mirror the boot path's post-replay reset (a still-running agent
+      // re-asserts on its next event).
+      state.working = handle.agent.status === 'running'
       // Rebind subscriptions to the resumed agent, then free the old one.
       const oldHandle = currentHandle
       const previousSessionId = String(agent.session.id)
@@ -2521,6 +2539,10 @@ export function createChannel(
       }
       streaming = undefined
       reasoning = undefined
+      // Stale sealed/thinking bookkeeping belongs to the OLD agent's rows;
+      // keep it out of the next turn's settle logs and revive cache.
+      sealedReasoning.length = 0
+      lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
       state.rows.length = 0
@@ -2698,6 +2720,10 @@ export function createChannel(
       }
       streaming = undefined
       reasoning = undefined
+      // Stale sealed/thinking bookkeeping belongs to the OLD agent's rows;
+      // keep it out of the next turn's settle logs and revive cache.
+      sealedReasoning.length = 0
+      lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
       state.rows.length = 0
@@ -2734,8 +2760,10 @@ export function createChannel(
         thinking: 0,
         tools: 0,
       }
-      for (const event of prepareReplayEvents(seed)) renderEvent(event)
+      replayEvents(seed)
       settleStreaming()
+      // Same mid-turn-seed spinner reset as resume above.
+      state.working = handle.agent.status === 'running'
       const oldHandle = currentHandle
       agent = handle.agent
       currentHandle = handle
@@ -4063,13 +4091,39 @@ ${output}
     return streaming
   }
 
-  const ensureReasoning = (seq?: number): ChatRow => {
+  /** Latest reasoning row keyed by its (turn, step) — lets a resumed
+   *  mid-step stream REVIVE the row the replay sealed (crash-orphan tail:
+   *  replay folds the partial row, live continuation chunks would
+   *  otherwise open a SECOND row for the same step, splitting one
+   *  thinking block in two). */
+  let lastReasoningRow: { row: ChatRow; turn: number; step: number } | undefined
+
+  const ensureReasoning = (seq?: number, turn?: number, step?: number): ChatRow => {
     if (reasoning === undefined) {
+      // Same-step revive: the sealed row is this step's thinking — continue
+      // it (durationMs carried over via reasoningStart back-dating).
+      if (
+        lastReasoningRow !== undefined &&
+        turn !== undefined &&
+        lastReasoningRow.turn === turn &&
+        lastReasoningRow.step === step
+      ) {
+        reasoning = lastReasoningRow.row
+        reasoning.streaming = true
+        const sealedIdx = sealedReasoning.indexOf(reasoning)
+        if (sealedIdx !== -1) sealedReasoning.splice(sealedIdx, 1)
+        reasoningStart = Date.now() - (reasoning.durationMs ?? 0)
+        logForDebugging('thinking: revived sealed reasoning row for same step')
+        return reasoning
+      }
       reasoningStart = Date.now()
       reasoning = { id: nextRowId, kind: 'reasoning', text: '', streaming: true, ...seq !== undefined ? { seq } : {} }
       nextRowId += 1
       state.rows.push(reasoning)
       logForDebugging('thinking: reasoning row open (expanded)')
+    }
+    if (turn !== undefined && step !== undefined) {
+      lastReasoningRow = { row: reasoning, turn, step }
     }
     return reasoning
   }
@@ -4170,6 +4224,23 @@ ${output}
     }
   }
 
+  /** True while the durable transcript is being replayed (boot /resume /
+   *  rewind / model-switch fork). The assistant/message reasoning-rebuild
+   *  branch below must run ONLY on this path: in a live stream the chunks
+   *  already created the reasoning row, and foldLiveReasoning clears the
+   *  `reasoning` handle before assistant/message arrives — so
+   *  `reasoning === undefined` alone cannot tell replay from live, and
+   *  using it would rebuild a second thinking block per step. */
+  let replaying = false
+  const replayEvents = (events: readonly SessionEvent[]): void => {
+    replaying = true
+    try {
+      for (const event of prepareReplayEvents(events)) renderEvent(event)
+    } finally {
+      replaying = false
+    }
+  }
+
   const renderEvent = (event: SessionEvent): void => {
     switch (event.type) {
       case 'user/message': {
@@ -4261,7 +4332,9 @@ ${output}
             state.responseChars += chunk.text.length
           }
         } else if (chunk.type === 'reasoning-delta') {
-          if (chunk.text) ensureReasoning(event.seq).text += chunk.text
+          if (chunk.text) {
+            ensureReasoning(event.seq, event.data.turn, event.data.step).text += chunk.text
+          }
         }
         const step = tpsStep
         if (
@@ -4286,11 +4359,15 @@ ${output}
         const text = textOf(event.data.message.content)
         // Replay without chunk deltas (prepareReplayEvents drops settled
         // ones): rebuild the reasoning row from the sealed message's
-        // reasoning blocks. Live streaming never reaches this — chunks
-        // created and hold the live row. Pushed BEFORE the assistant row
-        // so the transcript order matches the live stream; settled
-        // (folded) immediately, durationMs unknown without a live clock.
-        if (reasoning === undefined) {
+        // reasoning blocks. Replay-only — gated on the `replaying` flag,
+        // not on `reasoning === undefined`: a live stream's chunks already
+        // created the row, and foldLiveReasoning has cleared the `reasoning`
+        // handle by the time this event lands, so the undefined check alone
+        // would rebuild a duplicate thinking block per step. Pushed BEFORE
+        // the assistant row so the transcript order matches the live
+        // stream; settled (folded) immediately, durationMs unknown without
+        // a live clock.
+        if (replaying && reasoning === undefined) {
           const reasoningText = event.data.message.content
             .map(block => (block.type === 'reasoning' ? block.text : ''))
             .join('')
@@ -4603,7 +4680,7 @@ ${output}
   }
 
   // Replay the durable transcript first, then follow live events.
-  for (const event of prepareReplayEvents(agent.session.events)) renderEvent(event)
+  replayEvents(agent.session.events)
   settleStreaming()
   // Attached to an idle agent: any replayed turn/start belongs to a previous
   // session run, so the spinner must not come up on boot.

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -463,6 +463,9 @@ export interface Channel {
   readonly activityFrames: string | undefined
   /** Edit/Write diff presentation preference (`auto`/`split`/`unified`). */
   readonly diffLayout: 'auto' | 'split' | 'unified'
+  /** Thinking-block display (`preview` = 2-3 line live stream + fold per
+   *  step; `full` = expanded until turn end). */
+  readonly thinkingFold: 'preview' | 'full'
   /** Whether the in-process working-activity line is shown (config.activity). */
   readonly activityEnabled: boolean
   /** Whether the segmented context bar row shows in the status footer
@@ -792,8 +795,12 @@ export interface ChannelState {
   activityFrames: string | undefined
   /** Diff presentation preference (see the public Channel type). */
   diffLayout: 'auto' | 'split' | 'unified'
+  /** Thinking-block display (see the public Channel type). */
+  thinkingFold: 'preview' | 'full'
   /** Apply a diff-layout change (see the public Channel type). */
   setDiffLayout(layout: 'auto' | 'split' | 'unified'): void
+  /** Apply a thinking-display change (see the public Channel type). */
+  setThinkingFold(mode: 'preview' | 'full'): void
   /** Working-activity display switch (see the public Channel type). */
   activityEnabled: boolean
   /** Context bar row switch (see the public Channel type). */
@@ -1220,6 +1227,9 @@ export function createChannel(
     /** Edit/Write diff presentation; default `auto` (side-by-side ≥110
      *  columns, unified below). */
     diffLayout?: 'auto' | 'split' | 'unified'
+    /** Thinking-block display; default `preview` (2-3 line live preview,
+     *  fold per step) — `full` keeps thinking expanded until turn end. */
+    thinkingFold?: 'preview' | 'full'
     /** Show the segmented context bar row in the status footer; default on
      *  (cordis.yml `contextBar: false` hides it, issue #29). */
     contextBar?: boolean
@@ -1877,6 +1887,7 @@ export function createChannel(
     workingActivity: undefined,
     activityFrames: options.activityFrames,
     diffLayout: options.diffLayout ?? 'auto',
+    thinkingFold: options.thinkingFold ?? 'preview',
     activityEnabled: options.activity !== false,
     contextBarEnabled: options.contextBar !== false,
     agentPreset: options.agentPreset,
@@ -2799,6 +2810,11 @@ export function createChannel(
     setDiffLayout(layout) {
       if (layout === state.diffLayout) return
       state.diffLayout = layout
+      state.emit()
+    },
+    setThinkingFold(mode) {
+      if (mode === state.thinkingFold) return
+      state.thinkingFold = mode
       state.emit()
     },
     setActivityFrames(name) {
@@ -4260,14 +4276,14 @@ ${output}
         }
         streaming = undefined
         if (reasoning !== undefined) {
-          // Seal AND fold: the per-step duration settles here and the row
-          // folds to its `∴ Thinking · 12s` summary immediately — holding
+          // Seal here; fold NOW in preview mode (the default: holding
           // every finished step's reasoning expanded until turn/end meant a
-          // 35-step turn laid out 34 full thinking blocks live (the
+          // 35-step turn laid out 34 full thinking blocks live — the
           // dominant cost of long multi-step turns; CC folds per step too).
-          // The next step's reasoning opens a fresh, expanded row.
+          // `full` mode (/settings opt-in) keeps the block expanded until
+          // turn settle — settleStreaming folds the sealed rows then.
           reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
-          reasoning.streaming = false
+          if (state.thinkingFold === 'preview') reasoning.streaming = false
           sealedReasoning.push(reasoning)
           logForDebugging(`thinking: step sealed (${reasoning.durationMs}ms), expanded until turn/end`)
         }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -4078,6 +4078,26 @@ ${output}
     return reasoning
   }
 
+  /** Fold the live reasoning preview the moment the model moves PAST
+   *  thinking — the answer's first text token or a tool call — not at
+   *  `assistant/message` (end of step). A long reply pushes the thinking
+   *  block into terminal scrollback long before the message seals, and
+   *  scrollback rows cannot be repainted (the cursor cannot reach them),
+   *  so a late fold leaves a stale unfolded preview frozen above the
+   *  window — the user scrolls up and the thinking looks "not folded".
+   *  Folding while the block still sits in the live window keeps the
+   *  shrink inside the diff engine's reachable region. Preview mode only
+   *  (`full` holds every block open until turn settle by design). */
+  const foldLiveReasoning = (where: string): void => {
+    if (reasoning === undefined || state.thinkingFold !== 'preview') return
+    const duration = Math.max(0, Date.now() - reasoningStart)
+    reasoning.durationMs = duration
+    reasoning.streaming = false
+    sealedReasoning.push(reasoning)
+    reasoning = undefined
+    logForDebugging(`thinking: folded at ${where} (${duration}ms)`)
+  }
+
   const settleStreaming = (): void => {
     if (streaming !== undefined) streaming.streaming = false
     streaming = undefined
@@ -4237,6 +4257,10 @@ ${output}
         const chunk = event.data.chunk
         if (chunk.type === 'text-delta') {
           if (chunk.text) {
+            // Fold the thinking preview while it is still in the live
+            // window (see foldLiveReasoning) — before this text grows the
+            // transcript and pushes the block into scrollback.
+            foldLiveReasoning('first text token')
             ensureStreaming(event.seq).text += chunk.text
             state.responseChars += chunk.text.length
           }
@@ -4276,12 +4300,13 @@ ${output}
         }
         streaming = undefined
         if (reasoning !== undefined) {
-          // Seal here; fold NOW in preview mode (the default: holding
-          // every finished step's reasoning expanded until turn/end meant a
-          // 35-step turn laid out 34 full thinking blocks live — the
-          // dominant cost of long multi-step turns; CC folds per step too).
-          // `full` mode (/settings opt-in) keeps the block expanded until
-          // turn settle — settleStreaming folds the sealed rows then.
+          // Backstop fold: reasoning whose step ended with no text token
+          // and no tool call (foldLiveReasoning handles those earlier —
+          // while the block is still in the repaintable live window;
+          // here a long reply may already have pushed it into scrollback,
+          // where the shrink cannot be repainted). `full` mode
+          // (/settings opt-in) keeps the block expanded until turn settle
+          // — settleStreaming folds the sealed rows then.
           reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
           if (state.thinkingFold === 'preview') reasoning.streaming = false
           sealedReasoning.push(reasoning)
@@ -4354,6 +4379,10 @@ ${output}
         // by the TUI once the batch is answered; tool/result for a call with
         // no card is a no-op below.
         if (event.data.name === 'ask_user_question') break
+        // Reasoning that led to a tool call is done thinking — fold the
+        // preview now, before the tool card grows the transcript past it
+        // (see foldLiveReasoning).
+        foldLiveReasoning('tool call')
         const card: ChatRow = {
           id: nextRowId,
           kind: 'tool',

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1126,48 +1126,44 @@ function restoreToolResult(row: ChatRow, event: SessionEvent<'tool/result'>): vo
 
 
 /**
- * Coalesce runs of same-type assistant/chunk deltas into single synthetic
- * events for REPLAY only. A streamed turn logs one event per token (~100k
- * events in long sessions); replaying them one at a time costs per-chunk
- * string growth on every row (quadratic in the turn's length). Merging is
- * outcome-identical: ensureStreaming/ensureReasoning only read chunk.type
- * and the concatenated text, and the row's seq comes from the run's FIRST
- * chunk (the fork boundary rewindTo derives from it). Parts join once —
- * no quadratic concat. Live events never go through this.
+ * Prepare durable events for REPLAY (resume / rewind / model-switch fork):
+ * drop settled `assistant/chunk` stream deltas — the sealed
+ * `assistant/message` events carry the full text and reasoning blocks, so
+ * per-token chunks add nothing to the replayed transcript while costing a
+ * per-chunk renderEvent pass (a real 4.5MB session logs ~19k chunks against
+ * ~30 messages). The trailing chunk run AFTER the last message belongs to an
+ * unfinished step (crash-orphaned turn) and is kept, so a resumed session
+ * still shows its partial content. Storage-level packed rows
+ * (`text-chunks`/`reasoning-chunks`/`tool-call-chunks`) are dropped the
+ * same way — defensive: the jsonl reader expands them, but a future
+ * direct-pass path must not resurrect them. Replay-side tps sampling is
+ * lost with the chunks (a live metric; lastUsage comes from the message's
+ * own usage). Live events never go through this.
  */
-function coalesceReplayEvents(events: readonly SessionEvent[]): SessionEvent[] {
-  type ChunkEvent = Extract<SessionEvent, { type: 'assistant/chunk' }>
-  const out: SessionEvent[] = []
-  let run: { event: ChunkEvent; type: string; parts: string[] } | null = null
-  const flush = (): void => {
-    if (run === null) return
-    const chunk = run.event.data.chunk
-    out.push({
-      ...run.event,
-      data: { ...run.event.data, chunk: { ...chunk, text: run.parts.join('') } },
-    } as ChunkEvent)
-    run = null
-  }
+function prepareReplayEvents(events: readonly SessionEvent[]): SessionEvent[] {
+  let lastMessageSeq = -1
   for (const event of events) {
-    if (
-      event.type === 'assistant/chunk' &&
-      (event.data.chunk.type === 'text-delta' || event.data.chunk.type === 'reasoning-delta')
-    ) {
-      if (run !== null && run.type === event.data.chunk.type) {
-        // oxlint-disable-next-line typescript/no-unnecessary-condition -- durable replay data may lack text
-        run.parts.push(event.data.chunk.text ?? '')
-        continue
-      }
-      flush()
-      // oxlint-disable-next-line typescript/no-unnecessary-condition -- durable replay data may lack text
-      run = { event, type: event.data.chunk.type, parts: [event.data.chunk.text ?? ''] }
-      continue
-    }
-    flush()
-    out.push(event)
+    if (event.type === 'assistant/message') lastMessageSeq = event.seq
   }
-  flush()
-  return out
+  return events.filter(event => {
+    if (event.type === 'assistant/message') return true
+    if (event.type === 'assistant/chunk') {
+      // Keep only the in-flight tail (no message sealed after it).
+      return lastMessageSeq < 0 || event.seq > lastMessageSeq
+    }
+    // Storage-level packed rows: not in the SessionEvent union (they exist
+    // only in the durable JSON), so compare through a widened view — the
+    // defensive drop is exactly for data the static type doesn't know.
+    const packedType = (event as { type: string }).type
+    if (
+      packedType === 'text-chunks' ||
+      packedType === 'reasoning-chunks' ||
+      packedType === 'tool-call-chunks'
+    ) {
+      return false
+    }
+    return true
+  })
 }
 
 /** Buffer below the context window at which CC warns (autoCompact.ts). */
@@ -2241,7 +2237,7 @@ export function createChannel(
         thinking: 0,
         tools: 0,
       }
-      for (const event of coalesceReplayEvents(seed)) renderEvent(event)
+      for (const event of prepareReplayEvents(seed)) renderEvent(event)
       // Rebind subscriptions to the new agent, then free the old one.
       const oldHandle = currentHandle
       const sourceSessionId = String(agent.session.id)
@@ -2418,7 +2414,7 @@ export function createChannel(
         thinking: 0,
         tools: 0,
       }
-      for (const event of coalesceReplayEvents(handle.agent.session.events)) renderEvent(event)
+      for (const event of prepareReplayEvents(handle.agent.session.events)) renderEvent(event)
       settleStreaming()
       // Rebind subscriptions to the resumed agent, then free the old one.
       const oldHandle = currentHandle
@@ -2738,7 +2734,7 @@ export function createChannel(
         thinking: 0,
         tools: 0,
       }
-      for (const event of coalesceReplayEvents(seed)) renderEvent(event)
+      for (const event of prepareReplayEvents(seed)) renderEvent(event)
       settleStreaming()
       const oldHandle = currentHandle
       agent = handle.agent
@@ -4288,6 +4284,26 @@ ${output}
       }
       case 'assistant/message': {
         const text = textOf(event.data.message.content)
+        // Replay without chunk deltas (prepareReplayEvents drops settled
+        // ones): rebuild the reasoning row from the sealed message's
+        // reasoning blocks. Live streaming never reaches this — chunks
+        // created and hold the live row. Pushed BEFORE the assistant row
+        // so the transcript order matches the live stream; settled
+        // (folded) immediately, durationMs unknown without a live clock.
+        if (reasoning === undefined) {
+          const reasoningText = event.data.message.content
+            .map(block => (block.type === 'reasoning' ? block.text : ''))
+            .join('')
+          if (reasoningText !== '') {
+            state.rows.push({
+              id: nextRowId,
+              kind: 'reasoning',
+              text: reasoningText,
+              seq: event.seq,
+            })
+            nextRowId += 1
+          }
+        }
         // Reasoning/tool-only steps emit no text: creating an assistant row
         // anyway leaves an empty `●` bullet in the transcript. A pre-existing
         // streaming row always has text (ensureStreaming is only reached on
@@ -4587,7 +4603,7 @@ ${output}
   }
 
   // Replay the durable transcript first, then follow live events.
-  for (const event of coalesceReplayEvents(agent.session.events)) renderEvent(event)
+  for (const event of prepareReplayEvents(agent.session.events)) renderEvent(event)
   settleStreaming()
   // Attached to an idle agent: any replayed turn/start belongs to a previous
   // session run, so the spinner must not come up on boot.

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -77,6 +77,10 @@ export interface Config {
    *  terminals (≥110 cols) and unified below; `split`/`unified` force one
    *  layout. Editable live from the `/settings` screen. */
   diffLayout?: 'auto' | 'split' | 'unified'
+  /** Thinking-block display: `preview` (default) streams a 2-3 line live
+   *  preview and folds each step when it settles; `full` keeps thinking
+   *  expanded until the whole turn ends. Editable live from `/settings`. */
+  thinkingFold?: 'preview' | 'full'
   /** Shift+Tab session-mode cycle (array order IS the cycle order; index 0
    *  is the unmarked base mode). Each entry bundles any subset of the
    *  `plan`/`sandbox`/`approval` atoms; absent → the built-in
@@ -102,6 +106,7 @@ export const Config: Schema<Config> = Schema.object({
   lang: Schema.string().required(false),
   preset: Schema.string().required(false),
   diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
+  thinkingFold: Schema.union(['preview', 'full']).default('preview'),
   modes: Schema.array(
     Schema.object({
       id: Schema.string(),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -343,6 +343,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     // Edit/Write diff presentation (schema default 'auto'); the /settings
     // screen edits this key live through the dsh-tui namespace.
     diffLayout: config.diffLayout,
+    thinkingFold: config.thinkingFold,
     handle,
   })
   // Register the dsh-tui settings namespace so the /settings screen can
@@ -354,6 +355,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       settingsNamespace('dsh-tui'),
       Schema.object({
         diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
+        thinkingFold: Schema.union(['preview', 'full']).default('preview'),
         // No default on purpose: an unset `lang` keeps the field showing
         // the effective language (see the section's format below) and lets
         // cordis.yml / lang.json keep their precedence.
@@ -374,9 +376,15 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
         writeLangPref(value.lang)
       }
     }
-    const apply = (next: { diffLayout?: 'auto' | 'split' | 'unified'; lang?: 'zh' | 'en' }): void => {
+    // thinkingFold rides the same namespace: /settings writes it live and
+    // the channel picks it up at the next step seal.
+    const applyThinkingFold = (value: { thinkingFold?: 'preview' | 'full' }): void => {
+      channel.setThinkingFold(value.thinkingFold ?? config.thinkingFold ?? 'preview')
+    }
+    const apply = (next: { diffLayout?: 'auto' | 'split' | 'unified'; lang?: 'zh' | 'en'; thinkingFold?: 'preview' | 'full' }): void => {
       applyLayout(next)
       applyLang(next)
+      applyThinkingFold(next)
     }
     apply(scope.get())
     scope.watch(next => {
@@ -424,6 +432,18 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
             { value: 'auto', label: 'Auto (by width)', descriptions: { zh: '自动（按宽度）' } },
             { value: 'split', label: 'Side-by-side', descriptions: { zh: '双栏对照' } },
             { value: 'unified', label: 'Unified', descriptions: { zh: '统一式' } },
+          ],
+        },
+        {
+          path: ['thinkingFold'],
+          label: 'Thinking display',
+          descriptions: { zh: '思考块展示' },
+          hint: 'Streaming thinking shows a 2-3 line live preview and each step folds when it settles; Full keeps thinking expanded until the turn ends.',
+          hintDescriptions: { zh: '流式时思考显示 2-3 行动态预览，每步落定后折叠；展开模式保持思考展开直到整轮结束。' },
+          kind: 'select',
+          options: [
+            { value: 'preview', label: 'Preview (2-3 lines)', descriptions: { zh: '预览（2-3 行）' } },
+            { value: 'full', label: 'Full until turn end', descriptions: { zh: '展开至轮末' } },
           ],
         },
       ],

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -142,6 +142,8 @@ const dict = {
   'skill-release-notes-prompt': { zh: '请使用 release-notes 技能为当前项目生成发布说明。', en: 'Use the release-notes skill to generate release notes for the current project.' },
   'skill-vuln-check-prompt': { zh: '请使用 vuln-check 技能对当前项目做一次安全漏洞检查。', en: 'Use the vuln-check skill to run a security vulnerability check on the current project.' },
   'context-loaded': { zh: '已加载上下文', en: 'Context loaded' },
+  'context-panel-expand': { zh: '展开', en: 'Expand' },
+  'context-panel-collapse': { zh: '折叠', en: 'Collapse' },
   'copied-chars': { zh: '已复制 {{n}} 个字符', en: 'Copied {{n}} characters' },
   'activity-usage-name': { zh: '/activity frames <名>', en: '/activity frames <name>' },
   'activity-current-preset': { zh: '当前预设  {{name}}', en: 'Current preset  {{name}}' },

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -468,6 +468,23 @@ export default class Ink {
     // without the pop we'd accumulate depth on each editor round-trip).
     this.options.stdout.write('\x1b[?1004h' + (supportsWin32InputMode() ? ENABLE_WIN32_INPUT_MODE : supportsExtendedKeys() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS : ''));
   }
+  /**
+   * One-shot viewport re-anchor for the NEXT main-screen frame: repaint the
+   * visible viewport in place instead of diffing. Exposed for callers that
+   * know a layout flip just rewrote the whole frame (Ctrl+O transcript
+   * toggle): the ordinary scroll-based diff pushes rows into terminal
+   * scrollback on every expand and nothing removes them on collapse — rapid
+   * toggles drift the virtual↔scrollback mapping until writes misland.
+   * In-place repaint adds nothing to scrollback. No-op in alt-screen
+   * (already CSI H-anchored every frame). ONLY sets the flag: the caller's
+   * own state change (setExpanded) drives the render that consumes it —
+   * forcing an extra render here would paint the OLD layout once more and
+   * burn the flag before the real frame lands.
+   */
+  reanchorViewport() {
+    if (this.altScreenActive) return;
+    this.log.requestViewportReanchor();
+  }
   onRender() {
     if (this.isUnmounted || this.isPaused) {
       return;

--- a/src/ink/log-update.ts
+++ b/src/ink/log-update.ts
@@ -109,6 +109,11 @@ export class LogUpdate {
   /** Drop the previous-output state after the process resumes from suspension (SIGCONT) so terminal content is not clobbered. */
   reset(): void {
     this.state.previousOutput = ''
+    // Any anchored-pad offset is void: the next frame repaints from the
+    // physical cursor without it (SIGCONT resume, repaint(), forceRedraw,
+    // and alt-screen entry all land here — without the clear, rows the
+    // repaint just drew at the viewport top would stay marked unreachable).
+    this.state.anchoredPad = 0
   }
 
   private renderFullFrame(frame: Frame): Diff {
@@ -198,11 +203,13 @@ export class LogUpdate {
     // _after_ the viewport change which means calcuating text wrapping.
     // Resizing is a rare enough event that it's not practically a big issue.
     if (
-      next.viewport.height < prev.viewport.height ||
+      next.viewport.height !== prev.viewport.height ||
       (prev.viewport.width !== 0 && next.viewport.width !== prev.viewport.width)
     ) {
       // A resize re-aligns the whole terminal (reflow rewraps scrollback):
       // any anchored-pad offset from a previous shrink repaint is void.
+      // Height-only growth is included: the shrink branches below would
+      // otherwise mix the old and new viewport heights in their geometry.
       this.state.anchoredPad = 0
       return fullResetSequence_CAUSES_FLICKER(next, 'resize', stylePool)
     }
@@ -216,6 +223,25 @@ export class LogUpdate {
     // mutually exclusive anyway).
     if (this.state.reanchorPending && !altScreen) {
       this.state.reanchorPending = false
+      // An anchored layout is live: a plain in-place repaint would redraw
+      // the whole frame top-anchored, duplicating the scrollback originals
+      // the anchor just preserved, and dropping the pad would freeze the
+      // freshly drawn top rows as unreachable. Re-run the seam-aware
+      // anchored repaint instead — it keeps the bottom-anchored layout
+      // when the seam still matches (idle reanchor: prev ≈ next) and falls
+      // back to a top-anchored whole-frame repaint (pad 0) when the frame
+      // content changed meanwhile.
+      if (this.state.anchoredPad > 0 && next.screen.height < next.viewport.height) {
+        const { patches, anchoredPad } = shrinkAnchoredRepaint(
+          prev,
+          next,
+          stylePool,
+          this.state.anchoredPad,
+        )
+        this.state.anchoredPad = anchoredPad
+        return patches
+      }
+      this.state.anchoredPad = 0
       return repaintViewportInPlace(prev, next, stylePool)
     }
 
@@ -298,7 +324,7 @@ export class LogUpdate {
     // Use <= (not <) because even when next height equals viewport height,
     // the scrollback depth from the previous render differs from a fresh
     // render.
-    if (prevHadScrollback && nextFitsViewport && isShrinking) {
+    if (!altScreen && prevHadScrollback && nextFitsViewport && isShrinking) {
       // Anchored tail repaint (see shrinkAnchoredRepaint): rows already in
       // scrollback keep their originals; only the changed tail is
       // repainted. The former full reset here reprinted the whole short
@@ -811,7 +837,10 @@ function shrinkAnchoredRepaint(
   renderFrameSlice(screen, next, startY, height, stylePool, false)
   return {
     patches: [{ type: 'stdout', content: anchor }, ...screen.diff],
-    anchoredPad: skip,
+    // Cap at height-1: a seam that matches every row of a very short frame
+    // must not mark the WHOLE frame as scrollback — the last row (the
+    // input area) stays live and repaintable.
+    anchoredPad: Math.min(skip, height - 1),
   }
 }
 

--- a/src/ink/log-update.ts
+++ b/src/ink/log-update.ts
@@ -423,16 +423,23 @@ export class LogUpdate {
     // an additional row out of view at the end of the previous frame. Without
     // this, the diff loop treats that row as reachable — but the cursor clamps
     // at viewport top, causing writes to land 1 row off and garbling the output.
+    // Unreachable frame rows = terminal scrollback. Two contributors, take
+    // the MAX, never the sum: after an anchored shrink repaint the pad rows
+    // ARE the scrollback (heights undercount while H < V); once growth
+    // scrolls the blank band away, the heights formula takes over (summing
+    // would overcount and skip REACHABLE viewport rows — changes inside
+    // the viewport would never paint, scrambling the layout on mid-frame
+    // edits like Ctrl+O expansion).
     const viewportY = Math.max(
-      0,
-      (growing
+      this.state.anchoredPad,
+      growing
         ? Math.max(
             0,
             prev.screen.height - prev.viewport.height + cursorRestoreScroll,
           )
         : Math.max(prev.screen.height, next.screen.height) -
           next.viewport.height +
-          cursorRestoreScroll) + this.state.anchoredPad,
+          cursorRestoreScroll,
     )
 
     // Rows above viewportY live in terminal scrollback and are skipped by the

--- a/src/ink/log-update.ts
+++ b/src/ink/log-update.ts
@@ -21,6 +21,7 @@ import {
 } from './screen.js'
 import {
   CURSOR_HOME,
+  cursorDown,
   cursorUp,
   eraseToEndOfScreen,
   scrollDown as csiScrollDown,
@@ -38,6 +39,11 @@ type State = {
    *  the physical cursor position instead of diffing. See
    *  requestViewportReanchor. */
   reanchorPending: boolean
+  /** Rows of the current frame whose live copies live in terminal
+   *  scrollback (set by shrinkAnchoredRepaint): the diff loop's viewportY
+   *  must skip them and every height-based offset shifts down by this
+   *  amount. Cleared by resize resets (fresh alignment). */
+  anchoredPad: number
 }
 
 type Options = {
@@ -59,6 +65,7 @@ export class LogUpdate {
     this.state = {
       previousOutput: '',
       reanchorPending: false,
+      anchoredPad: 0,
     }
   }
 
@@ -194,6 +201,9 @@ export class LogUpdate {
       next.viewport.height < prev.viewport.height ||
       (prev.viewport.width !== 0 && next.viewport.width !== prev.viewport.width)
     ) {
+      // A resize re-aligns the whole terminal (reflow rewraps scrollback):
+      // any anchored-pad offset from a previous shrink repaint is void.
+      this.state.anchoredPad = 0
       return fullResetSequence_CAUSES_FLICKER(next, 'resize', stylePool)
     }
 
@@ -289,14 +299,24 @@ export class LogUpdate {
     // the scrollback depth from the previous render differs from a fresh
     // render.
     if (prevHadScrollback && nextFitsViewport && isShrinking) {
+      // Anchored tail repaint (see shrinkAnchoredRepaint): rows already in
+      // scrollback keep their originals; only the changed tail is
+      // repainted. The former full reset here reprinted the whole short
+      // frame from the viewport top — duplicating every pre-shrink row the
+      // user scrolls up to (the whale-logo / duplicated-transcript
+      // reports).
+      const scrollbackRows = Math.max(
+        0,
+        Math.max(prev.screen.height, next.screen.height) -
+          next.viewport.height +
+          (prevHadScrollback ? 1 : 0),
+      )
+      const { patches, anchoredPad } = shrinkAnchoredRepaint(prev, next, stylePool, scrollbackRows)
+      this.state.anchoredPad = anchoredPad
       logForDebugging(
-        `Full reset (shrink->below): prevHeight=${prev.screen.height}, nextHeight=${next.screen.height}, viewport=${prev.viewport.height}`,
+        `Anchored shrink repaint (shrink->below): prevHeight=${prev.screen.height}, nextHeight=${next.screen.height}, viewport=${prev.viewport.height}, skip=${anchoredPad}`,
       )
-      return fullResetSequence_CAUSES_FLICKER(
-        next,
-        'offscreen',
-        stylePool,
-      )
+      return patches
     }
 
     // Steady-state scrollback check removed: rows above the viewport used
@@ -351,14 +371,26 @@ export class LogUpdate {
         prev.screen.height > prev.viewport.height &&
         next.screen.height < next.viewport.height
       ) {
-        logForDebugging(
-          `Full reset (shrink to fit): prevHeight=${prev.screen.height}, nextHeight=${next.screen.height}, viewport=${prev.viewport.height}`,
+        // Same anchored tail repaint as the shrink->below branch above —
+        // rows already in scrollback keep their originals; only the
+        // non-scrollback tail is repainted. The former full reset
+        // reprinted the whole frame, duplicating the scrollback rows
+        // (whale-logo / duplicated-transcript reports).
+        const scrollbackRows = Math.max(
+          0,
+          prev.screen.height - prev.viewport.height + cursorRestoreScroll,
         )
-        return fullResetSequence_CAUSES_FLICKER(
+        const { patches, anchoredPad } = shrinkAnchoredRepaint(
+          prev,
           next,
-          'offscreen',
           this.options.stylePool,
+          scrollbackRows,
         )
+        this.state.anchoredPad = anchoredPad
+        logForDebugging(
+          `Anchored shrink repaint (shrink to fit): prevHeight=${prev.screen.height}, nextHeight=${next.screen.height}, viewport=${prev.viewport.height}, skip=${anchoredPad}`,
+        )
+        return patches
       }
 
       // eraseLines only works within the viewport - it can't clear scrollback.
@@ -391,14 +423,17 @@ export class LogUpdate {
     // an additional row out of view at the end of the previous frame. Without
     // this, the diff loop treats that row as reachable — but the cursor clamps
     // at viewport top, causing writes to land 1 row off and garbling the output.
-    const viewportY = growing
-      ? Math.max(
-          0,
-          prev.screen.height - prev.viewport.height + cursorRestoreScroll,
-        )
-      : Math.max(prev.screen.height, next.screen.height) -
-        next.viewport.height +
-        cursorRestoreScroll
+    const viewportY = Math.max(
+      0,
+      (growing
+        ? Math.max(
+            0,
+            prev.screen.height - prev.viewport.height + cursorRestoreScroll,
+          )
+        : Math.max(prev.screen.height, next.screen.height) -
+          next.viewport.height +
+          cursorRestoreScroll) + this.state.anchoredPad,
+    )
 
     // Rows above viewportY live in terminal scrollback and are skipped by the
     // diff loop (see below). Clip the damage region to the visible area so the
@@ -695,6 +730,82 @@ function fullResetSequence_CAUSES_FLICKER(
   const screen = new VirtualScreen({ x: 0, y: startY }, frame.viewport.width)
   renderFrameSlice(screen, frame, startY, height, stylePool, false)
   return [{ type: 'clearTerminal', reason, debug }, ...screen.diff]
+}
+
+/**
+ * Anchored tail repaint for shrink-to-fit frames — the fix for the
+ * duplicated-whale/duplicated-transcript family. When growth pushed frame
+ * rows into terminal scrollback and a shrink then brings the frame back
+ * below the viewport, repainting the whole (short) frame from the viewport
+ * top re-prints rows whose originals already sit in scrollback — the user
+ * scrolls up and sees every pre-shrink row twice.
+ *
+ * Two layouts, decided by content:
+ *  - The new frame's top rows are UNCHANGED from the previous frame (the
+ *    common small shrink — a fold, a spinner unmounting): those rows
+ *    already live in scrollback and keep their originals. Erase the
+ *    viewport in place (no 2J — history untouched) and repaint ONLY the
+ *    changed tail, anchored at the viewport BOTTOM so the frame continues
+ *    the scrollback seamlessly. The leading blank band is recorded as
+ *    `anchoredPad` so later frames' viewportY math skips the scrollback
+ *    rows and relative addressing stays consistent (the band scrolls away
+ *    naturally as the next turn grows).
+ *  - The frame's top content CHANGED (a panel collapsing, 38 rows → 2):
+ *    nothing in scrollback represents the new frame — repaint the whole
+ *    short frame top-anchored, matching a fresh render (collapse-shrink's
+ *    contract), pad 0.
+ */
+function shrinkAnchoredRepaint(
+  prev: Frame,
+  next: Frame,
+  stylePool: StylePool,
+  scrollbackRows: number,
+): { patches: Diff; anchoredPad: number } {
+  // Seam check, not prefix equality: the scrollback's DEEPEST row (old row
+  // skip-1) sits directly above the region we are about to paint — if it
+  // equals the new frame's row at the same index, the frame's lineage is
+  // intact (the shrink removed rows from the bottom region) and the
+  // scrollback originals stay authoritative. Volatile top rows (the
+  // status header's ticking counters) don't matter — only the seam does.
+  // Walk the skip down until the seam matches; 0 means the frame's top
+  // content changed (a collapsing panel) and the whole short frame gets a
+  // top-anchored repaint instead.
+  const width = Math.min(prev.screen.width, next.screen.width)
+  const rowsDiffer = (y: number): boolean => {
+    if (y >= prev.screen.height || y >= next.screen.height) return true
+    const po = y * prev.screen.width * 2
+    const no = y * next.screen.width * 2
+    for (let x = 0; x < width * 2; x++) {
+      if (prev.screen.cells[po + x] !== next.screen.cells[no + x]) return true
+    }
+    return false
+  }
+  let skip = Math.min(scrollbackRows, next.screen.height)
+  while (skip > 0 && rowsDiffer(skip - 1)) skip -= 1
+
+  const viewportHeight = prev.viewport.height
+  const height = next.screen.height
+  if (skip <= 0) {
+    // Top-anchored whole-frame repaint — the fresh-render layout.
+    const contentRows = Math.min(height, Math.max(1, viewportHeight - 1))
+    const startY = height - contentRows
+    const anchor = CURSOR_HOME + eraseToEndOfScreen()
+    const screen = new VirtualScreen({ x: 0, y: startY }, next.viewport.width)
+    renderFrameSlice(screen, next, startY, height, stylePool, false)
+    return { patches: [{ type: 'stdout', content: anchor }, ...screen.diff], anchoredPad: 0 }
+  }
+
+  const rowsToPaint = Math.max(1, Math.min(height, viewportHeight - 1, height - skip))
+  const startY = height - rowsToPaint
+  const blankBand = Math.max(0, viewportHeight - 1 - rowsToPaint)
+  const anchor =
+    CURSOR_HOME + eraseToEndOfScreen() + (blankBand > 0 ? cursorDown(blankBand) : '')
+  const screen = new VirtualScreen({ x: 0, y: startY }, next.viewport.width)
+  renderFrameSlice(screen, next, startY, height, stylePool, false)
+  return {
+    patches: [{ type: 'stdout', content: anchor }, ...screen.diff],
+    anchoredPad: skip,
+  }
 }
 
 /**

--- a/src/ink/log-update.ts
+++ b/src/ink/log-update.ts
@@ -223,24 +223,14 @@ export class LogUpdate {
     // mutually exclusive anyway).
     if (this.state.reanchorPending && !altScreen) {
       this.state.reanchorPending = false
-      // An anchored layout is live: a plain in-place repaint would redraw
-      // the whole frame top-anchored, duplicating the scrollback originals
-      // the anchor just preserved, and dropping the pad would freeze the
-      // freshly drawn top rows as unreachable. Re-run the seam-aware
-      // anchored repaint instead — it keeps the bottom-anchored layout
-      // when the seam still matches (idle reanchor: prev ≈ next) and falls
-      // back to a top-anchored whole-frame repaint (pad 0) when the frame
-      // content changed meanwhile.
-      if (this.state.anchoredPad > 0 && next.screen.height < next.viewport.height) {
-        const { patches, anchoredPad } = shrinkAnchoredRepaint(
-          prev,
-          next,
-          stylePool,
-          this.state.anchoredPad,
-        )
-        this.state.anchoredPad = anchoredPad
-        return patches
-      }
+      // Plain in-place viewport repaint, and the anchored layout (if any)
+      // is superseded: pad 0. An earlier revision routed pad>0 frames
+      // through shrinkAnchoredRepaint here to preserve the anchored layout
+      // — empirically that occasionally painted nothing after alt-screen
+      // exits (verify-trace-scene's settle-gap check, ~15% flake), while
+      // the plain path is verified stable; a reanchor-with-pad is rare
+      // (idle gap right after a settle shrink) and its cost is one stale
+      // scrollback copy, not a lost paint.
       this.state.anchoredPad = 0
       return repaintViewportInPlace(prev, next, stylePool)
     }

--- a/src/ink/output.ts
+++ b/src/ink/output.ts
@@ -497,7 +497,7 @@ export default class Output {
       this.packedChars -= oldest.value.length
       this.packedLines.delete(oldest.value)
     }
-    this.packedLines.set(line, run)
+    this.packedLines.set(detachString(line), run)
     this.packedChars += line.length
   }
 
@@ -1223,8 +1223,11 @@ function writeLineToScreen(
     offsetX += isWideCharacter ? 2 : 1
   }
 
-  // Commit the recording for the packed fast path (complete runs only).
-  if (runAlive && run !== undefined && packed !== undefined && run.lastX >= run.baseX) {
+  // Commit the recording for the packed fast path. Complete NON-EMPTY
+  // runs only: an empty line ('' from split('\n'), zero-width-only lines)
+  // records zero entries and would commit a degenerate run whose replay
+  // writes NaN damage (gaps[0] undefined) and poisons the whole frame diff.
+  if (runAlive && run !== undefined && packed !== undefined && run.gaps.length > 0) {
     packed.commit(line, run)
   }
 

--- a/src/ink/output.ts
+++ b/src/ink/output.ts
@@ -12,16 +12,22 @@ import { reorderBidi } from './bidi.js'
 import { type Rectangle, unionRect } from './layout/geometry.js'
 import {
   blitRegion,
+  cellRunSpan,
   CellWidth,
+  createCellRun,
   extractHyperlinkFromStyles,
   filterOutHyperlinkStyles,
   markNoSelectRegion,
   OSC8_PREFIX,
+  recordCellRunEntry,
+  recordSpacerRunEntry,
+  replayCellRun,
   resetScreen,
   type Screen,
   type StylePool,
   setCellAt,
   shiftRows,
+  type CellRun,
 } from './screen.js'
 import { stringWidth } from './stringWidth.js'
 import { widestLine } from './widest-line.js'
@@ -66,6 +72,12 @@ const MAX_CACHEABLE_LINE = 500
 const CHAR_CACHE_MAX_ENTRIES = 16384
 const CHAR_CACHE_MAX_CHARS = 100_000
 
+/** Packed-run line cap: runs are three integers per cell (no per-char
+ *  objects like charCache entries), so long ANSI-art lines (the whale
+ *  logo, ~700 chars) are worth caching — they would otherwise
+ *  re-tokenize and re-cluster every frame. */
+const PACKED_MAX_LINE = 4000
+
 /** Copy a string into a fresh flat string with no parent references. */
 function detachString(s: string): string {
   // Buffer round-trip guarantees a newly allocated flat string; cheaper
@@ -79,31 +91,59 @@ function detachString(s: string): string {
  * no caller can accidentally grow it unboundedly.
  */
 export class CharCache {
+  /**
+   * LRU of line → clustered characters. A full clear on overflow
+   * (the original behavior) thrashes during long-session streaming: the
+   * mounted window's static lines alone approach the char budget, so the
+   * streaming row's per-frame new keys tip it over every frame or two,
+   * nuking the cache and forcing ~1800 line re-tokenizations per frame
+   * (measured ~100ms/frame at a 175-row session). Evicting oldest-first
+   * keeps the hot mounted lines resident while streaming churn falls out
+   * the back. Recency is refreshed on hit (delete + re-insert) so lines
+   * read every frame are never evicted by one-shot churn.
+   */
   private map = new Map<string, ClusteredChar[]>()
   private chars = 0
 
   /**
-   * Return the cached clustered characters for a line, if present.
+   * Return the cached clustered characters for a line, if present, and
+   * refresh the entry's recency.
    * @param line - the line to look up.
    * @returns the cached characters, or undefined on a miss.
    */
   get(line: string): ClusteredChar[] | undefined {
-    return this.map.get(line)
+    const hit = this.map.get(line)
+    if (hit !== undefined) {
+      this.map.delete(line)
+      this.map.set(line, hit)
+    }
+    return hit
   }
 
   /**
-   * Cache clustered characters for a line, enforcing the cache bounds.
+   * Cache clustered characters for a line, enforcing the cache bounds by
+   * evicting least-recently-used entries (never a full clear).
    * @param line - the line key.
    * @param characters - the clustered characters to cache.
    */
   set(line: string, characters: ClusteredChar[]): void {
     if (line.length > MAX_CACHEABLE_LINE) return
-    if (
+    if (this.map.has(line)) {
+      this.map.delete(line)
+      this.chars -= line.length
+    }
+    // Evict oldest entries until the new one fits. A single line longer
+    // than the whole budget cannot fit even empty — skip caching it.
+    if (line.length > CHAR_CACHE_MAX_CHARS) return
+    while (
       this.map.size >= CHAR_CACHE_MAX_ENTRIES ||
       this.chars + line.length > CHAR_CACHE_MAX_CHARS
     ) {
-      this.map.clear()
-      this.chars = 0
+      const oldest = this.map.keys().next()
+      if (oldest.done === true) break
+      const oldestKey = oldest.value
+      this.chars -= oldestKey.length
+      this.map.delete(oldestKey)
     }
     this.map.set(detachString(line), characters)
     this.chars += line.length
@@ -424,6 +464,44 @@ export default class Output {
   private charCache = new CharCache()
 
   /**
+   * LRU of line → recorded packed cell run, mirroring charCache's bounds.
+   * The main-screen architecture repaints every settled line each frame;
+   * the recorded run replays as raw two-word stores (no interning, no
+   * packing, no guard branches) — the long-session streaming fix. Runs are
+   * validated against the screen they were interned on and die with it.
+   */
+  private packedLines = new Map<string, CellRun>()
+  private packedChars = 0
+
+  /** Stable owner handle passed to writeLineToScreen (no per-call closure). */
+  private readonly packedOwner = {
+    lines: this.packedLines,
+    commit: (line: string, run: CellRun): void => {
+      this.setPackedLine(line, run)
+    },
+  }
+
+  /** Insert into the packed-lines LRU, evicting oldest entries on budget. */
+  private setPackedLine(line: string, run: CellRun): void {
+    if (line.length > PACKED_MAX_LINE) return
+    if (this.packedLines.has(line)) {
+      this.packedLines.delete(line)
+      this.packedChars -= line.length
+    }
+    while (
+      this.packedLines.size >= CHAR_CACHE_MAX_ENTRIES ||
+      this.packedChars + line.length > CHAR_CACHE_MAX_CHARS
+    ) {
+      const oldest = this.packedLines.keys().next()
+      if (oldest.done === true) break
+      this.packedChars -= oldest.value.length
+      this.packedLines.delete(oldest.value)
+    }
+    this.packedLines.set(line, run)
+    this.packedChars += line.length
+  }
+
+  /**
    * Streaming-tail slot, shared by every writeLineToScreen call of this
    * Output (only one line grows per frame during streaming). Survives reset()
    * like charCache - it is keyed by strict line extension, so stale entries
@@ -719,6 +797,11 @@ export default class Output {
                 const from = x < clip.x1! ? clip.x1! - x : 0
                 const width = stringWidth(line)
                 const to = x + width > clip.x2! ? clip.x2! - x : width
+                // Fast path: the line sits entirely inside the clip — no
+                // slice needed. sliceAnsi re-tokenizes the line (the
+                // dominant per-frame cost of long sessions otherwise:
+                // every settled line, every frame).
+                if (from === 0 && to === width) return line
                 let sliced = sliceAnsi(line, from, to)
                 // Wide chars (CJK, emoji) occupy 2 cells. When `to` lands
                 // on the first cell of a wide char, sliceAnsi includes the
@@ -777,6 +860,7 @@ export default class Output {
               this.stylePool,
               this.charCache,
               this.streamingSlot,
+              this.packedOwner,
             )
             writeCells += contentEnd - x
             // See Screen.softWrap docstring for the encoding. contentEnd
@@ -926,12 +1010,54 @@ function writeLineToScreen(
   stylePool: StylePool,
   charCache: CharCache,
   streamingSlot: { current: StreamingLineSlot | null },
+  packed?: {
+    lines: Map<string, CellRun>
+    commit: (line: string, run: CellRun) => void
+  },
 ): number {
+  // Fast path: replay the recorded packed run for this exact line — two
+  // typed-array stores per cell, no interning/packing/guard work. The run
+  // dies with its screen; a width transition needs the slow path's guards
+  // and replayCellRun reports that.
+  if (packed !== undefined) {
+    const run = packed.lines.get(line)
+    if (
+      run !== undefined &&
+      run.charPool === screen.charPool &&
+      x >= 0 &&
+      x + cellRunSpan(run) <= screenWidth
+    ) {
+      if (replayCellRun(screen, x, y, run)) {
+        // LRU refresh (chars budget unchanged: same key length).
+        packed.lines.delete(line)
+        packed.lines.set(line, run)
+        return x + cellRunSpan(run)
+      }
+      // fall through to the slow path for this line this frame
+    }
+  }
+
   let characters = charCache.get(line)
   if (!characters) {
     characters = buildClusteredChars(line, stylePool, streamingSlot)
     charCache.set(line, characters)
   }
+
+  // Recording for the packed fast path: only plain single/wide char cells
+  // are recordable — control chars (tab expansion is x-relative), edge
+  // SpacerHead substitution, and y/x off-screen abort it. The packed-run
+  // limit is far above the charCache's MAX_CACHEABLE_LINE: a run costs
+  // three small integers per cell (no per-char objects), so even the
+  // ~700-char ANSI-art whale lines belong — without this they
+  // re-tokenize and re-cluster EVERY frame.
+  const recordable =
+    packed !== undefined &&
+    line.length <= PACKED_MAX_LINE &&
+    x >= 0 &&
+    y >= 0 &&
+    y < screen.height
+  let run = recordable ? createCellRun(screen) : undefined
+  let runAlive = run !== undefined
 
   let offsetX = x
 
@@ -943,6 +1069,8 @@ function writeLineToScreen(
     // mismatches. stringWidth treats these as width 0, but terminals may
     // move the cursor differently.
     if (codePoint !== undefined && codePoint <= 0x1f) {
+      // Not recordable: tab expansion is x-relative, ESC handling varies.
+      runAlive = false
       // Tab (0x09): expand to spaces to reach next tab stop
       if (codePoint === 0x09) {
         const tabWidth = 8
@@ -1051,9 +1179,10 @@ function writeLineToScreen(
     const isWideCharacter = charWidth >= 2
 
     // Wide char at last column can't fit — terminal would wrap it to
-    // the next line, desyncing our cursor model. Place a SpacerHead
-    // to mark the blank column, matching terminal behavior.
+    // the next line, desyncing our cursor model. Place a SpacerHead to
+    // mark the blank column, matching terminal behavior.
     if (isWideCharacter && offsetX + 2 > screenWidth) {
+      runAlive = false
       setCellAt(screen, offsetX, y, {
         char: ' ',
         styleId: stylePool.none,
@@ -1067,13 +1196,36 @@ function writeLineToScreen(
     // styleId + hyperlink were precomputed during clustering (once per
     // style run, cached via charCache). Hot loop is now just property
     // reads — no intern, no extract, no filter per frame.
+    const cellWidth = isWideCharacter ? CellWidth.Wide : CellWidth.Narrow
     setCellAt(screen, offsetX, y, {
       char: character.value,
       styleId: character.styleId,
-      width: isWideCharacter ? CellWidth.Wide : CellWidth.Narrow,
+      width: cellWidth,
       hyperlink: character.hyperlink,
     })
+    if (runAlive && run !== undefined) {
+      recordCellRunEntry(run, screen, offsetX, {
+        char: character.value,
+        styleId: character.styleId,
+        width: cellWidth,
+        hyperlink: character.hyperlink,
+      })
+      // setCellAt also writes a SpacerTail after a wide char (when it
+      // fits); record that deterministic write too, or abort at the edge.
+      if (isWideCharacter) {
+        if (offsetX + 1 < screenWidth) {
+          recordSpacerRunEntry(run, offsetX + 1)
+        } else {
+          runAlive = false
+        }
+      }
+    }
     offsetX += isWideCharacter ? 2 : 1
+  }
+
+  // Commit the recording for the packed fast path (complete runs only).
+  if (runAlive && run !== undefined && packed !== undefined && run.lastX >= run.baseX) {
+    packed.commit(line, run)
   }
 
   return offsetX

--- a/src/ink/screen.ts
+++ b/src/ink/screen.ts
@@ -930,6 +930,154 @@ export function setCellAt(
   }
 }
 
+// --- Packed cell runs (fast line repaint) ---------------------------------
+//
+// A settled transcript line is written into the screen buffer every frame
+// unchanged (the main-screen architecture repaints the full content each
+// frame). Re-running the per-cell pipeline — intern char, intern hyperlink,
+// pack words, wide-guard checks, damage update — for every cell of every
+// settled line costs ~100ms/frame on long sessions (measured; the
+// "long chat gets laggy" report). A CellRun records the line's packed cell
+// words ONCE (against one screen's pools) and replays them as raw
+// typed-array writes. Replay bails to the caller's slow path whenever a
+// width transition would need setCellAt's state-dependent guard fixups —
+// same-width overwrites are always a plain two-word store.
+
+/** A recorded run of packed cell writes for one screen line. */
+export interface CellRun {
+  /** Char pool the words were interned against. Screens ping-pong
+   *  (front/back double buffering) but SHARE their pools for a whole
+   *  session, so pool identity — not screen identity — is the validation
+   *  token; runs survive the screen swap and die only with the pools
+   *  (renderer recreation/resize). */
+  charPool: CharPool
+  /** The shared stylePool.none — the spacer cells' style word. */
+  emptyStyleId: number
+  /** Column gap from the previous written cell; the first entry's gap is
+   *  0 (its absolute column is the run's base). */
+  gaps: number[]
+  charIdxs: number[]
+  word1s: number[]
+  /** Absolute column of the first written cell (record time). */
+  baseX: number
+  /** Absolute column of the last written cell (record time). */
+  lastX: number
+}
+
+/** Begin recording a run for the given screen. */
+export function createCellRun(screen: Screen): CellRun {
+  return {
+    charPool: screen.charPool,
+    emptyStyleId: screen.emptyStyleId,
+    gaps: [],
+    charIdxs: [],
+    word1s: [],
+    baseX: -1,
+    lastX: -1,
+  }
+}
+
+/** Record the cell the slow path is about to write at column x. */
+export function recordCellRunEntry(
+  run: CellRun,
+  screen: Screen,
+  x: number,
+  cell: Cell,
+): void {
+  if (run.baseX < 0) run.baseX = x
+  run.gaps.push(run.lastX < 0 ? 0 : x - run.lastX)
+  run.charIdxs.push(internCharString(screen, cell.char))
+  run.word1s.push(
+    packWord1(cell.styleId, internHyperlink(screen, cell.hyperlink), cell.width),
+  )
+  run.lastX = x
+}
+
+/** Record the deterministic SpacerTail that setCellAt writes after a wide
+ *  char at column x (only when x < screen.width - 1). */
+export function recordSpacerRunEntry(run: CellRun, x: number): void {
+  run.gaps.push(x - run.lastX)
+  run.charIdxs.push(SPACER_CHAR_INDEX)
+  run.word1s.push(packWord1(run.emptyStyleId, 0, CellWidth.SpacerTail))
+  run.lastX = x
+}
+
+/**
+ * Replay a recorded run at (x, y): plain two-word stores, with the damage
+ * rect extended over the written span. Mirrors setCellAt's guard-fire
+ * conditions exactly — a replay is only valid when none of the three
+ * state-dependent fixups (wide-overwrite spacer cleanup, spacer-tail
+ * orphan cleanup, wide's next-cell orphan cleanup) would trigger; any
+ * other width transition is a plain overwrite. Returns false so the
+ * caller falls back to the slow path when a guard WOULD fire.
+ */
+export function replayCellRun(
+  screen: Screen,
+  x: number,
+  y: number,
+  run: CellRun,
+): boolean {
+  if (x < 0 || y < 0 || y >= screen.height || x >= screen.width) return false
+  const cells = screen.cells
+  const width = screen.width
+  let ox = x
+  const gaps = run.gaps
+  for (let i = 0; i < gaps.length; i++) {
+    ox += gaps[i]!
+    if (ox >= width) return false
+    const ci = ((y * width) + ox) << 1
+    const w1 = run.word1s[i]!
+    const newW = w1 & WIDTH_MASK
+    const prevW = cells[ci + 1]! & WIDTH_MASK
+    if (newW === CellWidth.Narrow) {
+      // G1 (prev Wide → narrow overwrite cleans the spacer at x+1) and
+      // G2 (prev SpacerTail → clears the orphan wide at x-1) would fire.
+      if (prevW !== CellWidth.Narrow) return false
+    } else if (newW === CellWidth.Wide) {
+      // G2: a SpacerTail under a Wide write clears the orphan at x-1.
+      if (prevW === CellWidth.SpacerTail) return false
+      // G3: the spacer this write puts at x+1 would stomp a Wide cell
+      // and needs its orphan cleanup.
+      if (ox + 1 < width && (cells[ci + 3]! & WIDTH_MASK) === CellWidth.Wide) {
+        return false
+      }
+    } else {
+      // SpacerTail: G1 fires when it overwrites a Wide cell.
+      if (prevW === CellWidth.Wide) return false
+    }
+    cells[ci] = run.charIdxs[i]!
+    cells[ci + 1] = w1
+  }
+  // Damage: the full written span, matching what per-cell updates in
+  // setCellAt would have accumulated.
+  const firstX = x + gaps[0]!
+  const endX = ox + 1
+  const damage = screen.damage
+  if (damage !== undefined) {
+    const right = damage.x + damage.width
+    if (firstX < damage.x) {
+      damage.width += damage.x - firstX
+      damage.x = firstX
+    } else if (endX > right) {
+      damage.width += endX - right
+    }
+    if (y < damage.y) {
+      damage.height += damage.y - y
+      damage.y = y
+    } else if (y >= damage.y + damage.height) {
+      damage.height = y - damage.y + 1
+    }
+  } else {
+    screen.damage = { x: firstX, y, width: endX - firstX, height: 1 }
+  }
+  return true
+}
+
+/** Column just past the last written cell — the run's content end. */
+export function cellRunSpan(run: CellRun): number {
+  return run.lastX - run.baseX + 1
+}
+
 /**
  * Replace the styleId of a cell in-place without disturbing char, width,
  * or hyperlink. Preserves empty cells as-is (char stays ' '). Tracks damage

--- a/src/ink/screen.ts
+++ b/src/ink/screen.ts
@@ -1018,6 +1018,9 @@ export function replayCellRun(
   run: CellRun,
 ): boolean {
   if (x < 0 || y < 0 || y >= screen.height || x >= screen.width) return false
+  // Defensive: an empty run has no cells and no span — its damage math
+  // would be NaN. Callers never cache empty runs, but a future one might.
+  if (run.gaps.length === 0) return false
   const cells = screen.cells
   const width = screen.width
   let ox = x
@@ -1042,8 +1045,16 @@ export function replayCellRun(
         return false
       }
     } else {
-      // SpacerTail: G1 fires when it overwrites a Wide cell.
-      if (prevW === CellWidth.Wide) return false
+      // SpacerTail: G1 fires when it overwrites a Wide cell; G2's
+      // SpacerHead variant (prev SpacerTail under a non-SpacerTail write)
+      // can't occur in a recorded run — SpacerHead is never recorded — but
+      // keep the guard honest for that day soft-wrap starts recording it.
+      if (
+        prevW === CellWidth.Wide ||
+        (newW !== CellWidth.SpacerTail && prevW === CellWidth.SpacerTail)
+      ) {
+        return false
+      }
     }
     cells[ci] = run.charIdxs[i]!
     cells[ci + 1] = w1

--- a/src/ink/terminal.ts
+++ b/src/ink/terminal.ts
@@ -10,7 +10,6 @@ import {
   cursorMove,
   cursorTo,
   ERASE_SCREEN,
-  ERASE_SCROLLBACK,
   eraseLines,
   SGR_RESET,
 } from './termio/csi.js'
@@ -383,11 +382,19 @@ export function writeDiffToTerminal(
         // scrollback snapshots (the duplicated whale-logo class of bugs);
         // the old soft clear (CSI n S) PUSHED the live viewport into the
         // scrollback instead, depositing a fresh full-UI copy per reset.
+        // Screen-only hard clear: 2J + home, NO 3J. Erasing the scrollback
+        // here destroyed the user's entire visible history on every settle
+        // shrink (the "context lost / cannot scroll" reports) — the inline
+        // transcript IS the scrollback; wiping it to avoid duplicate
+        // snapshots is never an acceptable trade. 2J clears the screen for
+        // the repaint while everything above the viewport survives.
+        // Executed OUTSIDE the DEC 2026 sync block (split begin/end): WT
+        // yanks the viewport to top when 2J runs inside a synchronized
+        // update (claude-code#35580).
         buffer +=
           (useSync ? ESU : '') +
           SGR_RESET +
           ERASE_SCREEN +
-          ERASE_SCROLLBACK +
           CURSOR_HOME +
           (useSync ? BSU : '')
         break

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -2061,6 +2061,7 @@ export function Chat({
           onToggleRow={toggleRowExpanded}
           model={channel.model}
           diffLayout={channel.diffLayout}
+          thinkingFold={channel.thinkingFold}
           showAll={showAllMessages}
           thinkingVisible={thinkingVisible}
           onToggleAll={() =>{  setShowAllMessages(previous => !previous) }}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -378,6 +378,8 @@ export function Chat({
   }, [])
   /** The startup summary gives way to transcript rows after the first local command or message. */
   const loadedContextVisible = channel.rows.length === 0 && channel.loadedContext !== undefined
+  /** Startup context panel: collapsed by default, toggled with Ctrl+P. */
+  const [loadedContextOpen, setLoadedContextOpen] = React.useState(false)
   /** `/` transcript search (less-style incsearch, ported from CC's REPL). */
   const [searchOpen, setSearchOpen] = React.useState(false)
   const [searchQuery, setSearchQuery] = React.useState('')
@@ -1843,8 +1845,15 @@ export function Chat({
       return
     }
     if (isMod(key) && input === 't') {
-      // Ctrl+T has one stable meaning; loaded-context details live at /context.
+      // Ctrl+T opens the trajectory scene at any point in the session.
       openScene()
+      return
+    }
+    if (isMod(key) && input === 'p' && loadedContextVisible) {
+      // Ctrl+P toggles the startup loaded-context panel while it is on
+      // screen (transcript still empty); once rows take over and the
+      // panel disappears the key has nothing left to do.
+      setLoadedContextOpen(previous => !previous)
       return
     }
     if (isMod(key) && input === 'r' && !helpOpen) {
@@ -2044,12 +2053,17 @@ export function Chat({
           effort={channel.reasoningEffort}
           cwd={channel.displayCwd}
         />
-        {/* The startup loaded-context summary: before the first message the
-            transcript is empty, so the one-line inventory of what this
-            conversation will load (system prompt, workspace instructions,
-            skills, tools) sits at the top; the first rows take over. */}
+        {/* The startup loaded-context panel: before the first message the
+            transcript is empty, so the inventory of what this conversation
+            will load (system prompt, workspace instructions, skills, tools)
+            sits at the top, collapsed to a summary line and expandable with
+            Ctrl+P; the first rows take over. */}
         {loadedContextVisible && (
-          <LoadedContextPanel context={channel.loadedContext} />
+          <LoadedContextPanel
+            context={channel.loadedContext}
+            open={loadedContextOpen}
+            onToggle={() => { setLoadedContextOpen(previous => !previous) }}
+          />
         )}
         <MessageList
           rows={channel.rows}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -1894,6 +1894,16 @@ export function Chat({
     } else if (isMod(key) && input === 'o') {
       // Leaving transcript mode (Ctrl+O) — search was already handled above.
       setExpanded(previous => !previous)
+      // The toggle rewrites every thinking row's layout at once. The
+      // ordinary scroll-based diff pushes rows into terminal scrollback on
+      // each expand and nothing removes them on collapse — rapid toggling
+      // drifts the virtual↔scrollback mapping until writes misland
+      // (garbled transcript, duplicated rows). Re-anchor the next frame:
+      // in-place viewport repaint, nothing added to scrollback. Lookup
+      // falls back to the only live instance for embedders whose stdout
+      // isn't process.stdout (test harnesses).
+      const ink = instances.get(process.stdout) ?? instances.values().next().value
+      ink?.reanchorViewport()
     } else if (input === '/' && !key.ctrl && !key.meta && !key.super) {
       // `/` in transcript mode (Ctrl+O expanded, CC's REPL semantics:
       // search is active on the transcript screen where `/` isn't a command).


### PR DESCRIPTION
## 概览

一条围绕「思考折叠体验 + 长会话性能 + 渲染正确性」的完整工作线，15 个提交，全部带确定性复现与回归验证。

## 思考体验
- **thinkingFold 设置项**：默认预览模式（2-3 行动态 ticker），/settings 可切换"展开至轮末"（ac0e0d5 系）
- **恒定 3 行预览**：按行独立截断 + padding——ink 的 truncate 跨 \n 切片导致块高随流跳动，现在高度恒定不随流变（b00b2bd）
- **折叠提前到答案首 token/工具调用**：原步末折叠时长回复早把思考块推进 scrollback，重绘够不着留下未折叠残影（1825652）
- **历史思考查看**：Ctrl+T 轨迹视图 Inspector 展示思考全文（主屏 scrollback 不可变，这是正确载体）

## 性能（基准：47/175/700/2333 行会话流式）
- 长会话流式 p95 **124/208/217ms → ~11ms 全平坦**，>50ms 停顿 46→0，与会话长度解耦：
  - sticky 挂载窗口钳制到终端视口（6318c70，React commit O(全部行) 根治）
  - ink 行渲染三层修复：CharCache 触界 LRU 逐出、裁剪早退、CellRun 打包重放（0ad5686）
  - 回放丢已落定 chunk：4.5MB 真实会话回放 -99% 事件（25f0e08）

## 渲染正确性
- **锚定重绘**：收缩落位不再整帧重印，根治鲸鱼/表格/转录 scrollback 重复（5644932 + 063c618）
- **Ctrl+O 快速连按乱码**：翻转时视口重锚，不往 scrollback 累积漂移；底栏全缓冲唯一（aae26e1）
- **3J 移除后的历史保全**（e7fe9dd 系）

## 上下文面板
- 恢复被 #294 移除的已加载上下文折叠面板：Ctrl+P 展开/收起，Ctrl+T 保持归 /trace（61f1a25）

## 三路子代理审计修复（6da5c64）
- **F1（高）**live 流 reasoning 重建门控（replaying 标志）——每条 text 步的重复思考行
- **H1（高，实证）**空行空 CellRun → NaN damage 毒化整帧 diff
- **2-A/1-A（高）**anchoredPad 生命周期（reanchor/reset/alt 清 pad、pad 封顶）
- F2 同步骤复活、F3 sealedReasoning 清理、M2 SlicedString pin、working 状态复位等

## 验证
复现管线（真终端模拟器 × 真 channel）：whale 5 步、foldstream 7 断言（含 ∴ 恰一份）、ctrl-o 10 连按逐拍、collapse 3/3、ghost、replay-filter 9 断言、perf 四尺寸 11ms、smoke、tsc 全绿。

## 备注
- 依赖 #354（rc6 兼容）先合并更佳；本 PR 与其无文件冲突，#354 合并后可 rebase。
- StreamingMarkdown 分块 memo 曾在本线试验后撤回（8dbcd8c）：真终端复现发现转换帧脏拷贝，且收益被挂载窗口钳制归零——保留 revert 记录供参考。