### PR TITLE
feat(ui): Kimi-style color polish — blue primary, warm accents

### DIFF
--- a/scripts/repro-diff-split.tsx
+++ b/scripts/repro-diff-split.tsx
@@ -94,7 +94,7 @@ async function renderAt(cols, tool, diffLayout = 'auto', toolBackground = 'none'
     const markX = lines[pairRow]!.indexOf('mark="!"')
     check('右栏改动词组使用亮绿词色', markX > 0 && fgAt(markX, pairRow) === 0x57956b, `fg=${fgAt(Math.max(markX, 0), pairRow).toString(16)}`)
     const defX = lines[pairRow]!.indexOf('def')
-    check('关键字使用语法色（syntaxKeyword）', defX > 0 && fgAt(defX, pairRow) === 0x8fa8e8, `fg=${fgAt(Math.max(defX, 0), pairRow).toString(16)}`)
+    check('关键字使用语法色（syntaxKeyword）', defX > 0 && fgAt(defX, pairRow) === 0x82aaff, `fg=${fgAt(Math.max(defX, 0), pairRow).toString(16)}`)
   }
   if (ctxRow >= 0) {
     check('默认 none 档：上下文行无卡片底色', bgAt(6, ctxRow) === 0xffffff, `bg=${bgAt(6, ctxRow).toString(16)}`)
@@ -202,7 +202,7 @@ async function renderAt(cols, tool, diffLayout = 'auto', toolBackground = 'none'
   const { lines: mlLines, fgAt: mlFg } = await renderAt(120, mlTool)
   const worldRow = mlLines.findIndex(line => line.includes('world'))
   const worldX = worldRow >= 0 ? mlLines[worldRow]!.indexOf('world') : -1
-  check('多行字符串后续行带字符串色', worldX > 0 && mlFg(worldX, worldRow) === 0x9fbf8f, `fg=${worldX > 0 ? mlFg(worldX, worldRow).toString(16) : 'n/a'}`)
+  check('多行字符串后续行带字符串色', worldX > 0 && mlFg(worldX, worldRow) === 0xe5c07b, `fg=${worldX > 0 ? mlFg(worldX, worldRow).toString(16) : 'n/a'}`)
 
   // P1-2: the syntax cache keys on the theme signature — a palette change
   // must not serve stale colors.

--- a/src/cc/figures.ts
+++ b/src/cc/figures.ts
@@ -89,3 +89,27 @@ export const BRIDGE_SPINNER_FRAMES = [
 export const BRIDGE_READY_INDICATOR = '\u00b7\u2714\ufe0e\u00b7'
 /** Bridge failed indicator (`×`). */
 export const BRIDGE_FAILED_INDICATOR = '\u00d7'
+
+// Thinking spinner (Kimi Code style braille cycle, shown while reasoning
+// streams; the static anchor takes over once the step settles). Each frame
+// is padded to 2 columns so it matches the settled ⚓ anchor exactly — a
+// 1-col frame would shift the whole label right by one column the moment
+// the step settles.
+export const THINKING_SPINNER_FRAMES = [
+  '\u280b ', // ⠋
+  '\u2819 ', // ⠙
+  '\u2839 ', // ⠹
+  '\u2838 ', // ⠸
+  '\u283c ', // ⠼
+  '\u2834 ', // ⠴
+  '\u2826 ', // ⠦
+  '\u2827 ', // ⠧
+  '\u2807 ', // ⠇
+  '\u280f ', // ⠏
+]
+export const THINKING_SPINNER_INTERVAL_MS = 80
+/** Thinking settled marker: anchor (`⚓`) — the static end-state glyph after
+ *  the reasoning block stops streaming. U+2693 is Emoji_Presentation in
+ *  ink/stringWidth, so it measures 2 columns; the braille spinner frames
+ *  above are padded to the same width to keep the label stationary. */
+export const THINKING_SETTLED_MARKER = '\u2693' // ⚓

--- a/src/cc/markdown.ts
+++ b/src/cc/markdown.ts
@@ -19,6 +19,7 @@ import { stringWidth } from '../ink/stringWidth.js'
 import { supportsHyperlinks } from '../ink/supports-hyperlinks.js'
 import { colorize } from '../ink/colorize.js'
 import { getActiveTheme } from '../theme.js'
+import { buildSyntaxTheme } from './syntaxTheme.js'
 import type { CliHighlight } from './cliHighlight.js'
 import { logForDebugging } from '../utils/debug.js'
 import { createHyperlink } from './hyperlink.js'
@@ -155,7 +156,10 @@ export function applyMarkdown(
     .lexer(stripPromptXMLTags(content))
     .map(token => dispatch(token, rootState))
     .join('')
-    .trim()
+    // trimEnd only: the input is already trimmed, so leading whitespace in
+    // the output is renderer-intended (e.g. the code block's 2-space indent
+    // on its first line). A full trim() would eat that first-line indent.
+    .trimEnd()
 }
 
 /**
@@ -210,20 +214,42 @@ function renderBlockquote(token: Tokens.Blockquote, state: RenderState): string 
 }
 
 function renderCodeBlock(token: Tokens.Code, state: RenderState): string {
-  if (!state.highlight) {
-    return token.text + EOL
-  }
-  let language = 'plaintext'
-  if (token.lang) {
-    if (state.highlight.supportsLanguage(token.lang)) {
-      language = token.lang
-    } else {
-      logForDebugging(
-        `Language not supported while highlighting code, falling back to plaintext: ${token.lang}`,
-      )
+  // Kimi Code style: a muted ```lang opening line (language tag + boundary
+  // for unhighlighted blocks) + 2-space indent; no closing fence (syntax
+  // colors or the indent already mark the end, it only cost vertical space).
+  const theme = getActiveTheme()
+  const openFence = colorize('```' + (token.lang ?? ''), theme.subtle, 'foreground')
+  const indent = '  '
+  const renderBody = (): string => {
+    if (!state.highlight) {
+      return token.text
     }
+    let language = 'plaintext'
+    if (token.lang) {
+      if (state.highlight.supportsLanguage(token.lang)) {
+        language = token.lang
+      } else {
+        logForDebugging(
+          `Language not supported while highlighting code, falling back to plaintext: ${token.lang}`,
+        )
+      }
+    }
+    return state.highlight.highlight(token.text, { language, theme: buildSyntaxTheme(theme) })
   }
-  return state.highlight.highlight(token.text, { language }) + EOL
+  // Strip ALL trailing newlines: trailing blank lines would otherwise leak a
+  // stray blank line at the end of the block.
+  const body = renderBody().replace(/\n+$/, '')
+  if (body === '') {
+    return `${openFence}${EOL}`
+  }
+  return (
+    openFence +
+    EOL +
+    body
+      .split(EOL)
+      .map(line => (line === '' ? line : indent + line))
+      .join(EOL) + EOL
+  )
 }
 
 function renderEmphasis(token: Tokens.Em, state: RenderState): string {
@@ -238,8 +264,15 @@ function renderStrong(token: Tokens.Strong, state: RenderState): string {
 
 function renderHeading(token: Tokens.Heading, state: RenderState): string {
   const text = token.tokens.map(child => dispatch(child, fresh(state))).join('')
-  // H1 gets the full banner treatment; every deeper level shares the bold style.
-  const styled = token.depth === 1 ? chalk.bold.italic.underline(text) : chalk.bold(text)
+  // Blue-primary progression: H1 gets the mist brand blue + underline, H2 the
+  // lighter border blue, deeper levels stay bold near-text (kimi-style).
+  const theme = getActiveTheme()
+  const styled =
+    token.depth === 1
+      ? chalk.bold.underline(colorize(text, theme.claude, 'foreground'))
+      : token.depth === 2
+        ? chalk.bold(colorize(text, theme.permission, 'foreground'))
+        : chalk.bold(text)
   return styled + EOL + EOL
 }
 
@@ -299,7 +332,10 @@ function renderText(token: Tokens.Text, state: RenderState): string {
     const body = token.tokens
       ? token.tokens.map(child => dispatch(child, withParent(state, token))).join('')
       : linkifyIssueReferences(token.text)
-    return `${bullet} ${body}${EOL}`
+    // Blue bullet marker: list structure gets a tint without loading the
+    // whole item (kimi-style `•` in the accent color).
+    const tinted = colorize(bullet, getActiveTheme().permission, 'foreground')
+    return `${tinted} ${body}${EOL}`
   }
 
   return linkifyIssueReferences(token.text)

--- a/src/cc/syntaxTheme.ts
+++ b/src/cc/syntaxTheme.ts
@@ -1,0 +1,78 @@
+import chalk from 'chalk'
+import type { Theme } from '../theme.js'
+
+// --- syntax highlighting theme bridge ----------------------------------------
+// Shared by SplitDiffView (diff panes) and the markdown renderer (fenced
+// code blocks). Both feed cli-highlight's `theme` option so code colors come
+// from the active dsh-tui theme instead of cli-highlight's own sparse
+// default palette.
+
+/** highlight.js token classes -> theme syntax tokens. `default` catches
+ *  every unmapped class so cli-highlight's own yellow never leaks through
+ *  (issue #250, P2-6). */
+export const SYNTAX_CLASS_TO_TOKEN: Record<string, string> = {
+  keyword: 'syntaxKeyword',
+  built_in: 'syntaxKeyword',
+  literal: 'syntaxKeyword',
+  string: 'syntaxString',
+  subst: 'syntaxString',
+  quote: 'syntaxString',
+  comment: 'syntaxComment',
+  number: 'syntaxNumber',
+  title: 'syntaxFunction',
+  'title.function_': 'syntaxFunction',
+  function: 'syntaxFunction',
+  'title.class_': 'syntaxType',
+  type: 'syntaxType',
+  class: 'syntaxType',
+  tag: 'syntaxType',
+  name: 'syntaxType',
+  attr: 'syntaxVariable',
+  attribute: 'syntaxVariable',
+  variable: 'syntaxVariable',
+  'template-variable': 'syntaxVariable',
+  params: 'syntaxVariable',
+  operator: 'syntaxOperator',
+  punctuation: 'syntaxPunctuation',
+  meta: 'syntaxPunctuation',
+  symbol: 'syntaxConstant',
+  regexp: 'syntaxConstant',
+  default: 'syntaxVariable',
+}
+
+/** chalk style for one raw theme value. Accepts every form the theme
+ *  loader documents: #rgb, #rrggbb, #rrggbbaa (alpha stripped), rgb() with
+ *  or without spaces, ansi256(n), ansi:name (issue #250, P2-5). */
+export function chalkFromToken(token: string): (text: string) => string {
+  let match = /^#([0-9a-fA-F]{3})$/.exec(token)
+  if (match !== null) {
+    const [r, g, b] = match[1]!.split('').map(c => parseInt(c + c, 16))
+    return chalk.rgb(r!, g!, b!)
+  }
+  match = /^#([0-9a-fA-F]{6})(?:[0-9a-fA-F]{2})?$/.exec(token)
+  if (match !== null) return chalk.hex(`#${match[1]}`)
+  match = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/.exec(token)
+  if (match !== null) return chalk.rgb(Number(match[1]), Number(match[2]), Number(match[3]))
+  match = /^ansi256\((\d+)\)$/.exec(token)
+  if (match !== null) return chalk.ansi256(Number(match[1]))
+  match = /^ansi:(\w+)$/.exec(token)
+  if (match !== null) {
+    const name = match[1] === 'blackBright' ? 'gray' : match[1]
+    const style = (chalk as unknown as Record<string, ((text: string) => string) | undefined>)[name]
+    if (style !== undefined) return style
+  }
+  return (text: string) => text
+}
+
+/** Build the cli-highlight `theme` option from an active theme palette. */
+export function buildSyntaxTheme(
+  theme: Theme,
+): Record<string, (text: string) => string> {
+  const palette = theme as unknown as Record<string, string>
+  const out: Record<string, (text: string) => string> = {}
+  for (const [tokenClass, tokenKey] of Object.entries(SYNTAX_CLASS_TO_TOKEN)) {
+    const value = palette[tokenKey]
+    if (value !== undefined) out[tokenClass] = chalkFromToken(value)
+  }
+  return out
+}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -20,7 +20,7 @@ import type { ToolBackground } from '../tuiDisplayPrefs.js'
 /**
  * Transcript rows rendered in the Claude Code visual language: user prompts
  * on a grey bubble with a `❯` pointer, assistant text with a `●` bullet and
- * markdown, thinking folded to `∴ Thinking (ctrl+o to expand)`, tool calls as
+ * markdown, thinking folded to `⚓ Thinking (ctrl+o to expand)`, tool calls as
  * status-dot cards. `expanded` (Ctrl+O) shows full reasoning + full tool
  * args/results; `expandedRows` (message-selection mode, Enter) expands single
  * rows; `selectedId` highlights the selected row.
@@ -120,12 +120,11 @@ export function MessageList({
       prev = row.kind
     }
   }
-  // CC's expanded rows keep a persistent hover-grey background (VirtualItem:
-  // `expanded ? userMessageBackgroundHover : undefined`).
+  // Selection keeps its highlight; expanded rows render with no fill (the
+  // diff line tints inside cards are the only backgrounds in the transcript).
   const rowBackground = (rowId: number) => {
     const isSelected = selectedId === rowId
     if (isSelected) return 'messageActionsBackground'
-    if (expandedRows.has(rowId)) return 'userMessageBackgroundHover'
     return undefined
   }
 
@@ -480,7 +479,7 @@ type MemoRowProps = {
   diffLayout: 'auto' | 'split' | 'unified'
   thinkingFold: 'preview' | 'full'
   toolBackground: ToolBackground
-  background: 'messageActionsBackground' | 'userMessageBackgroundHover' | undefined
+  background: 'messageActionsBackground' | undefined
   // ToolRow, flattened: the channel writes status/result fields in place,
   // so passing the object itself would make mutations invisible to memo.
   toolCallId: string | undefined
@@ -557,7 +556,6 @@ function TranscriptRow({
             text={text}
             addMargin={addMargin}
             isSelected={isSelected}
-            isExpanded={isExpanded}
             onClick={onClick}
           />
         </Box>
@@ -613,6 +611,7 @@ function TranscriptRow({
           <AssistantThinkingMessage
             thinking={text}
             addMargin={addMargin}
+            streaming={streaming}
             preview={
               streaming &&
               thinkingFold === 'preview' &&

--- a/src/components/SplitDiffView.tsx
+++ b/src/components/SplitDiffView.tsx
@@ -7,6 +7,9 @@ import type { ToolFileDiff } from '../dsh-adapter/channel.js'
 import type { Color } from '../ink/styles.js'
 import { getCliHighlightPromise, type CliHighlight } from '../cc/cliHighlight.js'
 import { SYNTAX_CLASS_TO_TOKEN, chalkFromToken } from '../cc/syntaxTheme.js'
+// Backward-compatible re-export: repro scripts import chalkFromToken from
+// this module's old home.
+export { chalkFromToken } from '../cc/syntaxTheme.js'
 import { getTheme } from '../theme.js'
 import { useTheme } from './design-system/ThemeProvider.js'
 import type { ToolBackground } from '../tuiDisplayPrefs.js'

--- a/src/components/SplitDiffView.tsx
+++ b/src/components/SplitDiffView.tsx
@@ -6,6 +6,7 @@ import { extname } from 'node:path'
 import type { ToolFileDiff } from '../dsh-adapter/channel.js'
 import type { Color } from '../ink/styles.js'
 import { getCliHighlightPromise, type CliHighlight } from '../cc/cliHighlight.js'
+import { SYNTAX_CLASS_TO_TOKEN, chalkFromToken } from '../cc/syntaxTheme.js'
 import { getTheme } from '../theme.js'
 import { useTheme } from './design-system/ThemeProvider.js'
 import type { ToolBackground } from '../tuiDisplayPrefs.js'
@@ -61,62 +62,8 @@ const expandTabs = (text: string): string => text.replaceAll('\t', '   ')
 
 // --- syntax highlighting ----------------------------------------------------
 
-/** highlight.js token classes → theme syntax tokens. `default` catches
- *  every unmapped class so cli-highlight's own yellow never leaks through
- *  (issue #250, P2-6). */
-const SYNTAX_CLASS_TO_TOKEN: Record<string, string> = {
-  keyword: 'syntaxKeyword',
-  built_in: 'syntaxKeyword',
-  literal: 'syntaxKeyword',
-  string: 'syntaxString',
-  subst: 'syntaxString',
-  quote: 'syntaxString',
-  comment: 'syntaxComment',
-  number: 'syntaxNumber',
-  title: 'syntaxFunction',
-  'title.function_': 'syntaxFunction',
-  function: 'syntaxFunction',
-  'title.class_': 'syntaxType',
-  type: 'syntaxType',
-  class: 'syntaxType',
-  tag: 'syntaxType',
-  name: 'syntaxType',
-  attr: 'syntaxVariable',
-  attribute: 'syntaxVariable',
-  variable: 'syntaxVariable',
-  'template-variable': 'syntaxVariable',
-  params: 'syntaxVariable',
-  operator: 'syntaxOperator',
-  punctuation: 'syntaxPunctuation',
-  meta: 'syntaxPunctuation',
-  symbol: 'syntaxConstant',
-  regexp: 'syntaxConstant',
-  default: 'syntaxVariable',
-}
-
-/** chalk style for one raw theme value. Accepts every form the theme
- *  loader documents: #rgb, #rrggbb, #rrggbbaa (alpha stripped), rgb() with
- *  or without spaces, ansi256(n), ansi:name (issue #250, P2-5). */
-export function chalkFromToken(token: string): (text: string) => string {
-  let match = /^#([0-9a-fA-F]{3})$/.exec(token)
-  if (match !== null) {
-    const [r, g, b] = match[1]!.split('').map(c => parseInt(c + c, 16))
-    return chalk.rgb(r!, g!, b!)
-  }
-  match = /^#([0-9a-fA-F]{6})(?:[0-9a-fA-F]{2})?$/.exec(token)
-  if (match !== null) return chalk.hex(`#${match[1]}`)
-  match = /^rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)$/.exec(token)
-  if (match !== null) return chalk.rgb(Number(match[1]), Number(match[2]), Number(match[3]))
-  match = /^ansi256\((\d+)\)$/.exec(token)
-  if (match !== null) return chalk.ansi256(Number(match[1]))
-  match = /^ansi:(\w+)$/.exec(token)
-  if (match !== null) {
-    const name = match[1] === 'blackBright' ? 'gray' : match[1]
-    const style = (chalk as unknown as Record<string, ((text: string) => string) | undefined>)[name]
-    if (style !== undefined) return style
-  }
-  return (text: string) => text
-}
+// The hljs-class → theme-token map and chalkFromToken live in
+// ../cc/syntaxTheme.ts (shared with the markdown code-block renderer).
 
 /** ANSI 16-color SGR codes → rgb() strings (the dark-ansi palette path). */
 const ANSI16: Record<number, string> = {

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -102,8 +102,8 @@ export function StreamingMarkdown({
 
   return (
     <Box flexDirection="column" gap={1}>
-      {stablePrefix && <Markdown dimColor>{stablePrefix}</Markdown>}
-      {hasDistinctSuffix && <Markdown dimColor cacheTokens={false}>{unstableSuffix}</Markdown>}
+      {stablePrefix && <Markdown dimColor={dimColor}>{stablePrefix}</Markdown>}
+      {hasDistinctSuffix && <Markdown dimColor={dimColor} cacheTokens={false}>{unstableSuffix}</Markdown>}
     </Box>
   )
 }

--- a/src/components/design-system/ThemedBox.tsx
+++ b/src/components/design-system/ThemedBox.tsx
@@ -60,7 +60,10 @@ function resolveColor(
   ) {
     return color as Color
   }
-  return theme[color as keyof Theme] as Color
+  // Theme keys may be '' ("no color" in that theme) - collapse to undefined
+  // so empty tokens render as no background/foreground instead of feeding
+  // an empty color string to Ink.
+  return (theme[color as keyof Theme] as Color) || undefined
 }
 
 /**

--- a/src/components/design-system/ThemedText.tsx
+++ b/src/components/design-system/ThemedText.tsx
@@ -29,8 +29,8 @@ function resolveColor(
   ) {
     return color as Color
   }
-  // It's a theme key - resolve it
-  return theme[color as keyof Theme] as Color
+  // It's a theme key - resolve it ('' means "no color" in that theme)
+  return (theme[color as keyof Theme] as Color) || undefined
 }
 
 export type Props = {

--- a/src/components/messages/AssistantThinkingMessage.tsx
+++ b/src/components/messages/AssistantThinkingMessage.tsx
@@ -3,6 +3,11 @@ import { Box, Text } from '../../ui.js'
 import { t } from '../../i18n.js'
 import { StreamingMarkdown } from '../StreamingMarkdown.js'
 import { formatDuration } from '../../cc/format.js'
+import {
+  THINKING_SPINNER_FRAMES,
+  THINKING_SPINNER_INTERVAL_MS,
+  THINKING_SETTLED_MARKER,
+} from '../../cc/figures.js'
 
 /** Preview body rows — a FIXED row count (kimicode-style constant-height
  *  ticker). Ink's truncate slices the whole string across newlines as one
@@ -18,6 +23,10 @@ type Props = {
   addMargin: boolean
   /** True when Ctrl+O transcript/verbose mode is on — show the full text. */
   verbose: boolean
+  /** True while the reasoning block is still streaming — the leading anchor
+   *  becomes a rotating braille spinner (Kimi Code style) and settles back
+   *  to the anchor once the step ends. */
+  streaming?: boolean
   /** Streaming compact mode (thinkingFold=preview): a 3-row live ticker of
    *  the model's latest reasoning lines instead of the full block —
    *  kimicode-style constant height; the block never resizes mid-stream. */
@@ -30,22 +39,38 @@ type Props = {
 }
 
 /**
- * Thinking block: folded `∴ Thinking (ctrl+o to expand)`, expanded shows the
- * full reasoning text indented under `∴ Thinking…`, mirroring Claude Code's
- * `messages/AssistantThinkingMessage.tsx`. When the channel records the
- * reasoning duration, the label carries it (`∴ Thinking · 12s …`) — dsh-tui's
- * take on making thinking time visible in the transcript.
+ * Thinking block: folded `⚓ Thinking (ctrl+o to expand)`, expanded shows the
+ * full reasoning text indented under `⚓ Thinking…`. While the reasoning
+ * streams the leading mark is a rotating braille spinner (`⠋⠙⠹…`, Kimi Code
+ * style), settling back to the static anchor (`⚓`) once the turn ends. When
+ * the channel records the reasoning duration, the label carries it
+ * (`⚓ Thinking · 12s …`) — dsh-tui's take on making thinking time visible in
+ * the transcript.
  */
 export function AssistantThinkingMessage({
   thinking,
   addMargin,
   verbose,
+  streaming = false,
   preview = false,
   durationMs,
   isSelected = false,
   onClick,
 }: Props): React.ReactNode {
   if (!thinking) return null
+
+  // Spinner frame (80ms cadence, only while the reasoning is still
+  // streaming — same pattern as BtwPanel's answering spinner).
+  const [frame, setFrame] = React.useState(0)
+  React.useEffect(() => {
+    if (!streaming) return
+    const interval = setInterval(() => setFrame(f => f + 1), THINKING_SPINNER_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [streaming])
+
+  const marker = streaming
+    ? THINKING_SPINNER_FRAMES[frame % THINKING_SPINNER_FRAMES.length]!
+    : THINKING_SETTLED_MARKER
 
   const duration =
     durationMs !== undefined && durationMs >= 1000
@@ -77,7 +102,7 @@ export function AssistantThinkingMessage({
         onClick={onClick}
       >
         <Text dimColor italic>
-          ∴ {t('thinking-label')}{duration}…
+          {marker} {t('thinking-label')}{duration}…
         </Text>
         <Box
           flexDirection="column"
@@ -109,7 +134,7 @@ export function AssistantThinkingMessage({
         onClick={onClick}
       >
         <Text dimColor italic>
-          ∴ {t('thinking-label')}{duration} {t('hint-expand-ctrl-o')}
+          {marker} {t('thinking-label')}{duration} {t('hint-expand-ctrl-o')}
         </Text>
       </Box>
     )
@@ -125,7 +150,7 @@ export function AssistantThinkingMessage({
       onClick={onClick}
     >
       <Text dimColor italic>
-        ∴ {t('thinking-label')}{duration}…
+        {marker} {t('thinking-label')}{duration}…
       </Text>
       <Box paddingLeft={2}>
         {/* StreamingMarkdown: the live thinking text grows per token — the

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -7,6 +7,7 @@ import { ToolUseLoader } from '../ToolUseLoader.js'
 import { SplitDiffView } from '../SplitDiffView.js'
 import { formatDuration } from '../../cc/format.js'
 import type { ToolBackground } from '../../tuiDisplayPrefs.js'
+import type { Theme } from '../../theme.js'
 
 type Props = {
   tool: ToolRow
@@ -62,7 +63,7 @@ function displayName(name: string): string {
 // tool output is visually nested under its header instead of flush-left.
 
 /** `hint` is the trajectory pointer: recessive, never competing with output. */
-type BodyTone = 'add' | 'del' | 'dim' | 'plain' | 'error' | 'hint'
+type BodyTone = 'add' | 'del' | 'dim' | 'plain' | 'error' | 'hint' | 'path'
 type BodyLine = { readonly text: string; readonly tone: BodyTone }
 
 /** CC's collapsed text body keeps 3 lines (renderTruncatedContent). */
@@ -82,6 +83,18 @@ const del = (text: string): BodyLine => ({ text, tone: 'del' })
 const dim = (text: string): BodyLine => ({ text, tone: 'dim' })
 const plain = (text: string): BodyLine => ({ text, tone: 'plain' })
 
+/** Tool-name color by category (mist-blue accents): read/search tools keep
+ *  the brand blue, file-mutating tools get the warm gold accent, exec /
+ *  terminal tools get mist cyan. */
+const TOOL_NAME_MUTATE = new Set(['edit', 'write', 'multiedit', 'notebookedit'])
+const TOOL_NAME_EXEC = new Set(['bash', 'bashpersistent', 'sh', 'shell', 'terminal'])
+function toolNameColor(raw: string): keyof Theme {
+  const n = raw.toLowerCase()
+  if (TOOL_NAME_MUTATE.has(n)) return 'toolNameMutate'
+  if (TOOL_NAME_EXEC.has(n)) return 'toolNameExec'
+  return 'claude'
+}
+
 /** One side's text → display lines (upstream contentLines rule: empty text
  *  is zero lines; a single trailing newline is a terminator, not a line;
  *  interior blanks survive). */
@@ -100,7 +113,7 @@ function diffLines(diffs: readonly ToolFileDiff[]): BodyLine[] {
   let prevPath: string | undefined
   for (const diff of diffs) {
     if (diffs.length > 1) {
-      if (diff.path !== prevPath) out.push(plain(diff.path))
+      if (diff.path !== prevPath) out.push({ text: diff.path, tone: 'path' })
       else out.push(dim('⋯'))
     }
     prevPath = diff.path
@@ -116,7 +129,7 @@ function diffLines(diffs: readonly ToolFileDiff[]): BodyLine[] {
 function contentLines(content: ReadonlyArray<{ readonly type: string; readonly text?: string }> | undefined): BodyLine[] {
   const text = (content ?? []).map(block => (block.type === 'text' ? block.text ?? '' : '')).join('').trimEnd()
   if (text === '') return []
-  return text.split('\n').map(dim)
+  return text.split('\n').map(plain)
 }
 
 /** Per-card body lines; unknown/absent shapes yield [] so the caller falls
@@ -129,7 +142,7 @@ function viewLines(view: ToolCallView | ToolResultView): BodyLine[] {
       // The call-side terminal card has no output yet; only presentResult's
       // does. `in` narrows the call/result union without extra types.
       const out = (('output' in view ? view.output : undefined) ?? '').trimEnd()
-      const lines: BodyLine[] = out === '' ? [] : out.split('\n').map(dim)
+      const lines: BodyLine[] = out === '' ? [] : out.split('\n').map(plain)
       if ('exitCode' in view && view.exitCode !== undefined && view.exitCode !== 0) {
         lines.push({ text: `Exit code ${view.exitCode}`, tone: 'error' })
       }
@@ -152,7 +165,7 @@ function viewLines(view: ToolCallView | ToolResultView): BodyLine[] {
       for (const file of view.files) {
         lines.push(plain(file.path))
         for (const match of file.matches) {
-          lines.push(dim(`${match.lineNumber}: ${match.line}`))
+          lines.push(plain(`${match.lineNumber}: ${match.line}`))
         }
       }
       if (view.truncated) lines.push(dim(`… (${view.total} total)`))
@@ -191,17 +204,18 @@ function clipHeaderArgs(args: string): string {
   return `${args.slice(0, HEADER_ARGS_BUDGET)}…`
 }
 
-function HeaderTitle({ name, title, isTerminal, displayArgs }: {
+function HeaderTitle({ name, title, isTerminal, displayArgs, nameColor }: {
   name: string
   title: string | undefined
   isTerminal: boolean
   displayArgs: string
+  nameColor: keyof Theme
 }): React.ReactNode {
   if (title === undefined) {
     return (
       <>
         <Box flexShrink={0}>
-          <Text bold wrap="truncate-end">{name}</Text>
+          <Text bold color={nameColor} wrap="truncate-end">{name}</Text>
         </Box>
         {displayArgs !== '' && (
           <Box flexWrap="nowrap">
@@ -215,7 +229,7 @@ function HeaderTitle({ name, title, isTerminal, displayArgs }: {
     return (
       <>
         <Box flexShrink={0}>
-          <Text bold wrap="truncate-end">{name}</Text>
+          <Text bold color={nameColor} wrap="truncate-end">{name}</Text>
         </Box>
         <Box flexWrap="nowrap">
           <Text>({title})</Text>
@@ -227,7 +241,7 @@ function HeaderTitle({ name, title, isTerminal, displayArgs }: {
   if (trimmed === '') {
     return (
       <Box flexShrink={0}>
-        <Text bold wrap="truncate-end">{name}</Text>
+        <Text bold color={nameColor} wrap="truncate-end">{name}</Text>
       </Box>
     )
   }
@@ -236,9 +250,9 @@ function HeaderTitle({ name, title, isTerminal, displayArgs }: {
   const tail = space === -1 ? '' : trimmed.slice(space)
   return (
     <Box flexWrap="nowrap">
-      <Text bold wrap="truncate-end">
+      <Text bold color={nameColor} wrap="truncate-end">
         {head}
-        <Text bold={false}>{tail}</Text>
+        <Text bold={false} color="text">{tail}</Text>
       </Text>
     </Box>
   )
@@ -298,7 +312,7 @@ export function AssistantToolUseMessage({
   } else if (!useSplitDiff) {
     if (view !== undefined) body = viewLines(view)
     if (body.length === 0 && result) {
-      body = result.trimEnd().split('\n').map(dim)
+      body = result.trimEnd().split('\n').map(plain)
     }
     if (isRunning && body.length === 0) {
       body = [dim(`Running… (${formatDuration(Math.max(0, Date.now() - (tool.startedAt ?? Date.now())))})`)]
@@ -326,15 +340,9 @@ export function AssistantToolUseMessage({
       justifyContent="space-between"
       marginTop={addMargin ? 1 : 0}
       width="100%"
-      // Selection and per-row expansion remain higher-priority interaction
-      // highlights; the configured treatment applies only to an ordinary card.
-      backgroundColor={
-        isSelected
-          ? 'messageActionsBackground'
-          : isExpanded
-            ? 'userMessageBackgroundHover'
-            : ordinaryBackground
-      }
+      // Only selection paints a highlight; the configured treatment applies
+      // to an ordinary card. Diff line tints stay - they are content, not chrome.
+      backgroundColor={isSelected ? 'messageActionsBackground' : ordinaryBackground}
     >
       <Box flexDirection="column" flexGrow={1}>
         <Box flexDirection="row" flexWrap="nowrap" minWidth={minWidth}>
@@ -344,7 +352,7 @@ export function AssistantToolUseMessage({
             isError={isError}
             toolName={tool.name}
           />
-          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} />
+          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} nameColor={toolNameColor(tool.name)} />
           {!isRunning && (
             <Box flexWrap="nowrap">
               <Text dimColor>{elapsedText}</Text>
@@ -368,7 +376,20 @@ export function AssistantToolUseMessage({
           rendered.map((line, index) => (
             <Box key={index} flexDirection="row">
               <Box width={3} flexShrink={0}>
-                <Text dimColor>{index === 0 ? GUTTER_FIRST : GUTTER_REST}</Text>
+                <Text
+                  color={
+                    line.tone === 'add'
+                      ? 'diffAddedWord'
+                      : line.tone === 'del'
+                        ? 'diffRemovedWord'
+                        : line.tone === 'path'
+                          ? 'ide'
+                          : undefined
+                  }
+                  dimColor={line.tone !== 'add' && line.tone !== 'del' && line.tone !== 'path'}
+                >
+                  {index === 0 ? GUTTER_FIRST : GUTTER_REST}
+                </Text>
               </Box>
               <Box flexGrow={1}>
                 <Text
@@ -381,7 +402,9 @@ export function AssistantToolUseMessage({
                           ? 'error'
                           : line.tone === 'hint'
                             ? 'subtle'
-                            : undefined
+                            : line.tone === 'path'
+                              ? 'ide'
+                              : undefined
                   }
                   dimColor={line.tone === 'dim'}
                   wrap="wrap"

--- a/src/components/messages/UserPromptMessage.tsx
+++ b/src/components/messages/UserPromptMessage.tsx
@@ -8,40 +8,30 @@ type Props = {
   addMargin: boolean
   /** Message-selection mode highlight. */
   isSelected?: boolean
-  /** Row expanded on its own (persistent hover-grey background, CC). */
-  isExpanded?: boolean
   onClick?(): void
 }
 
 /**
- * User prompt bubble: `❯ text` on the theme's userMessageBackground grey
- * (mirroring Claude Code's `messages/UserPromptMessage.tsx` +
- * `HighlightedThinkingText.tsx`, with the ultrathink rainbow removed).
+ * User prompt bubble: `❯ text` in bold briefLabelYou gold with no background
+ * fill (Kimi Code style: the user turn gets a distinct bold tint so it reads
+ * apart from assistant text; only selection mode paints a highlight).
  */
 export function UserPromptMessage({
   text,
   addMargin,
   isSelected = false,
-  isExpanded = false,
   onClick,
 }: Props): React.ReactNode {
   return (
     <Box
       flexDirection="column"
       marginTop={addMargin ? 1 : 0}
-      backgroundColor={
-        isSelected
-          ? 'messageActionsBackground'
-          : isExpanded
-            ? 'userMessageBackgroundHover'
-            : 'userMessageBackground'
-      }
+      backgroundColor={isSelected ? 'messageActionsBackground' : undefined}
       paddingRight={1}
       onClick={onClick}
     >
-      <Text>
-        <Text color="subtle">{POINTER} </Text>
-        <Text color="text">{text}</Text>
+      <Text color="briefLabelYou" bold>
+        {POINTER} {text}
       </Text>
     </Box>
   )

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -2392,19 +2392,15 @@ function StickyPromptHeader({
   text: string
   onClick: () => void
 }): React.ReactNode {
-  const [hover, setHover] = React.useState(false)
   return (
     <Box
       flexShrink={0}
       width="100%"
       height={1}
       paddingRight={1}
-      backgroundColor={hover ? 'userMessageBackgroundHover' : 'userMessageBackground'}
-      onMouseEnter={() =>{  setHover(true) }}
-      onMouseLeave={() =>{  setHover(false) }}
       onClick={onClick}
     >
-      <Text color="subtle" wrap="truncate-end">
+      <Text color="briefLabelYou" bold wrap="truncate-end">
         {POINTER} {text}
       </Text>
     </Box>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -20,6 +20,8 @@ export type Theme = {
   autoAccept: string
   bashBorder: string
   claude: string
+  toolNameMutate: string
+  toolNameExec: string
   claudeShimmer: string
   claudeBlue_FOR_SYSTEM_SPINNER: string
   claudeBlueShimmer_FOR_SYSTEM_SPINNER: string
@@ -171,6 +173,8 @@ const darkTheme: Theme = {
   autoAccept: rgb('#B3A0D4'), // Soft violet
   bashBorder: rgb('#D194AE'), // Mist rose
   claude: rgb('#7DA1DE'), // Accent Soft — mist brand blue
+  toolNameMutate: rgb('#E5C07B'), // soft gold — Edit/Write (warm accent)
+  toolNameExec: rgb('#56B6C2'), // mist cyan — Bash/exec tools
   claudeShimmer: rgb('#ABC2EC'), // Border Blue for shimmer effect
   claudeBlue_FOR_SYSTEM_SPINNER: rgb('#7DA1DE'),
   claudeBlueShimmer_FOR_SYSTEM_SPINNER: rgb('#ABC2EC'),
@@ -206,16 +210,16 @@ const darkTheme: Theme = {
   toolDotWrite: rgb('#B3A0D4'), // soft violet — edit/write
   toolDotWeb: rgb('#7DA1DE'), // mist blue — web search/fetch
   toolDotTask: rgb('#D194AE'), // mist rose — subagent/jobs
-  syntaxKeyword: rgb('#8FA8E8'), // mist blue
-  syntaxString: rgb('#9FBF8F'), // soft sage
+  syntaxKeyword: rgb('#82AAFF'), // vivid blue (theme anchor)
+  syntaxString: rgb('#E5C07B'), // gold - echoes the user-message gold accent
   syntaxComment: rgb('#6B7280'), // neutral grey
-  syntaxNumber: rgb('#D9A97E'), // warm tan
-  syntaxFunction: rgb('#82B8C7'), // cyan blue
-  syntaxType: rgb('#B39DDB'), // soft violet
+  syntaxNumber: rgb('#D19A66'), // warm orange
+  syntaxFunction: rgb('#56B6C2'), // vivid cyan
+  syntaxType: rgb('#C678DD'), // vivid violet
   syntaxVariable: rgb('#C9D1D9'), // near-text
   syntaxOperator: rgb('#93A1B0'), // blue grey
   syntaxPunctuation: rgb('#7A8694'), // dim blue grey
-  syntaxConstant: rgb('#D98C9B'), // soft rose
+  syntaxConstant: rgb('#E48A9B'), // soft rose
   red_FOR_SUBAGENTS_ONLY: rgb('#D4685E'),
   blue_FOR_SUBAGENTS_ONLY: rgb('#7496D6'),
   green_FOR_SUBAGENTS_ONLY: rgb('#66B285'),
@@ -228,8 +232,8 @@ const darkTheme: Theme = {
   chromeYellow: rgb('#D8B270'),
   clawd_body: rgb('#D98A63'), // Warm mascot orange
   clawd_background: rgb('#000000'),
-  userMessageBackground: rgb('#292D36'),
-  userMessageBackgroundHover: rgb('#343945'),
+  userMessageBackground: '', // user turn: no fill, gold bold text only (Kimi style)
+  userMessageBackgroundHover: rgb('#3B5BDB'), // hover/expand: blue block with gold text
   messageActionsBackground: rgb('#2E333D'),
   selectionBg: rgb('#3B4A66'), // Mist-blue tint on dark
   bashMessageBackgroundColor: rgb('#2C3038'),
@@ -238,7 +242,7 @@ const darkTheme: Theme = {
   rate_limit_empty: rgb('#3C414B'),
   fastMode: rgb('#E09A58'),
   fastModeShimmer: rgb('#EAB478'),
-  briefLabelYou: rgb('#ABC2EC'),
+  briefLabelYou: rgb('#FFDF80'),
   briefLabelClaude: rgb('#7DA1DE'),
   rainbow_red: rgb('#D98F8A'),
   rainbow_orange: rgb('#D9A97E'),
@@ -266,6 +270,8 @@ const lightTheme: Theme = {
   autoAccept: rgb('#9B86B8'), // Muted violet (from surface-alt pink-mist)
   bashBorder: rgb('#C07A93'), // Muted rose (from surface-alt pink-mist)
   claude: rgb('#3F6CC4'), // Primary Blue — brand
+  toolNameMutate: rgb('#8A6A00'), // deep gold - Edit/Write (warm accent)
+  toolNameExec: rgb('#0F7A8A'), // deep cyan - Bash/exec tools
   claudeShimmer: rgb('#5E88CC'), // Accent Blue for shimmer effect
   claudeBlue_FOR_SYSTEM_SPINNER: rgb('#3F6CC4'),
   claudeBlueShimmer_FOR_SYSTEM_SPINNER: rgb('#5E88CC'),
@@ -301,16 +307,16 @@ const lightTheme: Theme = {
   toolDotWrite: rgb('#7A5CA8'),
   toolDotWeb: rgb('#4A63A8'),
   toolDotTask: rgb('#B04A5A'),
-  syntaxKeyword: rgb('#4A63A8'),
-  syntaxString: rgb('#4E7A4E'),
+  syntaxKeyword: rgb('#2557C7'),
+  syntaxString: rgb('#8A6A00'),
   syntaxComment: rgb('#8A8F98'),
-  syntaxNumber: rgb('#A96B32'),
-  syntaxFunction: rgb('#3F7E8F'),
-  syntaxType: rgb('#7A5CA8'),
+  syntaxNumber: rgb('#B25E1E'),
+  syntaxFunction: rgb('#0F7A8A'),
+  syntaxType: rgb('#8A3FC7'),
   syntaxVariable: rgb('#343945'),
   syntaxOperator: rgb('#5B6672'),
   syntaxPunctuation: rgb('#9AA0A8'),
-  syntaxConstant: rgb('#B04A5A'),
+  syntaxConstant: rgb('#C2186B'),
   red_FOR_SUBAGENTS_ONLY: rgb('#BE5A52'),
   blue_FOR_SUBAGENTS_ONLY: rgb('#3F6CC4'),
   green_FOR_SUBAGENTS_ONLY: rgb('#4E9675'),
@@ -323,8 +329,8 @@ const lightTheme: Theme = {
   chromeYellow: rgb('#C99A3F'),
   clawd_body: rgb('#D98A63'), // Warm mascot orange
   clawd_background: rgb('#F6F3ED'),
-  userMessageBackground: rgb('#EEE5D2'), // Surface
-  userMessageBackgroundHover: rgb('#E4D9E5'), // Surface Alt
+  userMessageBackground: '', // user turn: no fill in light mode, gold text only
+  userMessageBackgroundHover: rgb('#DCE4FB'), // subtle blue tint on hover/expand
   messageActionsBackground: rgb('#E4D9E5'),
   selectionBg: rgb('#D5DEF2'), // Mist-blue tint on warm white
   bashMessageBackgroundColor: rgb('#EAE1D3'),
@@ -333,7 +339,7 @@ const lightTheme: Theme = {
   rate_limit_empty: rgb('#DDD5C7'),
   fastMode: rgb('#D98E4A'),
   fastModeShimmer: rgb('#E2A465'),
-  briefLabelYou: rgb('#5E88CC'),
+  briefLabelYou: rgb('#A67600'),
   briefLabelClaude: rgb('#3F6CC4'),
   rainbow_red: rgb('#D98888'),
   rainbow_orange: rgb('#D9A276'),
@@ -363,6 +369,8 @@ const darkAnsiTheme: Theme = {
   autoAccept: 'ansi:magentaBright',
   bashBorder: 'ansi:magentaBright',
   claude: 'ansi:blueBright',
+  toolNameMutate: 'ansi:yellowBright',
+  toolNameExec: 'ansi:cyanBright',
   claudeShimmer: 'ansi:blueBright',
   claudeBlue_FOR_SYSTEM_SPINNER: 'ansi:blueBright',
   claudeBlueShimmer_FOR_SYSTEM_SPINNER: 'ansi:blueBright',
@@ -420,8 +428,8 @@ const darkAnsiTheme: Theme = {
   chromeYellow: 'ansi:yellowBright',
   clawd_body: 'ansi:redBright',
   clawd_background: 'ansi:black',
-  userMessageBackground: 'ansi:blackBright',
-  userMessageBackgroundHover: 'ansi:white',
+  userMessageBackground: '',
+  userMessageBackgroundHover: 'ansi:blue',
   messageActionsBackground: 'ansi:blackBright',
   selectionBg: 'ansi:blue',
   bashMessageBackgroundColor: 'ansi:black',
@@ -430,7 +438,7 @@ const darkAnsiTheme: Theme = {
   rate_limit_empty: 'ansi:white',
   fastMode: 'ansi:redBright',
   fastModeShimmer: 'ansi:redBright',
-  briefLabelYou: 'ansi:blueBright',
+  briefLabelYou: 'ansi:yellowBright',
   briefLabelClaude: 'ansi:blueBright',
   rainbow_red: 'ansi:red',
   rainbow_orange: 'ansi:redBright',


### PR DESCRIPTION
## 改动内容

从 Kimi Code 借鉴的 UI 视觉优化，配色按 DeepSeek 蓝主 + 暖色点缀：

### 用户消息
- 金色加粗（`briefLabelYou`），去掉底色；hover/展开底色移除，仅保留选中态高亮

### 工具卡
- 工具名按类别着色：读取/搜索=雾蓝、改文件=柔金、执行/终端=雾青（新增 `toolNameMutate`/`toolNameExec` token，三套主题都配了）
- 正文去灰：read/terminal/search 内容与头部参数恢复正文色，灰色只留元信息
- diff 的 gutter 随行染色（+ 绿 / - 玫瑰），多文件路径行用 `ide` 蓝

### Markdown
- 标题蓝色系递进（h1 雾蓝+下划线、h2 亮蓝），列表 bullet 蓝色
- 代码块接入主题语法色板（`cc/syntaxTheme.ts` 共享模块，SplitDiffView 同用），开头 ```lang 标签行 + 2 空格缩进

### 修复
- `StreamingMarkdown` 硬编码 dimColor 导致流式正文被渲染成灰色（thinking 的灰串到了正文）

## 验证
- `tsc` 通过，`npm run smoke` 22 断言全绿

## 注意
- 工作区另有 4 个并发改动文件（spacing-probe/figures/LoadedContextPanel/AssistantThinkingMessage）已 stash 隔离为 `ui-refactor-foreign`，与本 PR 无关