### PR TITLE
fix(ui): 输入框布局加固 + Esc 中断竞态 + 长内容光标错位

### DIFF
--- a/src/components/EffortInputBorder.tsx
+++ b/src/components/EffortInputBorder.tsx
@@ -41,15 +41,17 @@ function BorderRow({
   idleColor: keyof Theme | Color
 }): React.ReactNode {
   return (
-    <Text>
-      <Text color={idleColor}>{left}</Text>
-      {runs.map((run, i) => (
-        <Text key={i} color={run.color}>
-          {run.glyph}
-        </Text>
-      ))}
-      <Text color={idleColor}>{right}</Text>
-    </Text>
+    <Box width="100%" height={1} flexShrink={0} overflow="hidden">
+      <Text wrap="truncate-end">
+        <Text color={idleColor}>{left}</Text>
+        {runs.map((run, i) => (
+          <Text key={i} color={run.color}>
+            {run.glyph}
+          </Text>
+        ))}
+        <Text color={idleColor}>{right}</Text>
+      </Text>
+    </Box>
   )
 }
 
@@ -124,7 +126,7 @@ export function EffortInputBorder({
       flexShrink={0}
     >
       <BorderRow left="╭" right="╮" runs={runs} idleColor={idleColor} />
-      {children}
+      <Box flexShrink={0}>{children}</Box>
       <BorderRow left="╰" right="╯" runs={runs} idleColor={idleColor} />
     </Box>
   )

--- a/src/components/EffortTierBadge.tsx
+++ b/src/components/EffortTierBadge.tsx
@@ -119,7 +119,7 @@ export function EffortTierBadge({
     column = at + 1
   }
   return (
-    <Text bold color={color}>
+    <Text bold color={color} wrap="truncate-end">
       {spaced}
     </Text>
   )

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1573,6 +1573,12 @@ export function createChannel(
   /** Monotonic token: only the latest `interruptAndDeliver` re-queues, so a
    *  second interrupt while the abort settles cannot double-deliver. */
   let interruptSeq = 0
+  // Cancellation is asynchronous: a fast second Esc can arrive after the
+  // driver has accepted the first abort but before its turn/end event lands.
+  // Do not cancel the same driver twice, or the second cancel can swallow the
+  // replacement work queued by interruptAndDeliver and leave the UI gated on
+  // a working flag that has not observed turn/end yet.
+  let cancelInFlight = false
   /** The llm runtime seam (dsh-llm LlmRuntime): route metadata resolution. */
   const llmRuntime = ctx.get('llm') as
     | {
@@ -2180,17 +2186,22 @@ export function createChannel(
     cancel() {
       // Keep the staged queue: an interrupt aborts the running turn but the
       // queued/steered messages are delivered as the next turn (web parity).
+      // Cancellation converges asynchronously; ignore a repeated Esc/Ctrl+C
+      // until the aborted turn has produced its terminal event.
+      if (cancelInFlight) return
+      cancelInFlight = true
       agent.cancel({ kind: 'user' }, { keepInbox: true })
     },
     interruptAndDeliver(texts: readonly string[]): number {
       const queued = texts.map(text => text.trim()).filter(text => text !== '')
-      if (queued.length === 0) return 0
+      if (queued.length === 0 || cancelInFlight) return 0
       // No keepInbox: the parked copies are dropped (their discard events
       // retire the preview), then each text is re-queued as a fresh
       // followup. dsh-agent's cancel-convergence wake latch accepts this
       // wake immediately after cancel and starts it once the aborted turn
       // retires; waiting for whenIdle is unsafe because it also follows
       // replacement work and may never settle.
+      cancelInFlight = true
       agent.cancel({ kind: 'user' })
       const token = ++interruptSeq
       const deliver = (): void => {
@@ -4801,6 +4812,7 @@ ${output}
         break
       }
       case 'turn/start': {
+        cancelInFlight = false
         state.working = true
         state.turnStart = Date.now()
         state.responseChars = 0
@@ -4816,6 +4828,7 @@ ${output}
         break
       }
       case 'turn/end': {
+        cancelInFlight = false
         settleStreaming()
         state.working = false
         state.activeToolCount = 0

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -740,9 +740,22 @@ export default class Ink {
     // and no move is emitted.
     const decl = this.cursorDeclaration;
     const rect = decl !== null ? nodeCache.get(decl.node) : undefined;
+    // Main-screen inline mode stores node rectangles in frame coordinates,
+    // while the physical terminal only exposes the viewport tail once the
+    // frame is taller than the terminal. Convert the declared row to that
+    // visible coordinate system before emitting the relative cursor move.
+    // Without this subtraction a long streaming frame asks the terminal to
+    // move to an off-screen row; terminals clamp it at the bottom, leaving
+    // the virtual and physical cursor origins out of sync for the next diff.
+    // Offset is exactly the rows pushed into scrollback: H - V when the frame
+    // outgrows the viewport, 0 when it fits (H <= V). A +1 here would nudge a
+    // just-fitting frame (H === V) up one row, misplacing the input caret.
+    const visibleFrameOffset = this.altScreenActive
+      ? 0
+      : Math.max(0, frame.screen.height - frame.viewport.height);
     const target = decl !== null && rect !== undefined ? {
       x: rect.x + decl.relativeX,
-      y: rect.y + decl.relativeY
+      y: rect.y + decl.relativeY - visibleFrameOffset
     } : null;
     const parked = this.displayCursor;
     // Diagnostics: the resolved park target per frame (DSH_TUI_DEBUG only).


### PR DESCRIPTION
## 变更内容

三个独立的稳定性修复（对应长期报告的三类问题）：

### 1. 输入框边框/档位徽标布局加固
- `EffortInputBorder`：边框行固定 `width=100% height=1 flexShrink=0 overflow=hidden`，内部文本 `wrap=truncate-end`——窄终端/动画帧下边框不再换行，帧高与渲染器记录一致
- `EffortTierBadge`：文本 `wrap=truncate-end`，避免徽标动画导致额外换行

### 2. Esc 快速中断竞态
- `channel.ts`：新增 `cancelInFlight`——取消是异步收敛的，快速第二次 Esc 不再对同一个 driver 重复取消（会吞掉 `interruptAndDeliver` 排队的替代工作），`turn/start`、`turn/end` 时解除保护

### 3. 主屏长内容光标错位
- `ink.tsx`：主屏 inline 模式下，声明的光标行号扣除滚入 scrollback 的行数（`max(0, H - V)`）——长任务帧超出视口后，输入光标不再被终端 clamp 到底部导致虚拟/物理光标失步、正文错位

## 验证
- `tsc --noEmit` ✓
- `verify-ime-cursor.tsx`（8 场景）✓
- `repro-inline-scrollback.tsx`（无 full-reset、标记唯一）✓
- `verify-shrink.mjs` / `verify-resticky.mjs` / `verify-resize-reflow.tsx` ✓
- `pnpm run compile` ✓