### PR TITLE
perf(input): wrap twice, not four times — memoized rows and char-width cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,15 @@ jobs:
       # 三种到达形态、CSI-u 与 modifyOtherKeys 的 Shift/Ctrl/Meta+Enter。
       - run: node --import tsx/esm scripts/verify-keys.tsx
 
+      # IME 光标锚定回归：物理光标必须停在输入 caret 上（问答面板输入
+      # 行、CJK 宽字符、历史搜索浮层）。
+      - run: node --import tsx/esm scripts/verify-ime-cursor.tsx
+
+      # PromptInput 折行光标回归（perf/prompt-input-wrap）：窄终端折行/
+      # Home/窗口滚动下，caret 行位随光标移动更新（抓 useMemo 依赖回归），
+      # 硬件光标与反色 caret 格重合。
+      - run: node --import tsx/esm scripts/verify-prompt-wrap-caret.tsx
+
       # 终端能力探测回归：延迟 OSC/XTVERSION 回复期间保持 raw mode，
       # 回复只进 querier，不回显成终端残影。
       - run: node --import tsx/esm scripts/verify-terminal-queries.tsx

--- a/scripts/verify-prompt-wrap-caret.tsx
+++ b/scripts/verify-prompt-wrap-caret.tsx
@@ -1,0 +1,157 @@
+/**
+ * PromptInput 折行光标回归（perf/prompt-input-wrap）：wrapToWidth 记忆化后
+ * caretVisualLine / caretCharCol / caretVisualCol 全部从 memo 化的 prefixRows
+ * 派生。本脚本在窄终端（20 列，内容宽 17）让输入真实折行，断言硬件光标
+ * 始终停在反色 caret 格上（useDeclaredCursor 的承诺），且窗口滚动把 caret
+ * 行留在屏内：
+ *   1. 8 个 CJK（16 列）单行：caret 在行 0，光标 == 反色 caret 格
+ *   2. 第 9 个 CJK（18 列 > 17）触发折行：反性格下移一行，光标仍重合
+ *   3. 折行后继续输入 ASCII：行中混合宽度，光标重合
+ *   4. Home：caret 回行 0，反性格回到首行，光标重合
+ *   5. 51 个 CJK（7 视觉行 > MAX_VISIBLE_LINES=5）：窗口下滚，caret 行仍在
+ *      屏内且光标重合；Home 后窗口回滚，反性格上移回首行区域
+ * 运行：node --import tsx/esm scripts/verify-prompt-wrap-caret.tsx
+ */
+export {} // 模块边界：避免顶层 await/全局名与其他 verify 脚本冲突
+
+process.env.FORCE_COLOR = '3'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { PromptInput }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/PromptInput.js'),
+])
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+function makeHarness(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 0, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode() { return this }
+    ref() { return this }
+    unref() { return this }
+  }
+  // 交叉类型：既满足 render() 的 tty 流类型，又保留测试写入/光标访问。
+  const stdout = new FakeStdout() as FakeStdout & NodeJS.WriteStream
+  const stdin = new FakeStdin() as FakeStdin & NodeJS.ReadStream
+  /** 硬件光标落点（useDeclaredCursor 的声明目标）。 */
+  const cursor = () => ({ x: term.buffer.active.cursorX, y: term.buffer.active.cursorY })
+  /** 屏幕上第一个反色格（聚焦 caret 的渲染形态）。 */
+  const findInverseCell = (): { x: number; y: number } | undefined => {
+    const buf = term.buffer.active
+    for (let y = 0; y < rows; y++) {
+      const line = buf.getLine(y)
+      if (!line) continue
+      for (let x = 0; x < line.length; x++) {
+        const cell = line.getCell(x)
+        if (cell && cell.isInverse()) return { x, y }
+      }
+    }
+    return undefined
+  }
+  return { stdout, stdin, cursor, findInverseCell }
+}
+
+// channel mock 与 verify-word-jump.mjs 同款：PromptInput 只消费这些面。
+const submitted: string[] = []
+const channel = {
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  cycleMode() {},
+  commandList: [],
+  commandCompletions: () => [],
+  notifications: [],
+  pending: [],
+  working: false,
+  notify() {},
+  submit(text: string) { submitted.push(text) },
+  steer() {},
+  interruptAndDeliver() {},
+  removePending() {},
+  stageImage() {},
+  listFiles: async () => [],
+}
+
+let failures = 0
+const report = (name: string, ok: boolean, detail: string) => {
+  if (ok) console.log(`PASS  ${name}`)
+  else { failures++; console.log(`FAIL  ${name} — ${detail}`) }
+}
+
+/** 核心断言式：硬件光标与反色 caret 格重合，返回该格坐标。 */
+const expectAnchored = (label: string, inv: { x: number; y: number } | undefined, cur: { x: number; y: number }) => {
+  report(label, Boolean(inv) && cur.x === inv!.x && cur.y === inv!.y,
+    `inverse=${JSON.stringify(inv)} cursor=${JSON.stringify(cur)}`)
+  return inv
+}
+
+// ── 场景 1-5：单实例顺序驱动（20 列终端，inputWidth = 17）─────────────────
+{
+  const { stdout, stdin, cursor, findInverseCell } = makeHarness(20, 24)
+  const app = await render(
+    React.createElement(PromptInput, {
+      channel,
+      helpOpen: false,
+      onToggleHelp() {},
+      onRunCommand: () => false,
+      selectionActive: false,
+    }),
+    { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(400)
+
+  const feed = async (seq: string) => { stdin.write(seq); await sleep(400) }
+
+  // 场景 1：8 个 CJK = 16 列 ≤ 17，单行，caret 行 0。
+  await feed('一二三四五六七八')
+  let inv = expectAnchored('single CJK row: cursor anchored on inverse caret cell', findInverseCell(), cursor())
+
+  // 场景 2：第 9 个 CJK（18 列 > 17）触发折行 —— caret 移到视觉行 1。
+  await feed('九')
+  const invBeforeWrap = inv
+  inv = findInverseCell()
+  report('wrap boundary: inverse caret cell moved down one row', Boolean(inv) && Boolean(invBeforeWrap) && inv!.y === invBeforeWrap!.y + 1,
+    `before=${JSON.stringify(invBeforeWrap)} after=${JSON.stringify(inv)}`)
+  expectAnchored('after wrap: cursor anchored on inverse caret cell', inv, cursor())
+
+  // 场景 3：折行后行中混合宽度（'九ab'），caret 在 b 之后。
+  await feed('ab')
+  expectAnchored('mid-row mixed CJK+ASCII: cursor anchored', findInverseCell(), cursor())
+
+  // 场景 4：Home —— caret 回行 0 之首，反性格回到首行。
+  await feed('\x1b[H')
+  const invHome = findInverseCell()
+  report('Home: inverse caret cell back on first row', Boolean(invHome) && Boolean(inv) && invHome!.y === inv!.y - 1,
+    `home=${JSON.stringify(invHome)} prev=${JSON.stringify(inv)}`)
+  expectAnchored('Home: cursor anchored on inverse caret cell', invHome, cursor())
+
+  // 场景 5：51 个 CJK = 102 列 → 7 视觉行 > MAX_VISIBLE_LINES(5)，窗口下滚；
+  // caret 行必须仍在屏内（反性格存在），随后 Home 令窗口回滚上移。
+  await feed('永'.repeat(51))
+  const invLong = findInverseCell()
+  report('long wrap (7 rows > 5): caret row still on screen', Boolean(invLong), JSON.stringify(invLong))
+  expectAnchored('long wrap: cursor anchored on inverse caret cell', invLong, cursor())
+  await feed('\x1b[H')
+  const invLongHome = findInverseCell()
+  report('long wrap + Home: window scrolled back up', Boolean(invLongHome) && Boolean(invLong) && invLongHome!.y < invLong!.y,
+    `home=${JSON.stringify(invLongHome)} prev=${JSON.stringify(invLong)}`)
+  expectAnchored('long wrap + Home: cursor anchored', invLongHome, cursor())
+
+  app.unmount()
+  await sleep(100)
+}
+
+if (failures > 0) {
+  console.error(`verify-prompt-wrap-caret: ${failures} assertion(s) failed`)
+  process.exit(1)
+}
+console.log('verify-prompt-wrap-caret OK')

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -924,8 +924,23 @@ export function PromptInput({
   // the window of visual lines with the caret row always visible (CC's
   // maxVisibleLines behavior with automatic wrapping).
   const inputWidth = Math.max(10, columns - 3)
-  const visualLines = wrapToWidth(value, inputWidth)
-  const caretVisualLine = wrapToWidth(value.slice(0, cursor), inputWidth).length - 1
+  // 换行去重（长输入每键性能）：此前渲染体每键做 4 遍全量换行（全文 1
+  // + 光标前缀 3），每遍逐字符 stringWidth——数千字符后单键即超帧预算。
+  // 现在只做 2 遍且各自记忆化：纯光标移动（←/→/Home/End/行间）不重包
+  // 装全文，输入未变时前缀行也零重算。所有光标量从 prefixRows 派生，
+  // 数学与原三处调用点逐位等价（verify-ime-cursor 逐格锁定）。
+  const visualLines = React.useMemo(
+    () => wrapToWidth(value, inputWidth),
+    [value, inputWidth],
+  )
+  const prefixRows = React.useMemo(
+    () => wrapToWidth(value.slice(0, cursor), inputWidth),
+    [value, cursor, inputWidth],
+  )
+  const caretVisualLine = prefixRows.length - 1
+  const caretPrefixRow = prefixRows[prefixRows.length - 1] ?? ''
+  const caretCharCol = caretPrefixRow.length
+  const caretVisualCol = stringWidth(caretPrefixRow)
   const windowStart = Math.max(
     0,
     Math.min(
@@ -944,19 +959,6 @@ export function PromptInput({
   //   occupy TWO terminal columns, so the raw char count would park the
   //   cursor mid-character and Windows Terminal would paint the IME
   //   preedit (pinyin) over the surrounding text).
-  const caretCharCol = () => {
-    const before = value.slice(0, cursor)
-    const rows = wrapToWidth(before, inputWidth)
-    const last = rows[rows.length - 1] ?? ''
-    return last.length
-  }
-  const caretVisualCol = () => {
-    const before = value.slice(0, cursor)
-    const rows = wrapToWidth(before, inputWidth)
-    const last = rows[rows.length - 1] ?? ''
-    return stringWidth(last)
-  }
-
   const rendered = visibleLines.map((line, index) => {
     const absoluteLine = windowStart + index
     if (absoluteLine !== caretVisualLine) {
@@ -967,7 +969,7 @@ export function PromptInput({
       )
     }
     // Caret row: invert the char at the caret column (solid block).
-    const col = caretCharCol()
+    const col = caretCharCol
     const before = line.slice(0, col)
     const at = line[col] ?? ' '
     const after = line.slice(col + 1)
@@ -992,7 +994,7 @@ export function PromptInput({
   // relative to the value box the ref attaches to.
   const valueBoxRef = useDeclaredCursor({
     line: caretVisualLine - windowStart,
-    column: caretVisualCol(),
+    column: caretVisualCol,
     active: !selectionActive,
   })
 
@@ -1144,6 +1146,22 @@ export function PromptInput({
  * stringWidth). Used by the input renderer so long lines wrap instead of
  * truncating, with exact caret-row mapping.
  */
+// 单字符宽度缓存：wrapToWidth 逐字符调用 stringWidth，无缓存时长输入
+// 每键 O(N) 次全量测量（CJK/emoji 常数更大）。上限整清（同
+// line-width-cache.ts 的既有模式）—— Unicode 码位空间远大于上限，
+// 淘汰策略只需防无界增长，整清后热字符自然重填。
+const CHAR_WIDTH_CACHE = new Map<string, number>()
+const CHAR_WIDTH_CACHE_LIMIT = 4096
+function charWidth(ch: string): number {
+  let cached = CHAR_WIDTH_CACHE.get(ch)
+  if (cached === undefined) {
+    cached = stringWidth(ch)
+    if (CHAR_WIDTH_CACHE.size >= CHAR_WIDTH_CACHE_LIMIT) CHAR_WIDTH_CACHE.clear()
+    CHAR_WIDTH_CACHE.set(ch, cached)
+  }
+  return cached
+}
+
 function wrapToWidth(text: string, width: number): string[] {
   const rows: string[] = []
   for (const line of text.split('\n')) {
@@ -1154,7 +1172,7 @@ function wrapToWidth(text: string, width: number): string[] {
     let current = ''
     let currentWidth = 0
     for (const ch of line) {
-      const w = stringWidth(ch)
+      const w = charWidth(ch)
       if (currentWidth + w > width && current !== '') {
         rows.push(current)
         current = ch

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -927,8 +927,10 @@ export function PromptInput({
   // 换行去重（长输入每键性能）：此前渲染体每键做 4 遍全量换行（全文 1
   // + 光标前缀 3），每遍逐字符 stringWidth——数千字符后单键即超帧预算。
   // 现在只做 2 遍且各自记忆化：纯光标移动（←/→/Home/End/行间）不重包
-  // 装全文，输入未变时前缀行也零重算。所有光标量从 prefixRows 派生，
-  // 数学与原三处调用点逐位等价（verify-ime-cursor 逐格锁定）。
+  // 装全文，value 与 cursor 均未变时前缀行也零重算。所有光标量从
+  // prefixRows 派生，数学与原三处调用点逐位等价（verify-prompt-wrap-caret
+  // 锁定：折行边界/Home/窗口滚动的行位断言抓 memo 依赖回归——重合断言
+  // 对 stale 派生量自洽不敏感，行位变化才是真判据）。
   const visualLines = React.useMemo(
     () => wrapToWidth(value, inputWidth),
     [value, inputWidth],


### PR DESCRIPTION
## 症状与实测

长输入后输入栏逐键严重卡顿：本机（tmux，2000 ASCII）单键 **236–753ms**，空输入对照 **~62ms**——随字符数线性放大。

## 根因

渲染体每键做 **4 遍全量换行**（`wrapToWidth(value)` ×1 + 光标前缀 ×3），每遍**逐字符**调用无缓存的 `stringWidth`：O(4N) 次测量/键。`MAX_VISIBLE_LINES` 只封住可见行，没封住计算。

## 修复（零可见行为变化）

1. **4 遍 → 2 遍 + useMemo**：全文 `visualLines`（键 `[value, inputWidth]`）与光标前缀 `prefixRows`（键 `[value, cursor, inputWidth]`）各记忆化；所有光标量（`caretVisualLine` / `caretCharCol` / `caretVisualCol`）从 `prefixRows` 派生，**与原三处调用点数学逐位等价**——纯光标移动（←/→/Home/End/行间）不再触发任何重包装；
2. **单字符宽度缓存**：`wrapToWidth` 内模块级 `Map`（上限 4096 整清，照搬流式转录 `line-width-cache.ts` 的既有模式）——首键后逐字符测量退化为 Map 查找，中文/emoji 常数大幅下降。

## 守门（九门全绿）

`verify-ime-cursor`（**逐格锁定光标数学**：CJK 宽字符/窄屏换行/窗口滚动）、word-jump、shift-tab-mode、picker-windowing、batched-prompt-input、plain-enter-guard、prompt-history-draft、file-completion、clipboard-image（CI 同款 `--import tsx/esm`）；tsc 0。
