### PR TITLE
feat(ui): 鲸鱼开关 /settings `whale`（默认开 / header whale toggle, default on）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,8 @@ jobs:
 
       - run: node --import tsx/esm scripts/verify-channel-goal-todo.mjs
 
+      - run: node --import tsx/esm scripts/verify-whale-toggle.mjs
+
       # 裸 ● 空行回归：纯思考/纯工具步骤（无文本块）的 assistant/message
       # 不得创建空 assistant 行，否则思考块折叠后转录里多出一个只有
       # ● 前缀、内容为空的行。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -407,11 +407,12 @@ dsh-tui
 ### 5.3 /settings 设置编辑器
 
 `/settings` 打开插件设置编辑器；**编辑是暂存制**：`s` 保存 / `d` 放弃 / `Esc` 丢弃脏区退出。
-dsh-tui 自身区块（写入 settings.yaml 用户层，实时生效）共 18 个字段：
+dsh-tui 自身区块（写入 settings.yaml 用户层，实时生效）共 19 个字段：
 
 | 字段 | 说明 |
 |---|---|
 | lang | 界面语言 zh/en（DSH_TUI_LANG 钉死时不可改） |
+| whale | 开屏头部像素鲸鱼娘（默认开） |
 | diffLayout | Edit/Write diff 布局：auto（≥110 列双栏）/ split / unified |
 | thinkingFold | 思考块：preview（流式 2-3 行预览 + 落定折叠）/ full（展开到轮末） |
 | toolBackground | 工具卡背景强调：none / subtle / strong |

--- a/scripts/verify-whale-toggle.mjs
+++ b/scripts/verify-whale-toggle.mjs
@@ -1,20 +1,38 @@
 /**
- * Channel-level verification of the header whale-art toggle (settings
- * `dsh-tui.whale`, default on): real Channel via createChannel + fake
- * ctx/agent, plain node against the compiled lib.
+ * Component and channel regression for settings `dsh-tui.whale`.
+ * Imports source through tsx, so it never relies on a pre-existing lib/ tree.
  *
- * - whale defaults to on, `whale: false` opts out
- * - setWhale flips the flag and notifies subscribers exactly once;
- *   setting the same value is a no-op (no re-emit)
- *
- * Run with plain node against the compiled lib: `node scripts/verify-whale-toggle.mjs`
+ * Run: node --import tsx/esm scripts/verify-whale-toggle.mjs
  */
-import { createChannel } from '../lib/types/dsh-adapter/channel.js'
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_LANG = 'en'
 
-let failed = 0
-function check(name, ok, extra = '') {
-  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
-  if (!ok) failed += 1
+const [
+  { strict: assert },
+  { PassThrough, Writable },
+  React,
+  { render, ThemeProvider },
+  { LogoHeader },
+  { createChannel },
+] = await Promise.all([
+  import('node:assert'),
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/components/MessageList.js'),
+  import('../src/dsh-adapter/channel.js'),
+])
+
+let checks = 0
+function check(name, test) {
+  try {
+    test()
+    checks += 1
+    console.log(`PASS: ${name}`)
+  } catch (error) {
+    console.error(`FAIL: ${name}`)
+    throw error
+  }
 }
 
 function makeChannel(options = {}) {
@@ -46,20 +64,96 @@ function makeChannel(options = {}) {
   })
 }
 
-// ---- default on / explicit opt-out
-check('whale defaults to on', makeChannel().whale === true)
-check('whale: false opts out', makeChannel({ whale: false }).whale === false)
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
 
