### PR TITLE
fix(ui): light-mode user message gold contrast

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -339,7 +339,7 @@ const lightTheme: Theme = {
   rate_limit_empty: rgb('#DDD5C7'),
   fastMode: rgb('#D98E4A'),
   fastModeShimmer: rgb('#E2A465'),
-  briefLabelYou: rgb('#A67600'),
+  briefLabelYou: rgb('#8A5A00'),
   briefLabelClaude: rgb('#3F6CC4'),
   rainbow_red: rgb('#D98888'),
   rainbow_orange: rgb('#D9A276'),


### PR DESCRIPTION
浅色模式下用户消息金色文字明度调暗：`#A67600` -> `#8A5A00`（白底对比度约 7.7:1），深色模式 `#FFDF80` 不动。