### PR TITLE
feat(provider): xAI SuperGrok 订阅 OAuth（device code）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,8 +350,12 @@ jobs:
 
       # /provider 向导回归：catalog/custom 两分支的 profile 形状、凭据回滚
       # （覆盖时恢复旧 key 而非误删）、env shadow 跳过、rc.6 兼容守卫、
-      # hideCustomInput 逐题标记。
+      # hideCustomInput 逐题标记、xAI SuperGrok 订阅 device-code 登录。
       - run: node scripts/verify-provider-wizard.mjs
+
+      # xAI Grok/X 订阅 OAuth 回归：store 存取与 0600、token 刷新、
+      # RFC 8628 device 流程、后台续期器启用条件。
+      - run: node scripts/verify-xai-oauth.mjs
 
       # /login 凭据状态回归（issue #213）：只通过 credentials.describe()
       # 展示 configured/source/writable，managed key 不得误报或泄露值。

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -193,6 +193,20 @@ restart:
   The wizard probes the endpoint with the draft credential and offers the
   advertised models for selection (manual id entry as fallback).
 
+**xAI SuperGrok (the `xai` route)**: `/provider` can authenticate with
+device-code OAuth (SuperGrok / X Premium) or a console API key. Device
+login is RFC 8628 against `https://auth.x.ai`: open the link and enter the
+code shown in the panel. There is no import of a local pi login.
+
+The subscription access token dies about hourly. dsh-tui stores it as the
+`XAI_API_KEY` credential and records the refresh token plus expiry in
+`~/.dsh-tui/xai-oauth.json` (mode 0600); a background refresher checks every
+minute and rotates five minutes before expiry. After device login the wizard
+probes `https://api.x.ai/v1` and, when the listing is non-empty, writes
+`api: openai-responses` so extra ids stay serviceable. When `XAI_API_KEY` is
+in the process environment (env shadow), auto-refresh cannot apply and the
+wizard warns.
+
 What gets written (on a profile start, where dsh-base provides the
 settings/credentials services):
 
@@ -200,6 +214,7 @@ settings/credentials services):
 | --- | --- |
 | Provider profile | `llm-pi-ai.providers.<route>` in `~/.dsh/settings.yaml`; the route registers on write |
 | API key | `~/.dsh/.credentials.yaml` (mode 0600), referenced as `<ROUTE>_API_KEY` |
+| xAI subscription refresh record | `~/.dsh-tui/xai-oauth.json` (mode 0600), read by the background refresher |
 
 Key answers render as `••••••` in the transcript; when the process environment
 already provides the same-named variable, the write is skipped and the value

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,12 +176,23 @@ Profile 模式不再使用旧的 `DSH_TUI_COMPACT_RATIO`、
   （`openai-completions` / `openai-responses` / `anthropic-messages`），
   向导会用草稿凭据探测端点公布的模型供勾选（探测失败则手输模型 id）。
 
+**xAI SuperGrok（`xai` 路由）**：`/provider` 可用 SuperGrok / X Premium 的
+device-code OAuth，或 console API key。Device 登录走 RFC 8628
+（`https://auth.x.ai`）：在面板中打开链接、输入代码。不会读取本机 pi 的登录。
+
+订阅 access token 约一小时过期，dsh-tui 会把它写成 `XAI_API_KEY` 凭据，并把
+refresh token 与过期时间记到 `~/.dsh-tui/xai-oauth.json`（0600）；后台续期器
+每 60 秒检查，到期前 5 分钟刷新。device 登录后向导会探测 `https://api.x.ai/v1`，
+若列出模型则写入 `api: openai-responses` 以便额外 id 可用。若进程环境已有
+`XAI_API_KEY`（env shadow），自动续期无法生效，向导会给出警告。
+
 写入产物（profile 启动时，dsh-base 提供 settings/credentials 服务）：
 
 | 产物 | 位置 |
 | --- | --- |
 | provider profile | `~/.dsh/settings.yaml` 的 `llm-pi-ai.providers.<路由名>`，写入即注册路由 |
 | API key | `~/.dsh/.credentials.yaml`（0600），引用名为 `<路由名大写>_API_KEY` |
+| xAI 订阅刷新记录 | `~/.dsh-tui/xai-oauth.json`（0600），供后台续期器读取 |
 
 密钥答案在会话记录中只显示 `••••••`；若进程环境已有同名变量，则跳过写入、
 运行时直接从环境解析。配置与 dsh web 端的 Models 设置页互通（同一 settings

--- a/scripts/verify-provider-wizard.mjs
+++ b/scripts/verify-provider-wizard.mjs
@@ -31,6 +31,7 @@ import {
   deriveKeyRef,
   runProviderWizard,
 } from '../lib/types/dsh-adapter/providerWizard.js'
+import { XaiOAuthError } from '../lib/types/dsh-adapter/xaiOAuth.js'
 import { t } from '../lib/types/i18n.js'
 
 let failed = 0
@@ -63,12 +64,14 @@ function makeDeps(script, options = {}) {
     hideFlags: {},
     /** question id → option descriptions, for catalog row-shape regressions. */
     optionDescriptions: {},
+    oauthStores: [],
   }
   const host = {
     listCatalogProviders: () => [
       { provider: 'deepseek', displayName: 'DeepSeek' },
       { provider: 'openai', displayName: 'OpenAI' },
       { provider: 'same-name', displayName: 'same-name' },
+      { provider: 'xai', displayName: 'xAI' },
     ],
     routeExists: () => false,
     discoverModels: async () => {
@@ -85,6 +88,28 @@ function makeDeps(script, options = {}) {
     writeProfile: async (route, profile) => {
       if (options.profileThrows) throw new Error('settings-rejected: unserviceable')
       calls.profiles.push([route, profile])
+    },
+    loginXaiOAuth: async onCode => {
+      if (options.xaiLoginThrows !== undefined) {
+        onCode(options.xaiDeviceCode ?? {
+          verificationUri: 'https://auth.x.ai/device',
+          userCode: 'ABCD-EFGH',
+        })
+        throw options.xaiLoginThrows
+      }
+      onCode(options.xaiDeviceCode ?? {
+        verificationUri: 'https://auth.x.ai/device',
+        userCode: 'ABCD-EFGH',
+      })
+      return options.xaiLoginCredential ?? {
+        access: 'xai-device-access', refresh: 'xai-device-refresh',
+        expires: Date.now() + 3_600_000,
+      }
+    },
+    writeXaiOAuthStore: (route, ref, credential) => {
+      if (options.xaiStoreThrows) return false
+      calls.oauthStores.push({ route, ref, credential })
+      return true
     },
   }
   const deps = {
@@ -407,6 +432,127 @@ const KEEP_MODEL = { selected: [t('provider-opt-switch-keep')] }
       'switch': true,
     }),
     JSON.stringify(custom.calls.hideFlags))
