### PR TITLE
docs(links): 收录 cc-dsh-notifier——Windows 失焦 Toast 通知社区插件

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -14,6 +14,7 @@
 | **deepseek-harness-ux** | <https://github.com/ayuanwong/deepseek-harness-ux> | 让你的 DeepSeek Harness 工作过程一目了然！ |
 | **dsh-tianshu-tui** | <https://github.com/huiliyi37/dsh-tianshu-tui> | Tianshu 风格的 dsh-tui |
 | **dsh-data-agent** | <https://github.com/omdsh-dev/dsh-data-agent> | 让 AI 帮你连数据库 |
+| **cc-dsh-notifier** | <https://github.com/baobaolaodie/cc-dsh-notifier> | DeepSeek Harness / Claude Code 会话失焦时的 Windows 原生 Toast 通知与点击跳回（web 与 dsh-tui 双 profile） |
 
 > 本页是社区与第三方项目的链接罗列。所列项目与组织由各自的维护者独立维护，
 > dsh-TUI 仓库与其不存在隶属关系，也不对其内容、质量或安全作任何担保，使用前


### PR DESCRIPTION
## 动机

cc-dsh-notifier 是 DeepSeek Harness / Claude Code 的 Windows 原生通知插件（dsh 侧为 Cordis 运行时插件，
订阅 session/event、agent/status 等），在会话失焦且需要用户介入（权限请求 / ask_user_question 提问 / 等待输入）时
弹出 Toast 提醒，点击可跳回对应会话窗口；web 与 dsh-tui 双 profile 共用同一 daemon 管线。
按 dsh-TUI 生态约定作为独立社区插件维护，希望在本页收录链接以提升社区可见度。

## 修改内容

- 在 docs/links.md 友情链接表新增一行，收录 baobaolaodie/cc-dsh-notifier。

## 修改边界

- 纯链接收录：不改动插件代码、配置与运行，不修改既有链接行与页尾免责声明。
- 本项目（dsh-TUI）中文档为单语 links.md（无 links.en.md），不涉及中英镜像同步。
- 纯文档改动，按 docs/contributing.md 无需重建（不跑 build）。

## 自动验证

- [x] git diff --check —— 对分支 tip `4e6e96a` 实际运行 `git show --check` 与 `git diff --check origin/main...HEAD`，均 exit 0（无尾随空白/冲突标记）
- [x] Markdown 表格行数与列对齐复核通过（1 文件 / +1 行）
- [x] GitHub API 复核：PR 文件改动仅 docs/links.md（+1/-0），patch 与提交内容一致