### PR TITLE
feat(provider): ChatGPT Codex 订阅 OAuth（device code）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,12 @@ jobs:
 
       # /provider 向导回归：catalog/custom 两分支的 profile 形状、凭据回滚
       # （覆盖时恢复旧 key 而非误删）、env shadow 跳过、rc.6 兼容守卫、
-      # hideCustomInput 逐题标记。
+      # hideCustomInput 逐题标记、Codex 订阅 device-code 登录。
       - run: node scripts/verify-provider-wizard.mjs
+
+      # OpenAI Codex (ChatGPT Plus/Pro) 订阅 OAuth 回归：store 存取与 0600、
+      # token 刷新、device 的 auth-code + PKCE 交换、后台续期器启用条件。
+      - run: node scripts/verify-codex-oauth.mjs
 
       # /login 凭据状态回归（issue #213）：只通过 credentials.describe()
       # 展示 configured/source/writable，managed key 不得误报或泄露值。

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -193,6 +193,24 @@ restart:
   The wizard probes the endpoint with the draft credential and offers the
   advertised models for selection (manual id entry as fallback).
 
+**OpenAI Codex (the `openai-codex` route, ChatGPT Plus/Pro subscription)**:
+`dsh-llm-pi-ai` withholds this route from the configurable catalog (it is
+OAuth-only), but `/provider` still offers it because the TUI can log in and
+refresh. Auth is OpenAI's device-code flow only
+(`https://auth.openai.com/codex/device`): open the link and enter the code
+shown in the panel. There is no console API-key option and no import of a
+local pi login.
+
+The subscription access token lasts about ten days. dsh-tui stores it as
+the `OPENAI_CODEX_API_KEY` credential and records the refresh token plus
+expiry in `~/.dsh-tui/codex-oauth.json` (mode 0600); a background refresher
+checks every minute and rotates five minutes before expiry. **Do not** set
+`api: openai-codex-responses` on this route — the adapter rejects that
+protocol. Omit `api` so the bundled catalog provider is reused (it extracts
+`chatgpt-account-id` from the JWT). When `OPENAI_CODEX_API_KEY` is in the
+process environment (env shadow), auto-refresh cannot apply and the wizard
+warns.
+
 What gets written (on a profile start, where dsh-base provides the
 settings/credentials services):
 
@@ -200,6 +218,7 @@ settings/credentials services):
 | --- | --- |
 | Provider profile | `llm-pi-ai.providers.<route>` in `~/.dsh/settings.yaml`; the route registers on write |
 | API key | `~/.dsh/.credentials.yaml` (mode 0600), referenced as `<ROUTE>_API_KEY` |
+| Codex subscription refresh record | `~/.dsh-tui/codex-oauth.json` (mode 0600), read by the background refresher |
 
 Key answers render as `••••••` in the transcript; when the process environment
 already provides the same-named variable, the write is skipped and the value

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,12 +176,27 @@ Profile 模式不再使用旧的 `DSH_TUI_COMPACT_RATIO`、
   （`openai-completions` / `openai-responses` / `anthropic-messages`），
   向导会用草稿凭据探测端点公布的模型供勾选（探测失败则手输模型 id）。
 
+**OpenAI Codex（`openai-codex` 路由，ChatGPT Plus/Pro 订阅）**：`dsh-llm-pi-ai`
+把该路由从可配置目录里藏起来（它只提供 OAuth、没有 API key 方法），但
+`/provider` 会单独把它列出来，因为 TUI 能完成登录并续期。认证只走 OpenAI
+的 device-code 授权（`https://auth.openai.com/codex/device`）：在面板中打开
+链接、输入代码。没有 console API key，也不会读取本机 pi 的登录。
+
+订阅 access token 约十天过期，dsh-tui 会把它写成 `OPENAI_CODEX_API_KEY`
+凭据，并把 refresh token 与过期时间记到 `~/.dsh-tui/codex-oauth.json`
+（0600）；后台续期器每 60 秒检查，到期前 5 分钟刷新。**不要**在该路由上写
+`api: openai-codex-responses`——适配器会拒绝这个协议；省略 `api` 才能复用
+捆绑 catalog provider（它会从 JWT 里取出 `chatgpt-account-id`）。若进程
+环境已有 `OPENAI_CODEX_API_KEY`（env shadow），自动续期无法生效，向导会
+给出警告。
+
 写入产物（profile 启动时，dsh-base 提供 settings/credentials 服务）：
 
 | 产物 | 位置 |
 | --- | --- |
 | provider profile | `~/.dsh/settings.yaml` 的 `llm-pi-ai.providers.<路由名>`，写入即注册路由 |
 | API key | `~/.dsh/.credentials.yaml`（0600），引用名为 `<路由名大写>_API_KEY` |
+| Codex 订阅刷新记录 | `~/.dsh-tui/codex-oauth.json`（0600），供后台续期器读取 |
 
 密钥答案在会话记录中只显示 `••••••`；若进程环境已有同名变量，则跳过写入、
 运行时直接从环境解析。配置与 dsh web 端的 Models 设置页互通（同一 settings

