### PR TITLE
feat(ui): three-act effort ignition overlay on the prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,13 @@ jobs:
       # scrollback 零增量、动效帧只含 SGR。
       - run: node --import tsx/esm scripts/verify-trace-scene.tsx
 
+      # 最高档思考强度点焰回归：数学层（波形/缓动/包络/逐列色契约）+
+      # 场景（headless xterm）：三幕（双框同步扫光/档名居中聚拢/渐隐
+      # 归零）断言帧间文本恒定、零行级 repaint、行数恒定、负路径全暗。
+      - run: node --import tsx/esm scripts/verify-effort-ignition.tsx
+      # 前缀充能回归：四态 + 充能窗内真实前景色采样（暗→全值单调）。
+      - run: node --import tsx/esm scripts/verify-effort-accent.tsx
+
       # 缩放重排回归（实机反馈：打开长会话后最大化窗口）：判据是终局等价
       # ——缩放后的物理终端必须等于在新尺寸上全新渲染的同一状态。缩放会让
       # 树内每个测量所依据的宽度失效，而没有任何节点被标脏，文本节点会沿用

--- a/scripts/verify-effort-accent.tsx
+++ b/scripts/verify-effort-accent.tsx
@@ -1,0 +1,138 @@
+/**
+ * Effort accent regression — the `❯ ` prompt prefix under the top tier.
+ *
+ * Mounts the real glyph in a headless xterm and asserts the three states a
+ * reader sees:
+ *
+ * - Off the top tier the prefix keeps its original dim rendering (no accent
+ *   SGR beyond the working dim, byte-comparable output).
+ * - Switching onto the top tier charges the prefix: bold + truecolor orange
+ *   appears within the 150ms charge window and stays solid after it.
+ * - Leaving the top tier restores the original rendering.
+ *
+ * Run: node --import tsx/esm scripts/verify-effort-accent.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+const [
+  { Writable, PassThrough },
+  React,
+  { Terminal: XTerm },
+  { render },
+  { EffortChargeGlyph },
+  { ClockProvider },
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/EffortChargeGlyph.js'),
+  import('../src/ink/components/ClockContext.js'),
+])
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+let failures = 0
+function check(name: string, ok: boolean, detail = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail === '' ? '' : ` (${detail})`}`)
+  if (!ok) failures++
+}
+
+const cols = 20
+const rows = 4
+const term = new XTerm({ cols, rows, scrollback: 100, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = cols
+  rows = rows
+  isTTY = true
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    term.write(String(chunk), callback)
+  }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+// The painted cells of the first screen row as {glyph, fg-is-truecolor, bold}.
+function firstRow(): string {
+  const line = term.buffer.active.getLine(term.buffer.active.baseY)
+  if (line === undefined) return ''
+  return Array.from({ length: cols }, (_, x) => line.getCell(x)?.getChars() ?? '').join('')
+}
+function prefixFgTruecolor(): boolean {
+  const line = term.buffer.active.getLine(term.buffer.active.baseY)
+  if (line === undefined) return false
+  for (let x = 0; x < 2; x++) {
+    if (line.getCell(x)?.isFgRGB()) return true
+  }
+  return false
+}
+function prefixBold(): boolean {
+  const line = term.buffer.active.getLine(term.buffer.active.baseY)
+  if (line === undefined) return false
+  for (let x = 0; x < 2; x++) {
+    if ((line.getCell(x)?.isBold() ?? 0) > 0) return true
+  }
+  return false
+}
+
+function Driver(): React.ReactNode {
+  // medium → high (top) at t=300ms, back to medium at t=900ms.
+  const [effort, setEffort] = React.useState('medium')
+  React.useEffect(() => {
+    const timers = [
+      setTimeout(() => setEffort('high'), 300),
+      setTimeout(() => setEffort('medium'), 900),
+    ]
+    return () => timers.forEach(clearTimeout)
+  }, [])
+  return (
+    <ClockProvider>
+      <EffortChargeGlyph effort={effort} levels={['low', 'medium', 'high']} working={false} />
+    </ClockProvider>
+  )
+}
+
+render(<Driver />, {
+  stdout: new FakeStdout() as never,
+  stdin: new FakeStdin() as never,
+  stderr: new FakeStdout() as never,
+  exitOnCtrlC: false,
+  patchConsole: false,
+})
+
+await sleep(200)
+check('off the top tier: plain prefix, no accent', firstRow().startsWith('❯') && !prefixFgTruecolor() && !prefixBold())
+
+// Sample the prefix's actual FG colour across the charge window's tail and
+// the settle: a constant colour or a reversed ramp must fail here, not just
+// a missing accent. luma(Rec.601) is the ramp's monotone observable — dim
+// (band-tinted) is darker than full (hues[0]).
+const luma = (rgb: number): number =>
+  0.299 * ((rgb >> 16) & 0xff) + 0.587 * ((rgb >> 8) & 0xff) + 0.114 * (rgb & 0xff)
+const samples: number[] = []
+await sleep(120)
+for (let i = 0; i < 8; i++) {
+  const line = term.buffer.active.getLine(term.buffer.active.baseY)
+  const cell = line?.getCell(0)
+  if (cell !== undefined && cell.isFgRGB()) samples.push(cell.getFgColor())
+  await sleep(28)
+}
+check('charging onto the top tier: bold + truecolor accent', prefixFgTruecolor() && prefixBold())
+check('charge ramps dark→full (sampled, monotone)',
+  samples.length >= 3
+  && luma(samples[0]!) < luma(samples[samples.length - 1]!)
+  && samples.slice(1).some((value, index) => luma(value) >= luma(samples[index]!)),
+  `${samples.length} samples, luma ${samples.length ? Math.round(luma(samples[0]!)) : '?'}→${samples.length ? Math.round(luma(samples[samples.length - 1]!)) : '?'}`)
+
+await sleep(300)
+check('past the charge window: accent stays solid', prefixFgTruecolor() && prefixBold())
+await sleep(500)
+check('off the top tier again: accent gone', !prefixFgTruecolor() && !prefixBold())
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`)
+  process.exit(1)
+}
+console.log('all checks passed')

--- a/scripts/verify-effort-ignition.tsx
+++ b/scripts/verify-effort-ignition.tsx
@@ -6,8 +6,8 @@
  * EffortInputBorder (self-drawn ╭─╮ / ╰─╯ rows; the top row carries the show)
  * in a headless xterm, one harness per scenario, and asserts:
  *
- * - **Every style runs over the row, deterministically** — the component
- *   accepts a fixed `style` prop here, so wave/aurora/pulse each get a run.
+ * - The sweep is a single wave style (the shipped shape); the math layer
+ *   below pins its contract directly.
  * - **Glyphs never change; only colours move.** The row's TEXT is
  *   byte-identical across frames (▁ × width, present at rest too) — the
  *   strongest form of the SGR-only rule, with no layout change at any
@@ -55,39 +55,30 @@ check('crest: 1 at the crest, 0 at one half-width out', math.crest(0) === 1 && m
 check('crest: beyond the half-width is silent, both directions',
   math.crest(1.5) === 0 && math.crest(-1) === 0 && math.crest(-2) === 0)
 check('easings: endpoints are exact',
-  math.easeInCubic(0) === 0 && math.easeInCubic(1) === 1
-  && math.easeOutCubic(0) === 0 && math.easeOutCubic(1) === 1
+  math.easeOutCubic(0) === 0 && math.easeOutCubic(1) === 1
   && math.easeInOutCubic(0) === 0 && math.easeInOutCubic(1) === 1)
 check('easings: clamped outside [0,1]',
-  math.easeInCubic(-1) === 0 && math.easeOutCubic(2) === 1 && math.easeInOutCubic(-3) === 0)
-check('envelope: zero outside the window',
-  math.envelope(0, 1, 0.25, 0.4) === 0 && math.envelope(1, 1, 0.25, 0.4) === 0)
-check('envelope: fully open in the middle', math.envelope(0.5, 1, 0.25, 0.4) === 1)
-check('envelope: ramp sides bind, not max',
-  math.envelope(0.1, 1, 0.25, 0.4) < 0.45 && Math.abs(math.envelope(0.1, 1, 0.25, 0.4) - 0.4) < 0.01)
+  math.easeOutCubic(2) === 1 && math.easeInOutCubic(-3) === 0)
 check('line colors: exactly one entry per column',
-  math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 40, onLight: false }).length === 40)
+  math.ignitionLineColors({ elapsedMs: 300, width: 40, onLight: false }).length === 40)
 check('line colors: empty before start and after the end',
-  math.ignitionLineColors({ style: 'wave', elapsedMs: 0, width: 40, onLight: false }).length === 0
-  && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave + 1, width: 40, onLight: false }).length === 0)
+  math.ignitionLineColors({ elapsedMs: 0, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ elapsedMs: math.SWEEP_TOTAL_MS + 1, width: 40, onLight: false }).length === 0)
 check('line colors: boundary guards (width 0, negative/NaN/at-total elapsed)',
-  math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 0, onLight: false }).length === 0
-  && math.ignitionLineColors({ style: 'wave', elapsedMs: -5, width: 40, onLight: false }).length === 0
-  && math.ignitionLineColors({ style: 'wave', elapsedMs: Number.NaN, width: 40, onLight: false }).length === 0
-  && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave, width: 40, onLight: false }).length === 0)
+  math.ignitionLineColors({ elapsedMs: 300, width: 0, onLight: false }).length === 0
+  && math.ignitionLineColors({ elapsedMs: -5, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ elapsedMs: Number.NaN, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ elapsedMs: math.SWEEP_TOTAL_MS, width: 40, onLight: false }).length === 0)
 check('line colors: single-column terminal yields one entry',
-  math.ignitionLineColors({ style: 'aurora', elapsedMs: 300, width: 1, onLight: false }).length === 1)
+  math.ignitionLineColors({ elapsedMs: 300, width: 1, onLight: false }).length === 1)
 check('line colors: every painted entry is a truecolor rgb() string',
   math
-    .ignitionLineColors({ style: 'pulse', elapsedMs: 200, width: 60, onLight: false })
+    .ignitionLineColors({ elapsedMs: 200, width: 60, onLight: false })
     .every(color => color === undefined || /^rgb\(\d+,\d+,\d+\)$/.test(String(color))))
 check('line colors: some columns are painted mid-wave',
   math
-    .ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 80, onLight: false })
+    .ignitionLineColors({ elapsedMs: 300, width: 80, onLight: false })
     .some(color => color !== undefined))
-check('random style: never repeats the previous one',
-  Array.from({ length: 20 }, () => math.randomIgnitionStyle('wave')).every(style => style !== 'wave'))
-
 // --- Part B: three acts on the prompt border, then back to nothing --------
 const LEVELS = ['low', 'medium', 'high'] as const
 const COLS = 60

--- a/scripts/verify-effort-ignition.tsx
+++ b/scripts/verify-effort-ignition.tsx
@@ -1,0 +1,260 @@
+/**
+ * Effort ignition regression — the three-act overlay on the prompt border.
+ *
+ * Part A asserts the math layer (waveform sampling, easings, envelope, the
+ * per-column colour contract, boundary guards). Part B mounts the real
+ * EffortInputBorder (self-drawn ╭─╮ / ╰─╯ rows; the top row carries the show)
+ * in a headless xterm, one harness per scenario, and asserts:
+ *
+ * - **Every style runs over the row, deterministically** — the component
+ *   accepts a fixed `style` prop here, so wave/aurora/pulse each get a run.
+ * - **Glyphs never change; only colours move.** The row's TEXT is
+ *   byte-identical across frames (▁ × width, present at rest too) — the
+ *   strongest form of the SGR-only rule, with no layout change at any
+ *   point: the bright wave is foreground colour running over a constant
+ *   ▁ layer, the dim rest is the same layer at its quiet end.
+ * - **Mount/unmount never scroll**: the rows are permanent, but the whole
+ *   stream still must contain no scroll sequences (#38/#39/#19/#10 family).
+ * - **It returns to rest**: wave colours vanish after the style's total.
+ * - **Negative paths stay dark**: cold mount on the top tier, single-tier
+ *   table, missing table, and leaving the top tier sweep nothing.
+ *
+ * Run: node --import tsx/esm scripts/verify-effort-ignition.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+const [
+  { Writable, PassThrough },
+  React,
+  { Terminal: XTerm },
+  { render, Text, Box },
+  { EffortInputBorder },
+  { EffortTierBadge },
+  { ClockProvider },
+  math,
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/EffortInputBorder.js'),
+  import('../src/components/EffortTierBadge.js'),
+  import('../src/ink/components/ClockContext.js'),
+  import('../src/trajectory/effortIgnition.js'),
+])
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+let failures = 0
+function check(name: string, ok: boolean, detail = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail === '' ? '' : ` (${detail})`}`)
+  if (!ok) failures++
+}
+
+// --- Part A: math layer --------------------------------------------------------
+check('crest: 1 at the crest, 0 at one half-width out', math.crest(0) === 1 && math.crest(1) === 0)
+check('crest: beyond the half-width is silent, both directions',
+  math.crest(1.5) === 0 && math.crest(-1) === 0 && math.crest(-2) === 0)
+check('easings: endpoints are exact',
+  math.easeInCubic(0) === 0 && math.easeInCubic(1) === 1
+  && math.easeOutCubic(0) === 0 && math.easeOutCubic(1) === 1
+  && math.easeInOutCubic(0) === 0 && math.easeInOutCubic(1) === 1)
+check('easings: clamped outside [0,1]',
+  math.easeInCubic(-1) === 0 && math.easeOutCubic(2) === 1 && math.easeInOutCubic(-3) === 0)
+check('envelope: zero outside the window',
+  math.envelope(0, 1, 0.25, 0.4) === 0 && math.envelope(1, 1, 0.25, 0.4) === 0)
+check('envelope: fully open in the middle', math.envelope(0.5, 1, 0.25, 0.4) === 1)
+check('envelope: ramp sides bind, not max',
+  math.envelope(0.1, 1, 0.25, 0.4) < 0.45 && Math.abs(math.envelope(0.1, 1, 0.25, 0.4) - 0.4) < 0.01)
+check('line colors: exactly one entry per column',
+  math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 40, onLight: false }).length === 40)
+check('line colors: empty before start and after the end',
+  math.ignitionLineColors({ style: 'wave', elapsedMs: 0, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave + 1, width: 40, onLight: false }).length === 0)
+check('line colors: boundary guards (width 0, negative/NaN/at-total elapsed)',
+  math.ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 0, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: -5, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: Number.NaN, width: 40, onLight: false }).length === 0
+  && math.ignitionLineColors({ style: 'wave', elapsedMs: math.IGNITION_TOTAL_MS.wave, width: 40, onLight: false }).length === 0)
+check('line colors: single-column terminal yields one entry',
+  math.ignitionLineColors({ style: 'aurora', elapsedMs: 300, width: 1, onLight: false }).length === 1)
+check('line colors: every painted entry is a truecolor rgb() string',
+  math
+    .ignitionLineColors({ style: 'pulse', elapsedMs: 200, width: 60, onLight: false })
+    .every(color => color === undefined || /^rgb\(\d+,\d+,\d+\)$/.test(String(color))))
+check('line colors: some columns are painted mid-wave',
+  math
+    .ignitionLineColors({ style: 'wave', elapsedMs: 300, width: 80, onLight: false })
+    .some(color => color !== undefined))
+check('random style: never repeats the previous one',
+  Array.from({ length: 20 }, () => math.randomIgnitionStyle('wave')).every(style => style !== 'wave'))
+
+// --- Part B: three acts on the prompt border, then back to nothing --------
+const LEVELS = ['low', 'medium', 'high'] as const
+const COLS = 60
+
+async function makeHarness(rows: number, driver: React.ReactNode) {
+  const term = new XTerm({ cols: COLS, rows, scrollback: 200, allowProposedApi: true })
+  const writes: string[] = []
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      writes.push(String(chunk))
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const rowText = (y: number): string =>
+    term.buffer.active.getLine(term.buffer.active.baseY + y)?.translateToString(true) ?? ''
+  const fgColors = (y: number): number => {
+    const line = term.buffer.active.getLine(term.buffer.active.baseY + y)
+    if (line === undefined) return 0
+    const found = new Set<number>()
+    for (let x = 0; x < COLS; x++) {
+      const cell = line.getCell(x)
+      if (cell !== undefined && cell.isFgRGB()) found.add(cell.getFgColor())
+    }
+    return found.size
+  }
+  const instance = await render(
+    React.createElement(ClockProvider, null, driver),
+    {
+      stdout: new FakeStdout() as never,
+      stdin: new FakeStdin() as never,
+      stderr: new FakeStdout() as never,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  )
+  return { term, writes, rowText, fgColors, instance }
+}
+
+function borderNode(effort: string | undefined): React.ReactNode {
+  // Children mirror the real empty input row: block caret + centered badge.
+  return React.createElement(
+    EffortInputBorder,
+    { effort, levels: LEVELS, columns: COLS, onLight: false, idleColor: 'promptBorder' },
+    React.createElement(Text, null,
+      ' ',
+      React.createElement(EffortTierBadge, { effort, levels: LEVELS, onLight: false, columns: COLS, leadingColumns: 2 })),
+  )
+}
+
+function SweepDriver(): React.ReactNode {
+  const [effort, setEffort] = React.useState<string>('medium')
+  React.useEffect(() => {
+    const timer = setTimeout(() => setEffort('high'), 300)
+    return () => clearTimeout(timer)
+  }, [])
+  return borderNode(effort)
+}
+
+// Act timings from the component: switch at t=300 → elapsed = t-300.
+//   sweep [0,800); letters appear from 400 (M) / 540 (A) / 680 (X), full at
+//   ~840; fade [1100,1600); gone at 1600.
+{
+  const harness = await makeHarness(6, React.createElement(SweepDriver))
+  try {
+    await sleep(150)
+    const restText = harness.rowText(0)
+    check('rest: plain theme border, no letters, one colour',
+      restText === '╭' + '─'.repeat(COLS - 2) + '╮' && harness.fgColors(0) <= 1)
+    check('rest: exactly three rows — bottom border sits directly under the input row',
+      harness.rowText(2) === '╰' + '─'.repeat(COLS - 2) + '╯' && harness.rowText(3) === '')
+    // elapsed ≈ 300: mid-sweep, letters not started (LABEL_START 600).
+    await sleep(450)
+    check('act 1 sweep: a light band runs left→right on BOTH borders, no letters yet',
+      harness.fgColors(0) >= 2 && harness.fgColors(2) >= 2, `${harness.fgColors(0)}/${harness.fgColors(2)} colours`)
+    // elapsed ≈ 950: the tier name shows centered on the input row, and NO
+    // extra row appears — the row under it stays the bottom border.
+    await sleep(650)
+    const inputRow = harness.rowText(1)
+    const tierLetters = LEVELS[LEVELS.length - 1]!.toUpperCase().split('')
+    const firstAt = inputRow.indexOf(tierLetters[0]!)
+    check('act 2 label: letters emerged CENTERED while still converging (gap > 1)',
+      tierLetters.every(letter => inputRow.includes(letter)) && firstAt >= Math.floor(COLS / 2) - 12,
+      `col ${firstAt}: ${inputRow.trim().slice(0, 24)}`)
+    // elapsed ≈ 1450: converge done (600+800), gap locked at 1, pre-fade.
+    await sleep(500)
+    const settled = harness.rowText(1)
+    const spacedName = tierLetters.join(' ')
+    check('act 2 label: letters settled at one-space gap',
+      settled.includes(spacedName), settled.trim().slice(0, 24))
+    // 终态精确居中：字样中点字母落在终端几何中心列上。
+    const midLetter = tierLetters[Math.floor(tierLetters.length / 2)]!
+    const midAt = settled.indexOf(spacedName) + spacedName.indexOf(midLetter)
+    const terminalCenter = Math.round((COLS - 1) / 2)
+    check('act 2 label: settled dead-center on the terminal',
+      Math.abs(midAt - terminalCenter) <= 1, `mid at ${midAt}, center ${terminalCenter}`)
+    check('act 2 label: no extra row — bottom border never moves',
+      harness.rowText(2) === '╰' + '─'.repeat(COLS - 2) + '╯')
+    const labelColors = harness.fgColors(1)
+    check('act 2 label: the badge carries the accent family', labelColors >= 1, `${labelColors} colours`)
+    // elapsed ≈ 1700 (past FADE_END 1600): everything gone, border identical to rest.
+    harness.writes.length = 0
+    await sleep(1050)
+    const stream = harness.writes.join('')
+    const scroll = [/\x1b\[\d*S/, /\x1b\[\d*T/].some(pattern => pattern.test(stream))
+    check('act 3 fade: badge and sweep are gone, border back to rest',
+      harness.rowText(0) === restText && harness.rowText(1).trim() === '' && harness.fgColors(0) <= 1)
+    check('lifecycle: no scroll sequences at any point', !scroll)
+    check('after the fade both borders rest in a single colour', harness.fgColors(0) <= 1 && harness.fgColors(2) <= 1)
+  } finally {
+    harness.instance.unmount()
+  }
+}
+
+// --- Negative paths: no sweep, no letters, ever -------------------------------
+async function runDarkScenario(name: string, node: React.ReactNode) {
+  const harness = await makeHarness(6, node)
+  try {
+    await sleep(300)
+    harness.writes.length = 0
+    await sleep(1800)
+    const stream = harness.writes.join('')
+    const top = harness.rowText(0)
+    const dim = harness.fgColors(0) <= 1 && !/[A-Z]/.test(top.slice(1, -1)) && !/\x1b\[38;2;.*\x1b\[38;2;/.test(stream)
+    check(`${name}: nothing plays`, dim)
+  } finally {
+    harness.instance.unmount()
+  }
+}
+
+await runDarkScenario('cold mount on the top tier', borderNode('high'))
+function SingleTierDriver(): React.ReactNode {
+  return React.createElement(
+    EffortInputBorder,
+    { effort: 'high', levels: ['high'], columns: COLS, onLight: false, idleColor: 'promptBorder' },
+    React.createElement(Text, null, 'row'),
+  )
+}
+await runDarkScenario('single-tier table', React.createElement(SingleTierDriver))
+function NoTableDriver(): React.ReactNode {
+  return React.createElement(
+    EffortInputBorder,
+    { effort: 'high', levels: undefined, columns: COLS, onLight: false, idleColor: 'promptBorder' },
+    React.createElement(Text, null, 'row'),
+  )
+}
+await runDarkScenario('missing level table', React.createElement(NoTableDriver))
+function LeaveTopDriver(): React.ReactNode {
+  const [effort, setEffort] = React.useState<string>('high')
+  React.useEffect(() => {
+    const timer = setTimeout(() => setEffort('medium'), 300)
+    return () => clearTimeout(timer)
+  }, [])
+  return borderNode(effort)
+}
+await runDarkScenario('leaving the top tier', React.createElement(LeaveTopDriver))
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`)
+  process.exit(1)
+}
+console.log('all checks passed')

--- a/scripts/verify-resize-reflow.tsx
+++ b/scripts/verify-resize-reflow.tsx
@@ -205,7 +205,13 @@ function makeHarness(cols: number, rows: number) {
     const buffer = term.buffer.active
     const lines = Array.from({ length: term.rows }, (_, y) =>
       (buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
-    const divider = lines.findLastIndex(line => /^─{8,}$/.test(line.trim()))
+    // Anchor: the LAST border row in the frame. The prompt box's own border
+    // used to render as a plain ─ row (round style with borderLeft/Right off);
+    // EffortInputBorder draws it as ╭─╮/╰─╯ with corners. Either shape is the
+    // bottom border of the frame, and everything from it down is the chrome —
+    // the logo header with its RANDOM startup tip must stay above the cut,
+    // or two independent mounts can never match.
+    const divider = lines.findLastIndex(line => /^(?:─{8,}|[╭╰]─{8,}[╮╯])$/.test(line.trim()))
     return lines.slice(divider === -1 ? 0 : divider)
       .filter(line => line !== '')
       .join('\n')

--- a/src/components/EffortChargeGlyph.tsx
+++ b/src/components/EffortChargeGlyph.tsx
@@ -7,19 +7,19 @@
  * 不充能（充能只属于切换瞬间），离开最高档恢复原样的 dim 行为。
  *
  * 触发判定在渲染期做（React 官方的「props 变化即调整 state」模式，
- * 与 EffortIgnitionLine 同一模式）——放 effect 会晚一帧，effort 变化
+ * 与 EffortInputBorder 同一模式）——放 effect 会晚一帧，effort 变化
  * 的首帧以全亮闪现、下一帧才跌回暗端重来。充能只动颜色，glyph 恒为
  * `❯ `，SGR-only 规则天然成立。
  *
  * 时钟复用 Ink core 共享时钟，且只在充能未满的那 150ms 内订阅；稳态
  * 零定时器、零重渲染，前缀色取记忆化常量。
  */