+}
+
+// 13. xai catalog + device login: live listing persisted, oauth store written.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['xai'] },
+    'xai-method': { selected: [t('provider-opt-xai-device')] },
+    'xai-device-wait': { selected: [t('provider-opt-xai-device-continue')] },
+    'confirm': CONFIRM_WRITE,
+    'switch': KEEP_MODEL,
+  }, {
+    discovered: [{ id: 'grok-4', name: 'Grok 4', contextWindow: 128000 }],
+    xaiLoginCredential: {
+      access: 'xai-device-access', refresh: 'xai-device-refresh',
+      expires: Date.now() + 3_600_000,
+    },
+  })
+  const outcome = await runProviderWizard(deps)
+  check('13 xai device: outcome added', outcome === 'added', outcome)
+  check('13 xai device: apikey ask skipped', !calls.asks.includes('apikey'))
+  check('13 xai device: API-key catalog tail skipped',
+    !calls.asks.includes('baseurl-choice') && !calls.asks.includes('models'))
+  check('13 xai device: token written under XAI_API_KEY',
+    eq(calls.credentials, [['XAI_API_KEY', 'xai-device-access']]),
+    JSON.stringify(calls.credentials))
+  check('13 xai device: oauth store written for the route',
+    calls.oauthStores.length === 1
+      && calls.oauthStores[0].route === 'xai'
+      && calls.oauthStores[0].ref === 'XAI_API_KEY'
+      && calls.oauthStores[0].credential.access === 'xai-device-access',
+    JSON.stringify(calls.oauthStores))
+  check('13 xai device: live listing persisted with openai-responses',
+    eq(calls.profiles, [['xai', {
+      apiKeyEnv: 'XAI_API_KEY',
+      api: 'openai-responses',
+      defaultInput: ['text', 'image'],
+      models: [{ id: 'grok-4', name: 'Grok 4', contextWindow: 128000 }],
+    }]]),
+    JSON.stringify(calls.profiles))
+  check('13 xai device: summary advertises auto-refresh',
+    calls.pushed.length === 1
+      && calls.pushed[0].lines.some(line => line.includes(t('provider-line-oauth-refresh'))))
+}
+
+// 14. xai device panel parks on xai-device-wait.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['xai'] },
+    'xai-method': { selected: [t('provider-opt-xai-device')] },
+    'xai-device-wait': { selected: [t('provider-opt-xai-device-continue')] },
+    'confirm': CONFIRM_WRITE,
+  })
+  const outcome = await runProviderWizard(deps)
+  check('14 xai device: outcome added', outcome === 'added', outcome)
+  check('14 xai device: panel showed the code and URI',
+    calls.asks.includes('xai-device-wait')
+      && calls.hideFlags['xai-device-wait'] === true)
+}
+
+// 15. xai device login denied.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['xai'] },
+    'xai-method': { selected: [t('provider-opt-xai-device')] },
+    'xai-device-wait': { selected: [t('provider-opt-xai-device-continue')] },
+  }, {
+    xaiLoginThrows: new XaiOAuthError('denied', 'xAI device authorization was denied'),
+  })
+  const outcome = await runProviderWizard(deps)
+  check('15 xai device denied: outcome failed', outcome === 'failed', outcome)
+  check('15 xai device denied: denial notified',
+    calls.notifications.some(n => n.color === 'error'
+      && n.text === t('provider-xai-device-denied')))
+  check('15 xai device denied: nothing written',
+    eq(calls.credentials, []) && eq(calls.profiles, []) && eq(calls.oauthStores, []))
+}
+
+// 16. xai subscription under an env-shadowed ref.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['xai'] },
+    'xai-method': { selected: [t('provider-opt-xai-device')] },
+    'xai-device-wait': { selected: [t('provider-opt-xai-device-continue')] },
+    'confirm': CONFIRM_WRITE,
+  }, {
+    shadow: 'XAI_API_KEY',
+  })
+  const outcome = await runProviderWizard(deps)
+  check('16 xai shadowed: outcome added', outcome === 'added', outcome)
+  check('16 xai shadowed: credential write skipped', eq(calls.credentials, []))
+  check('16 xai shadowed: no oauth store', eq(calls.oauthStores, []))
+  check('16 xai shadowed: env-shadow warning notified',
+    calls.notifications.some(n => n.text === t('provider-xai-env-shadowed')))
+  check('16 xai shadowed: no auto-refresh summary line',
+    calls.pushed[0]?.lines.every(line => line !== t('provider-line-oauth-refresh')))
+}
+
+// 17. xai catalog + plain API key: ordinary key write, no oauth store.
+{
+  const { deps, calls } = makeDeps({
+    'mode': MODE_CATALOG,
+    'catalog': { selected: ['xai'] },
+    'xai-method': { selected: [t('provider-opt-xai-apikey')] },
+    'apikey': { custom: 'xai-console-key' },
+    'baseurl-choice': SKIP_BASEURL,
+    'models': { selected: ['grok-3'] },
+    'confirm': CONFIRM_WRITE,
+    'switch': KEEP_MODEL,
+  }, {
+    discovered: [{ id: 'grok-3' }],
+  })
+  const outcome = await runProviderWizard(deps)
+  check('17 xai apikey: outcome added', outcome === 'added', outcome)
+  check('17 xai apikey: key written, no oauth store',
+    eq(calls.credentials, [['XAI_API_KEY', 'xai-console-key']])
+      && eq(calls.oauthStores, []),
+    JSON.stringify({ credentials: calls.credentials, oauthStores: calls.oauthStores }))
 }
 
 console.log(failed === 0 ? '\nAll provider-wizard checks passed' : `\n${failed} check(s) FAILED`)

