### PR TITLE
fix(picker): count the selection tick in the truncation budget (#396)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,10 @@ jobs:
       # （30 行终端 30 个模型，焦点在索引 0 不可见），且 yoga 挤压会产生
       # 零高丢行——焦点必须始终随窗口在屏。
       - run: node --import tsx/esm scripts/repro-picker-windowing.tsx
+      # 压边截断回归（#396）：长名在终端最后一格截断时选中 ✓ 计入截断
+      # 预算、行恒 1 不换行——断言零 wrapped 行、Pane 内无幽灵空行、翻页
+      # 后标题/页脚/焦点仍在屏。
+      - run: node --import tsx/esm scripts/verify-picker-edge.tsx
 
       # 按键解析回归（issue #110）：Option+Enter（ESC CR）精确/合并/分块
       # 三种到达形态、CSI-u 与 modifyOtherKeys 的 Shift/Ctrl/Meta+Enter。

--- a/scripts/verify-picker-edge.tsx
+++ b/scripts/verify-picker-edge.tsx
@@ -1,0 +1,145 @@
+/**
+ * Picker edge-truncation regression (#396).
+ *
+ * Long names (multi-provider ids) truncated at the terminal's last cell used
+ * to commit a pending-wrap: every list item swelled to two screen rows, the
+ * declared per-item heights in listWindow desynced, the pane top got clipped,
+ * and on real terminals the wrap leaked into scrollback — page turns drifted
+ * by a row each time (the doubled rows / stray ❯ / shell prompt leaking into
+ * the screenshot in the issue).
+ *
+ * This gate mounts the real ModelPicker in a headless xterm at narrow widths
+ * with names sized to land the ellipsis (and the focused row's ✓) exactly on
+ * the last cell, and asserts across a page turn:
+ *   - zero wrapped buffer rows (isWrapped),
+ *   - no phantom blank rows between items,
+ *   - the pane top (row 0 content) and the focus indicator stay on screen.
+ *
+ * Run: node --import tsx/esm scripts/verify-picker-edge.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const { mkdtempSync } = await import('node:fs')
+const { tmpdir } = await import('node:os')
+const { join: joinPath } = await import('node:path')
+process.env.HOME = mkdtempSync(joinPath(tmpdir(), 'dshtui-edge-'))
+process.env.USERPROFILE = process.env.HOME
+
+const [{ Terminal: XTerm }, React] = await Promise.all([
+  import('@xterm/headless'),
+  import('react'),
+])
+const { render } = await import('../src/ui.js')
+const { ModelPicker } = await import('../src/components/ModelPicker.js')
+
+let failures = 0
+function check(name: string, ok: boolean, detail = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail === '' ? '' : ` (${detail})`}`)
+  if (!ok) failures++
+}
+
+const ROWS = 30
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+async function mountAt(cols: number) {
+  // Name length lands the truncation ellipsis — and the focused+selected
+  // row's ✓ — exactly on the terminal's last cell.
+  const NAME = 'x'.repeat(cols - 2)
+  const models = Array.from({ length: 24 }, (_, i) => ({
+    provider: 'p',
+    id: `m${i}`,
+    name: `${NAME}-${i}`,
+    description: undefined,
+  }))
+  const term = new XTerm({ cols, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  class FakeStdout extends (await import('node:stream')).Writable {
+    columns = cols
+    rows = ROWS
+    isTTY = true
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void): void {
+      term.write(String(chunk), () => cb())
+    }
+  }
+  class FakeStderr extends (await import('node:stream')).Writable {
+    isTTY = true
+    _write(_c: unknown, _e: BufferEncoding, cb: () => void): void { cb() }
+  }
+  class FakeStdin extends (await import('node:stream')).PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const noop = () => {}
+  const frame = async (focusIndex: number) => {
+    instance.rerender(
+      React.createElement(ModelPicker, {
+        models, focusIndex, currentModel: 'p/m12', onHover: noop,
+      }) as never,
+    )
+    await sleep(400)
+    const buf = term.buffer.active
+    const texts: string[] = []
+    let wrapped = 0
+    let focusVisible = false
+    for (let y = 0; y < ROWS; y++) {
+      const line = buf.getLine(y)
+      if (line === undefined) { texts.push(''); continue }
+      if (line.isWrapped) wrapped++
+      const text = line.translateToString(true)
+      texts.push(text)
+      if (text.includes('❯')) focusVisible = true
+    }
+    // The picker is bare-mounted: blank rows above/below the pane are layout
+    // padding. The invariant is INSIDE the pane — between the title row and
+    // the footer row there must be no blank (phantom) rows beyond the title margin, and both title
+    // and footer must be on screen at all.
+    const titleAt = texts.findIndex(text => text.includes('模型'))
+    const footerAt = texts.findIndex(text => text.includes('Enter'))
+    let innerBlanks = -1
+    if (titleAt >= 0 && footerAt > titleAt) {
+      innerBlanks = texts.slice(titleAt, footerAt).filter(text => text === '').length
+    }
+    return { wrapped, innerBlanks, focusVisible, titleAt, footerAt }
+  }
+  const instance = await render(
+    React.createElement(ModelPicker, {
+      models, focusIndex: 12, currentModel: 'p/m12', onHover: noop,
+    }) as never,
+    {
+      stdout: new FakeStdout() as never,
+      stdin: new FakeStdin() as never,
+      stderr: new FakeStderr() as never,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  )
+  await sleep(400)
+  return { instance, frame, term }
+}
+
+for (const cols of [58, 61]) {
+  const m = await mountAt(cols)
+  try {
+    const before = await m.frame(12)
+    check(`${cols} cols: zero wrapped rows at rest`, before.wrapped === 0, `${before.wrapped} wrapped`)
+    check(`${cols} cols: no phantom blank rows inside the pane`, before.innerBlanks <= 1, `${before.innerBlanks} blank`)
+    check(`${cols} cols: title and footer on screen`, before.titleAt >= 0 && before.footerAt > before.titleAt)
+    check(`${cols} cols: focus indicator visible`, before.focusVisible)
+    const after = await m.frame(20)
+    check(`${cols} cols: page turn keeps zero wrapped rows`, after.wrapped === 0, `${after.wrapped} wrapped`)
+    check(`${cols} cols: page turn keeps pane and focus`,
+      after.innerBlanks <= 1 && after.titleAt >= 0 && after.focusVisible)
+  } finally {
+    m.instance.unmount()
+  }
+}
+
+if (failures > 0) {
+  console.error(`${failures} check(s) failed`)
+  process.exit(1)
+}
+console.log('all checks passed')

--- a/scripts/verify-picker-edge.tsx
+++ b/scripts/verify-picker-edge.tsx
@@ -85,6 +85,7 @@ async function mountAt(cols: number) {
     const texts: string[] = []
     let wrapped = 0
     let focusVisible = false
+    let tickVisible = false
     for (let y = 0; y < ROWS; y++) {
       const line = buf.getLine(y)
       if (line === undefined) { texts.push(''); continue }
@@ -92,6 +93,7 @@ async function mountAt(cols: number) {
       const text = line.translateToString(true)
       texts.push(text)
       if (text.includes('❯')) focusVisible = true
+      if (text.includes('✓')) tickVisible = true
     }
     // The picker is bare-mounted: blank rows above/below the pane are layout
     // padding. The invariant is INSIDE the pane — between the title row and
@@ -103,7 +105,7 @@ async function mountAt(cols: number) {
     if (titleAt >= 0 && footerAt > titleAt) {
       innerBlanks = texts.slice(titleAt, footerAt).filter(text => text === '').length
     }
-    return { wrapped, innerBlanks, focusVisible, titleAt, footerAt }
+    return { wrapped, innerBlanks, focusVisible, tickVisible, titleAt, footerAt }
   }
   const instance = await render(
     React.createElement(ModelPicker, {
@@ -129,10 +131,12 @@ for (const cols of [58, 61]) {
     check(`${cols} cols: no phantom blank rows inside the pane`, before.innerBlanks <= 1, `${before.innerBlanks} blank`)
     check(`${cols} cols: title and footer on screen`, before.titleAt >= 0 && before.footerAt > before.titleAt)
     check(`${cols} cols: focus indicator visible`, before.focusVisible)
+    check(`${cols} cols: selection tick visible`, before.tickVisible)
     const after = await m.frame(20)
     check(`${cols} cols: page turn keeps zero wrapped rows`, after.wrapped === 0, `${after.wrapped} wrapped`)
     check(`${cols} cols: page turn keeps pane and focus`,
       after.innerBlanks <= 1 && after.titleAt >= 0 && after.focusVisible)
+    check(`${cols} cols: page turn keeps selection tick`, after.tickVisible)
   } finally {
     m.instance.unmount()
   }

--- a/src/components/ModelPicker.tsx
+++ b/src/components/ModelPicker.tsx
@@ -28,11 +28,11 @@ export function ModelPicker({
   const { rows: terminalRows } = useTerminalSize()
   // 焦点窗口化按行预算：ListItem 带 description 时占 2 行（正文+描述，均
   // truncate 成单行），只数项数会把焦点裁出浮层（二次审查实证）。
-  // 框架行：浮层预留 8 + Pane 2 + 标题 2 + 页脚 1 = 13。
+  // 框架行：浮层预留 8 + Pane 2 + 标题 2 + 页脚 1 + 挂载包裹 marginTop 1 = 14。
   const { start, end } = listWindow(
     models.map(m => (m.description ? 2 : 1)),
     focusIndex,
-    Math.max(terminalRows - 13, 2),
+    Math.max(terminalRows - 14, 2),
   )
   return (
     <Pane color="permission">

--- a/src/components/SkillsPicker.tsx
+++ b/src/components/SkillsPicker.tsx
@@ -46,11 +46,11 @@ export function SkillsPicker({
 }): React.ReactNode {
   const { rows: terminalRows } = useTerminalSize()
   // 每项恒占 2 行（正文 + 来源/简述描述行，均 truncate 成单行）。
-  // 框架行：浮层预留 8 + Pane 2 + 标题 2 + 页脚 1 = 13（ModelPicker 同款）。
+  // 框架行：浮层预留 8 + Pane 2 + 标题 2 + 页脚 1 + 挂载包裹 marginTop 1 = 14（ModelPicker 同款）。
   const { start, end } = listWindow(
     skills.map(() => 2),
     focusIndex,
-    Math.max(terminalRows - 13, 2),
+    Math.max(terminalRows - 14, 2),
   )
   return (
     <Pane color="permission">

--- a/src/components/design-system/ListItem.tsx
+++ b/src/components/design-system/ListItem.tsx
@@ -96,19 +96,19 @@ export function ListItem({
       {/* 行高恒 1、不压缩、溢出隐藏：压边换行会把每个列表项膨胀成 2 个
           屏幕行，与 listWindow 按每项申报的高度失配——浮层顶行被裁、真
           终端上换行泄入 scrollback 使行寻址错位、翻页错位累加（#396）。
-          选中 ✓ 计入同一截断预算：放在截断 Text 之外会在长名截断后恰好
-          写满终端最后一格，提交 pending-wrap（与 e43021a 边框行加固同族）。 */}
+          选中 ✓ 仍作为独立列保留：行容器溢出隐藏后，长名截断不会因尾部
+          ✓ 把整行撑成两行，且 ✓ 不会被 truncate-end 截掉（与 e43021a
+          边框行加固同族）。 */}
       <Box flexDirection="row" gap={1} height={1} flexShrink={0} overflow="hidden" width="100%">
         {renderIndicator()}
         {styled ? (
           <Text color={getTextColor()} dimColor={disabled} wrap="truncate-end">
             {flatChildren}
-            {isSelected && !disabled ? ` ${TICK}` : ''}
           </Text>
         ) : (
           flatChildren
         )}