-// ---- setWhale flips once, idempotent on repeat
+class FakeOutput extends Writable {
+  constructor(columns) {
+    super()
+    this.columns = columns
+  }
+  rows = 30
+  isTTY = true
+  writes = []
+  _write(chunk, _encoding, callback) {
+    this.writes.push(String(chunk))
+    callback()
+  }
+}
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+const stripAnsi = text => text
+  .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '')
+  .replace(/\x1b\]9;[^\x07]*\x07/g, '')
+const WHALE_OUTLINE = '\x1b[38;2;20;38;96m'
+
+async function renderHeader({ columns, whale }) {
+  const stdout = new FakeOutput(columns)
+  const stderr = new FakeOutput(columns)
+  const props = { model: 'whale-model-probe', cwd: '/whale/cwd' }
+  if (whale !== undefined) props.whale = whale
+  const instance = await render(
+    React.createElement(
+      ThemeProvider,
+      { theme: 'dark' },
+      React.createElement(LogoHeader, props),
+    ),
+    {
+      stdout,
+      stderr,
+      stdin: new FakeStdin(),
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  )
+  await sleep(180)
+  const raw = stdout.writes.join('')
+  await instance.unmount()
+  return { raw, plain: stripAnsi(raw) }
+}
+
+// Channel defaults and live setter semantics.
+check('channel defaults whale to on', () => assert.equal(makeChannel().whale, true))
+check('channel preserves an explicit whale=false', () => assert.equal(makeChannel({ whale: false }).whale, false))
 const channel = makeChannel()
 let notified = 0
 channel.subscribe(() => { notified += 1 })
 channel.setWhale(false)
-check('setWhale(false) flips the flag', channel.whale === false)
-check('subscriber notified once', notified === 1)
+check('setWhale(false) updates and notifies once', () => {
+  assert.equal(channel.whale, false)
+  assert.equal(notified, 1)
+})
 channel.setWhale(false)
-check('repeat setWhale is a no-op', notified === 1)
+check('repeated setWhale(false) is a no-op', () => assert.equal(notified, 1))
 channel.setWhale(true)
-check('setWhale(true) restores the default view', channel.whale === true && notified === 2)
+check('setWhale(true) restores the default view', () => {
+  assert.equal(channel.whale, true)
+  assert.equal(notified, 2)
+})
 
-process.exit(failed === 0 ? 0 : 1)
+// Real LogoHeader -> LogoV2 rendering: default, explicit opt-out, and narrow fallback.
+const wideDefault = await renderHeader({ columns: 100 })
+check('wide LogoHeader shows whale by default', () => {
+  assert.ok(wideDefault.raw.includes(WHALE_OUTLINE), 'whale palette marker missing')
+  assert.ok(wideDefault.plain.includes('dsh-TUI'), 'text logo missing')
+})
+
+const wideDisabled = await renderHeader({ columns: 100, whale: false })
+check('LogoHeader forwards whale=false while preserving the text logo', () => {
+  assert.ok(!wideDisabled.raw.includes(WHALE_OUTLINE), 'whale palette marker still rendered')
+  assert.ok(wideDisabled.plain.includes('dsh-TUI'), 'text logo missing')
+  assert.ok(wideDisabled.plain.includes('whale-model-probe'), 'header details missing')
+})
+
+const narrowDefault = await renderHeader({ columns: 63 })
+check('narrow terminal hides whale but preserves the text logo', () => {
+  assert.ok(!narrowDefault.raw.includes(WHALE_OUTLINE), 'whale should hide below 64 columns')
+  assert.ok(narrowDefault.plain.includes('dsh-TUI'), 'text logo missing')
+  assert.ok(narrowDefault.plain.includes('whale-model-probe'), 'header details missing')
+})
+
+console.log(`\nAll ${checks} whale-toggle checks passed.`)

--- a/scripts/verify-whale-toggle.mjs
+++ b/scripts/verify-whale-toggle.mjs
@@ -1,0 +1,65 @@
+/**
+ * Channel-level verification of the header whale-art toggle (settings
+ * `dsh-tui.whale`, default on): real Channel via createChannel + fake
+ * ctx/agent, plain node against the compiled lib.
+ *
+ * - whale defaults to on, `whale: false` opts out
+ * - setWhale flips the flag and notifies subscribers exactly once;
+ *   setting the same value is a no-op (no re-emit)
+ *
+ * Run with plain node against the compiled lib: `node scripts/verify-whale-toggle.mjs`
+ */
+import { createChannel } from '../lib/types/dsh-adapter/channel.js'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+function makeChannel(options = {}) {
+  const handlers = new Map()
+  const ctx = {
+    on(event, handler) {
+      handlers.set(event, handler)
+      return () => handlers.delete(event)
+    },
+    get() {
+      return undefined
+    },
+    logger: { warn() {} },
+  }
+  const agent = {
+    id: 'a1',
+    status: 'idle',
+    session: { id: 's1', seq: 0, events: [] },
+    ctx: { on: () => () => {} },
+    followup() {},
+    steer() {},
+  }
+  return createChannel(ctx, agent, {
+    model: 'deepseek-chat',
+    cwd: '/tmp',
+    provider: 'deepseek',
+    activity: false,
+    ...options,
+  })
+}
+
+// ---- default on / explicit opt-out
+check('whale defaults to on', makeChannel().whale === true)
+check('whale: false opts out', makeChannel({ whale: false }).whale === false)
+
+// ---- setWhale flips once, idempotent on repeat
+const channel = makeChannel()
+let notified = 0
+channel.subscribe(() => { notified += 1 })
+channel.setWhale(false)
+check('setWhale(false) flips the flag', channel.whale === false)
+check('subscriber notified once', notified === 1)
+channel.setWhale(false)
+check('repeat setWhale is a no-op', notified === 1)
+channel.setWhale(true)
+check('setWhale(true) restores the default view', channel.whale === true && notified === 2)
+
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/LogoV2.tsx
+++ b/src/components/LogoV2.tsx
@@ -75,6 +75,7 @@ export function LogoV2({
   cwd,
   skipIntro = false,
   tip,
+  whale = true,
 }: {
   model: string
   effort?: string | undefined
@@ -83,6 +84,8 @@ export function LogoV2({
   skipIntro?: boolean
   /** Test seam: pin the startup tip line (probes need a deterministic tip). */
   tip?: Tip
+  /** Show the pixel whale art (settings `dsh-tui.whale`); off → text-only header. */
+  whale?: boolean
 }): React.ReactNode {
   const [step, setStep] = React.useState(skipIntro ? OPENING_SEQUENCE.length : 0)
   const settled = step >= OPENING_SEQUENCE.length
@@ -111,7 +114,7 @@ export function LogoV2({
   const wordmarkShimmerRGB = parseRGB(theme.claudeShimmer) ?? ICE
   const taglineRGB = parseRGB(theme.claudeBlue_FOR_SYSTEM_SPINNER) ?? ICE
 
-  const showWhale = columns >= WHALE_MIN_COLUMNS
+  const showWhale = whale && columns >= WHALE_MIN_COLUMNS
   const frameIndex = settled ? STANDARD_FRAME_INDEX : OPENING_SEQUENCE[step].frame
   // Frozen clock for the settled header: t=0 parks every sweep highlight
   // off-screen, leaving the static gradient behind.

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -739,14 +739,16 @@ export function LogoHeader({
   model,
   effort,
   cwd,
+  whale = true,
 }: {
   model: string
   effort?: string | undefined
   cwd: string
+  whale?: boolean
 }): React.ReactNode {
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <LogoV2 model={model} effort={effort} cwd={cwd} />
+      <LogoV2 model={model} effort={effort} cwd={cwd} whale={whale} />
     </Box>
   )
 }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -478,6 +478,8 @@ export interface Channel {
   readonly toolBackground: ToolBackground
   /** Live status-footer visibility and compactness preferences. */
   readonly statusBar: Readonly<StatusBarConfig>
+  /** Whether the header's pixel whale art shows (settings `dsh-tui.whale`). */
+  readonly whale: boolean
   /** Whether the in-process working-activity line is shown (config.activity). */
   readonly activityEnabled: boolean
   /** Whether the segmented context bar row shows in the status footer
@@ -823,6 +825,10 @@ export interface ChannelState {
   setToolBackground(background: ToolBackground): void
   /** Apply status-footer preference changes. */
   setStatusBar(config: Partial<StatusBarConfig>): void
+  /** Whale header art switch (see the public Channel type). */
+  whale: boolean
+  /** Apply a whale-visibility change (see the public Channel type). */
+  setWhale(visible: boolean): void
   /** Working-activity display switch (see the public Channel type). */
   activityEnabled: boolean
   /** Context bar row switch (see the public Channel type). */
@@ -1252,6 +1258,8 @@ export function createChannel(
     toolBackground?: ToolBackground
     /** Status-footer field visibility and compactness. */
     statusBar?: Partial<StatusBarConfig>
+    /** Show the header's pixel whale art; default on. */
+    whale?: boolean
     /** Show the segmented context bar row in the status footer; default on
      *  (cordis.yml `contextBar: false` hides it, issue #29). */
     contextBar?: boolean
@@ -2032,6 +2040,7 @@ export function createChannel(
     thinkingFold: options.thinkingFold ?? 'preview',
     toolBackground: normalizeToolBackground(options.toolBackground),
     statusBar: normalizeStatusBar(options.statusBar),
+    whale: options.whale !== false,
     activityEnabled: options.activity !== false,
     contextBarEnabled: options.contextBar !== false,
     agentPreset: options.agentPreset,
@@ -3030,6 +3039,11 @@ export function createChannel(
       )
       if (!changed) return
       state.statusBar = next
+      state.emit()
+    },
+    setWhale(visible) {
+      if (visible === state.whale) return
+      state.whale = visible
       state.emit()
     },
     setActivityFrames(name) {

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -394,6 +394,8 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
           trajectory: Schema.boolean().default(DEFAULT_STATUS_BAR.trajectory),
           shortcutHint: Schema.boolean().default(DEFAULT_STATUS_BAR.shortcutHint),
         }).default({ ...DEFAULT_STATUS_BAR }),
+        // Header pixel whale art; on unless settings.yaml says otherwise.
+        whale: Schema.boolean().default(true),
         // No default on purpose: an unset `lang` keeps the field showing
         // the effective language (see the section's format below) and lets
         // cordis.yml / lang.json keep their precedence.
@@ -403,12 +405,16 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     type SettingsValue = {
       diffLayout?: 'auto' | 'split' | 'unified'
       lang?: 'zh' | 'en'
+      whale?: boolean
       thinkingFold?: 'preview' | 'full'
       toolBackground?: ToolBackground
       statusBar?: Partial<StatusBarConfig>
     }
     const applyLayout = (value: SettingsValue): void => {
       channel.setDiffLayout(value.diffLayout ?? config.diffLayout ?? 'auto')
+    }
+    const applyWhale = (value: { whale?: boolean }): void => {
+      channel.setWhale(value.whale ?? true)
     }
     // The /settings language field writes `lang` through the settings
     // service (user layer): apply it live and mirror it to lang.json so
@@ -430,6 +436,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     }
     const apply = (next: SettingsValue): void => {
       applyLayout(next)
+      applyWhale(next)
       applyLang(next)
       applyDisplay(next)
     }
@@ -640,6 +647,14 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
           hint: 'Control only the idle `? for shortcuts` reminder; pressing ? and the Esc shortcut hints are unaffected.',
           hintDescriptions: { zh: '仅控制空闲时的 `? for shortcuts` 提示；按 ? 打开快捷键以及 Esc 快捷提示均不受影响。' },
           group: 'status-bar',
+          kind: 'boolean',
+        },
+        {
+          path: ['whale'],
+          label: 'Whale art',
+          descriptions: { zh: '鲸鱼娘' },
+          hint: 'Show the pixel whale in the header splash.',
+          hintDescriptions: { zh: '开屏头部显示像素鲸鱼娘。' },
           kind: 'boolean',
         },
       ],

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -2081,6 +2081,7 @@ export function Chat({
           model={channel.model}
           effort={channel.reasoningEffort}
           cwd={channel.displayCwd}
+          whale={channel.whale}
         />
         {/* The startup loaded-context panel: before the first message the
             transcript is empty, so the inventory of what this conversation


### PR DESCRIPTION
## 动机

开屏头部的像素鲸鱼娘目前只随终端宽度（`WHALE_MIN_COLUMNS`）显隐，用户无法关闭；补一个设置开关，**默认保持显示**。

## 改动点

- `src/dsh-adapter/plugin.ts`：Config 增加 `whale: Schema.boolean().default(true)`；注册 `/settings` 布尔字段（`Whale art` / 鲸鱼娘），随 settings 变更实时应用。
- `src/dsh-adapter/channel.ts`：`Channel.whale` 只读字段 + `setWhale()`（同值不重复 emit）；`options.whale !== false` 保证缺省为开。
- `src/components/LogoV2.tsx` / `MessageList.tsx` / `screens/Chat.tsx`：`whale` prop 贯穿 `LogoHeader → LogoV2`，与宽度条件合成 `showWhale`。
- `scripts/verify-whale-toggle.mjs`：channel 级回归（默认开 / 显式关 / setWhale 单次 emit / 幂等），注册进 CI。
- `docs/user-guide.md`：/settings 字段表 18 → 19，新增 `whale` 行。

## 验证方式

- `tsc -p tsconfig.json` 通过；`verify:boundary` / `verify:contract` / `verify:patch-surface` 三门禁通过。
- `node scripts/verify-whale-toggle.mjs`：6 项断言全过。
- 手工：`/settings → whale` 切换即时生效；关闭后头部只剩文字 logo，重启沿用设置。