--- a/scripts/verify-xai-oauth.mjs
+++ b/scripts/verify-xai-oauth.mjs
@@ -1,0 +1,250 @@
+/**
+ * Headless verification for the xAI (Grok/X subscription) OAuth plumbing
+ * (src/dsh-adapter/xaiOAuth.ts + xaiRefresher.ts).
+ *
+ * Scenarios (all against temp dirs — nothing under ~/.dsh-tui is ever
+ * touched; this module does not read ~/.pi):
+ *
+ *  1. store round trip: write → read identity, corrupt store → undefined,
+ *     created file mode is 0600.
+ *  2. refreshXaiCredential: fresh short-circuit (no network), stale refresh
+ *     mints a new access token, network failure throws XaiOAuthError.
+ *  3. loginXaiDevice: device code → polling → token; denied error.
+ *  4. refreshXaiSubscriptionOnce: expired store rotated; fresh / route
+ *     removed / env shadow / cleared credential stop the refresh.
+ *
+ * Run with plain node against the compiled lib (after `pnpm build`):
+ * `node scripts/verify-xai-oauth.mjs`
+ */
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  XaiOAuthError,
+  loginXaiDevice,
+  readXaiOAuthStore,
+  refreshXaiCredential,
+  writeXaiOAuthStore,
+} from '../lib/types/dsh-adapter/xaiOAuth.js'
+import { refreshXaiSubscriptionOnce } from '../lib/types/dsh-adapter/xaiRefresher.js'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b)
+
+const dir = mkdtempSync(join(tmpdir(), 'dsh-tui-xai-'))
+const storePath = join(dir, 'xai-oauth.json')
+
+{
+  const store = {
+    route: 'xai',
+    ref: 'XAI_API_KEY',
+    credential: { access: 'a1', refresh: 'r1', expires: 1234 },
+  }
+  check('1 store: write succeeds', writeXaiOAuthStore(store, storePath) === true)
+  check('1 store: round trip identity', eq(readXaiOAuthStore(storePath), store))
+  const mode = statSync(storePath).mode & 0o777
+  check('1 store: file mode 0600', mode === 0o600, mode.toString(8))
+  writeFileSync(storePath, '{not json')
+  check('1 store: corrupt file → undefined', readXaiOAuthStore(storePath) === undefined)
+}
+
+{
+  const originalFetch = globalThis.fetch
+  let fetchCalls = 0
+  globalThis.fetch = async () => {
+    fetchCalls += 1
+    return new Response(JSON.stringify({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+    }), { status: 200 })
+  }
+  try {
+    const fresh = { access: 'old', refresh: 'r', expires: Date.now() + 3_600_000 }
+    const untouched = await refreshXaiCredential(fresh)
+    check('2 refresh: fresh credential short-circuits (no network)',
+      untouched === fresh && fetchCalls === 0)
+
+    const stale = { access: 'old', refresh: 'r', expires: Date.now() - 1000 }
+    const rotated = await refreshXaiCredential(stale)
+    check('2 refresh: stale token rotated',
+      fetchCalls === 1
+        && rotated.access === 'new-access'
+        && rotated.refresh === 'new-refresh',
+      JSON.stringify(rotated))
+    check('2 refresh: expiry computed with skew',
+      rotated.expires > Date.now() && rotated.expires < Date.now() + 3_600_000)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({ error: 'invalid_grant' }), { status: 400 })
+  }
+  try {
+    await refreshXaiCredential({ access: 'old', refresh: 'r', expires: Date.now() - 1000 })
+    check('2 refresh: network failure throws', false)
+  } catch (error) {
+    check('2 refresh: network failure throws XaiOAuthError',
+      error instanceof XaiOAuthError && error.code === 'failed',
+      error instanceof Error ? error.message : String(error))
+  }
+  globalThis.fetch = originalFetch
+}
+
+{
+  const originalFetch = globalThis.fetch
+  const calls = []
+  globalThis.fetch = async (url, init) => {
+    const href = String(url)
+    calls.push(href)
+    if (href.includes('/device/code')) {
+      return new Response(JSON.stringify({
+        device_code: 'dc',
+        user_code: 'ABCD-EFGH',
+        verification_uri: 'https://auth.x.ai/device',
+        interval: 1,
+        expires_in: 600,
+      }), { status: 200 })
+    }
+    if (calls.length === 2) {
+      return new Response(JSON.stringify({ error: 'authorization_pending' }), { status: 400 })
+    }
+    return new Response(JSON.stringify({
+      access_token: 'device-access',
+      refresh_token: 'device-refresh',
+      expires_in: 3600,
+    }), { status: 200 })
+  }
+  try {
+    let codeInfo = null
+    const credential = await loginXaiDevice(info => {
+      codeInfo = info
+    })
+    check('3 device: onCode surfaced the URI and code',
+      eq(codeInfo, { verificationUri: 'https://auth.x.ai/device', userCode: 'ABCD-EFGH' }),
+      JSON.stringify(codeInfo))
+    check('3 device: device flow polled then minted a credential',
+      calls.length === 3
+        && credential.access === 'device-access'
+        && credential.refresh === 'device-refresh',
+      `${calls.length} calls, access=${credential.access}`)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('/device/code')) {
+      return new Response(JSON.stringify({
+        device_code: 'dc',
+        user_code: 'ABCD-EFGH',
+        verification_uri: 'https://auth.x.ai/device',
+        interval: 1,
+        expires_in: 600,
+      }), { status: 200 })
+    }
+    return new Response(JSON.stringify({ error: 'access_denied' }), { status: 400 })
+  }
+  try {
+    await loginXaiDevice(() => {})
+    check('3 device: denial rejected', false)
+  } catch (error) {
+    check('3 device: denial rejected as XaiOAuthError(denied)',
+      error instanceof XaiOAuthError && error.code === 'denied',
+      error instanceof Error ? error.message : String(error))
+  }
+  globalThis.fetch = originalFetch
+}
+
+{
+  const originalFetch = globalThis.fetch
+  const originalEnv = process.env.XAI_API_KEY
+  delete process.env.XAI_API_KEY
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    access_token: 'new-access',
+    expires_in: 3600,
+  }), { status: 200 })
+  const sets = []
+  const ctx = {
+    get(name) {
+      if (name === 'credentials') {
+        return {
+          resolve: async ref => ref === 'XAI_API_KEY' ? { value: 'old' } : undefined,
+          set: async (ref, value) => { sets.push([ref, value]) },
+        }
+      }
+      if (name === 'settings') {
+        return { get: ns => ns === 'llm-pi-ai' ? { providers: { xai: {} } } : undefined }
+      }
+      return undefined
+    },
+    logger: { info: () => {}, warn: () => {} },
+  }
+  try {
+    const expired = {
+      route: 'xai',
+      ref: 'XAI_API_KEY',
+      credential: { access: 'old', refresh: 'r', expires: Date.now() - 1000 },
+    }
+    await refreshXaiSubscriptionOnce(ctx, expired, storePath)
+    check('4 refresher: expired token rotated into the credential seam',
+      eq(sets, [['XAI_API_KEY', 'new-access']]), JSON.stringify(sets))
+    check('4 refresher: store file records the rotated token',
+      readXaiOAuthStore(storePath)?.credential.access === 'new-access')
+
+    const fetchCalls = []
+    globalThis.fetch = async () => { fetchCalls.push(1); return new Response('{}', { status: 200 }) }
+    sets.length = 0
+    const fresh = {
+      route: 'xai',
+      ref: 'XAI_API_KEY',
+      credential: { access: 'old', refresh: 'r', expires: Date.now() + 3_600_000 },
+    }
+    await refreshXaiSubscriptionOnce(ctx, fresh, storePath)
+    check('4 refresher: fresh token untouched', sets.length === 0 && fetchCalls.length === 0)
+
+    const noRouteCtx = {
+      ...ctx,
+      get(name) {
+        if (name === 'settings') return { get: () => ({ providers: {} }) }
+        return name === 'credentials' ? ctx.get('credentials') : undefined
+      },
+    }
+    await refreshXaiSubscriptionOnce(noRouteCtx, fresh, storePath)
+    check('4 refresher: route removed from settings stops the refresh',
+      sets.length === 0 && fetchCalls.length === 0)
+
+    process.env.XAI_API_KEY = 'shadow'
+    await refreshXaiSubscriptionOnce(ctx, fresh, storePath)
+    check('4 refresher: env shadow stops the refresh',
+      sets.length === 0 && fetchCalls.length === 0)
+    delete process.env.XAI_API_KEY
+
+    const clearedCtx = {
+      ...ctx,
+      get(name) {
+        if (name === 'credentials') return { resolve: async () => undefined, set: async () => {} }
+        return name === 'settings' ? ctx.get('settings') : undefined
+      },
+    }
+    await refreshXaiSubscriptionOnce(clearedCtx, {
+      route: 'xai',
+      ref: 'XAI_API_KEY',
+      credential: { access: 'old', refresh: 'r', expires: Date.now() - 1000 },
+    }, storePath)
+    check('4 refresher: cleared credential stops the refresh',
+      sets.length === 0 && fetchCalls.length === 0)
+  } finally {
+    globalThis.fetch = originalFetch
+    if (originalEnv === undefined) delete process.env.XAI_API_KEY
+    else process.env.XAI_API_KEY = originalEnv
+  }
+}
+
+rmSync(dir, { recursive: true, force: true })
+console.log(failed === 0 ? '\nAll xai-oauth checks passed' : `\n${failed} check(s) FAILED`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -39,6 +39,7 @@ import { readEffortPref, writeEffortPref } from '../effortPrefs.js'
 import { readModelPref, writeModelPref } from '../modelPrefs.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ProviderSetupHost } from './providerWizard.js'
+import * as xaiOAuth from './xaiOAuth.js'
 import { readPresetPref, writePresetPref } from '../presetPrefs.js'
 import { composePreset, resolvePersistedPreset, rosterOf, runningPresetOf, serviceForAgent, type AgentPresetInfo } from './presets.js'
 import { isPresetName } from '../components/activityFrames.js'
@@ -3294,6 +3295,12 @@ export function createChannel(
             if (code !== 'SETTINGS_CONFLICT') throw error
             await settings.mutate('llm-pi-ai', ops, revision())
           }
+        },
+        loginXaiOAuth(onCode, signal) {
+          return xaiOAuth.loginXaiDevice(onCode, signal)
+        },
+        writeXaiOAuthStore(route, ref, credential) {
+          return xaiOAuth.writeXaiOAuthStore({ route, ref, credential })
         },
       }
     },

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -17,6 +17,7 @@ import { registerPackagedSkills } from './packaged-skills.js'
 import { registerPromptDebug } from './promptDebug.js'
 import { readActivityFrames } from '../activityPrefs.js'
 import { readModelPref } from '../modelPrefs.js'