-        {isSelected && !disabled && !styled && <Text color="success">{TICK}</Text>}
+        {isSelected && !disabled && <Text color="success">{TICK}</Text>}
       </Box>
       {description && (
         <Box paddingLeft={2}>

--- a/src/components/design-system/ListItem.tsx
+++ b/src/components/design-system/ListItem.tsx
@@ -93,16 +93,22 @@ export function ListItem({
 
   return (
     <Box ref={cursorRef} flexDirection="column">
-      <Box flexDirection="row" gap={1}>
+      {/* 行高恒 1、不压缩、溢出隐藏：压边换行会把每个列表项膨胀成 2 个
+          屏幕行，与 listWindow 按每项申报的高度失配——浮层顶行被裁、真
+          终端上换行泄入 scrollback 使行寻址错位、翻页错位累加（#396）。
+          选中 ✓ 计入同一截断预算：放在截断 Text 之外会在长名截断后恰好
+          写满终端最后一格，提交 pending-wrap（与 e43021a 边框行加固同族）。 */}
+      <Box flexDirection="row" gap={1} height={1} flexShrink={0} overflow="hidden" width="100%">
         {renderIndicator()}
         {styled ? (
-          <Text color={getTextColor()} dimColor={disabled} wrap="truncate">
+          <Text color={getTextColor()} dimColor={disabled} wrap="truncate-end">
             {flatChildren}
+            {isSelected && !disabled ? ` ${TICK}` : ''}
           </Text>
         ) : (
           flatChildren
         )}
-        {isSelected && !disabled && <Text color="success">{TICK}</Text>}
+        {isSelected && !disabled && !styled && <Text color="success">{TICK}</Text>}
       </Box>
       {description && (
         <Box paddingLeft={2}>


### PR DESCRIPTION
## 根因（headless 探针复现实证）

`ListItem` 主行把截断正文与尾部选中 `✓`（及 gap）**分节点渲染**——截断预算未计入尾部列。多厂商长名截断后，省略号/✓ 恰好写满（或超出 1-2 格）终端最后一格，提交 pending-wrap：

- 每个列表项实际占 2 屏幕行，与 `listWindow` 按每项 1 行申报的高度失配；
- 浮层顶行被裁；真终端上换行泄入 scrollback 使 ink 行寻址与物理终端错位，翻页错位累加——正是 #396 截图中的重复行/多个 ❯/shell 提示符漏入视口。

次级缺陷：`ModelPicker`/`SkillsPicker` 框架行预算 `terminalRows-13` 漏算 Chat 挂载处 `marginTop=1`（实际 14）。

## 修复

- `✓`（含 1 列间隔）并入同一截断 Text（`truncate-end`），预算内永不压边；外层行恒高 1、不压缩、溢出隐藏（与 e43021a 边框行加固同族）；
- 预算 13 → 14；
- 共用 `ListItem` 的 SkillsPicker / ThemePicker / RewindPicker / HistorySearchDialog 一并受益。

## 验证

- 新增 `scripts/verify-picker-edge.tsx`（已接 CI）：58/61 列长名 + 翻页，断言零 wrapped 行、Pane 内无幽灵空行、标题/页脚/焦点在屏；
- **检出力实证**：临时回退本修复 → 门转红（title/footer 被裁断言命中）；恢复 → 双跑全绿；
- 相关门全绿：repro-picker-windowing（35 断言）、verify-ime-cursor、verify-word-jump、verify-shift-tab-mode；tsc 0。

Fixes #396