--- a/scripts/verify-codex-oauth.mjs
+++ b/scripts/verify-codex-oauth.mjs
@@ -1,0 +1,282 @@
+/**
+ * Headless verification for the OpenAI Codex (ChatGPT Plus/Pro) OAuth
+ * plumbing (src/dsh-adapter/codexOAuth.ts + codexRefresher.ts).
+ *
+ * Scenarios (all against temp dirs — nothing under ~/.dsh-tui is ever
+ * touched; this module does not read ~/.pi):
+ *
+ *  1. extractCodexAccountId from a JWT.
+ *  2. store round trip: write → read identity, corrupt store → undefined,
+ *     created file mode is 0600.
+ *  3. refreshCodexCredential: fresh short-circuit (no network), stale
+ *     refresh mints a new access token, network failure throws.
+ *  4. loginCodexDevice: user code → pending poll → auth-code exchange;
+ *     denied error.
+ *  5. refreshCodexSubscriptionOnce: expired store rotated; fresh / route
+ *     removed / env shadow / cleared credential stop the refresh.
+ *
+ * Run with plain node against the compiled lib (after `pnpm build`):
+ * `node scripts/verify-codex-oauth.mjs`
+ */
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CodexOAuthError,
+  extractCodexAccountId,
+  loginCodexDevice,
+  readCodexOAuthStore,
+  refreshCodexCredential,
+  writeCodexOAuthStore,
+} from '../lib/types/dsh-adapter/codexOAuth.js'
+import { refreshCodexSubscriptionOnce } from '../lib/types/dsh-adapter/codexRefresher.js'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b)
+
+/** A JWT-shaped access token carrying ChatGPT account id and optional exp. */
+function jwtWithAccount(accountId, expSeconds) {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify({
+    ...(expSeconds === undefined ? {} : { exp: expSeconds }),
+    'https://api.openai.com/auth': { chatgpt_account_id: accountId },
+  })).toString('base64url')
+  return `${header}.${payload}.sig`
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'dsh-tui-codex-'))
+const storePath = join(dir, 'codex-oauth.json')
+const accountId = '95bcba73-bd54-4e5a-93a3-5ceeb179b2b8'
+const accessJwt = jwtWithAccount(accountId, 1_800_000)
+
+check('1 extract: accountId from JWT', extractCodexAccountId(accessJwt) === accountId)
+check('1 extract: stored accountId wins', extractCodexAccountId(accessJwt, 'stored-id') === 'stored-id')
+check('1 extract: missing JWT claim → undefined', extractCodexAccountId('not-a-jwt') === undefined)
+
+{
+  const store = {
+    route: 'openai-codex',
+    ref: 'OPENAI_CODEX_API_KEY',
+    credential: { access: 'a1', refresh: 'r1', expires: 1234, accountId },
+  }
+  check('2 store: write succeeds', writeCodexOAuthStore(store, storePath) === true)
+  check('2 store: round trip identity', eq(readCodexOAuthStore(storePath), store))
+  const mode = statSync(storePath).mode & 0o777
+  check('2 store: file mode 0600', mode === 0o600, mode.toString(8))
+  writeFileSync(storePath, '{not json')
+  check('2 store: corrupt file → undefined', readCodexOAuthStore(storePath) === undefined)
+}
+
+{
+  const originalFetch = globalThis.fetch
+  let fetchCalls = 0
+  const freshAccess = jwtWithAccount('acct-rotated', 2_000_000)
+  globalThis.fetch = async () => {
+    fetchCalls += 1
+    return new Response(JSON.stringify({
+      access_token: freshAccess,
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+    }), { status: 200 })
+  }
+  try {
+    const fresh = { access: 'old', refresh: 'r', expires: Date.now() + 3_600_000, accountId }
+    const untouched = await refreshCodexCredential(fresh)
+    check('3 refresh: fresh credential short-circuits (no network)',
+      untouched === fresh && fetchCalls === 0)
+
+    const stale = { access: 'old', refresh: 'r', expires: Date.now() - 1000, accountId }
+    const rotated = await refreshCodexCredential(stale)
+    check('3 refresh: stale token rotated',
+      fetchCalls === 1
+        && rotated.access === freshAccess
+        && rotated.refresh === 'new-refresh'
+        && rotated.accountId === 'acct-rotated',
+      JSON.stringify({ ...rotated, access: 'jwt' }))
+    check('3 refresh: expiry computed with skew',
+      rotated.expires > Date.now() && rotated.expires < Date.now() + 3_600_000)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 })
+  }
+  try {
+    await refreshCodexCredential({ access: 'old', refresh: 'r', expires: Date.now() - 1000 })
+    check('3 refresh: network failure throws', false)
+  } catch (error) {
+    check('3 refresh: network failure throws CodexOAuthError',
+      error instanceof CodexOAuthError && error.code === 'failed',
+      error instanceof Error ? error.message : String(error))
+  }
+  globalThis.fetch = originalFetch
+}
+
+{
+  const originalFetch = globalThis.fetch
+  const calls = []
+  const deviceAccess = jwtWithAccount('acct-device', 2_000_000)
+  globalThis.fetch = async (url, init) => {
+    const href = String(url)
+    calls.push(href)
+    if (href.includes('/deviceauth/usercode')) {
+      return new Response(JSON.stringify({
+        device_auth_id: 'da-1',
+        user_code: 'ABCD-EFGH',
+        interval: 1,
+      }), { status: 200 })
+    }
+    if (href.includes('/deviceauth/token')) {
+      if (calls.filter(item => item.includes('/deviceauth/token')).length === 1) {
+        return new Response(JSON.stringify({ error: { code: 'deviceauth_authorization_pending' } }), { status: 403 })
+      }
+      return new Response(JSON.stringify({
+        authorization_code: 'auth-code',
+        code_verifier: 'verifier',
+      }), { status: 200 })
+    }
+    const body = Object.fromEntries(new URLSearchParams(init.body))
+    if (body.grant_type !== 'authorization_code' || body.code !== 'auth-code' || body.code_verifier !== 'verifier') {
+      return new Response(JSON.stringify({ error: 'invalid_request' }), { status: 400 })
+    }
+    return new Response(JSON.stringify({
+      access_token: deviceAccess,
+      refresh_token: 'device-refresh',
+      expires_in: 3600,
+    }), { status: 200 })
+  }
+  try {
+    let codeInfo = null
+    const credential = await loginCodexDevice(info => {
+      codeInfo = info
+    })
+    check('4 device: onCode surfaced the URI and code',
+      eq(codeInfo, { verificationUri: 'https://auth.openai.com/codex/device', userCode: 'ABCD-EFGH' }),
+      JSON.stringify(codeInfo))
+    check('4 device: device flow polled then exchanged a credential',
+      calls.length === 4
+        && credential.access === deviceAccess
+        && credential.refresh === 'device-refresh'
+        && credential.accountId === 'acct-device',
+      `${calls.length} calls, account=${credential.accountId}`)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('/deviceauth/usercode')) {
+      return new Response(JSON.stringify({
+        device_auth_id: 'da-1',
+        user_code: 'ABCD-EFGH',
+        interval: 1,
+      }), { status: 200 })
+    }
+    return new Response(JSON.stringify({ error: 'access_denied' }), { status: 400 })
+  }
+  try {
+    await loginCodexDevice(() => {})
+    check('4 device: denial rejected', false)
+  } catch (error) {
+    check('4 device: denial rejected as CodexOAuthError(denied)',
+      error instanceof CodexOAuthError && error.code === 'denied',
+      error instanceof Error ? error.message : String(error))
+  }
+  globalThis.fetch = originalFetch
+}
+
+{
+  const originalFetch = globalThis.fetch
+  const originalEnv = process.env.OPENAI_CODEX_API_KEY
+  delete process.env.OPENAI_CODEX_API_KEY
+  const freshAccess = jwtWithAccount('acct-refresh', 2_000_000)
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    access_token: freshAccess,
+    refresh_token: 'kept-refresh',
+    expires_in: 3600,
+  }), { status: 200 })
+  const sets = []
+  const ctx = {
+    get(name) {
+      if (name === 'credentials') {
+        return {
+          resolve: async ref => ref === 'OPENAI_CODEX_API_KEY' ? { value: 'old' } : undefined,
+          set: async (ref, value) => { sets.push([ref, value]) },
+        }
+      }
+      if (name === 'settings') {
+        return { get: ns => ns === 'llm-pi-ai' ? { providers: { 'openai-codex': {} } } : undefined }
+      }
+      return undefined
+    },
+    logger: { info: () => {}, warn: () => {} },
+  }
+  try {
+    const expired = {
+      route: 'openai-codex',
+      ref: 'OPENAI_CODEX_API_KEY',
+      credential: { access: 'old', refresh: 'r', expires: Date.now() - 1000, accountId },
+    }
+    await refreshCodexSubscriptionOnce(ctx, expired, storePath)
+    check('5 refresher: expired token rotated into the credential seam',
+      eq(sets, [['OPENAI_CODEX_API_KEY', freshAccess]]),
+      JSON.stringify(sets.map(([ref]) => ref)))
+    check('5 refresher: store file records the rotated token',
+      readCodexOAuthStore(storePath)?.credential.access === freshAccess)
+
+    const fetchCalls = []
+    globalThis.fetch = async () => { fetchCalls.push(1); return new Response('{}', { status: 200 }) }
+    sets.length = 0
+    const fresh = {
+      route: 'openai-codex',
+      ref: 'OPENAI_CODEX_API_KEY',
+      credential: { access: 'old', refresh: 'r', expires: Date.now() + 3_600_000, accountId },
+    }
+    await refreshCodexSubscriptionOnce(ctx, fresh, storePath)
+    check('5 refresher: fresh token untouched', sets.length === 0 && fetchCalls.length === 0)
+
+    const noRouteCtx = {
+      ...ctx,
+      get(name) {
+        if (name === 'settings') return { get: () => ({ providers: {} }) }
+        return name === 'credentials' ? ctx.get('credentials') : undefined
+      },
+    }
+    await refreshCodexSubscriptionOnce(noRouteCtx, fresh, storePath)
+    check('5 refresher: route removed from settings stops the refresh',
+      sets.length === 0 && fetchCalls.length === 0)
+
+    process.env.OPENAI_CODEX_API_KEY = 'shadow'
+    await refreshCodexSubscriptionOnce(ctx, fresh, storePath)
+    check('5 refresher: env shadow stops the refresh',
+      sets.length === 0 && fetchCalls.length === 0)
+    delete process.env.OPENAI_CODEX_API_KEY
+
+    const clearedCtx = {
+      ...ctx,
+      get(name) {
+        if (name === 'credentials') return { resolve: async () => undefined, set: async () => {} }
+        return name === 'settings' ? ctx.get('settings') : undefined
+      },
+    }
+    await refreshCodexSubscriptionOnce(clearedCtx, {
+      route: 'openai-codex',
+      ref: 'OPENAI_CODEX_API_KEY',
+      credential: { access: 'old', refresh: 'r', expires: Date.now() - 1000, accountId },
+    }, storePath)
+    check('5 refresher: cleared credential stops the refresh',
+      sets.length === 0 && fetchCalls.length === 0)
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalEnv === undefined) delete process.env.OPENAI_CODEX_API_KEY
+    else process.env.OPENAI_CODEX_API_KEY = originalEnv
+  }
+}
+
+rmSync(dir, { recursive: true, force: true })
+console.log(failed === 0 ? '\nAll codex-oauth checks passed' : `\n${failed} check(s) FAILED`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-provider-wizard.mjs
+++ b/scripts/verify-provider-wizard.mjs
@@ -22,6 +22,11 @@
  * 11. providerSetup availability must not call APIs absent from dsh-llm rc.6
  *    (regression: listModelDiscoveryNamespaces() is undefined there and the
  *    guard threw before the wizard could open).
+ * 13. openai-codex is injected into the catalog list even when the host
+ *    withholds it; device login writes OPENAI_CODEX_API_KEY, omits `api`.
+ * 14. openai-codex device login parks on codex-device-wait.
+ * 15. openai-codex device denied: outcome 'failed', nothing written.
+ * 16. openai-codex under an env-shadowed ref: warning, no oauth store.
  *
  * Run with plain node against the compiled lib (after `pnpm build`):
  * `node scripts/verify-provider-wizard.mjs`
@@ -31,6 +36,7 @@ import {
   deriveKeyRef,
   runProviderWizard,
 } from '../lib/types/dsh-adapter/providerWizard.js'
+import { CodexOAuthError } from '../lib/types/dsh-adapter/codexOAuth.js'
 import { t } from '../lib/types/i18n.js'
 
 let failed = 0
@@ -63,6 +69,7 @@ function makeDeps(script, options = {}) {
     hideFlags: {},
     /** question id → option descriptions, for catalog row-shape regressions. */
     optionDescriptions: {},
+    codexStores: [],
   }
   const host = {
     listCatalogProviders: () => [
@@ -85,6 +92,28 @@ function makeDeps(script, options = {}) {
     writeProfile: async (route, profile) => {
       if (options.profileThrows) throw new Error('settings-rejected: unserviceable')
       calls.profiles.push([route, profile])
+    },
+    loginCodexOAuth: async onCode => {
+      if (options.codexLoginThrows !== undefined) {
+        onCode(options.codexDeviceCode ?? {
+          verificationUri: 'https://auth.openai.com/codex/device',
+          userCode: 'ABCD-EFGH',
+        })
+        throw options.codexLoginThrows
+      }
+      onCode(options.codexDeviceCode ?? {
+        verificationUri: 'https://auth.openai.com/codex/device',
+        userCode: 'ABCD-EFGH',
+      })
+      return options.codexLoginCredential ?? {
+        access: 'codex-device-access', refresh: 'codex-device-refresh',
+        expires: Date.now() + 3_600_000, accountId: 'acct-device',
+      }
+    },
+    writeCodexOAuthStore: (route, ref, credential) => {
+      if (options.codexStoreThrows) return false
+      calls.codexStores.push({ route, ref, credential })
+      return true
     },
   }
   const deps = {
@@ -407,6 +436,97 @@ const KEEP_MODEL = { selected: [t('provider-opt-switch-keep')] }
       'switch': true,
     }),
     JSON.stringify(custom.calls.hideFlags))
+}
+
+// 13. openai-codex is injected + device login: no api field, bundled catalog.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['openai-codex'] },
+    'codex-device-wait': { selected: [t('provider-opt-codex-device-continue')] },
+    'confirm': CONFIRM_WRITE,
+  }, {
+    codexLoginCredential: {
+      access: 'codex-device-access', refresh: 'codex-device-refresh',
+      expires: Date.now() + 3_600_000, accountId: 'acct-device',
+    },
+  })
+  const outcome = await runProviderWizard(deps)
+  check('13 codex injected into catalog',
+    Object.prototype.hasOwnProperty.call(calls.optionDescriptions.catalog ?? {}, 'openai-codex'),
+    JSON.stringify(calls.optionDescriptions.catalog))
+  check('13 codex device: outcome added', outcome === 'added', outcome)
+  check('13 codex device: apikey ask skipped', !calls.asks.includes('apikey'))
+  check('13 codex device: API-key catalog tail skipped',
+    !calls.asks.includes('baseurl-choice') && !calls.asks.includes('models'))
+  check('13 codex device: token written under OPENAI_CODEX_API_KEY',
+    eq(calls.credentials, [['OPENAI_CODEX_API_KEY', 'codex-device-access']]),
+    JSON.stringify(calls.credentials))
+  check('13 codex device: oauth store written for the route',
+    calls.codexStores.length === 1
+      && calls.codexStores[0].route === 'openai-codex'
+      && calls.codexStores[0].ref === 'OPENAI_CODEX_API_KEY'
+      && calls.codexStores[0].credential.access === 'codex-device-access',
+    JSON.stringify(calls.codexStores))
+  check('13 codex device: profile has no api field',
+    eq(calls.profiles, [['openai-codex', { apiKeyEnv: 'OPENAI_CODEX_API_KEY' }]]),
+    JSON.stringify(calls.profiles))
+  check('13 codex device: summary advertises auto-refresh',
+    calls.pushed.length === 1
+      && calls.pushed[0].lines.some(line => line.includes(t('provider-line-codex-oauth-refresh'))))
+}
+
+// 14. openai-codex device panel parks on codex-device-wait.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['openai-codex'] },
+    'codex-device-wait': { selected: [t('provider-opt-codex-device-continue')] },
+    'confirm': CONFIRM_WRITE,
+  })
+  const outcome = await runProviderWizard(deps)
+  check('14 codex device: outcome added', outcome === 'added', outcome)
+  check('14 codex device: panel showed the code and URI',
+    calls.asks.includes('codex-device-wait')
+      && calls.hideFlags['codex-device-wait'] === true)
+}
+
+// 15. openai-codex device login denied.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['openai-codex'] },
+    'codex-device-wait': { selected: [t('provider-opt-codex-device-continue')] },
+  }, {
+    codexLoginThrows: new CodexOAuthError('denied', 'OpenAI Codex device authorization was denied'),
+  })
+  const outcome = await runProviderWizard(deps)
+  check('15 codex device denied: outcome failed', outcome === 'failed', outcome)
+  check('15 codex device denied: denial notified',
+    calls.notifications.some(n => n.color === 'error'
+      && n.text === t('provider-codex-device-denied')))
+  check('15 codex device denied: nothing written',
+    eq(calls.credentials, []) && eq(calls.profiles, []) && eq(calls.codexStores, []))
+}
+
+// 16. openai-codex under an env-shadowed ref.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['openai-codex'] },
+    'codex-device-wait': { selected: [t('provider-opt-codex-device-continue')] },
+    'confirm': CONFIRM_WRITE,
+  }, {
+    shadow: 'OPENAI_CODEX_API_KEY',
+  })
+  const outcome = await runProviderWizard(deps)
+  check('16 codex shadowed: outcome added', outcome === 'added', outcome)
+  check('16 codex shadowed: credential write skipped', eq(calls.credentials, []))
+  check('16 codex shadowed: no oauth store', eq(calls.codexStores, []))
+  check('16 codex shadowed: env-shadow warning notified',
+    calls.notifications.some(n => n.text === t('provider-codex-env-shadowed')))
+  check('16 codex shadowed: no auto-refresh summary line',
+    calls.pushed[0]?.lines.every(line => line !== t('provider-line-codex-oauth-refresh')))
 }
 
 console.log(failed === 0 ? '\nAll provider-wizard checks passed' : `\n${failed} check(s) FAILED`)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -39,6 +39,7 @@ import { readEffortPref, writeEffortPref } from '../effortPrefs.js'
 import { readModelPref, writeModelPref } from '../modelPrefs.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ProviderSetupHost } from './providerWizard.js'