+import { startXaiSubscriptionRefresh } from './xaiRefresher.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ModelRoute } from '../modelRoute.js'
 import { readPresetPref } from '../presetPrefs.js'
@@ -646,6 +647,10 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     })
     ctx.effect(() => unregister)
   }
+  // xAI SuperGrok/X subscription tokens die hourly; the `/provider`
+  // wizard's oauth store tells this ticker to keep the route's credential
+  // fresh while it stays configured.
+  ctx.effect(() => startXaiSubscriptionRefresh(ctx))
   // DSH approval seam: the permission layer asks ApprovalService.request(),
   // which dispatches an `approval/request` waterfall. With no answerer the
   // chain falls through to the fail-closed 'unavailable', so register this

--- a/src/dsh-adapter/providerWizard.ts
+++ b/src/dsh-adapter/providerWizard.ts
@@ -24,6 +24,14 @@ import {
   type AskUserQuestionRequest,
 } from '@deepseek-ai/dsh-user-questions'
 import type { LlmDiscoveredModel } from '@deepseek-ai/dsh-llm'
+import {
+  XaiOAuthError,
+  XAI_DEFAULT_BASE_URL,
+  XAI_SUBSCRIPTION_API,
+  type XaiCatalogModel,
+  type XaiDeviceCodeInfo,
+  type XaiOAuthCredential,
+} from './xaiOAuth.js'
 
 /** Route id rule shared with the dsh configuration surface (web Models page). */
 export const PROVIDER_ROUTE_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
