### PR TITLE
fix: repair launcher/profile version skew guidance (0.8.3 hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,14 @@ sh install.sh
 已上架 VS Code Marketplace**）见
 [在 VS Code 中运行 dsh-TUI](docs/vscode.md)。
 
-TUI 启动后会在后台检查 npm 是否有新版本；发现更新时会提示，输入 `/update`
-即可自动更新并重启恢复当前会话。
+TUI 启动后会在后台检查 npm 是否有新版本；发现更新时可输入 `/update`。
+`/update` 更新当前 `dsh-tui` profile 中的 runtime 并重启会话，它不会静默修改
+npm/pnpm 的全局安装。若通过全局 `dsh-tui` 命令启动且 Launcher 版本落后，
+0.8.3 起会给出精确的全局对齐命令，例如：
+
+```sh
+npm install -g @deepseek-harness-tui/dsh-tui@<profile-version>
+```
 
 旧版 `dsh-cc-tui` / `cc-tui` profile 的迁移命令与兼容数据说明见
 [安装与快速开始](docs/getting-started.md#从旧包迁移)。

--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -30,6 +30,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { gt, valid } from 'semver'
 import { shellQuote } from '../lib/types/utils/shellQuote.js'
 import { detectLegacyEnv, RENAMED_ENV } from '../lib/types/utils/paths.js'
 
@@ -63,15 +64,32 @@ const MSG = {
     en: `[dsh-tui] Plugin install failed. Retry manually later:\n  dsh plugin --profile ${PROFILE} add -w ${PACKAGE}@${ownVersion}`,
     zh: `[dsh-tui] 插件安装失败。可稍后手工重试：\n  dsh plugin --profile ${PROFILE} add -w ${PACKAGE}@${ownVersion}`,
   },
-  versionMismatch: {
+  // Non-fatal skew comes in two directions and each needs its own repair:
+  // a profile NEWER than the launcher (typical after /update) must point at
+  // the global install, while a profile older only in patch must point back
+  // at the profile. The old generic message told forward-skew users to run
+  // /update again — an "Already up to date" loop.
+  profileOutdated: {
     en: (installed, own) =>
       `[dsh-tui] note: the profile is running v${installed} but this launcher is v${own}.\n` +
-      `  To update the profile: run /update inside the TUI, or:\n` +
-      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@latest`,
+      `  Align the profile to this launcher:\n` +
+      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${own}`,
     zh: (installed, own) =>
-      `[dsh-tui] 提示：profile 内运行的是 v${installed}，而启动器是 v${own}。\n` +
-      `  更新 profile：在 TUI 内执行 /update，或运行：\n` +
-      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@latest`,
+      `[dsh-tui] 提示：profile 内运行的是 v${installed}，启动器是 v${own}。\n` +
+      `  请把 profile 对齐到启动器版本：\n` +
+      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${own}`,
+  },
+  launcherOutdated: {
+    en: (installed, own) =>
+      `[dsh-tui] note: the profile is already v${installed}, but the global launcher is still v${own}.\n` +
+      `  Align the global dsh-tui launcher to the profile:\n` +
+      `  npm install -g ${PACKAGE}@${installed}\n` +
+      `  (if you installed it globally with pnpm: pnpm add -g ${PACKAGE}@${installed})`,
+    zh: (installed, own) =>
+      `[dsh-tui] 提示：profile 已是 v${installed}，但全局启动器仍是 v${own}。\n` +
+      `  请把全局 dsh-tui 启动器对齐到 profile 版本：\n` +
+      `  npm install -g ${PACKAGE}@${installed}\n` +
+      `  （如果你使用 pnpm 全局安装：pnpm add -g ${PACKAGE}@${installed}）`,
   },
   // Reverse skew (issue #183): the dsh CLI reads the bundle patch from the
   // FIRST copy found from its own install anchor — this globally installed
@@ -182,7 +200,19 @@ if (installedVersion === undefined) {
     console.error(MSG.profileOlderThanLauncher[lang](installedVersion, ownVersion))
     process.exit(1)
   }
-  console.error(MSG.versionMismatch[lang](installedVersion, ownVersion))
+
+  // Non-fatal skew: repair in the direction the versions actually moved.
+  // A profile NEWER than the launcher (e.g. right after /update) means the
+  // GLOBAL launcher is stale — never point those users back at /update.
+  // Exact versions only: @latest could skip past the alignment point if a
+  // newer release or a mirror dist-tag is in play.
+  const installedSemver = valid(installedVersion)
+  const ownSemver = valid(ownVersion)
+  if (installedSemver !== null && ownSemver !== null && gt(installedSemver, ownSemver)) {
+    console.error(MSG.launcherOutdated[lang](installedVersion, ownVersion))
+  } else {
+    console.error(MSG.profileOutdated[lang](installedVersion, ownVersion))
+  }
 }
 
 // --- 3. --resume 拦截 ---------------------------------------------------------
@@ -240,6 +270,12 @@ for (const oldName of detectLegacyEnv()) {
 }
 
 // --- 4. 启动 ------------------------------------------------------------------
+// Contract for the profile runtime: lets /update diagnose whether the
+// global dsh-tui launcher is older than the profile it just installed.
+// Not a one-shot marker — it must survive restarts so the runtime always
+// knows the launcher generation it boots under.
+process.env.DSH_TUI_LAUNCHER_VERSION = ownVersion
+
 const child = spawn(...cmd('dsh', ['--profile', PROFILE, ...args]), {
   stdio: 'inherit',
   env: process.env,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,12 +141,25 @@ dsh-tui.cmd --resume
 项目迭代很快，更新复用安装命令，显式指定 `@latest`：
 
 ```sh
+# 更新 Profile runtime（TUI 内 /update 做的就是这件事）
 dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui@latest
+```
+
+如果你通过全局 `dsh-tui` 命令启动，还需要让 Launcher 对齐（TUI 内的
+`/update` 只更新 profile，不会动全局安装）：
+
+```sh
+npm install -g @deepseek-harness-tui/dsh-tui@latest
+# 或（原本用 pnpm 全局安装时）
+pnpm add -g @deepseek-harness-tui/dsh-tui@latest
 ```
 
 - 不带 `@latest` 时 pnpm 会按 profile `package.json` 里已记录的版本范围
   （如 `^0.1.4`）就地解析，可能停留在旧的主线上——这是"重复执行安装命令
   但版本没变"的常见原因。
+- 修复"版本不一致"时，优先使用启动器打印的"精确版本"命令（例如
+  `npm install -g @deepseek-harness-tui/dsh-tui@0.8.3`）；日常主动升级才
+  使用 `@latest`。
 - 确认生效：启动横幅右上角显示当前版本（`✦ dsh-TUI vX.Y.Z`）。
 - 用户覆盖层 `cordis.patch.yml` 在更新中原样保留；会话数据的存放位置
   可能随版本变化（如 0.3.7 起 `/resume` 改用与 dsh web 共享的 JSONL

--- a/docs/project-documentation/update.md
+++ b/docs/project-documentation/update.md
@@ -71,6 +71,14 @@ dsh 不设 profile 环境变量）；源码运行/--config 直启时 onUpdate �
      （避免赋值 undefined 变字符串泄漏给子进程）；现版本未严格新于标记值时
      logger.warn + stderr 中文提示（"可能是镜像 registry 未同步，请稍后重试
      或检查 registry 配置"）
+  -> 0.8.3 Launcher 对齐桥接（同一核验区块）：/update 只替换 profile 内
+     的包，全局 dsh-tui Launcher 是独立安装。Launcher（bin/dsh-tui.js，
+     >=0.8.3）spawn dsh 前设置 DSH_TUI_LAUNCHER_VERSION；更新成功后若该
+     marker 缺失（旧 Launcher <=0.8.2 不设置），给一次性"如果你使用全局
+     dsh-tui，请同步更新"提示；若 marker 明确比新 Profile 旧，给精确的
+     `npm install -g @deepseek-harness-tui/dsh-tui@<profile版本>` 命令。
+     marker 非一次性，后续 /update 重启需继承，才能知道外层 Launcher
+     是否落后。
 ```
 
 失败路径（src/plugin.ts:236-244）：updateCode 非 0 时不重启，打印 'cc-tui update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-harness-tui/dsh-tui",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "repository": {

--- a/scripts/verify-launcher.mjs
+++ b/scripts/verify-launcher.mjs
@@ -27,6 +27,8 @@ import { shellQuote } from '../lib/types/utils/shellQuote.js'
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const bin = join(root, 'bin', 'dsh-tui.js')
 const ownVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version
+const PROFILE = 'dsh-tui'
+const PACKAGE = '@deepseek-harness-tui/dsh-tui'
 const PKG_DIR = join('profiles', 'dsh-tui', 'node_modules', '@deepseek-harness-tui', 'dsh-tui')
 
 let failures = 0
@@ -124,14 +126,24 @@ check('nonzero exit: stderr gives the direct command', r.stderr.includes('dsh --
 r = runBin([], { DSH_STUB_EXIT: '42', DSH_TUI_LANG: 'zh' })
 check('nonzero exit: Chinese message names the status', r.stderr.includes('退出码 42'))
 
-// --- 3. 前向错位（profile 更新）：打印提示但不阻塞启动（0.7.2 起降级可用）---
+// --- 3. 前向错位（profile 更新）：必须指向「更新全局 Launcher」------------
+// 0.8.3 起修复方向按版本方向区分：profile 比 Launcher 新时再让用户跑
+// /update 会得到 "Already up to date" 循环——必须给精确的全局升级命令。
 const [ownMajor, ownMinor] = ownVersion.split('-')[0].split('.').map(Number)
 const newerProfile = `${ownMajor}.${ownMinor + 1}.0`
 setProfileVersion(newerProfile)
 resetStubLog()
 r = runBin([])
-check('mismatch: hint names both versions', r.stderr.includes(`v${newerProfile}`) && r.stderr.includes(`v${ownVersion}`))
-check('mismatch: still launches', stubCalls().at(-1) === '<--profile><dsh-tui>' && r.status === 0)
+check('forward skew: hint names both versions', r.stderr.includes(`v${newerProfile}`) && r.stderr.includes(`v${ownVersion}`))
+check(
+  'forward skew: tells user to align the global launcher',
+  r.stderr.includes(`npm install -g ${PACKAGE}@${newerProfile}`),
+)
+check(
+  'forward skew: never tells user to update the profile again',
+  !r.stderr.includes('/update') && !r.stderr.includes(`plugin --profile ${PROFILE}`),
+)
+check('forward skew: still launches', stubCalls().at(-1) === '<--profile><dsh-tui>' && r.status === 0)
 
 // --- 3.5 反向错位（profile 更旧，issue #183）：拒绝启动并给出对齐命令 --------
 // dsh CLI 的 bundle patch 取自启动器拷贝、插件模块取自 profile 拷贝；启动器
@@ -145,6 +157,36 @@ check('reverse skew: names both versions', r.stderr.includes('v0.0.0') && r.stde
 check('reverse skew: prints the align command', r.stderr.includes(`add @deepseek-harness-tui/dsh-tui@${ownVersion}`))
 r = runBin([], { DSH_TUI_LANG: 'en' })
 check('reverse skew: English message', r.stderr.includes('cannot start'))
+
+// --- 3.6 同 minor 反向 patch-skew（0.8.2 Launcher / 0.8.1 Profile）---------
+// 非致命：允许启动，但应把 profile 对齐到启动器（用 prerelease 构造
+// "同 core、较旧"的 semver——对稳定发布 x.y.z，x.y.z-0 一定更旧且 major/
+// minor 相同）。
+const olderSameMinorProfile = `${ownVersion}-0`
+setProfileVersion(olderSameMinorProfile)
+resetStubLog()
+r = runBin([])
+check(
+  'patch skew: older profile still launches',
+  stubCalls().at(-1) === '<--profile><dsh-tui>' && r.status === 0,
+)
+check(
+  'patch skew: tells user to align the profile to the launcher',
+  r.stderr.includes(`dsh plugin --profile ${PROFILE} add ${PACKAGE}@${ownVersion}`),
+)
+check(
+  'patch skew: does not tell user to update the global launcher',
+  !r.stderr.includes('npm install -g'),
+)
+
+// --- 3.7 Launcher→runtime 契约：子进程必须收到 DSH_TUI_LAUNCHER_VERSION ---
+// 让 /update 能诊断「全局 Launcher 是否落后于刚装的 profile」。先做源码
+// 静态断言，更强的 e2e（stub 记录子进程 env）后续再补。
+const launcherSource = readFileSync(bin, 'utf8')
+check(
+  'launcher env: child receives DSH_TUI_LAUNCHER_VERSION',
+  launcherSource.includes('process.env.DSH_TUI_LAUNCHER_VERSION = ownVersion'),
+)
 
 // --- 5. 消息双语：缺 dsh 时的报错（契约同 TUI：DSH_TUI_LANG 指定才生效，否则默认中文）
 const envNoDsh = { PATH: noDshPath }

--- a/scripts/verify-update.mjs
+++ b/scripts/verify-update.mjs
@@ -263,6 +263,24 @@ check(
   (compiledSource.match(/isBootDeadlockTarget/g) ?? []).length >= 2,
 )
 
+// ---- launcher bridge (0.8.3): the compiled runtime must keep the
+// post-/update launcher-alignment hints — static contract against the built
+// output so future refactors cannot silently drop the bridge.
+const compiledPluginPath = join(repoRoot, 'lib', 'types', 'dsh-adapter', 'plugin.js')
+const compiledPluginSource = readFileSync(compiledPluginPath, 'utf8')
+check(
+  'launcher bridge: runtime reads the launcher version marker',
+  compiledPluginSource.includes('DSH_TUI_LAUNCHER_VERSION'),
+)
+check(
+  'launcher bridge: old-launcher update path keeps a generic alignment hint',
+  compiledPluginSource.includes('update-launcher-align-unknown'),
+)
+check(
+  'launcher bridge: known older launcher gets a directional hint',
+  compiledPluginSource.includes('update-launcher-outdated'),
+)
+
 // ---- isTransientUpdateFailure: the Windows tmp-rename race (issue #225)
 check(
   'transient: pnpm tmp-rename ENOENT qualifies',

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -126,6 +126,23 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
               `可能是镜像 registry 未同步，请稍后重试或检查 registry 配置。\n`,
           )
         }
+      } else if (process.stderr.isTTY) {
+        // Launcher alignment bridge (0.8.3): /update only replaces the
+        // package inside the DSH profile; a globally installed `dsh-tui`
+        // launcher is a separate copy that keeps its old version. Launchers
+        // >=0.8.3 export DSH_TUI_LAUNCHER_VERSION so we can tell whether
+        // the outer launcher lags the freshly installed profile. Launchers
+        // <=0.8.2 never set the marker — the generic branch below is
+        // intentionally one-shot: DSH_TUI_UPDATED_FROM exists only on the
+        // replacement process immediately after /update.
+        const launcherVersion = process.env.DSH_TUI_LAUNCHER_VERSION
+        if (launcherVersion === undefined) {
+          process.stderr.write(`\n[dsh-tui] ${t('update-launcher-align-unknown', { version: now })}\n`)
+        } else if (isVersionNewer(now, launcherVersion)) {
+          process.stderr.write(
+            `\n[dsh-tui] ${t('update-launcher-outdated', { profile: now, launcher: launcherVersion })}\n`,
+          )
+        }
       }
     }
   }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -263,6 +263,16 @@ const dict = {
 
   // ── plugin.ts — /update flow ───────────────────────────────────────
   'update-aborted-no-profile': { zh: 'dsh-tui 更新中止：未解析到 dsh profile。', en: 'dsh-tui update aborted: no dsh profile resolved.' },
+  // 0.8.3 launcher alignment bridge: /update only replaces the profile
+  // copy; the global `dsh-tui` launcher must be aligned separately.
+  'update-launcher-align-unknown': {
+    zh: 'Profile 已更新到 v{{version}}。如果你平时使用全局 dsh-tui 命令启动，请同步更新全局启动器：\n  npm install -g @deepseek-harness-tui/dsh-tui@{{version}}',
+    en: 'The profile is now v{{version}}. If you normally launch with the global dsh-tui command, align the global launcher too:\n  npm install -g @deepseek-harness-tui/dsh-tui@{{version}}',
+  },
+  'update-launcher-outdated': {
+    zh: 'Profile 已更新到 v{{profile}}，但全局启动器仍是 v{{launcher}}。请同步更新：\n  npm install -g @deepseek-harness-tui/dsh-tui@{{profile}}',
+    en: 'The profile is now v{{profile}}, but the global launcher is still v{{launcher}}. Align it with:\n  npm install -g @deepseek-harness-tui/dsh-tui@{{profile}}',
+  },
 
   // ── components/ActivityLine.tsx ──────────────────────────────────────
   'activity-ctx-warn': { zh: '⚠ 上下文', en: '⚠ ctx ' },


### PR DESCRIPTION
## What changed
- split launcher/profile version-skew guidance by direction
- export `DSH_TUI_LAUNCHER_VERSION` from the global launcher
- add a one-shot post-`/update` bridge for users upgrading from launchers that predate the marker
- add regression coverage for repair-direction messaging
- document that `/update` updates the profile runtime, not the global launcher

## Root cause
`/update` updates only the package installed in the DSH profile. The global
`dsh-tui` launcher is a separate installation. When the profile became newer,
the old launcher used a generic mismatch message that incorrectly told users
to update the profile again, producing an `Already up to date` loop.

## Safety
- no `cordis.patch.yml` changes
- no bundle-surface changes
- no automatic global package-manager mutation
- existing fatal reverse-skew guard from issue #183 remains intact

## Validation
- `pnpm compile`
- `node scripts/verify-launcher.mjs`
- `node scripts/verify-update.mjs`
- `pnpm verify:build`
- `pnpm verify:package`