+import * as codexOAuth from './codexOAuth.js'
 import { readPresetPref, writePresetPref } from '../presetPrefs.js'
 import { composePreset, resolvePersistedPreset, rosterOf, runningPresetOf, serviceForAgent, type AgentPresetInfo } from './presets.js'
 import { isPresetName } from '../components/activityFrames.js'
@@ -3294,6 +3295,12 @@ export function createChannel(
             if (code !== 'SETTINGS_CONFLICT') throw error
             await settings.mutate('llm-pi-ai', ops, revision())
           }
+        },
+        loginCodexOAuth(onCode, signal) {
+          return codexOAuth.loginCodexDevice(onCode, signal)
+        },
+        writeCodexOAuthStore(route, ref, credential) {
+          return codexOAuth.writeCodexOAuthStore({ route, ref, credential })
         },
       }
     },

--- a/src/dsh-adapter/codexOAuth.ts
+++ b/src/dsh-adapter/codexOAuth.ts
@@ -1,0 +1,431 @@
+/**
+ * OpenAI Codex (ChatGPT Plus/Pro subscription) OAuth credential management
+ * for the `/provider` wizard and its background refresher.
+ *
+ * Codex authenticates through OpenAI's ChatGPT OAuth (the same client pi
+ * uses: `app_EMoamEEZ73f0CkXaXp7hrann`). The access token is a JWT that
+ * `dsh-llm-pi-ai` sends as the bearer; pi-ai's `openai-codex-responses`
+ * implementation extracts `chatgpt_account_id` from that JWT at request
+ * time, so the harness credential store only needs the access string.
+ * Refresh token + expiry live in `~/.dsh-tui/codex-oauth.json` (0600).
+ *
+ * Device login is OpenAI's custom device-auth (not RFC 8628): a user-code
+ * request, a poll that yields an authorization code + PKCE verifier, then
+ * a standard authorization-code exchange. Subscription auth is device-code
+ * only — this module does not read `~/.pi` auth or model files.
+ *
+ * The module is React-free so `scripts/verify-codex-oauth.mjs` can drive
+ * it headless and the refresher can run without UI state.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DATA_DIR } from '../utils/paths.js'
+
+/** The OAuth client pi's SDK uses for Codex; tokens are interchangeable with pi's. */
+export const CODEX_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann'
+
+const AUTH_BASE_URL = 'https://auth.openai.com'
+const TOKEN_URL = `${AUTH_BASE_URL}/oauth/token`
+const DEVICE_USER_CODE_URL = `${AUTH_BASE_URL}/api/accounts/deviceauth/usercode`
+const DEVICE_TOKEN_URL = `${AUTH_BASE_URL}/api/accounts/deviceauth/token`
+const DEVICE_VERIFICATION_URI = `${AUTH_BASE_URL}/codex/device`
+const DEVICE_REDIRECT_URI = `${AUTH_BASE_URL}/deviceauth/callback`
+
+/** Device-code lifetime; OpenAI does not return `expires_in` on the user-code reply. */
+const DEVICE_CODE_TIMEOUT_SECONDS = 15 * 60
+
+/** JWT claim object that carries the ChatGPT account id. */
+const JWT_CLAIM_PATH = 'https://api.openai.com/auth'
+
+/** Refresh before the reported expiry so a token never dies mid-request. */
+export const CODEX_REFRESH_SKEW_MS = 5 * 60 * 1000
+
+/** Poll interval fallback when the device response omits `interval`. */
+const DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+/** The TUI's own refresh record (see the module header). */
+export const CODEX_OAUTH_STORE_PATH = join(DATA_DIR, 'codex-oauth.json')
+
+/** One Codex OAuth credential: the bearer plus what it takes to rotate it. */
+export interface CodexOAuthCredential {
+  /** Access token, sent as the bearer for chatgpt.com/backend-api. */
+  access: string
+  /** Refresh token; OpenAI may rotate it on refresh. */
+  refresh: string
+  /** Epoch ms at which the access token counts as expired (skew included when minted here). */
+  expires: number
+  /** ChatGPT account id; also embedded in the access JWT. */
+  accountId?: string
+}
+
+/** What the refresher needs to keep a route's credential alive. */
+export interface CodexOAuthStore {
+  /** Provider route the credential belongs to (the `llm-pi-ai` profile). */
+  route: string
+  /** Credential-ref the access token is written under (`apiKeyEnv`). */
+  ref: string
+  credential: CodexOAuthCredential
+}
+
+/** Device-code info the wizard surfaces to the user. */
+export interface CodexDeviceCodeInfo {
+  /** https URL the user opens. */
+  verificationUri: string
+  /** The human-typed authorization code. */
+  userCode: string
+}
+
+/** OAuth failure kinds the wizard can translate to user-facing text. */
+export type CodexOAuthErrorCode = 'cancelled' | 'denied' | 'expired' | 'failed'
+
+/** A failed Codex OAuth exchange, carrying the wizard-mappable kind. */
+export class CodexOAuthError extends Error {
+  constructor(
+    readonly code: CodexOAuthErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'CodexOAuthError'
+  }
+}
+
+/** Decode a JWT payload, when parseable. */
+function decodeJwt(access: string): Record<string, unknown> | undefined {
+  try {
+    const payload = access.split('.')[1]
+    if (payload === undefined) return undefined
+    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+    return decoded !== null && typeof decoded === 'object' && !Array.isArray(decoded)
+      ? decoded as Record<string, unknown>
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * ChatGPT account id from a stored field or the access JWT. Requests fail
+ * without it (`chatgpt-account-id`), so a credential that cannot name one
+ * is unusable.
+ */
+export function extractCodexAccountId(access: string, stored?: string): string | undefined {
+  if (typeof stored === 'string' && stored.length > 0) return stored
+  const auth = decodeJwt(access)?.[JWT_CLAIM_PATH]
+  if (auth === null || typeof auth !== 'object' || Array.isArray(auth)) return undefined
+  const accountId = (auth as Record<string, unknown>).chatgpt_account_id
+  return typeof accountId === 'string' && accountId.length > 0 ? accountId : undefined
+}
+
+/**
+ * The persisted refresh record, when present and well-formed.
+ * @param path - The store file (injectable for tests).
+ * @returns The store, or undefined when absent or corrupt.
+ */
+export function readCodexOAuthStore(path: string = CODEX_OAUTH_STORE_PATH): CodexOAuthStore | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return undefined
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+  const record = parsed as Record<string, unknown>
+  if (typeof record.route !== 'string' || record.route === '') return undefined
+  if (typeof record.ref !== 'string' || record.ref === '') return undefined
+  const credential = record.credential
+  if (credential === null || typeof credential !== 'object' || Array.isArray(credential)) {
+    return undefined
+  }
+  const parts = credential as Record<string, unknown>
+  if (typeof parts.access !== 'string' || parts.access === '') return undefined
+  if (typeof parts.refresh !== 'string' || parts.refresh === '') return undefined
+  if (typeof parts.expires !== 'number' || !Number.isFinite(parts.expires as number)) {
+    return undefined
+  }
+  const accountId = typeof parts.accountId === 'string' && parts.accountId !== ''
+    ? parts.accountId
+    : undefined
+  return {
+    route: record.route,
+    ref: record.ref,
+    credential: {
+      access: parts.access,
+      refresh: parts.refresh,
+      expires: parts.expires as number,
+      ...(accountId === undefined ? {} : { accountId }),
+    },
+  }
+}
+
+/**
+ * Persist the refresh record under `~/.dsh-tui/codex-oauth.json` with mode
+ * 0600 (it holds a long-lived refresh secret). Best effort: the wizard warns
+ * when this fails, because the alternative — no refresh record — means the
+ * route dies with its access token.
+ * @param store - The record to persist.
+ * @param path - The store file (injectable for tests).
+ * @returns True when written.
+ */
+export function writeCodexOAuthStore(
+  store: CodexOAuthStore,
+  path: string = CODEX_OAUTH_STORE_PATH,
+): boolean {
+  try {
+    mkdirSync(join(path, '..'), { recursive: true })
+    writeFileSync(path, JSON.stringify(store, null, 2), { mode: 0o600 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function postForm(
+  url: string,
+  fields: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<{ ok: boolean; status: number; body: Record<string, unknown> }> {
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(fields),
+      signal,
+    })
+  } catch (error) {
+    if (signal?.aborted) throw new CodexOAuthError('cancelled', 'OpenAI Codex OAuth cancelled')
+    throw error
+  }
+  return readJsonResponse(response)
+}
+
+async function postJson(
+  url: string,
+  payload: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<{ ok: boolean; status: number; body: Record<string, unknown>; text: string }> {
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+      signal,
+    })
+  } catch (error) {
+    if (signal?.aborted) throw new CodexOAuthError('cancelled', 'OpenAI Codex OAuth cancelled')
+    throw error
+  }
+  const text = await response.text().catch(() => '')
+  let parsed: unknown
+  try {
+    parsed = text === '' ? {} : JSON.parse(text)
+  } catch {
+    parsed = {}
+  }
+  const body = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {}
+  return { ok: response.ok, status: response.status, body, text }
+}
+
+async function readJsonResponse(
+  response: Response,
+): Promise<{ ok: boolean; status: number; body: Record<string, unknown> }> {
+  let parsed: unknown
+  try {
+    parsed = await response.json()
+  } catch {
+    throw new CodexOAuthError(
+      'failed',
+      `OpenAI Codex OAuth returned invalid JSON (HTTP ${response.status})`,
+    )
+  }
+  const body = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {}
+  return { ok: response.ok, status: response.status, body }
+}
+
+function grantFailure(body: Record<string, unknown>, status: number): string {
+  const error = typeof body.error === 'string' ? body.error : undefined
+  const description = typeof body.error_description === 'string' ? body.error_description : undefined
+  const detail = [error, description].filter(Boolean).join(': ')
+  return `OpenAI Codex OAuth request failed (HTTP ${status})${detail === '' ? '' : `: ${detail}`}`
+}
+
+function requiredString(body: Record<string, unknown>, field: string): string {
+  const value = body[field]
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new CodexOAuthError('failed', `Invalid OpenAI Codex OAuth response field: ${field}`)
+  }
+  return value
+}
+
+function optionalPositiveNumber(body: Record<string, unknown>, field: string): number | undefined {
+  const value = body[field]
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+function deviceErrorCode(body: Record<string, unknown>): string | undefined {
+  const error = body.error
+  if (typeof error === 'string') return error
+  if (error !== null && typeof error === 'object' && !Array.isArray(error)) {
+    const code = (error as Record<string, unknown>).code
+    return typeof code === 'string' ? code : undefined
+  }
+  return undefined
+}
+
+/**
+ * Build a credential from a token response. OpenAI always returns a refresh
+ * token on this client (offline_access). The account id must be present in
+ * the access JWT or the token cannot drive Codex requests.
+ */
+function credentialFromTokenResponse(body: Record<string, unknown>): CodexOAuthCredential {
+  const access = requiredString(body, 'access_token')
+  const refresh = requiredString(body, 'refresh_token')
+  const lifetimeSeconds = optionalPositiveNumber(body, 'expires_in')
+  if (lifetimeSeconds === undefined) {
+    throw new CodexOAuthError('failed', 'Invalid OpenAI Codex OAuth response field: expires_in')
+  }
+  const accountId = extractCodexAccountId(access)
+  if (accountId === undefined) {
+    throw new CodexOAuthError('failed', 'Failed to extract accountId from token')
+  }
+  return {
+    access,
+    refresh,
+    expires: Date.now() + lifetimeSeconds * 1000 - CODEX_REFRESH_SKEW_MS,
+    accountId,
+  }
+}
+
+/**
+ * Refresh a Codex credential with its refresh token. A credential still
+ * outside the refresh skew is returned unchanged.
+ * @param credential - The stored credential.
+ * @param signal - Aborts the request; aborted calls throw `cancelled`.
+ * @returns A credential whose access token is fresh enough to send.
+ */
+export async function refreshCodexCredential(
+  credential: CodexOAuthCredential,
+  signal?: AbortSignal,
+): Promise<CodexOAuthCredential> {
+  if (credential.expires - Date.now() > CODEX_REFRESH_SKEW_MS) return credential
+  const { ok, status, body } = await postForm(TOKEN_URL, {
+    grant_type: 'refresh_token',
+    client_id: CODEX_CLIENT_ID,
+    refresh_token: credential.refresh,
+  }, signal)
+  if (!ok) throw new CodexOAuthError('failed', grantFailure(body, status))
+  return credentialFromTokenResponse(body)
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new CodexOAuthError('cancelled', 'OpenAI Codex OAuth cancelled'))
+      return
+    }
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new CodexOAuthError('cancelled', 'OpenAI Codex OAuth cancelled'))
+    }, { once: true })
+  })
+}
+
+/**
+ * Run the Codex device-authorization flow: request a user code, surface it
+ * through `onCode`, poll until OpenAI yields an authorization code, then
+ * exchange it for tokens.
+ * @param onCode - Called once the user code is obtained.
+ * @param signal - Aborts the polls; aborted calls throw `cancelled`.
+ * @returns The fresh credential.
+ */
+export async function loginCodexDevice(
+  onCode: (info: CodexDeviceCodeInfo) => void,
+  signal?: AbortSignal,
+): Promise<CodexOAuthCredential> {
+  const start = await postJson(DEVICE_USER_CODE_URL, { client_id: CODEX_CLIENT_ID }, signal)
+  if (!start.ok) {
+    if (start.status === 404) {
+      throw new CodexOAuthError(
+        'failed',
+        'OpenAI Codex device code login is not enabled for this server. Use browser login or verify the server URL.',
+      )
+    }
+    throw new CodexOAuthError(
+      'failed',
+      `OpenAI Codex device code request failed with status ${start.status}${
+        start.text === '' ? '' : `: ${start.text}`
+      }`,
+    )
+  }
+  const deviceAuthId = requiredString(start.body, 'device_auth_id')
+  const userCode = requiredString(start.body, 'user_code')
+  const intervalRaw = start.body.interval
+  const intervalSeconds = typeof intervalRaw === 'string'
+    ? Number(intervalRaw.trim())
+    : optionalPositiveNumber(start.body, 'interval') ?? DEFAULT_POLL_INTERVAL_SECONDS
+  if (!Number.isFinite(intervalSeconds) || intervalSeconds < 0) {
+    throw new CodexOAuthError('failed', `Invalid OpenAI Codex device code response: ${JSON.stringify(start.body)}`)
+  }
+  onCode({ verificationUri: DEVICE_VERIFICATION_URI, userCode })
+
+  const deadline = Date.now() + DEVICE_CODE_TIMEOUT_SECONDS * 1000
+  let intervalMs = Math.max(1000, Math.floor(intervalSeconds * 1000))
+  let firstPoll = true
+  while (Date.now() < deadline) {
+    if (firstPoll) {
+      firstPoll = false
+    } else {
+      await sleep(intervalMs, signal)
+    }
+    const poll = await postJson(DEVICE_TOKEN_URL, {
+      device_auth_id: deviceAuthId,
+      user_code: userCode,
+    }, signal)
+    if (poll.ok) {
+      const authorizationCode = requiredString(poll.body, 'authorization_code')
+      const codeVerifier = requiredString(poll.body, 'code_verifier')
+      const { ok, status, body } = await postForm(TOKEN_URL, {
+        grant_type: 'authorization_code',
+        client_id: CODEX_CLIENT_ID,
+        code: authorizationCode,
+        code_verifier: codeVerifier,
+        redirect_uri: DEVICE_REDIRECT_URI,
+      }, signal)
+      if (!ok) throw new CodexOAuthError('failed', grantFailure(body, status))
+      return credentialFromTokenResponse(body)
+    }
+    if (poll.status === 403 || poll.status === 404) continue
+    const error = deviceErrorCode(poll.body)
+    if (error === 'deviceauth_authorization_pending' || error === 'authorization_pending') continue
+    if (error === 'slow_down') {
+      intervalMs += DEFAULT_POLL_INTERVAL_SECONDS * 1000
+      continue
+    }
+    if (error === 'access_denied' || error === 'authorization_denied') {
+      throw new CodexOAuthError('denied', 'OpenAI Codex device authorization was denied')
+    }
+    if (error === 'expired_token') {
+      throw new CodexOAuthError('expired', 'OpenAI Codex device code expired')
+    }
+    throw new CodexOAuthError(
+      'failed',
+      `OpenAI Codex device auth failed with status ${poll.status}${
+        poll.text === '' ? '' : `: ${poll.text}`
+      }`,
+    )
+  }
+  throw new CodexOAuthError('expired', 'OpenAI Codex device code expired')
+}