@@ -84,6 +92,18 @@ export interface ProviderSetupHost {
    * rejects when the adapter's validation deems it unserviceable.
    */
   writeProfile(route: string, profile: Record<string, unknown>): Promise<void>
+  /**
+   * Run the xAI device-authorization flow; the info callback fires once the
+   * code is issued, so the caller can show the URI/code and wait.
+   */
+  loginXaiOAuth(
+    onCode: (info: XaiDeviceCodeInfo) => void,
+    signal?: AbortSignal,
+  ): Promise<XaiOAuthCredential>
+  /**
+   * Persist the xAI refresh record (~/.dsh-tui/xai-oauth.json, 0600).
+   */
+  writeXaiOAuthStore(route: string, ref: string, credential: XaiOAuthCredential): boolean
 }
 
 export interface ProviderWizardDeps {
@@ -195,16 +215,61 @@ export async function runProviderWizard(
       if (route === '') return 'cancelled'
     }
 
-    // ── 3. API key (own batch so redact covers exactly the secret) ─────
-    const keyAnswer = await ask({
-      questions: [textQuestion('apikey', t('provider-q-apikey'), t('provider-q-apikey-detail'))],
-    }, { redact: true })
-    const apiKey = answerText(keyAnswer, 'apikey')
+    // ── 3. authentication ──────────────────────────────────────────────
+    // xAI can authenticate with SuperGrok/X Premium device-code OAuth or a
+    // console API key. There is no import of a local pi login.
+    let apiKey = ''
+    let oauthCredential: XaiOAuthCredential | undefined
+    if (route === 'xai') {
+      const methodAnswer = await ask({
+        questions: [optionQuestion('xai-method', t('provider-q-xai-method'), [
+          { label: t('provider-opt-xai-device'), description: t('provider-opt-xai-device-desc') },
+          { label: t('provider-opt-xai-apikey'), description: t('provider-opt-xai-apikey-desc') },
+        ], { hideCustomInput: true })],
+      })
+      const method = answerSelected(methodAnswer, 'xai-method')[0]
+      if (method === t('provider-opt-xai-device')) {
+        const result = await runXaiDeviceLogin({
+          login: (onCode, signal) => host.loginXaiOAuth(onCode, signal),
+          ask,
+        })
+        if (result.kind === 'cancelled') return 'cancelled'
+        if (result.kind === 'failed') {
+          notify(result.text, { color: 'error', timeoutMs: 8000 })
+          return 'failed'
+        }
+        oauthCredential = result.credential
+        apiKey = oauthCredential.access
+      }
+    }
+    if (apiKey === '') {
+      const keyAnswer = await ask({
+        questions: [textQuestion('apikey', t('provider-q-apikey'), t('provider-q-apikey-detail'))],
+      }, { redact: true })
+      apiKey = answerText(keyAnswer, 'apikey')
+    }
 
-    // ── 4. endpoint / protocol ─────────────────────────────────────────
+    // ── 4–6. endpoint / discovery / model pick ─────────────────────────
     let baseURL: string | undefined
     let api: string | undefined
-    if (isCatalog) {
+    let models: string[] = []
+    let discoveredById = new Map<string, LlmDiscoveredModel>()
+    let oauthModels: readonly XaiCatalogModel[] | undefined
+    if (oauthCredential !== undefined) {
+      const live = await host.discoverModels({
+        baseURL: XAI_DEFAULT_BASE_URL,
+        api: 'openai-completions',
+        apiKey,
+      }).catch(() => [])
+      oauthModels = live.map(model => ({
+        id: model.id,
+        ...(model.name === undefined ? {} : { name: model.name }),
+        ...(model.contextWindow === undefined ? {} : { contextWindow: model.contextWindow }),
+        ...(model.maxTokens === undefined ? {} : { maxTokens: model.maxTokens }),
+      }))
+      models = live.map(model => model.id)
+      if (models.length > 0) api = XAI_SUBSCRIPTION_API
+    } else if (isCatalog) {
       const choiceAnswer = await ask({
         questions: [optionQuestion('baseurl-choice', t('provider-q-baseurl-choice'), [
           { label: t('provider-opt-baseurl-skip') },
@@ -232,52 +297,48 @@ export async function runProviderWizard(
       api = answerSelected(endpointAnswer, 'protocol')[0]
     }
 
-    // ── 5. model discovery (draft credential, nothing persisted) ───────
-    notify(t('provider-discovery-running'))
-    const discovered = await host.discoverModels({
-      ...(isCatalog ? { provider: route } : {}),
-      ...(baseURL !== undefined && baseURL !== '' ? { baseURL } : {}),
-      ...(api !== undefined ? { api } : {}),
-      apiKey,
-    }).catch(() => [])
+    if (oauthCredential === undefined) {
+      notify(t('provider-discovery-running'))
+      const discovered = await host.discoverModels({
+        ...(isCatalog ? { provider: route } : {}),
+        ...(baseURL !== undefined && baseURL !== '' ? { baseURL } : {}),
+        ...(api !== undefined ? { api } : {}),
+        apiKey,
+      }).catch(() => [])
 
-    // ── 6. model selection ─────────────────────────────────────────────
-    let models: string[] = []
-    let discoveredById = new Map<string, LlmDiscoveredModel>()
-    if (discovered.length > 0) {
-      discoveredById = new Map(discovered.map(model => [model.id, model] as const))
-      const modelsAnswer = await ask({
-        questions: [optionQuestion('models', t('provider-q-models'),
-          discovered.map(model => ({
-            label: model.id,
-            description: [
-              model.name ?? '',
-              model.contextWindow !== undefined ? `${model.contextWindow}` : '',
-            ].filter(part => part !== '').join(' · ') || undefined,
-          })),
-          { multiSelect: true },
-        )],
-      })
-      models = mergeModelIds(
-        answerSelected(modelsAnswer, 'models'),
-        answerText(modelsAnswer, 'models'),
-      )
-    } else {
-      notify(t('provider-discovery-failed'), { color: 'warning' })
-      for (let attempt = 0; attempt < MAX_RETRY && models.length === 0; attempt += 1) {
-        const fallbackAnswer = await ask({
-          questions: [textQuestion('models-fallback', t('provider-q-models-fallback'))],
+      if (discovered.length > 0) {
+        discoveredById = new Map(discovered.map(model => [model.id, model] as const))
+        const modelsAnswer = await ask({
+          questions: [optionQuestion('models', t('provider-q-models'),
+            discovered.map(model => ({
+              label: model.id,
+              description: [
+                model.name ?? '',
+                model.contextWindow !== undefined ? `${model.contextWindow}` : '',
+              ].filter(part => part !== '').join(' · ') || undefined,
+            })),
+            { multiSelect: true },
+          )],
         })
-        models = mergeModelIds([], answerText(fallbackAnswer, 'models-fallback'))
-        if (models.length === 0) notify(t('provider-models-required'), { color: 'warning' })
+        models = mergeModelIds(
+          answerSelected(modelsAnswer, 'models'),
+          answerText(modelsAnswer, 'models'),
+        )
+      } else {
+        notify(t('provider-discovery-failed'), { color: 'warning' })
+        for (let attempt = 0; attempt < MAX_RETRY && models.length === 0; attempt += 1) {
+          const fallbackAnswer = await ask({
+            questions: [textQuestion('models-fallback', t('provider-q-models-fallback'))],
+          })
+          models = mergeModelIds([], answerText(fallbackAnswer, 'models-fallback'))
+          if (models.length === 0) notify(t('provider-models-required'), { color: 'warning' })
+        }
+        if (models.length === 0) return 'cancelled'
       }
-      if (models.length === 0) return 'cancelled'
-    }
-    if (!isCatalog && models.length === 0) {
-      // A manual route without models fails the adapter validation; the
-      // loops above should prevent this, but guard before writing.
-      notify(t('provider-models-required'), { color: 'error' })
-      return 'cancelled'
+      if (!isCatalog && models.length === 0) {
+        notify(t('provider-models-required'), { color: 'error' })
+        return 'cancelled'
+      }
     }
 
     // ── 7. confirm ─────────────────────────────────────────────────────
@@ -285,6 +346,7 @@ export async function runProviderWizard(
     const shadowed = host.envShadows(ref)
     const summaryLines = buildSummaryLines({
       route, ref, shadowed, baseURL, api, models, isCatalog,
+      oauthRefresh: oauthCredential !== undefined && !shadowed,
     })
     const detail = host.routeExists(route)
       ? `${summaryLines.join('\n')}\n${t('provider-route-exists-warning')}`
@@ -304,14 +366,14 @@ export async function runProviderWizard(
     let wroteCredential = false
     let previousCredential: string | undefined
     if (!shadowed) {
-      // Capture any pre-existing value BEFORE overwriting: when the profile
-      // write below fails, rollback must restore it — an unconditional unset
-      // would destroy the old key of the route being overwritten.
       previousCredential = await host.readCredential(ref)
       await host.writeCredential(ref, apiKey)
       wroteCredential = true
     }
-    const profile = buildProfile({ isCatalog, ref, baseURL, api, models, discoveredById })
+    const profile = buildProfile({
+      isCatalog: isCatalog || oauthCredential !== undefined,
+      ref, baseURL, api, models, discoveredById, oauthModels,
+    })
     try {
       await host.writeProfile(route, profile)
     } catch (error) {
@@ -330,6 +392,14 @@ export async function runProviderWizard(
       const err = error instanceof Error ? error.message : String(error)
       notify(t('provider-write-failed', { err }), { color: 'error', timeoutMs: 8000 })
       return 'failed'
+    }
+    if (oauthCredential !== undefined) {
+      if (shadowed) {
+        notify(t('provider-xai-env-shadowed'), { color: 'warning' })
+      } else {
+        const stored = host.writeXaiOAuthStore(route, ref, oauthCredential)
+        if (!stored) notify(t('provider-write-oauth-store-failed'), { color: 'warning' })
+      }
     }
 
     // ── 9. success: transcript summary + optional live switch ──────────
@@ -362,6 +432,106 @@ export async function runProviderWizard(
     const err = error instanceof Error ? error.message : String(error)
     notify(t('provider-write-failed', { err }), { color: 'error', timeoutMs: 8000 })
     return 'failed'
+  }
+}
+
+/** Copy used by the xAI device-code wait panel. */
+interface XaiDeviceLoginUi {
+  login: (
+    onCode: (info: XaiDeviceCodeInfo) => void,
+    signal?: AbortSignal,
+  ) => Promise<XaiOAuthCredential>
+  ask: ProviderWizardDeps['ask']
+}
+
+/**
+ * Run xAI device authorization: request a code, surface it in a question
+ * panel that parks while the poll runs, and wait for the user to authorize
+ * in their browser.
+ */
+async function runXaiDeviceLogin(deps: XaiDeviceLoginUi): Promise<
+  | { kind: 'credential'; credential: XaiOAuthCredential }
+  | { kind: 'cancelled' }
+  | { kind: 'failed'; text: string }
+> {
+  const controller = new AbortController()
+  try {
+    const credential = await withXaiDeviceCodeDisplay(deps, controller.signal)
+    return { kind: 'credential', credential }
+  } catch (error) {
+    controller.abort()
+    if (error instanceof UserQuestionError) return { kind: 'cancelled' }
+    if (error instanceof XaiOAuthError && error.code === 'cancelled') return { kind: 'cancelled' }
+    return {
+      kind: 'failed',
+      text: error instanceof XaiOAuthError && error.code === 'denied'
+        ? t('provider-xai-device-denied')
+        : error instanceof XaiOAuthError && error.code === 'expired'
+          ? t('provider-xai-device-expired')
+          : t('provider-xai-device-failed', {
+            err: error instanceof Error ? error.message : String(error),
+          }),
+    }
+  }
+}
+
+/**
+ * Present the device code and await the browser authorization. The login
+ * promise runs concurrently with the panel; a failure before a code was ever
+ * issued surfaces through the race instead of hanging the display step.
+ */
+async function withXaiDeviceCodeDisplay(
+  deps: XaiDeviceLoginUi,
+  signal: AbortSignal,
+): Promise<XaiOAuthCredential> {
+  let resolveCode!: (info: XaiDeviceCodeInfo) => void
+  const codeReady = new Promise<XaiDeviceCodeInfo>(resolve => {
+    resolveCode = resolve
+  })
+  const login = deps.login(resolveCode, signal)
+  const info = await Promise.race([codeReady, login]) as XaiDeviceCodeInfo
+  const panelAbort = new AbortController()
+  const onOuterAbort = (): void => panelAbort.abort()
+  signal.addEventListener('abort', onOuterAbort, { once: true })
+  const panel = deps.ask({
+    questions: [optionQuestion('xai-device-wait', t('provider-xai-device-prompt', {
+      url: info.verificationUri,
+      code: info.userCode,
+    }), [
+      { label: t('provider-opt-xai-device-continue') },
+    ], { detail: t('provider-xai-device-detail'), hideCustomInput: true })],
+    signal: panelAbort.signal,
+  })
+  try {
+    const credential = await new Promise<XaiOAuthCredential>((resolve, reject) => {
+      let settled = false
+      const finish = (apply: () => void): void => {
+        if (settled) return
+        settled = true
+        apply()
+      }
+      login.then(
+        cred => finish(() => resolve(cred)),
+        err => finish(() => reject(err)),
+      )
+      panel.then(
+        () => {
+          login.then(
+            cred => finish(() => resolve(cred)),
+            err => finish(() => reject(err)),
+          )
+        },
+        err => {
+          if (panelAbort.signal.aborted) return
+          finish(() => reject(err))
+        },
+      )
+    })
+    return credential
+  } finally {
+    signal.removeEventListener('abort', onOuterAbort)
+    panelAbort.abort()
+    await panel.catch(() => {})
   }
 }
 
@@ -399,6 +569,7 @@ function buildSummaryLines(input: {
   api: string | undefined
   models: readonly string[]
   isCatalog: boolean
+  oauthRefresh: boolean
 }): string[] {
   const lines = [t('provider-line-route', { route: input.route })]
   lines.push(input.shadowed
@@ -411,6 +582,7 @@ function buildSummaryLines(input: {
   lines.push(input.models.length > 0
     ? t('provider-line-models', { models: input.models.join(', ') })
     : t('provider-line-models-catalog'))
+  if (input.oauthRefresh) lines.push(t('provider-line-oauth-refresh'))
   return lines
 }
 
@@ -421,12 +593,24 @@ function buildProfile(input: {
   api: string | undefined
   models: readonly string[]
   discoveredById: ReadonlyMap<string, LlmDiscoveredModel>
+  oauthModels?: readonly XaiCatalogModel[]
 }): Record<string, unknown> {
   const profile: Record<string, unknown> = { apiKeyEnv: input.ref }
   if (input.baseURL !== undefined && input.baseURL !== '') profile['baseURL'] = input.baseURL
   if (input.isCatalog) {
-    // `models` replaces the catalog when present; omit it to keep the whole
-    // catalog served.
+    if (input.oauthModels !== undefined && input.oauthModels.length > 0) {
+      if (input.api !== undefined) profile['api'] = input.api
+      profile['defaultInput'] = ['text', 'image']
+      profile['models'] = input.oauthModels.map(model => ({
+        id: model.id,
+        ...(model.name === undefined ? {} : { name: model.name }),
+        ...(model.contextWindow === undefined ? {} : { contextWindow: model.contextWindow }),
+        ...(model.maxTokens === undefined ? {} : { maxTokens: model.maxTokens }),
+        ...(model.input === undefined ? {} : { input: [...model.input] }),
+        ...(model.reasoningEfforts === undefined ? {} : { reasoningEfforts: { ...model.reasoningEfforts } }),
+      }))
+      return profile
+    }
     if (input.models.length > 0) {
       profile['models'] = input.models.map(id => ({ id }))
     }

--- a/src/dsh-adapter/xaiOAuth.ts
+++ b/src/dsh-adapter/xaiOAuth.ts
@@ -1,0 +1,350 @@
+/**
+ * xAI (Grok/X subscription) OAuth credential management for the `/provider`
+ * wizard and its background refresher.
+ *
+ * The Grok/X subscription authenticates through xAI's OAuth device flow and
+ * yields a short-lived access token that `https://api.x.ai/v1` accepts as a
+ * bearer API key. This module mirrors the client id, scope, and endpoints
+ * pi uses (`@earendil-works/pi-ai`). The credential rides two stores — the
+ * harness credential store (the access token, under the route's `apiKeyEnv`
+ * ref, resolved per request) and this TUI's own refresh record
+ * `~/.dsh-tui/xai-oauth.json` (0600), which carries the refresh token and
+ * expiry. Subscription auth is device-code (or a console API key); this
+ * module does not read `~/.pi` auth or model files.
+ *
+ * The module is React-free so `scripts/verify-xai-oauth.mjs` can drive it
+ * headless and the refresher can run without UI state.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DATA_DIR } from '../utils/paths.js'
+
+/** The OAuth client pi's SDK uses for xAI; tokens are interchangeable with pi's. */
+export const XAI_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828'
+
+/** OAuth scope granting Grok CLI and xAI API access under the subscription. */
+const XAI_SCOPE = 'openid profile email offline_access grok-cli:access api:access'
+
+/** Device-authorization endpoint (RFC 8628). */
+const XAI_DEVICE_CODE_URL = 'https://auth.x.ai/oauth2/device/code'
+
+/** Token endpoint; used for both the device grant and refresh grants. */
+const XAI_TOKEN_URL = 'https://auth.x.ai/oauth2/token'
+
+/** Refresh before the reported expiry so a token never dies mid-request. */
+export const XAI_REFRESH_SKEW_MS = 5 * 60 * 1000
+
+/** xAI expiry fallback when the token response omits `expires_in`. */
+const DEFAULT_TOKEN_LIFETIME_SECONDS = 3600
+
+/** Poll interval fallback when the device response omits `interval`. */
+const DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+/** Device-code lifetime fallback when the response omits `expires_in`. */
+const DEFAULT_DEVICE_EXPIRES_SECONDS = 1800
+
+/** Default xAI endpoint; the subscription token is a bearer for this URL. */
+export const XAI_DEFAULT_BASE_URL = 'https://api.x.ai/v1'
+
+/**
+ * Wire protocol pi's current xAI catalog uses for every SuperGrok model.
+ * The bundled pi-ai catalog still splits completions vs responses and omits
+ * grok-4.6; a subscription route must name this so extra ids are serviceable.
+ */
+export const XAI_SUBSCRIPTION_API = 'openai-responses'
+
+/** The TUI's own refresh record (see the module header). */
+export const XAI_OAUTH_STORE_PATH = join(DATA_DIR, 'xai-oauth.json')
+
+/** One xAI OAuth credential: the bearer plus what it takes to rotate it. */
+export interface XaiOAuthCredential {
+  /** Access token, sent as the bearer for api.x.ai. */
+  access: string
+  /** Refresh token; xAI may rotate it on refresh. */
+  refresh: string
+  /** Epoch ms at which the access token counts as expired (skew included). */
+  expires: number
+}
+
+/** What the refresher needs to keep a route's credential alive. */
+export interface XaiOAuthStore {
+  /** Provider route the credential belongs to (the `llm-pi-ai` profile). */
+  route: string
+  /** Credential-ref the access token is written under (`apiKeyEnv`). */
+  ref: string
+  credential: XaiOAuthCredential
+}
+
+/** Device-code info the wizard surfaces to the user. */
+export interface XaiDeviceCodeInfo {
+  /** https URL the user opens, with the code pre-filled when offered. */
+  verificationUri: string
+  /** The human-typed authorization code. */
+  userCode: string
+}
+
+/**
+ * One xAI model from a live listing. Written onto the route profile so
+ * `/model` can serve ids the bundled catalog does not yet ship.
+ */
+export interface XaiCatalogModel {
+  id: string
+  name?: string
+  contextWindow?: number
+  maxTokens?: number
+  input?: readonly string[]
+  reasoningEfforts?: Readonly<Record<string, string | null>>
+}
+
+/** OAuth failure kinds the wizard can translate to user-facing text. */
+export type XaiOAuthErrorCode = 'cancelled' | 'denied' | 'expired' | 'failed'
+
+/** A failed xAI OAuth exchange, carrying the wizard-mappable kind. */
+export class XaiOAuthError extends Error {
+  constructor(
+    readonly code: XaiOAuthErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'XaiOAuthError'
+  }
+}
+
+/**
+ * The persisted refresh record, when present and well-formed.
+ * @param path - The store file (injectable for tests).
+ * @returns The store, or undefined when absent or corrupt.
+ */
+export function readXaiOAuthStore(path: string = XAI_OAUTH_STORE_PATH): XaiOAuthStore | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'))
+  } catch {
+    return undefined
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+  const record = parsed as Record<string, unknown>
+  if (typeof record.route !== 'string' || record.route === '') return undefined
+  if (typeof record.ref !== 'string' || record.ref === '') return undefined
+  const credential = record.credential
+  if (credential === null || typeof credential !== 'object' || Array.isArray(credential)) {
+    return undefined
+  }
+  const parts = credential as Record<string, unknown>
+  if (typeof parts.access !== 'string' || parts.access === '') return undefined
+  if (typeof parts.refresh !== 'string' || parts.refresh === '') return undefined
+  if (typeof parts.expires !== 'number' || !Number.isFinite(parts.expires as number)) {
+    return undefined
+  }
+  return {
+    route: record.route,
+    ref: record.ref,
+    credential: {
+      access: parts.access,
+      refresh: parts.refresh,
+      expires: parts.expires as number,
+    },
+  }
+}
+
+/**
+ * Persist the refresh record under `~/.dsh-tui/xai-oauth.json` with mode
+ * 0600 (it holds a long-lived refresh secret). Best effort: the wizard warns
+ * when this fails, because the alternative — no refresh record — means the
+ * route dies with its access token.
+ * @param store - The record to persist.
+ * @param path - The store file (injectable for tests).
+ * @returns True when written.
+ */
+export function writeXaiOAuthStore(
+  store: XaiOAuthStore,
+  path: string = XAI_OAUTH_STORE_PATH,
+): boolean {
+  try {
+    mkdirSync(join(path, '..'), { recursive: true })
+    writeFileSync(path, JSON.stringify(store, null, 2), { mode: 0o600 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * POST a form body to a xAI OAuth endpoint and parse the JSON reply.
+ * Non-2xx statuses are returned, not thrown, so the device poll can tell a
+ * pending grant from a denial; the grant callers decide what non-ok means.
+ */
+async function postForm(
+  url: string,
+  fields: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<{ ok: boolean; status: number; body: Record<string, unknown> }> {
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(fields),
+      signal,
+    })
+  } catch (error) {
+    if (signal?.aborted) throw new XaiOAuthError('cancelled', 'xAI OAuth cancelled')
+    throw error
+  }
+  let parsed: unknown
+  try {
+    parsed = await response.json()
+  } catch {
+    throw new XaiOAuthError(
+      'failed',
+      `xAI OAuth returned invalid JSON (HTTP ${response.status})`,
+    )
+  }
+  const body = parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? parsed as Record<string, unknown>
+    : {}
+  return { ok: response.ok, status: response.status, body }
+}
+
+/** The `error`/`error_description` pair of a failed grant, for diagnostics. */
+function grantFailure(body: Record<string, unknown>, status: number): string {
+  const error = typeof body.error === 'string' ? body.error : undefined
+  const description = typeof body.error_description === 'string' ? body.error_description : undefined
+  const detail = [error, description].filter(Boolean).join(': ')
+  return `xAI OAuth request failed (HTTP ${status})${detail === '' ? '' : `: ${detail}`}`
+}
+
+function requiredString(body: Record<string, unknown>, field: string): string {
+  const value = body[field]
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new XaiOAuthError('failed', `Invalid xAI OAuth response field: ${field}`)
+  }
+  return value
+}
+
+function optionalPositiveNumber(body: Record<string, unknown>, field: string): number | undefined {
+  const value = body[field]
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+/**
+ * Build a credential from a token response, computing the expiry with the
+ * refresh skew applied so `refreshXaiCredential` re-runs before the instant
+ * the token actually dies. A refresh may omit `refresh_token` when xAI does
+ * not rotate; the previous token then stays valid. The device grant has no
+ * previous token and must be offered one (it asked for `offline_access`).
+ */
+function credentialFromTokenResponse(
+  body: Record<string, unknown>,
+  previousRefresh: string | undefined,
+): XaiOAuthCredential {
+  const access = requiredString(body, 'access_token')
+  const refresh = body.refresh_token === undefined && previousRefresh !== undefined
+    ? previousRefresh
+    : requiredString(body, 'refresh_token')
+  const lifetimeSeconds = optionalPositiveNumber(body, 'expires_in')
+    ?? DEFAULT_TOKEN_LIFETIME_SECONDS
+  return {
+    access,
+    refresh,
+    expires: Date.now() + lifetimeSeconds * 1000 - XAI_REFRESH_SKEW_MS,
+  }
+}
+
+/**
+ * Refresh an xAI credential with its refresh token. A credential still
+ * outside the refresh skew is returned unchanged — the caller's one call
+ * covers both "make it fresh" and "leave it alone".
+ * @param credential - The stored credential.
+ * @param signal - Aborts the request; aborted calls throw `cancelled`.
+ * @returns A credential whose access token is fresh enough to send.
+ */
+export async function refreshXaiCredential(
+  credential: XaiOAuthCredential,
+  signal?: AbortSignal,
+): Promise<XaiOAuthCredential> {
+  if (credential.expires - Date.now() > XAI_REFRESH_SKEW_MS) return credential
+  const { ok, status, body } = await postForm(XAI_TOKEN_URL, {
+    grant_type: 'refresh_token',
+    client_id: XAI_CLIENT_ID,
+    refresh_token: credential.refresh,
+  }, signal)
+  if (!ok) throw new XaiOAuthError('failed', grantFailure(body, status))
+  return credentialFromTokenResponse(body, credential.refresh)
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms)
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer)
+      reject(new XaiOAuthError('cancelled', 'xAI OAuth cancelled'))
+    }, { once: true })
+  })
+}
+
+/**
+ * Run the xAI device-authorization flow: request a device code, surface it
+ * through `onCode`, then poll the token endpoint until the user authorizes
+ * (or the code dies).
+ * @param onCode - Called once the device code is obtained; the caller shows
+ *   the verification URI and user code and waits.
+ * @param signal - Aborts the polls; aborted calls throw `cancelled`.
+ * @returns The fresh credential.
+ */
+export async function loginXaiDevice(
+  onCode: (info: XaiDeviceCodeInfo) => void,
+  signal?: AbortSignal,
+): Promise<XaiOAuthCredential> {
+  const deviceResponse = await postForm(XAI_DEVICE_CODE_URL, {
+    client_id: XAI_CLIENT_ID,
+    scope: XAI_SCOPE,
+    referrer: 'dsh-tui',
+  }, signal)
+  if (!deviceResponse.ok) {
+    throw new XaiOAuthError('failed', grantFailure(deviceResponse.body, deviceResponse.status))
+  }
+  const deviceBody = deviceResponse.body
+  const deviceCode = requiredString(deviceBody, 'device_code')
+  const userCode = requiredString(deviceBody, 'user_code')
+  const verificationUri = requiredString(deviceBody, 'verification_uri')
+  onCode({ verificationUri, userCode })
+  const expiresInSeconds = optionalPositiveNumber(deviceBody, 'expires_in')
+    ?? DEFAULT_DEVICE_EXPIRES_SECONDS
+  let intervalSeconds = optionalPositiveNumber(deviceBody, 'interval')
+    ?? DEFAULT_POLL_INTERVAL_SECONDS
+  const deadline = Date.now() + expiresInSeconds * 1000
+  let firstPoll = true
+  while (Date.now() < deadline) {
+    if (firstPoll) {
+      firstPoll = false
+    } else {
+      await sleep(intervalSeconds * 1000, signal)
+    }
+    const { ok, status, body } = await postForm(XAI_TOKEN_URL, {
+      grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      client_id: XAI_CLIENT_ID,
+      device_code: deviceCode,
+    }, signal)
+    const error = typeof body.error === 'string' ? body.error : undefined
+    if (ok) return credentialFromTokenResponse(body, undefined)
+    if (error === 'authorization_pending') continue
+    if (error === 'slow_down') {
+      const slowed = optionalPositiveNumber(body, 'interval')
+      intervalSeconds = (slowed ?? intervalSeconds) + DEFAULT_POLL_INTERVAL_SECONDS
+      continue
+    }
+    if (error === 'access_denied' || error === 'authorization_denied') {
+      throw new XaiOAuthError('denied', 'xAI device authorization was denied')
+    }
+    if (error === 'expired_token') {
+      throw new XaiOAuthError('expired', 'xAI device code expired')
+    }
+    throw new XaiOAuthError('failed', grantFailure(body, status))
+  }
+  throw new XaiOAuthError('expired', 'xAI device code expired')
+}

--- a/src/dsh-adapter/xaiRefresher.ts
+++ b/src/dsh-adapter/xaiRefresher.ts
@@ -1,0 +1,95 @@
+/**
+ * Background auto-refresh for the xAI (Grok/X subscription) route added by
+ * the `/provider` wizard. The subscription's access token dies hourly; the
+ * refresher keeps the harness credential store's value fresh so every
+ * request resolves a live token (the llm-pi-ai adapter reads `apiKeyEnv` per
+ * request, so a refresh lands on the next request with no restart).
+ *
+ * Refreshes only while the whole chain is still alive: the record exists,
+ * the route profile still exists in `llm-pi-ai` settings, the credential
+ * store still holds the ref (a `/logout` or plain setting removal stops the
+ * loop rather than resurrecting the route), and the ref is not shadowed by
+ * the process environment (an env value is not writable here). Failures are
+ * logged and retried on the next tick; nothing here reaches the UI.
+ */
+
+import type { Context } from '@deepseek-ai/cordis'
+import {
+  readXaiOAuthStore,
+  refreshXaiCredential,
+  writeXaiOAuthStore,
+  type XaiOAuthStore,
+} from './xaiOAuth.js'
+
+/** How often the refresher evaluates the stored credential. */
+const REFRESH_TICK_MS = 60 * 1000
+
+/** Credential-ref resolution: the `dsh-credentials` seam's shape. */
+interface CredentialSeam {
+  resolve(ref: string): Promise<{ value?: unknown } | undefined>
+  set(ref: string, value: string): Promise<void>
+}
+
+/** Settings-section read: the `dsh-settings` seam's shape. */
+interface SettingsSeam {
+  get(ns: string): unknown
+}
+
+/**
+ * One refresh evaluation: read the store, decide whether a refresh is due,
+ * and rotate the token into both the credential store and the refresh
+ * record. Exported so the headless verify script can drive it with a fake
+ * `ctx`; the ticker below is just this on an interval.
+ * @param ctx - The plugin context; seams are resolved lazily so mount order
+ *   never matters.
+ * @param store - The refresh record to evaluate (defaults to the file).
+ * @param storePath - Where to persist the rotated record (injectable for
+ *   tests; defaults to the file the store was read from).
+ */
+export async function refreshXaiSubscriptionOnce(
+  ctx: Context,
+  store: XaiOAuthStore | undefined = readXaiOAuthStore(),
+  storePath?: string,
+): Promise<void> {
+  if (store === undefined) return
+  if (process.env[store.ref] !== undefined) return
+  if (store.credential.expires - Date.now() > 0) return
+  const credentials = ctx.get('credentials') as CredentialSeam | undefined
+  if (credentials === undefined) return
+  const settings = ctx.get('settings') as SettingsSeam | undefined
+  if (settings !== undefined) {
+    const section = settings.get('llm-pi-ai') as
+      | { providers?: Record<string, unknown> }
+      | undefined
+    if (section?.providers === undefined || !(store.route in section.providers)) return
+  }
+  const resolved = await credentials.resolve(store.ref)
+  if (resolved === undefined || resolved.value === undefined) return
+  try {
+    const fresh = await refreshXaiCredential(store.credential)
+    await credentials.set(store.ref, fresh.access)
+    writeXaiOAuthStore({ ...store, credential: fresh }, storePath)
+    ctx.logger.info(
+      `dsh-tui: xAI subscription token for "${store.route}" refreshed (valid until ${new Date(fresh.expires).toISOString()})`,
+    )
+  } catch (error) {
+    ctx.logger.warn(
+      `dsh-tui: xAI subscription token refresh for "${store.route}" failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+}
+
+/**
+ * Start the xAI subscription refresher. Registered through `ctx.effect` by
+ * the plugin; the returned disposer stops the ticker.
+ * @param ctx - The plugin context.
+ * @returns The disposer.
+ */
+export function startXaiSubscriptionRefresh(ctx: Context): () => void {
+  const timer = setInterval(() => void refreshXaiSubscriptionOnce(ctx), REFRESH_TICK_MS)
+  timer.unref?.()
+  void refreshXaiSubscriptionOnce(ctx)
+  return () => clearInterval(timer)
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -651,6 +651,20 @@ const dict = {
   'provider-q-switch': { zh: '立即切换到新 provider？', en: 'Switch to the new provider now?' },
   'provider-opt-switch-now': { zh: '切换到 {{model}}', en: 'Switch to {{model}}' },
   'provider-opt-switch-keep': { zh: '保持当前模型', en: 'Keep the current model' },
+  'provider-q-xai-method': { zh: '如何用 xAI 认证？', en: 'How do you want to authenticate with xAI?' },
+  'provider-opt-xai-device': { zh: '用 SuperGrok / X Premium 账号登录', en: 'Sign in with SuperGrok or X Premium' },
+  'provider-opt-xai-device-desc': { zh: '浏览器授权（device code），token 到期自动续期', en: 'Browser authorization (device code); the token auto-refreshes' },
+  'provider-opt-xai-apikey': { zh: '输入 API key', en: 'Enter an API key' },
+  'provider-opt-xai-apikey-desc': { zh: '在 console.x.ai 为订阅生成的常规 API key', en: 'A regular API key minted for the subscription at console.x.ai' },
+  'provider-xai-device-prompt': { zh: '在浏览器打开 {{url}}，输入代码 {{code}}。授权完成后会自动继续', en: 'Open {{url}} in a browser, enter code {{code}}. This continues automatically after authorization' },
+  'provider-xai-device-detail': { zh: '代码与链接仅本次有效；等待授权期间请勿关闭本终端。也可选「我已授权，继续」或按回车。', en: 'The code and link are single-use; keep this terminal open while waiting. You can also choose “I have authorized — continue” or press Enter.' },
+  'provider-opt-xai-device-continue': { zh: '我已授权，继续', en: 'I have authorized — continue' },
+  'provider-xai-device-denied': { zh: '授权被拒绝', en: 'Authorization denied' },
+  'provider-xai-device-expired': { zh: '设备代码已过期，请重试', en: 'Device code expired — try again' },
+  'provider-xai-device-failed': { zh: '授权失败 · {{err}}', en: 'Authorization failed · {{err}}' },
+  'provider-xai-env-shadowed': { zh: '环境中已有 XAI_API_KEY，订阅 token 无法自动续期——请移除该环境变量或改用 API key', en: 'XAI_API_KEY is set in the environment, so the subscription token cannot auto-refresh — unset it or use an API key instead' },
+  'provider-write-oauth-store-failed': { zh: '订阅刷新信息写入失败，token 不会自动续期', en: 'Failed to store the subscription refresh info; the token will not auto-refresh' },
+  'provider-line-oauth-refresh': { zh: '订阅 token 自动续期已启用（~/.dsh-tui/xai-oauth.json）', en: 'Subscription token auto-refresh enabled (~/.dsh-tui/xai-oauth.json)' },
 
   // ── commands.ts — slash-command descriptions ─────────────────────────
   // zh-only on purpose: the English text stays in `LOCAL_COMMANDS` (and in


### PR DESCRIPTION
Closes #400

## Motivation

`/provider` can add the catalog `xai` route with an API key today, but SuperGrok / X Premium subscription access is OAuth.

## What changed

- Auth question is device-code vs console API key only.
- Device login is RFC 8628 against https://auth.x.ai: show URL + user code, poll until authorized.
- Persist the access token as `XAI_API_KEY` and the refresh record in `~/.dsh-tui/xai-oauth.json` (mode 0600). A background ticker rotates the hourly-class token while the route stays configured.
- After device login, probe https://api.x.ai/v1 and, when the listing is non-empty, write `api: openai-responses`.
- Env-shadowed `XAI_API_KEY` skips credential/store write and warns.

## What was stripped vs a local prototype

- No read of `~/.pi/agent/auth.json`.
- No read of `~/.pi/agent/models-store.json`.
- No ChatGPT Codex work (separate PR #399).

## Verify

- `pnpm build`
- `node scripts/verify-provider-wizard.mjs`
- `node scripts/verify-xai-oauth.mjs`