-import React, { useContext, useEffect, useReducer, useRef, useState } from 'react'
+import React, { useContext, useEffect, useReducer, useState } from 'react'
 import { Text, useTheme } from '../ui.js'
 import { ClockContext } from '../ink/components/ClockContext.js'
 import { accentRamp } from '../trajectory/effortIgnition.js'
 import { rgbString } from '../trajectory/motion.js'
-import { interpolateColor, type RGBColor } from './Spinner/spinnerUtils.js'
+import { interpolateColor } from './Spinner/spinnerUtils.js'
 import { isLightThemeActive } from '../theme.js'
 
 /** 充能时长（ms）。 */
@@ -42,12 +42,11 @@ export function EffortChargeGlyph({
   const [chargeStartedAt, setChargeStartedAt] = useState<number | null>(null)
   const [prevEffort, setPrevEffort] = useState(effort)
   const [, forceRender] = useReducer((tick: number) => tick + 1, 0)
-  const steadyColor = useRef<RGBColor | null>(null)
 
   const topActive =
     effort !== undefined && levels !== undefined && levels.length > 1 && effort === levels[levels.length - 1]
 
-  // Render-phase trigger (same pattern as EffortIgnitionLine): switching from
+  // Render-phase trigger (same pattern as EffortInputBorder): switching from
   // an existing tier onto the top tier starts the charge NOW, not one effect
   // later — the first frame of the new effort must not flash fully lit.
   // Cold mounts enter the steady state directly; without a shared clock
@@ -76,10 +75,10 @@ export function EffortChargeGlyph({
   if (!topActive) return <Text dimColor={working}>❯ </Text>
   const ramp = accentRamp(isLightThemeActive(themeName))
   if (!charging) {
-    // Steady state: cache the resolved full-accent colour — every PromptInput
-    // re-render (each keystroke) reuses it without re-deriving the ramp.
-    if (steadyColor.current === null) steadyColor.current = ramp.full
-    const color = rgbString(steadyColor.current)
+    // Steady state re-derives on every render (two allocations + one blend
+    // per keystroke — negligible) instead of caching: a cached colour would
+    // go stale across a light/dark theme flip while the tier stays active.
+    const color = rgbString(ramp.full)
     return (
       <Text bold color={color} dimColor={working}>
         ❯{' '}

--- a/src/components/EffortChargeGlyph.tsx
+++ b/src/components/EffortChargeGlyph.tsx
@@ -1,0 +1,95 @@
+/**
+ * EffortChargeGlyph — 输入提示前缀 `❯ ` 的最高档强调与充能。
+ *
+ * 思考强度处于当前路线最高档期间，前缀换为点火强调色（加粗，与点焰波
+ * 共用 hues[0]——同一瞬间前缀与波是同一种橙）；切到最高档的瞬间做一次
+ * 150ms「充能」渐变（accentRamp 的暗端 → 全值）。冷启动已在最高档时
+ * 不充能（充能只属于切换瞬间），离开最高档恢复原样的 dim 行为。
+ *
+ * 触发判定在渲染期做（React 官方的「props 变化即调整 state」模式，
+ * 与 EffortIgnitionLine 同一模式）——放 effect 会晚一帧，effort 变化
+ * 的首帧以全亮闪现、下一帧才跌回暗端重来。充能只动颜色，glyph 恒为
+ * `❯ `，SGR-only 规则天然成立。
+ *
+ * 时钟复用 Ink core 共享时钟，且只在充能未满的那 150ms 内订阅；稳态
+ * 零定时器、零重渲染，前缀色取记忆化常量。
+ */
+import React, { useContext, useEffect, useReducer, useRef, useState } from 'react'
+import { Text, useTheme } from '../ui.js'
+import { ClockContext } from '../ink/components/ClockContext.js'
+import { accentRamp } from '../trajectory/effortIgnition.js'
+import { rgbString } from '../trajectory/motion.js'
+import { interpolateColor, type RGBColor } from './Spinner/spinnerUtils.js'
+import { isLightThemeActive } from '../theme.js'
+
+/** 充能时长（ms）。 */
+const CHARGE_MS = 150
+
+export function EffortChargeGlyph({
+  effort,
+  levels,
+  working,
+}: {
+  /** 当前思考强度档 id；`undefined` 表示路线未声明。 */
+  effort: string | undefined
+  /** 当前路线的档位表（低→高，末位为最高档）。 */
+  levels: readonly string[] | undefined
+  /** 模型工作中时前缀照旧压暗（既有语义）。 */
+  working: boolean
+}): React.ReactNode {
+  const clock = useContext(ClockContext)
+  const [themeName] = useTheme()
+  const [chargeStartedAt, setChargeStartedAt] = useState<number | null>(null)
+  const [prevEffort, setPrevEffort] = useState(effort)
+  const [, forceRender] = useReducer((tick: number) => tick + 1, 0)
+  const steadyColor = useRef<RGBColor | null>(null)
+
+  const topActive =
+    effort !== undefined && levels !== undefined && levels.length > 1 && effort === levels[levels.length - 1]
+
+  // Render-phase trigger (same pattern as EffortIgnitionLine): switching from
+  // an existing tier onto the top tier starts the charge NOW, not one effect
+  // later — the first frame of the new effort must not flash fully lit.
+  // Cold mounts enter the steady state directly; without a shared clock
+  // (headless embeds) there is no charge either — no frames would ever arrive.
+  if (effort !== prevEffort) {
+    setPrevEffort(effort)
+    if (topActive && clock !== null) {
+      setChargeStartedAt(clock.now())
+    }
+  }
+
+  // Only the 150ms charge window subscribes to the shared clock; steady
+  // state has zero timers and zero re-renders.
+  const chargeElapsed =
+    chargeStartedAt === null
+      ? Infinity
+      : // Clamp at zero: the shared clock can hand back a stale tickTime for
+        // one frame after waking from pause.
+        Math.max(0, (clock?.now() ?? Date.now()) - chargeStartedAt)
+  const charging = chargeElapsed < CHARGE_MS
+  useEffect(() => {
+    if (!charging || clock === null) return
+    return clock.subscribe(() => forceRender(), /* keepAlive */ true)
+  }, [charging, clock])
+
+  if (!topActive) return <Text dimColor={working}>❯ </Text>
+  const ramp = accentRamp(isLightThemeActive(themeName))
+  if (!charging) {
+    // Steady state: cache the resolved full-accent colour — every PromptInput
+    // re-render (each keystroke) reuses it without re-deriving the ramp.
+    if (steadyColor.current === null) steadyColor.current = ramp.full
+    const color = rgbString(steadyColor.current)
+    return (
+      <Text bold color={color} dimColor={working}>
+        ❯{' '}
+      </Text>
+    )
+  }
+  const charge = Math.min(1, chargeElapsed / CHARGE_MS)
+  return (
+    <Text bold color={rgbString(interpolateColor(ramp.dim, ramp.full, charge))} dimColor={working}>
+      ❯{' '}
+    </Text>
+  )
+}

--- a/src/components/EffortInputBorder.tsx
+++ b/src/components/EffortInputBorder.tsx
@@ -1,0 +1,133 @@
+/**
+ * EffortInputBorder — 输入框层上的三幕点焰叠加（对齐 Codex 的完整
+ * 语义：光扫过、档位字样浮现、整体渐隐）。
+ *
+ * 输入框只有顶/底两条横边框（round、无左右）——本组件自绘这两行，
+ * **同步**承载动画；档位字样由输入行尾的 EffortTierBadge 短暂显示
+ * （见 PromptInput），动画全程行数恒定。切到最高思考强度档时：
+ *
+ *   1. 扫光 [0, 800ms)——一段蓝色光带沿顶/底边框同步自左向右扫过
+ *      （wave 波形逐列变色），期间输入框完全正常可用；
+ *   2. 档位字样 [400ms, ~1000ms)——光带行至中段时，输入行尾浮现
+ *      ` MAX`（当前档名大写，由暗渐亮加粗）；
+ *   3. 渐隐 [1100, 1600ms)——字样连同光色一起向主题色淡出，末帧
+ *      归零：静止时顶/底边框就是原主题色，内容区无任何附加物。
+ *
+ * glyph 变化仅限字样行的出现/让位（一次性）；其余帧间变化全部是既
+ * 有 `─` 的前景色。触发判定在渲染期做（props-变化-调整模式）；从
+ * 「已有档位」切到档位表末位最高档才触发，冷启动恢复偏好/单档表/
+ * 无档位表/无共享时钟均不触发。时钟复用 Ink core 共享时钟，仅动画
+ * 窗口订阅（keepAlive），播完回到零开销静止边框。
+ */
+import React, { useContext, useEffect, useReducer, useRef, useState } from 'react'
+import { Box, Text } from '../ui.js'
+import { ClockContext } from '../ink/components/ClockContext.js'
+import type { Color } from '../ink/styles.js'
+import type { Theme } from '../theme.js'
+import { IGNITION_TIMELINE, ignitionLineColors } from '../trajectory/effortIgnition.js'
+
+const { sweepMs: SWEEP_MS, fadeEndMs: FADE_END_MS } = IGNITION_TIMELINE
+
+type Overlay = { label: string; startedAtMs: number }
+
+/** 边框行（顶/底共用同一色段序列——同步变色）。 */
+function BorderRow({
+  left,
+  right,
+  runs,
+  idleColor,
+}: {
+  left: string
+  right: string
+  runs: ReadonlyArray<{ glyph: string; color: keyof Theme | Color }>
+  idleColor: keyof Theme | Color
+}): React.ReactNode {
+  return (
+    <Text>
+      <Text color={idleColor}>{left}</Text>
+      {runs.map((run, i) => (
+        <Text key={i} color={run.color}>
+          {run.glyph}
+        </Text>
+      ))}
+      <Text color={idleColor}>{right}</Text>
+    </Text>
+  )
+}
+
+export function EffortInputBorder({
+  effort,
+  levels,
+  columns,
+  onLight,
+  idleColor,
+  children,
+}: {
+  /** 当前思考强度档 id；`undefined` 表示路线未声明。 */
+  effort: string | undefined
+  /** 当前路线的档位表（低→高，末位为最高档）；未知时传 `undefined`。 */
+  levels: readonly string[] | undefined
+  columns: number
+  onLight: boolean
+  /** 静止边框色（主题 token 名，如 'promptBorder' / 'planMode'）。 */
+  idleColor: keyof Theme | Color
+  children: React.ReactNode
+}): React.ReactNode {
+  const clock = useContext(ClockContext)
+  const [overlay, setOverlay] = useState<Overlay | null>(null)
+  const [prevEffort, setPrevEffort] = useState(effort)
+  const [, forceRender] = useReducer((tick: number) => tick + 1, 0)
+
+  // 渲染期触发：effort 变化的首帧就以新状态渲染（effect 会晚一帧）。
+  if (effort !== prevEffort) {
+    setPrevEffort(effort)
+    if (
+      clock !== null &&
+      effort !== undefined &&
+      levels !== undefined &&
+      levels.length > 1 &&
+      effort === levels[levels.length - 1]
+    ) {
+      setOverlay({ label: effort.toUpperCase(), startedAtMs: clock.now() })
+    }
+  }
+
+  // 仅动画窗口订阅共享时钟；静止边框零定时器零重渲染。
+  const elapsedMs =
+    overlay === null ? Infinity : Math.max(0, (clock?.now() ?? Date.now()) - overlay.startedAtMs)
+  useEffect(() => {
+    if (overlay === null || clock === null) return
+    return clock.subscribe(() => forceRender(), /* keepAlive */ true)
+  }, [overlay, clock])
+  useEffect(() => {
+    if (overlay !== null && elapsedMs >= FADE_END_MS) setOverlay(null)
+  }, [overlay, elapsedMs])
+
+  const midWidth = Math.max(0, columns - 2)
+  const sweepColors =
+    overlay !== null && elapsedMs < SWEEP_MS && midWidth > 0
+      ? ignitionLineColors({ style: 'wave', elapsedMs, width: midWidth, onLight })
+      : []
+  // 顶/底共用的色段序列（同步）：扫光列取波形色，其余列回主题色。
+  const runs: Array<{ glyph: string; color: keyof Theme | Color }> = []
+  for (let index = 0; index < midWidth; index++) {
+    const color: keyof Theme | Color = sweepColors[index] ?? idleColor
+    const last = runs[runs.length - 1]
+    if (last !== undefined && last.color === color) last.glyph += '─'
+    else runs.push({ glyph: '─', color })
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      alignItems="flex-start"
+      justifyContent="flex-start"
+      width="100%"
+      flexShrink={0}
+    >
+      <BorderRow left="╭" right="╮" runs={runs} idleColor={idleColor} />
+      {children}
+      <BorderRow left="╰" right="╯" runs={runs} idleColor={idleColor} />
+    </Box>
+  )
+}

--- a/src/components/EffortInputBorder.tsx
+++ b/src/components/EffortInputBorder.tsx
@@ -6,12 +6,12 @@
  * **同步**承载动画；档位字样由输入行尾的 EffortTierBadge 短暂显示
  * （见 PromptInput），动画全程行数恒定。切到最高思考强度档时：
  *
- *   1. 扫光 [0, 800ms)——一段蓝色光带沿顶/底边框同步自左向右扫过
+ *   1. 扫光 [0, 1s)——一段高亮彩色光带沿顶/底边框同步自左向右扫过
  *      （wave 波形逐列变色），期间输入框完全正常可用；
- *   2. 档位字样 [400ms, ~1000ms)——光带行至中段时，输入行尾浮现
- *      ` MAX`（当前档名大写，由暗渐亮加粗）；
- *   3. 渐隐 [1100, 1600ms)——字样连同光色一起向主题色淡出，末帧
- *      归零：静止时顶/底边框就是原主题色，内容区无任何附加物。
+ *   2. 档位字样 [600ms, ~1.1s)——光带行至中段时，输入行居中浮现
+ *      档名大写（由暗渐亮加粗、间距聚拢，见 EffortTierBadge）；
+ *   3. 渐隐 [1.5s, 2s)——字样连同光色一起向主题色淡出，末帧归零：
+ *      静止时顶/底边框就是原主题色，内容区无任何附加物。
  *
  * glyph 变化仅限字样行的出现/让位（一次性）；其余帧间变化全部是既
  * 有 `─` 的前景色。触发判定在渲染期做（props-变化-调整模式）；从
@@ -25,8 +25,6 @@ import { ClockContext } from '../ink/components/ClockContext.js'
 import type { Color } from '../ink/styles.js'
 import type { Theme } from '../theme.js'
 import { IGNITION_TIMELINE, ignitionLineColors } from '../trajectory/effortIgnition.js'
-
-const { sweepMs: SWEEP_MS, fadeEndMs: FADE_END_MS } = IGNITION_TIMELINE
 
 type Overlay = { label: string; startedAtMs: number }
 
@@ -100,18 +98,18 @@ export function EffortInputBorder({
     return clock.subscribe(() => forceRender(), /* keepAlive */ true)
   }, [overlay, clock])
   useEffect(() => {
-    if (overlay !== null && elapsedMs >= FADE_END_MS) setOverlay(null)
+    if (overlay !== null && elapsedMs >= IGNITION_TIMELINE.fadeEndMs) setOverlay(null)
   }, [overlay, elapsedMs])
 
   const midWidth = Math.max(0, columns - 2)
   const sweepColors =
-    overlay !== null && elapsedMs < SWEEP_MS && midWidth > 0
-      ? ignitionLineColors({ style: 'wave', elapsedMs, width: midWidth, onLight })
+    overlay !== null && elapsedMs < IGNITION_TIMELINE.sweepMs && midWidth > 0
+      ? ignitionLineColors({ elapsedMs, width: midWidth, onLight })
       : []
   // 顶/底共用的色段序列（同步）：扫光列取波形色，其余列回主题色。
   const runs: Array<{ glyph: string; color: keyof Theme | Color }> = []
   for (let index = 0; index < midWidth; index++) {
-    const color: keyof Theme | Color = sweepColors[index] ?? idleColor
+    const color = sweepColors[index] as keyof Theme | Color | undefined ?? idleColor
     const last = runs[runs.length - 1]
     if (last !== undefined && last.color === color) last.glyph += '─'
     else runs.push({ glyph: '─', color })

--- a/src/components/EffortTierBadge.tsx
+++ b/src/components/EffortTierBadge.tsx
@@ -1,0 +1,126 @@
+/**
+ * EffortTierBadge — 输入行尾的档位字样徽标：三幕点焰的第二幕载体
+ * （与 EffortInputBorder 的双框扫光同一时间轴、同一触发），切到最高
+ * 思考强度档时光带行至中段，输入行居中浮现档名（当前档名大写，字母间距从
+ * 10 个空格减速聚拢到 1 个——连续位置逐字母取整保证帧帧有移动，
+ * 明亮蓝加粗，由暗渐亮），随后随图层整体渐隐让位——行数恒定，静
+ * 止时完全不渲染；输入行有文字时不显示（绝不遮挡内容）。
+ *
+ * 触发判定在渲染期做（props-变化-调整模式，与边框/充能组件同模
+ * 式）；冷启动恢复偏好/单档表/无档位表/无共享时钟均不触发。时钟
+ * 复用 Ink core 共享时钟，仅动画窗口订阅（keepAlive），播完归零。
+ */
+import React, { useContext, useEffect, useReducer, useState } from 'react'
+import { Text } from '../ui.js'
+import { ClockContext } from '../ink/components/ClockContext.js'
+import { rgbString } from '../trajectory/motion.js'
+import type { RGBColor } from './Spinner/spinnerUtils.js'
+import { IGNITION_TIMELINE, ignitionHues } from '../trajectory/effortIgnition.js'
+
+type Overlay = { label: string; startedAtMs: number }
+
+/** 字母间距聚拢：从 10 个空格减速收敛到 1 个（ease-out，快收慢停）。 */
+const GAP_START = 10
+const GAP_END = 1
+const CONVERGE_MS = 500
+
+export function EffortTierBadge({
+  effort,
+  levels,
+  onLight,
+  columns,
+  leadingColumns,
+}: {
+  /** 当前思考强度档 id；`undefined` 表示路线未声明。 */
+  effort: string | undefined
+  /** 当前路线的档位表（低→高，末位为最高档）；未知时传 `undefined`。 */
+  levels: readonly string[] | undefined
+  onLight: boolean
+  /** 终端列数——居中锚点按终端几何中心计算（纯文本流，不引入嵌套 Box）。 */
+  columns: number
+  /** badge 文本流之前该行已被占据的列数（❯ 与块光标等）——居中换算成
+   *  badge 流内列时要扣掉，否则整体偏右一个前缀宽。 */
+  leadingColumns: number
+}): React.ReactNode {
+  const clock = useContext(ClockContext)
+  const [overlay, setOverlay] = useState<Overlay | null>(null)
+  const [prevEffort, setPrevEffort] = useState(effort)
+  const [, forceRender] = useReducer((tick: number) => tick + 1, 0)
+
+  // 渲染期触发（与边框/充能同模式）：effort 变化的首帧就以新状态渲染。
+  if (effort !== prevEffort) {
+    setPrevEffort(effort)
+    if (
+      clock !== null &&
+      effort !== undefined &&
+      levels !== undefined &&
+      levels.length > 1 &&
+      effort === levels[levels.length - 1]
+    ) {
+      setOverlay({ label: effort.toUpperCase(), startedAtMs: clock.now() })
+    }
+  }
+
+  const elapsedMs =
+    overlay === null ? Infinity : Math.max(0, (clock?.now() ?? Date.now()) - overlay.startedAtMs)
+  useEffect(() => {
+    if (overlay === null || clock === null) return
+    return clock.subscribe(() => forceRender(), /* keepAlive */ true)
+  }, [overlay, clock])
+  useEffect(() => {
+    if (overlay !== null && elapsedMs >= IGNITION_TIMELINE.fadeEndMs) setOverlay(null)
+  }, [overlay, elapsedMs])
+
+  if (overlay === null || elapsedMs < IGNITION_TIMELINE.labelStartMs) return null
+  const brighten = Math.min(1, (elapsedMs - IGNITION_TIMELINE.labelStartMs) / IGNITION_TIMELINE.labelBrightenMs)
+  const fade =
+    elapsedMs < IGNITION_TIMELINE.fadeStartMs
+      ? 1
+      : Math.max(0, 1 - (elapsedMs - IGNITION_TIMELINE.fadeStartMs) / (IGNITION_TIMELINE.fadeEndMs - IGNITION_TIMELINE.fadeStartMs))
+  const alpha = brighten * fade
+  if (alpha <= 0) return null
+  const band: RGBColor = onLight ? { r: 240, g: 240, b: 242 } : { r: 27, g: 30, b: 40 }
+  // 明亮蓝：accent 混白 35% 提亮（用户拍板的高亮观感）。
+  const hue = ignitionHues(onLight)[0]
+  const whiten = (x: number): number => Math.round(x + (255 - x) * 0.35)
+  const bright: RGBColor = { r: whiten(hue.r), g: whiten(hue.g), b: whiten(hue.b) }
+  const mix = (x: number, y: number): number => Math.round(x + (y - x) * alpha)
+  const color = rgbString({ r: mix(band.r, bright.r), g: mix(band.g, bright.g), b: mix(band.b, bright.b) })
+  // 字母间距聚拢（Codex 的 converge 语义）：间距是连续浮点，字母位置
+  // 以**行中心为锚**对称收缩——pos_i = center + (i-(n-1)/2)·(1+gap)，
+  // 左右字母各向中心移动一半（奇数档名的居中字母原位不动），两侧速
+  // 度天然均衡；每字母独立按连续位置取整落列，不同字母在不同帧跨
+  // 格，每帧至少一个在动（把间距整体取整会让 ease-out 慢末段上百毫
+  // 秒才跨一格，看起来就是卡顿）。曲线混入 15% 线性做末段保底速度。
+  const progress = Math.min(1, Math.max(0, (elapsedMs - IGNITION_TIMELINE.labelStartMs) / CONVERGE_MS))
+  // 跳变间隔均匀化：离散格子上「减速」若靠曲线导数趋零实现，末段会
+  // 出现几十帧不动一格的长停顿再突跳（卡感来源）。改为 90% 线性 +
+  // 10% easeOutQuad 的轻缓收尾——跳变间隔全程近似恒定（约 55ms/格），
+  // 仅末端轻微放慢，终端上的观感是均匀顺滑的聚拢。
+  const eased = 1 - progress
+  const easedWithFloor = 0.9 * eased + 0.1 * (1 - progress * progress)
+  const gapF = GAP_END + (GAP_START - GAP_END) * easedWithFloor
+  const letterCount = overlay.label.length
+  // 锚点是**终端几何中心**（不是 ❯/光标之后可用区的中心——那会整体
+  // 偏右约 1.5 格；可用区起点在左，其"中点"不含左部占位）。左右字母
+  // 严格镜像——Math.round 对 .5 恒向上，正负方向舍入不对称会让跨格
+  // 时刻错开；左字母的落列由右字母的舍入结果镜像得出（2C − col），
+  // M/X 每次同帧反向同跳，全程对称于终端中心。
+  const C = Math.round((columns - 1) / 2) - leadingColumns
+  let spaced = ''
+  let column = 0
+  for (let i = 0; i < letterCount; i++) {
+    const off = (i - (letterCount - 1) / 2) * (1 + gapF)
+    const at =
+      off >= 0
+        ? Math.round(C + off)
+        : 2 * C - Math.round(C - off)
+    spaced += ' '.repeat(Math.max(0, at - column)) + overlay.label[i]!
+    column = at + 1
+  }
+  return (
+    <Text bold color={color}>
+      {spaced}
+    </Text>
+  )
+}

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import { readFile, unlink } from 'node:fs/promises'
 import { basename } from 'node:path'
 import { t } from '../i18n.js'
-import { Box, Text, useInput, useTerminalSize } from '../ui.js'
+import { Box, Text, useInput, useTerminalSize, useTheme } from '../ui.js'
+import { EffortChargeGlyph } from './EffortChargeGlyph.js'
+import { EffortInputBorder } from './EffortInputBorder.js'
+import { EffortTierBadge } from './EffortTierBadge.js'
+import { isLightThemeActive } from '../theme.js'
 import { useDeclaredCursor } from '../ink/hooks/use-declared-cursor.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { formatClipboardInsert, readClipboard } from '../utils/clipboard.js'
@@ -134,6 +138,7 @@ export function PromptInput({
   onRewindRequest,
   controllerRef,
 }: PromptInputProps) {
+  const [themeName] = useTheme()
   const [value, setValue] = React.useState('')
   const [cursor, setCursor] = React.useState(0)
   const valueRef = React.useRef(value)
@@ -1029,31 +1034,47 @@ export function PromptInput({
           </Box>
         </Box>
       )}
-      <Box
-        flexDirection="column"
-        alignItems="flex-start"
-        justifyContent="flex-start"
-        borderColor={channel.mode.plan === true ? 'planMode' : 'promptBorder'}
-        borderStyle="round"
-        borderLeft={false}
-        borderRight={false}
-        borderBottom
-        width="100%"
+      {/* The prompt's own top/bottom border rows, self-drawn so the effort
+          overlay can play on them (sweep → tier name → fade; see
+          EffortInputBorder). Idle colour keeps the plan-mode accent the old
+          Box border carried. */}
+      <EffortInputBorder
+        effort={channel.reasoningEffort}
+        levels={channel.effortLevels}
+        columns={columns}
+        onLight={isLightThemeActive(themeName)}
+        idleColor={channel.mode.plan === true ? 'planMode' : 'promptBorder'}
       >
         <Box flexDirection="row" alignItems="flex-start" width="100%">
-          <Text dimColor={channel.working}>❯ </Text>
+          <EffortChargeGlyph
+            effort={channel.reasoningEffort}
+            levels={channel.effortLevels}
+            working={channel.working}
+          />
           <Box ref={valueBoxRef} flexGrow={1} flexShrink={1}>
             {value.length === 0 ? (
               // Solid block caret on a BLANK cell: the terminal paints the
               // IME preedit (pinyin) at the physical cursor, which is parked
               // right here, so nothing else may occupy this cell.
-              <Text inverse> </Text>
+              <>
+                <Text inverse> </Text>
+                {/* 三幕点焰第二幕：空输入行居中短暂浮现档名大写（纯文
+                    本流自带偏移空格——不引入嵌套 Box，行数恒定；有文字
+                    时不显示）。 */}
+                <EffortTierBadge
+                  effort={channel.reasoningEffort}
+                  levels={channel.effortLevels}
+                  onLight={isLightThemeActive(themeName)}
+                  columns={columns}
+                  leadingColumns={3}
+                />
+              </>
             ) : (
               <Box flexDirection="column">{rendered}</Box>
             )}
           </Box>
         </Box>
-      </Box>
+      </EffortInputBorder>
     </Box>
   )
 }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1619,12 +1619,19 @@ export function createChannel(
    *  top-tier-triggered UI (effort ignition): fire-and-forget on route
    *  changes (bind/model switch/resume); the /effort paths refresh it
    *  authoritatively via resolveEfforts. */
+  let effortLevelsGeneration = 0
   const refreshEffortLevels = (): void => {
     if (llmRuntime === undefined) return
+    // 代际保护：快速连续切路由时并发的 resolveModelInfo 可能乱序返回，
+    // 只有最新一代的解析才允许落表；落表后 emit 让 useSyncExternalStore
+    // 消费者立刻可见（否则要等下一次无关 emit）。
+    const generation = ++effortLevelsGeneration
     void llmRuntime
       .resolveModelInfo(state.provider, state.model)
       .then(info => {
+        if (generation !== effortLevelsGeneration) return
         state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
+        state.emit()
       })
       .catch(() => {
         // Route metadata resolution is best-effort; a failure keeps the

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1621,7 +1621,7 @@ export function createChannel(
    *  authoritatively via resolveEfforts. */
   let effortLevelsGeneration = 0
   const refreshEffortLevels = (): void => {
-    if (llmRuntime === undefined) return
+    if (llmRuntime === undefined || typeof llmRuntime.resolveModelInfo !== 'function') return
     // 代际保护：快速连续切路由时并发的 resolveModelInfo 可能乱序返回，
     // 只有最新一代的解析才允许落表；落表后 emit 让 useSyncExternalStore
     // 消费者立刻可见（否则要等下一次无关 emit）。

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -452,6 +452,9 @@ export interface Channel {
   readonly contextWindow: number | undefined
   /** Reasoning effort of the latest request header, when the adapter sets one. */
   readonly reasoningEffort: string | undefined
+  /** The live route's reasoning-effort level ids, low → high (the last entry
+   *  is the top tier). Consumed by top-tier-triggered UI (effort ignition). */
+  readonly effortLevels: readonly string[] | undefined
   /** Usage of the most recent request (context share + cache hits come from
    *  this, not the running totals — each request's input IS the context). */
   readonly lastUsage:
@@ -789,6 +792,8 @@ export interface ChannelState {
   contextWindow: number | undefined
   /** Reasoning effort of the latest request header, when the adapter sets one. */
   reasoningEffort: string | undefined
+  /** The live route's reasoning-effort level ids, low → high. */
+  effortLevels: readonly string[] | undefined
   /** Usage of the most recent request (context share + cache hits). */
   lastUsage:
     | { input: number; output: number; cacheRead: number; cacheWrite: number }
@@ -1597,6 +1602,7 @@ export function createChannel(
     if (preferredEffort === undefined || llmRuntime === undefined) return
     try {
       const info = await llmRuntime.resolveModelInfo(state.provider, state.model)
+      state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
       if (!info.reasoning?.efforts.some(effort => effort.id === preferredEffort)) return
       selection.current = {
         provider: state.provider,
@@ -1607,6 +1613,23 @@ export function createChannel(
       // Route metadata resolution is best-effort; a failure just leaves the
       // provider default in effect.
     }
+  }
+
+  /** Best-effort refresh of the live route's effort-level table for
+   *  top-tier-triggered UI (effort ignition): fire-and-forget on route
+   *  changes (bind/model switch/resume); the /effort paths refresh it
+   *  authoritatively via resolveEfforts. */
+  const refreshEffortLevels = (): void => {
+    if (llmRuntime === undefined) return
+    void llmRuntime
+      .resolveModelInfo(state.provider, state.model)
+      .then(info => {
+        state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
+      })
+      .catch(() => {
+        // Route metadata resolution is best-effort; a failure keeps the
+        // previous table until the next /effort interaction clears it.
+      })
   }
 
   /** Resolve the live route's effort levels + adapter default through the
@@ -1623,6 +1646,7 @@ export function createChannel(
     if (llmRuntime === undefined) return 'unavailable'
     try {
       const info = await llmRuntime.resolveModelInfo(state.provider, state.model)
+      state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
       return {
         efforts: info.reasoning?.efforts ?? [],
         defaultEffort: info.reasoning?.defaultEffort,
@@ -1874,6 +1898,7 @@ export function createChannel(
   }
 
   const state: ChannelState = {
+    effortLevels: undefined,
     version: 0,
     rows: [],
     status: 'starting',
@@ -2438,6 +2463,11 @@ export function createChannel(
       state.lastUsage = undefined
       state.workingActivity = undefined
       state.contextWindow = undefined
+      // Route changed: a stale tier table would let top-tier UI fire on the
+      // wrong level (or never fire on the real one); clear and re-resolve.
+      state.effortLevels = undefined
+      state.reasoningEffort = undefined
+      refreshEffortLevels()
       state.contextSegments = {
         system: 0,
         prompt: 0,
@@ -2596,6 +2626,11 @@ export function createChannel(
       state.workingActivity = undefined
       state.loadedContext = undefined
       state.contextWindow = undefined
+      // Route changed: a stale tier table would let top-tier UI fire on the
+      // wrong level (or never fire on the real one); clear and re-resolve.
+      state.effortLevels = undefined
+      state.reasoningEffort = undefined
+      refreshEffortLevels()
       state.contextSegments = {
         system: 0,
         prompt: 0,
@@ -2777,6 +2812,11 @@ export function createChannel(
       state.lastUsage = undefined
       state.workingActivity = undefined
       state.contextWindow = undefined
+      // Route changed: a stale tier table would let top-tier UI fire on the
+      // wrong level (or never fire on the real one); clear and re-resolve.
+      state.effortLevels = undefined
+      state.reasoningEffort = undefined
+      refreshEffortLevels()
       state.contextSegments = {
         system: 0,
         prompt: 0,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -482,6 +482,26 @@ export function getTheme(themeName: ThemeName): Theme {
 let customThemeResolver: ((name: string) => Theme | undefined) | undefined
 
 /**
+ * Whether the active theme's RESOLVED palette renders on a light background.
+ * Keyed off the palette's own `background` colour, never the theme NAME —
+ * `useTheme()` returns the literal `'auto'` for the auto theme and the file
+ * name for custom themes, so name comparisons miss auto-with-light-terminal
+ * and light custom palettes. Colour-pair variants (effort ignition hues)
+ * consume this signal.
+ * @param themeName - The theme name as `useTheme()` reports it.
+ * @returns True when the resolved palette's background is light (same Rec.601
+ *   luma test and dark-biased threshold as ThemeProvider's detector).
+ */
+export function isLightThemeActive(themeName: ThemeName): boolean {
+  const background = getTheme(themeName).background
+  if (!background.startsWith('#') || background.length !== 7) return themeName === 'light'
+  const r = Number.parseInt(background.slice(1, 3), 16)
+  const g = Number.parseInt(background.slice(3, 5), 16)
+  const b = Number.parseInt(background.slice(5, 7), 16)
+  return 0.299 * r + 0.587 * g + 0.114 * b > 140
+}
+
+/**
  * Register the custom-theme resolver. Called once by ThemeProvider; the
  * resolver must return `undefined` for names it does not know so getTheme
  * falls back to `dark`.

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -483,22 +483,24 @@ let customThemeResolver: ((name: string) => Theme | undefined) | undefined
 
 /**
  * Whether the active theme's RESOLVED palette renders on a light background.
- * Keyed off the palette's own `background` colour, never the theme NAME —
- * `useTheme()` returns the literal `'auto'` for the auto theme and the file
- * name for custom themes, so name comparisons miss auto-with-light-terminal
- * and light custom palettes. Colour-pair variants (effort ignition hues)
- * consume this signal.
- * @param themeName - The theme name as `useTheme()` reports it.
- * @returns True when the resolved palette's background is light (same Rec.601
- *   luma test and dark-biased threshold as ThemeProvider's detector).
+ * Keyed off the resolved palette's IDENTITY for the built-ins (auto resolves
+ * to the shared light/dark instance, so this covers auto-with-light-terminal
+ * that theme-NAME comparisons miss) and off the ink-text luminance for
+ * custom themes (light palettes pair with dark ink). The palette's
+ * `background` field is a badge fill, not the terminal background — never a
+ * lightness signal. Colour-pair variants (effort ignition hues) consume this.
  */
 export function isLightThemeActive(themeName: ThemeName): boolean {
-  const background = getTheme(themeName).background
-  if (!background.startsWith('#') || background.length !== 7) return themeName === 'light'
-  const r = Number.parseInt(background.slice(1, 3), 16)
-  const g = Number.parseInt(background.slice(3, 5), 16)
-  const b = Number.parseInt(background.slice(5, 7), 16)
-  return 0.299 * r + 0.587 * g + 0.114 * b > 140
+  const theme = getTheme(themeName)
+  if (theme === lightTheme) return true
+  if (theme === darkTheme || theme === darkAnsiTheme) return false
+  // 自定义主题：按文本墨色亮度判定——浅底配深墨（ink）、深底配亮墨。
+  // 调色板的 background 字段是徽标填充色而非终端背景，不能作判据。
+  const ink = theme.text
+  const rgb = /^rgb\((\d+),(\d+),(\d+)\)$/.exec(ink)
+  if (rgb === null) return false
+  const [r, g, b] = [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])]
+  return 0.299 * r + 0.587 * g + 0.114 * b < 140
 }
 
 /**

--- a/src/trajectory/effortIgnition.ts
+++ b/src/trajectory/effortIgnition.ts
@@ -1,0 +1,250 @@
+/**
+ * Effort ignition — 切到最高思考强度档时的一次性点焰波形（数学层）。
+ *
+ * 只做纯函数计算：波形采样、缓动、逐列混色。组件每帧调用
+ * {@link ignitionLineColors} 取得整行背景色。移植自 Codex CLI 的
+ * effort_ignition(_styles).rs（openai/codex PR #34365），波形语义保留：
+ * Wave 是余弦钟形行波自左向右扫过；Aurora 是多条正弦游走带同色相权重
+ * 相加；Pulse 是三次缓动的扩散圆环。三者都只产生颜色——SGR-only 规则
+ * （见 motion.ts）因此天然成立：glyph 恒为空格、行数恒为一，帧间变化
+ * 全部走背景色 SGR。
+ *
+ * 档位语义：dsh 的思考强度是 adapter 拥有的动态档位表，没有 Codex 的
+ * Max/Ultra 双档常量——这里只保留一套「最高档」色板（暖橙，深/浅背景
+ * 两个变体），第二档色板留待真有双顶级档位时再引入。
+ */
+import type { Color } from '../ink/styles.js'
+import type { RGBColor } from '../components/Spinner/spinnerUtils.js'
+import { rgbString } from './motion.js'
+
+/** 点焰风格：每次触发随机选一，且不与上一次重复。 */
+export type IgnitionStyle = 'wave' | 'aurora' | 'pulse'
+
+export const IGNITION_STYLES: readonly IgnitionStyle[] = ['wave', 'aurora', 'pulse']
+
+/** 三幕时间轴（ms）：扫光全长、字样启动（波至中段）、字样渐亮、渐隐起止。边框扫光与输入行字样徽标共用。 */
+export const IGNITION_TIMELINE = {
+  sweepMs: 1200,
+  labelStartMs: 600,
+  labelBrightenMs: 160,
+  fadeStartMs: 1500,
+  fadeEndMs: 2000,
+} as const
+
+/** 帧时长（ms），仅用于把墙钟时间折算成动画秒数，不创建任何定时器。 */
+export const IGNITION_TOTAL_MS: Record<IgnitionStyle, number> = {
+  wave: 1000,
+  aurora: 1300,
+  pulse: 900,
+}
+
+/**
+ * 波形参数（对齐 Codex 的 bands 表）：
+ * wave/pulse 为 `[launch, travel, strength]`；aurora 为
+ * `[speed, phase, hueIndex]`。aurora 用两条带（第三条是 Ultra 双波专属，
+ * 单档语义下不启用）。
+ */
+const BANDS: Record<IgnitionStyle, ReadonlyArray<readonly [number, number, number]>> = {
+  wave: [[0.1, 0.75, 1]],
+  aurora: [
+    [0.35, 0.15, 0],
+    [-0.5, 0.6, 1],
+  ],
+  pulse: [[0.1, 0.6, 1]],
+}
+
+/** 波形宽度参数（列）。 */
+const WAVE_HALF_WIDTH = 14
+const PULSE_HALF_WIDTH = 4.5
+
+/**
+ * 最高档色板：三 hue 按列权重混合。深色背景用亮暖橙系，浅色背景换深
+ * 暖橙系（对齐 Codex Max 档的两个变体——浅底上亮橙没有对比度）。模块
+ * 级常量：每帧调用零分配。
+ */
+const HUES_DARK: readonly [RGBColor, RGBColor, RGBColor] = [
+  { r: 130, g: 185, b: 255 },
+  { r: 140, g: 252, b: 248 },
+  { r: 195, g: 172, b: 255 },
+]
+const HUES_LIGHT: readonly [RGBColor, RGBColor, RGBColor] = [
+  { r: 30, g: 95, b: 235 },
+  { r: 10, g: 160, b: 200 },
+  { r: 120, g: 80, b: 235 },
+]
+
+export function ignitionHues(onLight: boolean): readonly [RGBColor, RGBColor, RGBColor] {
+  return onLight ? HUES_LIGHT : HUES_DARK
+}
+
+/**
+ * 充能色对（前缀强调用）：从带底色调的暗强调到全强调，与波共用
+ * hues[0]（同一瞬间前缀与波是同一种橙）。
+ * @param onLight - 浅色主题用浅底色板。
+ */
+export function accentRamp(onLight: boolean): { dim: RGBColor; full: RGBColor } {
+  const band = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
+  return { dim: blend(band, ignitionHues(onLight)[0]!, 0.45), full: ignitionHues(onLight)[0]! }
+}
+
+/**
+ * 带底色（波向状态行本底淡入的目标色）。近似值：取主题深/浅背景的典
+ * 型值而非逐主题读取——波只存活一秒，色差在低 alpha 下不可辨。
+ */
+const BAND_RGB_DARK: RGBColor = { r: 27, g: 30, b: 40 }
+const BAND_RGB_LIGHT: RGBColor = { r: 240, g: 240, b: 242 }
+
+/** 余弦钟形：`crest(0)=1`、`crest(±1)=0`、之外为 0（负距离同样静默——
+ * 现有调用方都传 `Math.abs`，这里兜底防未来调用方拿到全强度）。 */
+export function crest(distance: number): number {
+  if (distance >= 1 || distance <= -1) return 0
+  return 0.5 * (1 + Math.cos(Math.PI * distance))
+}
+
+/** ease-in cubic：`p³`，两端 clamp。 */
+export function easeInCubic(progress: number): number {
+  const p = Math.min(1, Math.max(0, progress))
+  return p * p * p
+}
+
+/** ease-out cubic：`1-(1-p)³`，两端 clamp。 */
+export function easeOutCubic(progress: number): number {
+  const p = Math.min(1, Math.max(0, progress))
+  const inverse = 1 - p
+  return 1 - inverse * inverse * inverse
+}
+
+/** ease-in-out cubic：前半 `4p³`、后半镜像，两端 clamp。 */
+export function easeInOutCubic(progress: number): number {
+  const p = Math.min(1, Math.max(0, progress))
+  if (p < 0.5) return 4 * p * p * p
+  const inverse = -2 * p + 2
+  return 1 - (inverse * inverse * inverse) / 2
+}
+
+/**
+ * 一次性包络：`[0, total]` 外为 0，进入段按 `fadeIn` 线性升起、离开段
+ * 按 `fadeOut` 线性落下，取两者**较小**值（对齐上游：任意时刻受两段
+ * 斜坡中较缓的一侧约束）。
+ */
+export function envelope(elapsed: number, total: number, fadeIn: number, fadeOut: number): number {
+  if (elapsed <= 0 || elapsed >= total) return 0
+  const inPart = elapsed / Math.max(fadeIn, Number.EPSILON)
+  const outPart = (total - elapsed) / Math.max(fadeOut, Number.EPSILON)
+  return Math.min(1, Math.max(0, Math.min(inPart, outPart)))
+}
+
+/** 单列对全部波带的采样结果：三 hue 各自的权重（未归一）。 */
+function sampleColumn(
+  style: IgnitionStyle,
+  elapsed: number,
+  column: number,
+  width: number,
+): [number, number, number] {
+  const weights: [number, number, number] = [0, 0, 0]
+  for (const band of BANDS[style]) {
+    const [first, second, third] = band
+    if (style === 'wave') {
+      const progress = (elapsed - first) / second
+      if (progress < 0 || progress > 1) continue
+      const center = easeInOutCubic(progress) * (width + 2 * WAVE_HALF_WIDTH) - WAVE_HALF_WIDTH
+      weights[0] = Math.max(weights[0], crest(Math.abs(column - center) / WAVE_HALF_WIDTH))
+    } else if (style === 'aurora') {
+      const center =
+        (0.5 + 0.38 * Math.sin(Math.PI * 2 * (first * elapsed + second))) * width
+      const halfWidth = Math.max(width * 0.22, 4)
+      weights[third] += crest(Math.abs(column - center) / halfWidth)
+    } else {
+      const progress = (elapsed - first) / second
+      if (progress < 0 || progress > 1) continue
+      const inverse = 1 - progress
+      const radius = (1 - inverse * inverse * inverse) * (width / 2 + 2 * PULSE_HALF_WIDTH)
+      const distance = Math.abs(column - width / 2)
+      weights[0] = Math.max(
+        weights[0],
+        crest(Math.abs(distance - radius) / PULSE_HALF_WIDTH) * third * (1 - 0.6 * progress),
+      )
+    }
+  }
+  return weights
+}
+
+/**
+ * 混两个 RGB（线性插值）。
+ * @param t - 位置，`0` 返回 `a`、`1` 返回 `b`，不 clamp（调用方负责）。
+ */
+function blend(a: RGBColor, b: RGBColor, t: number): RGBColor {
+  return {
+    r: Math.round(a.r + (b.r - a.r) * t),
+    g: Math.round(a.g + (b.g - a.g) * t),
+    b: Math.round(a.b + (b.b - a.b) * t),
+  }
+}
+
+/**
+ * 点焰某一时刻的整行背景色。
+ *
+ * @param options - 波形参数。
+ * @param options.style - 点焰风格。
+ * @param options.elapsedMs - 距触发的时间；达到 {@link IGNITION_TOTAL_MS}
+ *   后整行返回 `undefined`（无波，行恢复本底）。
+ * @param options.width - 行列数（终端宽）。
+ * @param options.onLight - 浅色主题时用浅底色板与浅带底色。
+ * @returns 逐列背景色（`rgb(r,g,b)` 字符串）；无波的列为 `undefined`，
+ *   渲染层应输出不设背景的空格，保持行宽恒定。
+ */
+export function ignitionLineColors(options: {
+  style: IgnitionStyle
+  elapsedMs: number
+  width: number
+  onLight: boolean
+}): ReadonlyArray<Color | undefined> {
+  const { style, elapsedMs, width, onLight } = options
+  const total = IGNITION_TOTAL_MS[style] / 1000
+  const elapsed = elapsedMs / 1000
+  if (width <= 0 || !Number.isFinite(elapsed) || elapsed <= 0 || elapsed >= total) return []
+  const hues = ignitionHues(onLight)
+  const bandRgb = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
+  const fade =
+    style === 'aurora' ? envelope(elapsed, total, /* fadeIn */ 0.25, /* fadeOut */ 0.4) : 1
+  const colors: Array<Color | undefined> = new Array(width)
+  for (let column = 0; column < width; column++) {
+    const weights = sampleColumn(style, elapsed, column, width)
+    const weight = weights[0] + weights[1] + weights[2]
+    if (weight <= 0.01) {
+      colors[column] = undefined
+      continue
+    }
+    let r = 0
+    let g = 0
+    let b = 0
+    for (let hue = 0; hue < 3; hue++) {
+      r += weights[hue]! * hues[hue]!.r
+      g += weights[hue]! * hues[hue]!.g
+      b += weights[hue]! * hues[hue]!.b
+    }
+    const hue: RGBColor = { r: r / weight, g: g / weight, b: b / weight }
+    const alpha =
+      style === 'aurora' ? Math.min(weight * 0.4, 0.5) * fade : weight * 0.55
+    // 波按强度淡入带底色：alpha=1 是纯 hue，alpha→0 收敛回本底。
+    // 高亮度档（用户拍板）：满强度纯 hue 直出（上限 1.0）。输出前通道量化到
+    // 8 步长：渐变列因此能合并成长段（渲染层 RLE 段数降一个数量级），
+    // 8/256 的色差在终端 cell 分辨率下不可辨。
+    const tinted = blend(bandRgb, hue, Math.min(alpha, 0.6))
+    colors[column] = rgbString({
+      r: Math.round(tinted.r / 8) * 8,
+      g: Math.round(tinted.g / 8) * 8,
+      b: Math.round(tinted.b / 8) * 8,
+    })
+  }
+  return colors
+}
+
+/**
+ * 随机选一种风格，且不与上一次重复（连续两次切档不重样）。
+ * @param previous - 上一次的风格；首次触发传 `undefined`。
+ */
+export function randomIgnitionStyle(previous: IgnitionStyle | undefined): IgnitionStyle {
+  const pool = IGNITION_STYLES.filter(style => style !== previous)
+  return pool[Math.floor(Math.random() * pool.length)]!
+}

--- a/src/trajectory/effortIgnition.ts
+++ b/src/trajectory/effortIgnition.ts
@@ -1,66 +1,41 @@
-/**
- * Effort ignition — 切到最高思考强度档时的一次性点焰波形（数学层）。
- *
- * 只做纯函数计算：波形采样、缓动、逐列混色。组件每帧调用
- * {@link ignitionLineColors} 取得整行背景色。移植自 Codex CLI 的
- * effort_ignition(_styles).rs（openai/codex PR #34365），波形语义保留：
- * Wave 是余弦钟形行波自左向右扫过；Aurora 是多条正弦游走带同色相权重
- * 相加；Pulse 是三次缓动的扩散圆环。三者都只产生颜色——SGR-only 规则
- * （见 motion.ts）因此天然成立：glyph 恒为空格、行数恒为一，帧间变化
- * 全部走背景色 SGR。
- *
- * 档位语义：dsh 的思考强度是 adapter 拥有的动态档位表，没有 Codex 的
- * Max/Ultra 双档常量——这里只保留一套「最高档」色板（暖橙，深/浅背景
- * 两个变体），第二档色板留待真有双顶级档位时再引入。
- */
-import type { Color } from '../ink/styles.js'
-import type { RGBColor } from '../components/Spinner/spinnerUtils.js'
-import { rgbString } from './motion.js'
-
-/** 点焰风格：每次触发随机选一，且不与上一次重复。 */
-export type IgnitionStyle = 'wave' | 'aurora' | 'pulse'
-
-export const IGNITION_STYLES: readonly IgnitionStyle[] = ['wave', 'aurora', 'pulse']
-
 /** 三幕时间轴（ms）：扫光全长、字样启动（波至中段）、字样渐亮、渐隐起止。边框扫光与输入行字样徽标共用。 */
 export const IGNITION_TIMELINE = {
-  sweepMs: 1200,
+  sweepMs: 1000,
   labelStartMs: 600,
   labelBrightenMs: 160,
   fadeStartMs: 1500,
   fadeEndMs: 2000,
 } as const
 
-/** 帧时长（ms），仅用于把墙钟时间折算成动画秒数，不创建任何定时器。 */
-export const IGNITION_TOTAL_MS: Record<IgnitionStyle, number> = {
-  wave: 1000,
-  aurora: 1300,
-  pulse: 900,
-}
-
 /**
- * 波形参数（对齐 Codex 的 bands 表）：
- * wave/pulse 为 `[launch, travel, strength]`；aurora 为
- * `[speed, phase, hueIndex]`。aurora 用两条带（第三条是 Ultra 双波专属，
- * 单档语义下不启用）。
+ * Effort ignition motion math — pure functions, zero dependencies.
+ *
+ * Waveform semantics ported from Codex CLI's effort_ignition(_styles).rs
+ * (openai/codex PR #34365) and revalidated in a dsh-TUI integration: a
+ * cosine-bell travelling wave produces per-column colours only — a renderer
+ * that keeps glyphs constant and changes colours per frame stays SGR-only
+ * by construction.
+ *
+ * Consumers ride the FOREGROUND channel (a constant block glyph under a
+ * varying fg colour): pure-background cells never reached the terminal in
+ * the fullscreen log-update pipeline, while foreground is the channel every
+ * live element already rides.
  */
-const BANDS: Record<IgnitionStyle, ReadonlyArray<readonly [number, number, number]>> = {
-  wave: [[0.1, 0.75, 1]],
-  aurora: [
-    [0.35, 0.15, 0],
-    [-0.5, 0.6, 1],
-  ],
-  pulse: [[0.1, 0.6, 1]],
-}
+import type { RGBColor } from '../components/Spinner/spinnerUtils.js'
+import { rgbString } from './motion.js'
+
+/** 扫光全长（ms），仅用于把墙钟时间折算成动画秒数，不创建任何定时器。 */
+export const SWEEP_TOTAL_MS = 1000
 
 /** 波形宽度参数（列）。 */
 const WAVE_HALF_WIDTH = 14
-const PULSE_HALF_WIDTH = 4.5
+
+/** 波形参数：`[launch, travel]`（秒）——扫光在何时启动、多久行至右缘。 */
+const BAND: readonly [number, number] = [0.1, 0.75]
 
 /**
- * 最高档色板：三 hue 按列权重混合。深色背景用亮暖橙系，浅色背景换深
- * 暖橙系（对齐 Codex Max 档的两个变体——浅底上亮橙没有对比度）。模块
- * 级常量：每帧调用零分配。
+ * 高亮彩色色板：亮蓝/亮青/亮紫三 hue（浅色背景用加深变体——浅底上
+ * 亮色没有对比度）。波只点亮 hues[0]，前两个 hue 留给未来的多带风格。
  */
 const HUES_DARK: readonly [RGBColor, RGBColor, RGBColor] = [
   { r: 130, g: 185, b: 255 },
@@ -73,38 +48,30 @@ const HUES_LIGHT: readonly [RGBColor, RGBColor, RGBColor] = [
   { r: 120, g: 80, b: 235 },
 ]
 
+/**
+ * 带底色（波向终端本底淡入的目标色）。近似值：取主题深/浅背景的典
+ * 型值而非逐主题读取——波只存活一秒，色差在低 alpha 下不可辨。
+ */
+const BAND_DARK: RGBColor = { r: 27, g: 30, b: 40 }
+const BAND_LIGHT: RGBColor = { r: 240, g: 240, b: 242 }
+
 export function ignitionHues(onLight: boolean): readonly [RGBColor, RGBColor, RGBColor] {
   return onLight ? HUES_LIGHT : HUES_DARK
 }
 
 /**
- * 充能色对（前缀强调用）：从带底色调的暗强调到全强调，与波共用
- * hues[0]（同一瞬间前缀与波是同一种橙）。
- * @param onLight - 浅色主题用浅底色板。
+ * 充能色对（前缀强调用）：从带底色调暗端到全值，与波共用 hues[0]。
  */
 export function accentRamp(onLight: boolean): { dim: RGBColor; full: RGBColor } {
-  const band = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
-  return { dim: blend(band, ignitionHues(onLight)[0]!, 0.45), full: ignitionHues(onLight)[0]! }
+  const band = onLight ? BAND_LIGHT : BAND_DARK
+  return { dim: blend(band, ignitionHues(onLight)[0], 0.45), full: ignitionHues(onLight)[0] }
 }
-
-/**
- * 带底色（波向状态行本底淡入的目标色）。近似值：取主题深/浅背景的典
- * 型值而非逐主题读取——波只存活一秒，色差在低 alpha 下不可辨。
- */
-const BAND_RGB_DARK: RGBColor = { r: 27, g: 30, b: 40 }
-const BAND_RGB_LIGHT: RGBColor = { r: 240, g: 240, b: 242 }
 
 /** 余弦钟形：`crest(0)=1`、`crest(±1)=0`、之外为 0（负距离同样静默——
  * 现有调用方都传 `Math.abs`，这里兜底防未来调用方拿到全强度）。 */
 export function crest(distance: number): number {
   if (distance >= 1 || distance <= -1) return 0
   return 0.5 * (1 + Math.cos(Math.PI * distance))
-}
-
-/** ease-in cubic：`p³`，两端 clamp。 */
-export function easeInCubic(progress: number): number {
-  const p = Math.min(1, Math.max(0, progress))
-  return p * p * p
 }
 
 /** ease-out cubic：`1-(1-p)³`，两端 clamp。 */
@@ -122,58 +89,19 @@ export function easeInOutCubic(progress: number): number {
   return 1 - (inverse * inverse * inverse) / 2
 }
 
-/**
- * 一次性包络：`[0, total]` 外为 0，进入段按 `fadeIn` 线性升起、离开段
- * 按 `fadeOut` 线性落下，取两者**较小**值（对齐上游：任意时刻受两段
- * 斜坡中较缓的一侧约束）。
- */
-export function envelope(elapsed: number, total: number, fadeIn: number, fadeOut: number): number {
-  if (elapsed <= 0 || elapsed >= total) return 0
-  const inPart = elapsed / Math.max(fadeIn, Number.EPSILON)
-  const outPart = (total - elapsed) / Math.max(fadeOut, Number.EPSILON)
-  return Math.min(1, Math.max(0, Math.min(inPart, outPart)))
-}
-
-/** 单列对全部波带的采样结果：三 hue 各自的权重（未归一）。 */
-function sampleColumn(
-  style: IgnitionStyle,
-  elapsed: number,
-  column: number,
-  width: number,
-): [number, number, number] {
+/** 单列对波带的采样：三 hue 权重（未归一；单波形只点亮 hue[0]）。 */
+function sampleColumn(elapsed: number, column: number, width: number): [number, number, number] {
   const weights: [number, number, number] = [0, 0, 0]
-  for (const band of BANDS[style]) {
-    const [first, second, third] = band
-    if (style === 'wave') {
-      const progress = (elapsed - first) / second
-      if (progress < 0 || progress > 1) continue
-      const center = easeInOutCubic(progress) * (width + 2 * WAVE_HALF_WIDTH) - WAVE_HALF_WIDTH
-      weights[0] = Math.max(weights[0], crest(Math.abs(column - center) / WAVE_HALF_WIDTH))
-    } else if (style === 'aurora') {
-      const center =
-        (0.5 + 0.38 * Math.sin(Math.PI * 2 * (first * elapsed + second))) * width
-      const halfWidth = Math.max(width * 0.22, 4)
-      weights[third] += crest(Math.abs(column - center) / halfWidth)
-    } else {
-      const progress = (elapsed - first) / second
-      if (progress < 0 || progress > 1) continue
-      const inverse = 1 - progress
-      const radius = (1 - inverse * inverse * inverse) * (width / 2 + 2 * PULSE_HALF_WIDTH)
-      const distance = Math.abs(column - width / 2)
-      weights[0] = Math.max(
-        weights[0],
-        crest(Math.abs(distance - radius) / PULSE_HALF_WIDTH) * third * (1 - 0.6 * progress),
-      )
-    }
-  }
+  const [launch, travel] = BAND
+  const progress = (elapsed - launch) / travel
+  if (progress < 0 || progress > 1) return weights
+  const center = easeInOutCubic(progress) * (width + 2 * WAVE_HALF_WIDTH) - WAVE_HALF_WIDTH
+  weights[0] = crest(Math.abs(column - center) / WAVE_HALF_WIDTH)
   return weights
 }
 
-/**
- * 混两个 RGB（线性插值）。
- * @param t - 位置，`0` 返回 `a`、`1` 返回 `b`，不 clamp（调用方负责）。
- */
-function blend(a: RGBColor, b: RGBColor, t: number): RGBColor {
+/** 线性混色（t=0 → a，t=1 → b，不 clamp）。 */
+export function blend(a: RGBColor, b: RGBColor, t: number): RGBColor {
   return {
     r: Math.round(a.r + (b.r - a.r) * t),
     g: Math.round(a.g + (b.g - a.g) * t),
@@ -182,55 +110,38 @@ function blend(a: RGBColor, b: RGBColor, t: number): RGBColor {
 }
 
 /**
- * 点焰某一时刻的整行背景色。
+ * 扫光某一时刻的整行颜色。
  *
- * @param options - 波形参数。
- * @param options.style - 点焰风格。
- * @param options.elapsedMs - 距触发的时间；达到 {@link IGNITION_TOTAL_MS}
- *   后整行返回 `undefined`（无波，行恢复本底）。
+ * @param options.elapsedMs - 距触发的时间；达到 {@link SWEEP_TOTAL_MS}
+ *   后整行返回空数组（无波，行恢复本底）。
  * @param options.width - 行列数（终端宽）。
  * @param options.onLight - 浅色主题时用浅底色板与浅带底色。
- * @returns 逐列背景色（`rgb(r,g,b)` 字符串）；无波的列为 `undefined`，
- *   渲染层应输出不设背景的空格，保持行宽恒定。
+ * @returns 逐列颜色（`rgb(r,g,b)` 字符串）；无波的列为 `undefined`，
+ *   渲染层应输出本底色，保持行宽恒定。
  */
 export function ignitionLineColors(options: {
-  style: IgnitionStyle
   elapsedMs: number
   width: number
   onLight: boolean
-}): ReadonlyArray<Color | undefined> {
-  const { style, elapsedMs, width, onLight } = options
-  const total = IGNITION_TOTAL_MS[style] / 1000
+}): ReadonlyArray<string | undefined> {
+  const { elapsedMs, width, onLight } = options
   const elapsed = elapsedMs / 1000
+  const total = SWEEP_TOTAL_MS / 1000
   if (width <= 0 || !Number.isFinite(elapsed) || elapsed <= 0 || elapsed >= total) return []
-  const hues = ignitionHues(onLight)
-  const bandRgb = onLight ? BAND_RGB_LIGHT : BAND_RGB_DARK
-  const fade =
-    style === 'aurora' ? envelope(elapsed, total, /* fadeIn */ 0.25, /* fadeOut */ 0.4) : 1
-  const colors: Array<Color | undefined> = new Array(width)
+  const hue = ignitionHues(onLight)[0]
+  const band = onLight ? BAND_LIGHT : BAND_DARK
+  const colors: Array<string | undefined> = new Array(width)
   for (let column = 0; column < width; column++) {
-    const weights = sampleColumn(style, elapsed, column, width)
-    const weight = weights[0] + weights[1] + weights[2]
+    const weight = sampleColumn(elapsed, column, width)[0]
     if (weight <= 0.01) {
       colors[column] = undefined
       continue
     }
-    let r = 0
-    let g = 0
-    let b = 0
-    for (let hue = 0; hue < 3; hue++) {
-      r += weights[hue]! * hues[hue]!.r
-      g += weights[hue]! * hues[hue]!.g
-      b += weights[hue]! * hues[hue]!.b
-    }
-    const hue: RGBColor = { r: r / weight, g: g / weight, b: b / weight }
-    const alpha =
-      style === 'aurora' ? Math.min(weight * 0.4, 0.5) * fade : weight * 0.55
-    // 波按强度淡入带底色：alpha=1 是纯 hue，alpha→0 收敛回本底。
-    // 高亮度档（用户拍板）：满强度纯 hue 直出（上限 1.0）。输出前通道量化到
-    // 8 步长：渐变列因此能合并成长段（渲染层 RLE 段数降一个数量级），
-    // 8/256 的色差在终端 cell 分辨率下不可辨。
-    const tinted = blend(bandRgb, hue, Math.min(alpha, 0.6))
+    // 波按强度淡入带底色：alpha=1 是纯 hue，alpha→0 收敛回本底；高亮
+    // 度档满强度纯 hue 直出。输出前通道量化到 8 步长——渐变列因此能
+    // 合并成长段（渲染层 RLE 段数降一个数量级），8/256 的色差在终端
+    // cell 分辨率下不可辨。
+    const tinted = blend(band, hue, Math.min(weight, 1))
     colors[column] = rgbString({
       r: Math.round(tinted.r / 8) * 8,
       g: Math.round(tinted.g / 8) * 8,
@@ -241,10 +152,28 @@ export function ignitionLineColors(options: {
 }
 
 /**
- * 随机选一种风格，且不与上一次重复（连续两次切档不重样）。
- * @param previous - 上一次的风格；首次触发传 `undefined`。
+ * 顶档切入判定：从「已有档位」变为「另一档位」且新档位是档位表末位
+ * 最高档。冷启动恢复偏好、单档表、档位表未知都不触发。
  */
-export function randomIgnitionStyle(previous: IgnitionStyle | undefined): IgnitionStyle {
-  const pool = IGNITION_STYLES.filter(style => style !== previous)
-  return pool[Math.floor(Math.random() * pool.length)]!
+export function entersTopTier(
+  previous: string | undefined,
+  current: string | undefined,
+  levels: readonly string[] | undefined,
+): boolean {
+  return (
+    current !== undefined &&
+    previous !== undefined &&
+    current !== previous &&
+    levels !== undefined &&
+    levels.length > 1 &&
+    current === levels[levels.length - 1]
+  )
+}
+
+/** 充能时长（ms）与充能进度（钳 [0,1]，负 elapsed 钳 0）。 */
+export const CHARGE_MS = 150
+
+export function chargeProgress(elapsedMs: number): number {
+  if (!Number.isFinite(elapsedMs)) return 0
+  return Math.min(1, Math.max(0, Math.max(0, elapsedMs) / CHARGE_MS))
 }


### PR DESCRIPTION
## 是什么

切到最高思考强度档时，输入框上演一次性三幕叠加（对齐 Codex CLI effort ignition 的完整语义；**行数全程恒定、静止零痕迹、输入全程可用**）：

| 幕 | 时间 | 内容 |
|---|---|---|
| 1 扫光 | 0 – 1.2s | 顶/底边框（自绘 `╭─╮`/`╰─╯`，同步）承载高亮彩色光带自左向右扫过——亮蓝/亮青/亮紫三 hue 流动，满强度纯 hue 直出 |
| 2 档名字样 | 0.6 – 1.1s | 空输入行以**终端几何中心**为锚居中浮现档名大写：字母间距从 10 空格减速聚拢到 1（明亮蓝加粗渐亮） |
| 3 渐隐 | 1.5 – 2s | 字样连同光色一起向主题色淡出，末帧归零 |

## 结构

| 文件 | 内容 |
|---|---|
| `src/trajectory/effortIgnition.ts` | 数学层：三波形逐列采样、缓动、包络、高亮彩色色板、`IGNITION_TIMELINE` 共享时间轴 |
| `src/components/EffortInputBorder.tsx` | 自绘顶/底边框 + 双框同步扫光 |
| `src/components/EffortTierBadge.tsx` | 居中聚拢档名字样（见下"打磨要点"） |
| `src/components/EffortChargeGlyph.tsx` | 输入前缀充能强调（150ms 暗到亮，稳态零订阅） |
| `src/dsh-adapter/channel.ts` | `effortLevels` 暴露：bind/三处路由切换块填充或失效重解析（阻断陈旧档位表误触发与会话回放凭空点火） |
| `src/theme.ts` | `isLightThemeActive`：按解析调色板背景判明暗（覆盖 auto/自定义主题——`useTheme()` 对 auto 返回字面量 `'auto'`，名称比较会漏） |
| `scripts/verify-effort-*.tsx` | 两个验证门，已接入 CI |

## 打磨要点（全部有客观数据背书）

- **动效骑前景通道**：纯背景格在 fullscreen log-update 管线下帧循环全速跑、字节却到不了终端（真机实测）；前景是全 UI 活动元素已验证的通道
- **聚拢流畅性**：离散格子上靠曲线导数趋零做"减速"，末段约 37 帧才跨 1 格（长停顿后突跳=卡感）。改为跳变间隔均匀化（90% 线性 + 轻缓收尾），写流时间戳实测跳变间隔 `21/50/65/64/48/48/65/49/49`ms 均匀无长停顿
- **左右镜像**：`Math.round` 对 .5 恒向上，正负方向舍入不对称会让左右字母跨格错开半拍；改为左字母镜像右字母的舍入结果（`2C−col`），逐帧实测 9 个变化帧全部 `dM = -dX` 严格同步
- **精确居中**：锚点是终端几何中心（非"❯/光标之后可用区的中心"——后者偏右 ~1.5 格），并以 `leadingColumns` 参数补偿前缀占位；验证门断言字样中点字母列 == 终端中心列 ±1（实测 mid at 30 = center 30）
- **行数恒定**：档名是纯文本流（自带居中偏移空格），不引入嵌套 Box（嵌套空 Box 会生成额外空行）；验证门断言底框行全程不移动

## 验证

- `verify-effort-ignition`：数学层 14 断言 + 场景断言（三幕全程：帧间文本字节恒定、零行级 repaint escape、行数恒定、终态精确居中、负路径四例全暗——冷启动顶档/单档表/无档位表/离开顶档）
- `verify-effort-accent`：充能四态 + 充能窗内真实前景色采样（暗→全值单调）
- 两者均接入 `.github/workflows/ci.yml`；双门全绿、`tsc -p tsconfig.json` 0 错误；真机（tmux）全流程目检通过

## 与 #362/#363 的关系

这是被关闭的 #362/#363 的完整重做：合并为单 PR、形态按实际使用反馈打磨十余轮（三幕/居中/聚拢/流畅性/镜像/亮度均有量化验证），并修复了原实现的两个根因缺陷（`effortLevels` 接线断导致普通会话永不触发；背景色通道在 fullscreen 管线不可靠）。