--- a/src/dsh-adapter/codexRefresher.ts
+++ b/src/dsh-adapter/codexRefresher.ts
@@ -1,0 +1,96 @@
+/**
+ * Background auto-refresh for the OpenAI Codex (ChatGPT Plus/Pro) route
+ * added by the `/provider` wizard. The subscription's access token dies
+ * in about ten days; the refresher keeps the harness credential store's
+ * value fresh so every request resolves a live token (the llm-pi-ai
+ * adapter reads `apiKeyEnv` per request, so a refresh lands on the next
+ * request with no restart).
+ *
+ * Refreshes only while the whole chain is still alive: the record exists,
+ * the route profile still exists in `llm-pi-ai` settings, the credential
+ * store still holds the ref (a `/logout` or plain setting removal stops the
+ * loop rather than resurrecting the route), and the ref is not shadowed by
+ * the process environment (an env value is not writable here). Failures are
+ * logged and retried on the next tick; nothing here reaches the UI.
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import {
+  readCodexOAuthStore,
+  refreshCodexCredential,
+  writeCodexOAuthStore,
+  type CodexOAuthStore,
+} from './codexOAuth.js'
+
+/** How often the refresher evaluates the stored credential. */
+const REFRESH_TICK_MS = 60 * 1000
+
+/** Credential-ref resolution: the `dsh-credentials` seam's shape. */
+interface CredentialSeam {
+  resolve(ref: string): Promise<{ value?: unknown } | undefined>
+  set(ref: string, value: string): Promise<void>
+}
+
+/** Settings-section read: the `dsh-settings` seam's shape. */
+interface SettingsSeam {
+  get(ns: string): unknown
+}
+
+/**
+ * One refresh evaluation: read the store, decide whether a refresh is due,
+ * and rotate the token into both the credential store and the refresh
+ * record. Exported so the headless verify script can drive it with a fake
+ * `ctx`; the ticker below is just this on an interval.
+ * @param ctx - The plugin context; seams are resolved lazily so mount order
+ *   never matters.
+ * @param store - The refresh record to evaluate (defaults to the file).
+ * @param storePath - Where to persist the rotated record (injectable for
+ *   tests; defaults to the file the store was read from).
+ */
+export async function refreshCodexSubscriptionOnce(
+  ctx: Context,
+  store: CodexOAuthStore | undefined = readCodexOAuthStore(),
+  storePath?: string,
+): Promise<void> {
+  if (store === undefined) return
+  if (process.env[store.ref] !== undefined) return
+  if (store.credential.expires - Date.now() > 0) return
+  const credentials = ctx.get('credentials') as CredentialSeam | undefined
+  if (credentials === undefined) return
+  const settings = ctx.get('settings') as SettingsSeam | undefined
+  if (settings !== undefined) {
+    const section = settings.get('llm-pi-ai') as
+      | { providers?: Record<string, unknown> }
+      | undefined
+    if (section?.providers === undefined || !(store.route in section.providers)) return
+  }
+  const resolved = await credentials.resolve(store.ref)
+  if (resolved === undefined || resolved.value === undefined) return
+  try {
+    const fresh = await refreshCodexCredential(store.credential)
+    await credentials.set(store.ref, fresh.access)
+    writeCodexOAuthStore({ ...store, credential: fresh }, storePath)
+    ctx.logger.info(
+      `dsh-tui: Codex subscription token for "${store.route}" refreshed (valid until ${new Date(fresh.expires).toISOString()})`,
+    )
+  } catch (error) {
+    ctx.logger.warn(
+      `dsh-tui: Codex subscription token refresh for "${store.route}" failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+}
+
+/**
+ * Start the Codex subscription refresher. Registered through `ctx.effect` by
+ * the plugin; the returned disposer stops the ticker.
+ * @param ctx - The plugin context.
+ * @returns The disposer.
+ */
+export function startCodexSubscriptionRefresh(ctx: Context): () => void {
+  const timer = setInterval(() => void refreshCodexSubscriptionOnce(ctx), REFRESH_TICK_MS)
+  timer.unref?.()
+  void refreshCodexSubscriptionOnce(ctx)
+  return () => clearInterval(timer)
+}

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -17,6 +17,7 @@ import { registerPackagedSkills } from './packaged-skills.js'
 import { registerPromptDebug } from './promptDebug.js'
 import { readActivityFrames } from '../activityPrefs.js'
 import { readModelPref } from '../modelPrefs.js'
+import { startCodexSubscriptionRefresh } from './codexRefresher.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ModelRoute } from '../modelRoute.js'
 import { readPresetPref } from '../presetPrefs.js'
@@ -646,6 +647,10 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     })
     ctx.effect(() => unregister)
   }
+  // Codex (ChatGPT Plus/Pro) subscription tokens last about ten days; the
+  // `/provider` wizard's oauth store tells this ticker to keep the route's
+  // credential fresh while it stays configured.
+  ctx.effect(() => startCodexSubscriptionRefresh(ctx))
   // DSH approval seam: the permission layer asks ApprovalService.request(),
   // which dispatches an `approval/request` waterfall. With no answerer the
   // chain falls through to the fail-closed 'unavailable', so register this

--- a/src/dsh-adapter/providerWizard.ts
+++ b/src/dsh-adapter/providerWizard.ts
@@ -24,6 +24,11 @@ import {
   type AskUserQuestionRequest,
 } from '@deepseek-ai/dsh-user-questions'
 import type { LlmDiscoveredModel } from '@deepseek-ai/dsh-llm'
+import {
+  CodexOAuthError,
+  type CodexDeviceCodeInfo,
+  type CodexOAuthCredential,
+} from './codexOAuth.js'
 
 /** Route id rule shared with the dsh configuration surface (web Models page). */
 export const PROVIDER_ROUTE_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
@@ -84,6 +89,18 @@ export interface ProviderSetupHost {
    * rejects when the adapter's validation deems it unserviceable.
    */
   writeProfile(route: string, profile: Record<string, unknown>): Promise<void>
+  /**
+   * Run the Codex device-authorization flow; the info callback fires once
+   * the user code is issued, so the caller can show the URI/code and wait.
+   */
+  loginCodexOAuth(
+    onCode: (info: CodexDeviceCodeInfo) => void,
+    signal?: AbortSignal,
+  ): Promise<CodexOAuthCredential>
+  /**
+   * Persist the Codex refresh record (~/.dsh-tui/codex-oauth.json, 0600).
+   */
+  writeCodexOAuthStore(route: string, ref: string, credential: CodexOAuthCredential): boolean
 }
 
 export interface ProviderWizardDeps {
@@ -172,7 +189,7 @@ export async function runProviderWizard(
     // ── 2. route ───────────────────────────────────────────────────────
     let route = ''
     if (isCatalog) {
-      const candidates = host.listCatalogProviders()
+      const candidates = catalogChoices(host)
       if (candidates.length > 0) {
         const otherLabel = t('provider-opt-other-route')
         const catalogAnswer = await ask({
@@ -195,16 +212,40 @@ export async function runProviderWizard(
       if (route === '') return 'cancelled'
     }
 
-    // ── 3. API key (own batch so redact covers exactly the secret) ─────
-    const keyAnswer = await ask({
-      questions: [textQuestion('apikey', t('provider-q-apikey'), t('provider-q-apikey-detail'))],
-    }, { redact: true })
-    const apiKey = answerText(keyAnswer, 'apikey')
+    // ── 3. authentication ──────────────────────────────────────────────
+    // openai-codex is OAuth-only (ChatGPT Plus/Pro). Device-code web login
+    // is the sole auth path; there is no console API key and no import of
+    // a local pi login. Every other route keeps the single API-key ask.
+    let apiKey = ''
+    let oauthCredential: CodexOAuthCredential | undefined
+    if (route === 'openai-codex') {
+      const result = await runCodexDeviceLogin({
+        login: (onCode, signal) => host.loginCodexOAuth(onCode, signal),
+        ask,
+      })
+      if (result.kind === 'cancelled') return 'cancelled'
+      if (result.kind === 'failed') {
+        notify(result.text, { color: 'error', timeoutMs: 8000 })
+        return 'failed'
+      }
+      oauthCredential = result.credential
+      apiKey = oauthCredential.access
+    }
+    if (apiKey === '') {
+      const keyAnswer = await ask({
+        questions: [textQuestion('apikey', t('provider-q-apikey'), t('provider-q-apikey-detail'))],
+      }, { redact: true })
+      apiKey = answerText(keyAnswer, 'apikey')
+    }
 
     // ── 4. endpoint / protocol ─────────────────────────────────────────
+    // Codex OAuth already authenticated; skip the API-key baseURL question
+    // and serve the bundled catalog (omit `api` so llm-pi-ai reuses it).
     let baseURL: string | undefined
     let api: string | undefined
-    if (isCatalog) {
+    if (oauthCredential !== undefined) {
+      // bundled catalog; no discovery, no model narrowing
+    } else if (isCatalog) {
       const choiceAnswer = await ask({
         questions: [optionQuestion('baseurl-choice', t('provider-q-baseurl-choice'), [
           { label: t('provider-opt-baseurl-skip') },
@@ -232,52 +273,53 @@ export async function runProviderWizard(
       api = answerSelected(endpointAnswer, 'protocol')[0]
     }
 
-    // ── 5. model discovery (draft credential, nothing persisted) ───────
-    notify(t('provider-discovery-running'))
-    const discovered = await host.discoverModels({
-      ...(isCatalog ? { provider: route } : {}),
-      ...(baseURL !== undefined && baseURL !== '' ? { baseURL } : {}),
-      ...(api !== undefined ? { api } : {}),
-      apiKey,
-    }).catch(() => [])
-
-    // ── 6. model selection ─────────────────────────────────────────────
+    // ── 5–6. model discovery / selection ───────────────────────────────
     let models: string[] = []
     let discoveredById = new Map<string, LlmDiscoveredModel>()
-    if (discovered.length > 0) {
-      discoveredById = new Map(discovered.map(model => [model.id, model] as const))
-      const modelsAnswer = await ask({
-        questions: [optionQuestion('models', t('provider-q-models'),
-          discovered.map(model => ({
-            label: model.id,
-            description: [
-              model.name ?? '',
-              model.contextWindow !== undefined ? `${model.contextWindow}` : '',
-            ].filter(part => part !== '').join(' · ') || undefined,
-          })),
-          { multiSelect: true },
-        )],
-      })
-      models = mergeModelIds(
-        answerSelected(modelsAnswer, 'models'),
-        answerText(modelsAnswer, 'models'),
-      )
-    } else {
-      notify(t('provider-discovery-failed'), { color: 'warning' })
-      for (let attempt = 0; attempt < MAX_RETRY && models.length === 0; attempt += 1) {
-        const fallbackAnswer = await ask({
-          questions: [textQuestion('models-fallback', t('provider-q-models-fallback'))],
+    if (oauthCredential === undefined) {
+      notify(t('provider-discovery-running'))
+      const discovered = await host.discoverModels({
+        ...(isCatalog ? { provider: route } : {}),
+        ...(baseURL !== undefined && baseURL !== '' ? { baseURL } : {}),
+        ...(api !== undefined ? { api } : {}),
+        apiKey,
+      }).catch(() => [])
+
+      if (discovered.length > 0) {
+        discoveredById = new Map(discovered.map(model => [model.id, model] as const))
+        const modelsAnswer = await ask({
+          questions: [optionQuestion('models', t('provider-q-models'),
+            discovered.map(model => ({
+              label: model.id,
+              description: [
+                model.name ?? '',
+                model.contextWindow !== undefined ? `${model.contextWindow}` : '',
+              ].filter(part => part !== '').join(' · ') || undefined,
+            })),
+            { multiSelect: true },
+          )],
         })
-        models = mergeModelIds([], answerText(fallbackAnswer, 'models-fallback'))
-        if (models.length === 0) notify(t('provider-models-required'), { color: 'warning' })
+        models = mergeModelIds(
+          answerSelected(modelsAnswer, 'models'),
+          answerText(modelsAnswer, 'models'),
+        )
+      } else {
+        notify(t('provider-discovery-failed'), { color: 'warning' })
+        for (let attempt = 0; attempt < MAX_RETRY && models.length === 0; attempt += 1) {
+          const fallbackAnswer = await ask({
+            questions: [textQuestion('models-fallback', t('provider-q-models-fallback'))],
+          })
+          models = mergeModelIds([], answerText(fallbackAnswer, 'models-fallback'))
+          if (models.length === 0) notify(t('provider-models-required'), { color: 'warning' })
+        }
+        if (models.length === 0) return 'cancelled'
       }
-      if (models.length === 0) return 'cancelled'
-    }
-    if (!isCatalog && models.length === 0) {
-      // A manual route without models fails the adapter validation; the
-      // loops above should prevent this, but guard before writing.
-      notify(t('provider-models-required'), { color: 'error' })
-      return 'cancelled'
+      if (!isCatalog && models.length === 0) {
+        // A manual route without models fails the adapter validation; the
+        // loops above should prevent this, but guard before writing.
+        notify(t('provider-models-required'), { color: 'error' })
+        return 'cancelled'
+      }
     }
 
     // ── 7. confirm ─────────────────────────────────────────────────────
@@ -285,6 +327,7 @@ export async function runProviderWizard(
     const shadowed = host.envShadows(ref)
     const summaryLines = buildSummaryLines({
       route, ref, shadowed, baseURL, api, models, isCatalog,
+      oauthRefresh: oauthCredential !== undefined && !shadowed,
     })
     const detail = host.routeExists(route)
       ? `${summaryLines.join('\n')}\n${t('provider-route-exists-warning')}`
@@ -311,7 +354,10 @@ export async function runProviderWizard(
       await host.writeCredential(ref, apiKey)
       wroteCredential = true
     }
-    const profile = buildProfile({ isCatalog, ref, baseURL, api, models, discoveredById })
+    const profile = buildProfile({
+      isCatalog: isCatalog || oauthCredential !== undefined,
+      ref, baseURL, api, models, discoveredById,
+    })
     try {
       await host.writeProfile(route, profile)
     } catch (error) {
@@ -330,6 +376,17 @@ export async function runProviderWizard(
       const err = error instanceof Error ? error.message : String(error)
       notify(t('provider-write-failed', { err }), { color: 'error', timeoutMs: 8000 })
       return 'failed'
+    }
+    // The refresh record lands only after the profile: a failed profile write
+    // rolls the credential back with no dangling record claiming otherwise.
+    // An env-shadowed ref cannot be refreshed from here and is warned instead.
+    if (oauthCredential !== undefined) {
+      if (shadowed) {
+        notify(t('provider-codex-env-shadowed'), { color: 'warning' })
+      } else {
+        const stored = host.writeCodexOAuthStore(route, ref, oauthCredential)
+        if (!stored) notify(t('provider-write-oauth-store-failed'), { color: 'warning' })
+      }
     }
 
     // ── 9. success: transcript summary + optional live switch ──────────
@@ -363,6 +420,125 @@ export async function runProviderWizard(
     notify(t('provider-write-failed', { err }), { color: 'error', timeoutMs: 8000 })
     return 'failed'
   }
+}
+
+/** Copy used by the Codex device-code wait panel. */
+interface CodexDeviceLoginUi {
+  login: (
+    onCode: (info: CodexDeviceCodeInfo) => void,
+    signal?: AbortSignal,
+  ) => Promise<CodexOAuthCredential>
+  ask: ProviderWizardDeps['ask']
+}
+
+/**
+ * Run Codex device authorization: request a code, surface it in a question
+ * panel that parks while the poll runs, and wait for the user to authorize
+ * in their browser. Esc (UserQuestionError) or an aborted login cancels;
+ * the remaining OAuth failures map to user-facing text.
+ */
+async function runCodexDeviceLogin(deps: CodexDeviceLoginUi): Promise<
+  | { kind: 'credential'; credential: CodexOAuthCredential }
+  | { kind: 'cancelled' }
+  | { kind: 'failed'; text: string }
+> {
+  const controller = new AbortController()
+  try {
+    const credential = await withCodexDeviceCodeDisplay(deps, controller.signal)
+    return { kind: 'credential', credential }
+  } catch (error) {
+    controller.abort()
+    if (error instanceof UserQuestionError) return { kind: 'cancelled' }
+    if (error instanceof CodexOAuthError && error.code === 'cancelled') return { kind: 'cancelled' }
+    return {
+      kind: 'failed',
+      text: error instanceof CodexOAuthError && error.code === 'denied'
+        ? t('provider-codex-device-denied')
+        : error instanceof CodexOAuthError && error.code === 'expired'
+          ? t('provider-codex-device-expired')
+          : t('provider-codex-device-failed', {
+            err: error instanceof Error ? error.message : String(error),
+          }),
+    }
+  }
+}
+
+/**
+ * Present the device code and await the browser authorization. The login
+ * promise runs concurrently with the panel; a failure before a code was ever
+ * issued surfaces through the race instead of hanging the display step.
+ */
+async function withCodexDeviceCodeDisplay(
+  deps: CodexDeviceLoginUi,
+  signal: AbortSignal,
+): Promise<CodexOAuthCredential> {
+  let resolveCode!: (info: CodexDeviceCodeInfo) => void
+  const codeReady = new Promise<CodexDeviceCodeInfo>(resolve => {
+    resolveCode = resolve
+  })
+  const login = deps.login(resolveCode, signal)
+  // login resolves only after onCode fires (the device flow issues the
+  // code before it starts polling), so the race winner is always the code
+  // info; an early login rejection is what rejects the race instead.
+  const info = await Promise.race([codeReady, login]) as CodexDeviceCodeInfo
+  // A text-only question rejects empty Enter ("Type your answer before
+  // submitting"), so this step is a Continue option. The grant also
+  // auto-dismisses the panel once polling succeeds — the user should not
+  // have to confirm after the browser already authorized.
+  const panelAbort = new AbortController()
+  const onOuterAbort = (): void => panelAbort.abort()
+  signal.addEventListener('abort', onOuterAbort, { once: true })
+  const panel = deps.ask({
+    questions: [optionQuestion('codex-device-wait', t('provider-codex-device-prompt', {
+      url: info.verificationUri,
+      code: info.userCode,
+    }), [
+      { label: t('provider-opt-codex-device-continue') },
+    ], { detail: t('provider-codex-device-detail'), hideCustomInput: true })],
+    signal: panelAbort.signal,
+  })
+  try {
+    const credential = await new Promise<CodexOAuthCredential>((resolve, reject) => {
+      let settled = false
+      const finish = (apply: () => void): void => {
+        if (settled) return
+        settled = true
+        apply()
+      }
+      login.then(
+        cred => finish(() => resolve(cred)),
+        err => finish(() => reject(err)),
+      )
+      panel.then(
+        () => {
+          login.then(
+            cred => finish(() => resolve(cred)),
+            err => finish(() => reject(err)),
+          )
+        },
+        err => {
+          if (panelAbort.signal.aborted) return
+          finish(() => reject(err))
+        },
+      )
+    })
+    return credential
+  } finally {
+    signal.removeEventListener('abort', onOuterAbort)
+    panelAbort.abort()
+    await panel.catch(() => {})
+  }
+}
+
+/**
+ * Catalog routes the wizard offers. `openai-codex` is withheld by
+ * dsh-llm-pi-ai (OAuth-only), but this TUI can authenticate it, so it is
+ * injected when the adapter does not already list it.
+ */
+function catalogChoices(host: ProviderSetupHost): CatalogProviderCandidate[] {
+  const listed = [...host.listCatalogProviders()]
+  if (listed.some(entry => entry.provider === 'openai-codex')) return listed
+  return [...listed, { provider: 'openai-codex', displayName: 'OpenAI Codex' }]
 }
 
 /** Prompt for a route id until it validates or the retry budget runs out. */
@@ -399,6 +575,7 @@ function buildSummaryLines(input: {
   api: string | undefined
   models: readonly string[]
   isCatalog: boolean
+  oauthRefresh: boolean
 }): string[] {
   const lines = [t('provider-line-route', { route: input.route })]
   lines.push(input.shadowed
@@ -411,6 +588,7 @@ function buildSummaryLines(input: {
   lines.push(input.models.length > 0
     ? t('provider-line-models', { models: input.models.join(', ') })
     : t('provider-line-models-catalog'))
+  if (input.oauthRefresh) lines.push(t('provider-line-codex-oauth-refresh'))
   return lines
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -651,6 +651,15 @@ const dict = {
   'provider-q-switch': { zh: '立即切换到新 provider？', en: 'Switch to the new provider now?' },
   'provider-opt-switch-now': { zh: '切换到 {{model}}', en: 'Switch to {{model}}' },
   'provider-opt-switch-keep': { zh: '保持当前模型', en: 'Keep the current model' },
+  'provider-codex-device-prompt': { zh: '在浏览器打开 {{url}}，输入代码 {{code}}。授权完成后会自动继续', en: 'Open {{url}} in a browser, enter code {{code}}. This continues automatically after authorization' },
+  'provider-codex-device-detail': { zh: '代码与链接仅本次有效；等待授权期间请勿关闭本终端。也可选「我已授权，继续」或按回车。', en: 'The code and link are single-use; keep this terminal open while waiting. You can also choose “I have authorized — continue” or press Enter.' },
+  'provider-opt-codex-device-continue': { zh: '我已授权，继续', en: 'I have authorized — continue' },
+  'provider-codex-device-denied': { zh: '授权被拒绝', en: 'Authorization denied' },
+  'provider-codex-device-expired': { zh: '设备代码已过期，请重试', en: 'Device code expired — try again' },
+  'provider-codex-device-failed': { zh: '授权失败 · {{err}}', en: 'Authorization failed · {{err}}' },
+  'provider-codex-env-shadowed': { zh: '环境中已有 OPENAI_CODEX_API_KEY，订阅 token 无法自动续期——请移除该环境变量', en: 'OPENAI_CODEX_API_KEY is set in the environment, so the subscription token cannot auto-refresh — unset it' },
+  'provider-write-oauth-store-failed': { zh: '订阅刷新信息写入失败，token 不会自动续期', en: 'Failed to store the subscription refresh info; the token will not auto-refresh' },
+  'provider-line-codex-oauth-refresh': { zh: '订阅 token 自动续期已启用（~/.dsh-tui/codex-oauth.json）', en: 'Subscription token auto-refresh enabled (~/.dsh-tui/codex-oauth.json)' },
 
   // ── commands.ts — slash-command descriptions ─────────────────────────
   // zh-only on purpose: the English text stays in `LOCAL_COMMANDS` (and in


### PR DESCRIPTION
Closes #398

## Motivation

`dsh-llm-pi-ai` withholds `openai-codex` (ChatGPT Plus/Pro, OAuth-only) from the configurable catalog. `/provider` can still add it because the TUI can complete device-code login and refresh the token.

## What changed

- Inject `openai-codex` into the `/provider` catalog list.
- Auth is OpenAI device-code only (`https://auth.openai.com/codex/device`): show URL + user code, poll, then authorization-code + PKCE exchange. No console API key path.
- Persist the access token as `OPENAI_CODEX_API_KEY` and the refresh record in `~/.dsh-tui/codex-oauth.json` (0600). A background ticker rotates the token while the route stays configured.
- Omit `api` on the profile so the bundled catalog provider is reused (`chatgpt-account-id` comes from the JWT).
- Env-shadowed `OPENAI_CODEX_API_KEY` skips credential/store write and warns.

## What was stripped vs a local prototype

- No read of `~/.pi/agent/auth.json`.
- No read of `~/.pi/agent/models-store.json`.
- No xAI / SuperGrok work (separate PR).

## Verify

- `pnpm build`
- `node scripts/verify-provider-wizard.mjs`
- `node scripts/verify-codex-oauth.mjs`