### PR TITLE
fix(render): stabilize streaming inline frames

### DIFF
--- a/scripts/repro-diff-split.tsx
+++ b/scripts/repro-diff-split.tsx
@@ -94,7 +94,7 @@ async function renderAt(cols, tool, diffLayout = 'auto', toolBackground = 'none'
     const markX = lines[pairRow]!.indexOf('mark="!"')
     check('右栏改动词组使用亮绿词色', markX > 0 && fgAt(markX, pairRow) === 0x57956b, `fg=${fgAt(Math.max(markX, 0), pairRow).toString(16)}`)
     const defX = lines[pairRow]!.indexOf('def')
-    check('关键字使用语法色（syntaxKeyword）', defX > 0 && fgAt(defX, pairRow) === 0x82aaff, `fg=${fgAt(Math.max(defX, 0), pairRow).toString(16)}`)
+    check('关键字使用语法色（syntaxKeyword）', defX > 0 && fgAt(defX, pairRow) === 0x78a0d6, `fg=${fgAt(Math.max(defX, 0), pairRow).toString(16)}`)
   }
   if (ctxRow >= 0) {
     check('默认 none 档：上下文行无卡片底色', bgAt(6, ctxRow) === 0xffffff, `bg=${bgAt(6, ctxRow).toString(16)}`)
@@ -202,11 +202,20 @@ async function renderAt(cols, tool, diffLayout = 'auto', toolBackground = 'none'
   const { lines: mlLines, fgAt: mlFg } = await renderAt(120, mlTool)
   const worldRow = mlLines.findIndex(line => line.includes('world'))
   const worldX = worldRow >= 0 ? mlLines[worldRow]!.indexOf('world') : -1
-  check('多行字符串后续行带字符串色', worldX > 0 && mlFg(worldX, worldRow) === 0xe5c07b, `fg=${worldX > 0 ? mlFg(worldX, worldRow).toString(16) : 'n/a'}`)
+  check('多行字符串后续行带字符串色', worldX > 0 && mlFg(worldX, worldRow) === 0x79ad91, `fg=${worldX > 0 ? mlFg(worldX, worldRow).toString(16) : 'n/a'}`)
+
+  // Shared helper regressions: JSON args, multiline TS state, and safe unknown fallback.
+  const hl = await getCliHighlightPromise()
+  const jsonRuns = highlightLines('{"file_path":"src/a.ts","line":2}', 'json', hl, {
+    string: chalkFromToken('#82B89D'), number: chalkFromToken('#D19A66'),
+  }, 'json-dark')
+  check('JSON 参数产生字符串/数字 token', jsonRuns?.flat().some(run => run.color === 'rgb(130,184,157)') === true && jsonRuns.flat().some(run => run.color === 'rgb(209,154,102)') === true)
+  const tsRuns = highlightLines('const value = `first\nsecond`', 'ts', hl, { string: chalkFromToken('#82B89D') }, 'ts-dark')
+  check('TypeScript 多行字符串保持 lexer 状态', tsRuns?.[1]?.some(run => run.color === 'rgb(130,184,157)') === true)
+  check('未知语言安全回退', highlightLines('plain output', 'future-agent-language', hl, {}, 'unknown') === undefined)
 
   // P1-2: the syntax cache keys on the theme signature — a palette change
   // must not serve stale colors.
-  const hl = await getCliHighlightPromise()
   const chDark = { keyword: chalkFromToken('#8FA8E8') }
   const chLight = { keyword: chalkFromToken('#4A63A8') }
   const darkRuns = highlightLines('def f():', 'py', hl, chDark, 'sig-dark')

--- a/scripts/repro-inline-scrollback.tsx
+++ b/scripts/repro-inline-scrollback.tsx
@@ -5,9 +5,11 @@
  * 超过视口无法全部擦除），旧帧内容会永久落入 scrollback：用户上滚看到
  * "UI 重复渲染 / 启动页随机插入 / 输出结束后上方内容乱掉"。
  *
- * 场景照 issue #39：预置 2 轮历史（冷高度缓存）+ 长流式回复 + spinner/
- * 指标独立 tick。xterm-headless 开 2000 行 scrollback 重建终端视角，
- * 断言 scrollback + 视口中每段唯一 UI 文本只出现一次。
+ * 场景照 issue #39：小视口下预置 2 轮历史（冷高度缓存）+ 长流式回复 +
+ * spinner/指标独立 tick。xterm-headless 开 2000 行 scrollback 重建终端视角，
+ * 断言 scrollback + 视口中每段唯一 UI 文本只出现一次；完整跑过 streaming
+ * reasoning → tool → assistant/working → idle 后，还断言硬件 cursor 与输入 caret
+ * 重合，且思考、工具、正文、输入边框各占独立行，没有互相覆盖。
  * 运行：node --import tsx/esm scripts/repro-inline-scrollback.tsx
  */
 process.env.FORCE_COLOR = '3'
@@ -25,8 +27,9 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
 ])
 
 const COLS = 100
-const ROWS = 40
+const ROWS = 20
 const SCROLLBACK = 2000
+const INPUT_MARKER = 'CARET_ANCHOR_7F31'
 const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: SCROLLBACK, allowProposedApi: true })
 
 const rawChunks: string[] = []
@@ -193,7 +196,7 @@ const tool1 = {
   id: id++, kind: 'tool', text: '',
   tool: {
     callId: 'c1', name: 'Bash',
-    argsText: '{"command": "git log --oneline -15"}',
+    argsText: '{"command": "printf TOOL_CALL_ONCE_7F31"}',
     argsFull: '{}',
     status: 'running' as string, resultText: undefined as string | undefined, startedAt: Date.now(), durationMs: undefined as number | undefined,
   },
@@ -209,7 +212,7 @@ bump(); await sleep(200)
 const finalMsg = { id: id++, kind: 'assistant', text: '', streaming: true }
 channel.rows.push(finalMsg); bump()
 const sections = ['一、项目定位', '二、技术栈', '三、核心功能', '四、数据设计要点', '五、代码结构', '六、工程规范', '七、构建与发布', '八、数据迁移', '九、当前状态备注']
-const docLines: string[] = []
+const docLines: string[] = ['ASSISTANT_BODY_ONCE_7F31\n\n']
 for (const sec of sections) {
   docLines.push(sec + '\n')
   for (let i = 0; i < 11; i++) docLines.push(`- ${sec} 的第 ${i + 1} 条说明文字：应用装配、主题系统、同步与加密打包\n`)
@@ -229,10 +232,16 @@ for (const chunk of doc) {
 }
 finalMsg.streaming = false
 channel.working = false
+channel.status = 'idle'
 bump()
 await sleep(800)
 clearInterval(ticker)
 await sleep(300)
+
+// 闲置后在真实 PromptInput 输入短标记：caret 的反色格和 xterm 硬件
+// cursor 必须重合。此时整帧远高于小视口，覆盖 native cursor 的长帧坐标路径。
+stdin.write(INPUT_MARKER)
+await sleep(500)
 
 // ---- 字节取证：erase/清屏/滚动序列统计（定位残留的发生机制） ----------------
 const allRaw = rawChunks.join('')
@@ -293,14 +302,58 @@ for (const t of [
   '看看这个项目，给个概览',
   'READ_ONCE_7F31',
   'READ_RESULT_ONCE_7F31',
+  'TOOL_CALL_ONCE_7F31',
+  'ASSISTANT_BODY_ONCE_7F31',
+  INPUT_MARKER,
 ]) {
   const n = count(t)
   check(`「${t}」恰好一份`, n === 1, `实际 ${n} 次`)
 }
-for (const t of ['五、代码结构', '九、当前状态备注']) {
+for (const t of ['五、代码结构']) {
   const n = countExact(t)
   check(`「${t}」标题行恰好一份`, n === 1, `实际 ${n} 次`)
 }
+
+const rowOf = (needle: string) => lines.findIndex(line => line.includes(needle))
+const thinkingRow = lines.findLastIndex(line => line.includes('思考 ·'))
+const toolRow = rowOf('TOOL_CALL_ONCE_7F31')
+const bodyRow = rowOf('ASSISTANT_BODY_ONCE_7F31')
+const inputRow = rowOf(INPUT_MARKER)
+const semanticRows = [thinkingRow, toolRow, bodyRow, inputRow]
+const separateRows = semanticRows.every(row => row >= 0) && new Set(semanticRows).size === semanticRows.length
+check(
+  '思考、工具、正文、输入各占独立行',
+  separateRows,
+  `rows=${semanticRows.join(',')}`,
+)
+
+let caretX = -1
+if (inputRow >= 0) {
+  const inputLine = buf.getLine(inputRow)
+  if (inputLine) {
+    for (let x = 0; x < inputLine.length; x++) {
+      if (inputLine.getCell(x)?.isInverse()) { caretX = x; break }
+    }
+  }
+}
+const hardwareCursor = { x: buf.cursorX, y: buf.baseY + buf.cursorY }
+check(
+  '长帧 idle 输入：硬件 cursor 与反色 caret 重合',
+  caretX >= 0 && hardwareCursor.x === caretX && hardwareCursor.y === inputRow,
+  `caret=${caretX},${inputRow} cursor=${hardwareCursor.x},${hardwareCursor.y} baseY=${buf.baseY}`,
+)
+
+const topBorder = lines[inputRow - 1] ?? ''
+const bottomBorder = lines[inputRow + 1] ?? ''
+const borderIntact = topBorder.includes('╭') && topBorder.includes('╮')
+  && bottomBorder.includes('╰') && bottomBorder.includes('╯')
+  && ![topBorder, bottomBorder].some(line => /思考 ·|TOOL_CALL_ONCE|ASSISTANT_BODY_ONCE/.test(line))
+check(
+  '输入边框完整且未覆盖思考、工具或正文',
+  borderIntact,
+  `top=${JSON.stringify(topBorder)} bottom=${JSON.stringify(bottomBorder)}`,
+)
+
 // full-reset 零触发：收缩帧（thinking 折叠、回合结束 spinner 卸载）必须走
 // 视口就地重画，任何一次 clearTerminal 都会把整份 UI 复制进 scrollback。
 const resets = (allRaw.match(/\x1b\[\d+S/g) ?? []).length

--- a/src/cc/syntaxRuns.ts
+++ b/src/cc/syntaxRuns.ts
@@ -1,0 +1,85 @@
+import type { CliHighlight } from './cliHighlight.js'
+import { SYNTAX_CLASS_TO_TOKEN, buildSyntaxTheme } from './syntaxTheme.js'
+import type { Theme } from '../theme.js'
+
+export type SyntaxRun = { readonly text: string; readonly color?: string }
+export type SyntaxLines = readonly (readonly SyntaxRun[])[]
+type SyntaxTheme = Theme | Record<string, (text: string) => string>
+
+const ANSI16: Record<number, string> = {
+  30: 'rgb(0,0,0)', 31: 'rgb(128,0,0)', 32: 'rgb(0,128,0)', 33: 'rgb(128,128,0)',
+  34: 'rgb(0,0,128)', 35: 'rgb(128,0,128)', 36: 'rgb(0,128,128)', 37: 'rgb(192,192,192)',
+  90: 'rgb(128,128,128)', 91: 'rgb(255,0,0)', 92: 'rgb(0,255,0)', 93: 'rgb(255,255,0)',
+  94: 'rgb(0,0,255)', 95: 'rgb(255,0,255)', 96: 'rgb(0,255,255)', 97: 'rgb(255,255,255)',
+}
+
+/** Parse ANSI once, preserving active syntax colors over embedded newlines. */
+export function parseAnsiRuns(text: string): SyntaxRun[] {
+  const runs: SyntaxRun[] = []
+  let color: string | undefined
+  let rest = text
+  // eslint-disable-next-line no-control-regex -- parsing SGR is intentional
+  const sgr = /\x1b\[([0-9;]+)m/
+  while (rest.length > 0) {
+    const match = sgr.exec(rest)
+    const chunk = match === null ? rest : rest.slice(0, match.index)
+    if (chunk !== '') runs.push(color === undefined ? { text: chunk } : { text: chunk, color })
+    if (match === null) break
+    const codes = match[1]!.split(';').map(Number)
+    if (codes.includes(0) || codes.includes(39)) color = undefined
+    else if (codes[0] === 38 && codes[1] === 2 && codes.length >= 5) color = `rgb(${codes[2]},${codes[3]},${codes[4]})`
+    else if (codes[0] === 38 && codes[1] === 5 && codes.length >= 3) color = `ansi256(${codes[2]})`
+    else if (codes.length === 1 && ANSI16[codes[0]!] !== undefined) color = ANSI16[codes[0]!]
+    rest = rest.slice(match.index + match[0].length)
+  }
+  return runs
+}
+
+export function splitRunsToLines(runs: readonly SyntaxRun[]): SyntaxLines {
+  const lines: SyntaxRun[][] = [[]]
+  for (const run of runs) {
+    const parts = run.text.split('\n')
+    for (let i = 0; i < parts.length; i++) {
+      if (i > 0) lines.push([])
+      if (parts[i] !== '') lines[lines.length - 1]!.push(run.color === undefined ? { text: parts[i]! } : { text: parts[i]!, color: run.color })
+    }
+  }
+  return lines
+}
+
+const syntaxCache = new Map<string, SyntaxLines>()
+const SYNTAX_CACHE_MAX = 64
+
+/** Highlight complete text, then split it; unsupported or failed languages are plain. */
+export function highlightLines(
+  text: string,
+  language: string | undefined,
+  highlighter: CliHighlight | null,
+  theme: SyntaxTheme | undefined,
+  themeSig: string,
+): SyntaxLines | undefined {
+  if (highlighter === null || theme === undefined || language === undefined || text === '' || !highlighter.supportsLanguage(language)) return undefined
+  const key = `${themeSig}\u0000${language}\u0000${text}`
+  const cached = syntaxCache.get(key)
+  if (cached !== undefined) return cached
+  try {
+    const themeOption = 'syntaxKeyword' in theme
+      ? buildSyntaxTheme(theme as Theme)
+      : theme
+    const highlighted = highlighter.highlight(text, { language, theme: themeOption })
+    const lines = splitRunsToLines(parseAnsiRuns(highlighted))
+    if (syntaxCache.size >= SYNTAX_CACHE_MAX) {
+      const first = syntaxCache.keys().next().value
+      if (first !== undefined) syntaxCache.delete(first)
+    }
+    syntaxCache.set(key, lines)
+    return lines
+  } catch {
+    return undefined
+  }
+}
+
+export function syntaxThemeSignature(theme: Theme): string {
+  const palette = theme as unknown as Record<string, string>
+  return Object.values(SYNTAX_CLASS_TO_TOKEN).map(key => palette[key] ?? '').join('|')
+}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -568,6 +568,7 @@ function TranscriptRow({
           marginTop={addMargin ? 1 : 0}
           width="100%"
           backgroundColor={background}
+          ref={ref}
         >
           <Box minWidth={2}>
             <Text color="text">●</Text>

--- a/src/components/SplitDiffView.tsx
+++ b/src/components/SplitDiffView.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { Box, Text } from '../ui.js'
 import * as JsDiff from 'diff'
-import chalk from 'chalk'
 import { extname } from 'node:path'
 import type { ToolFileDiff } from '../dsh-adapter/channel.js'
 import type { Color } from '../ink/styles.js'
 import { getCliHighlightPromise, type CliHighlight } from '../cc/cliHighlight.js'
-import { SYNTAX_CLASS_TO_TOKEN, chalkFromToken } from '../cc/syntaxTheme.js'
+import { chalkFromToken } from '../cc/syntaxTheme.js'
+import { highlightLines, syntaxThemeSignature, type SyntaxRun } from '../cc/syntaxRuns.js'
 // Backward-compatible re-export: repro scripts import chalkFromToken from
 // this module's old home.
 export { chalkFromToken } from '../cc/syntaxTheme.js'
+export { parseAnsiRuns, highlightLines } from '../cc/syntaxRuns.js'
 import { getTheme } from '../theme.js'
 import { useTheme } from './design-system/ThemeProvider.js'
 import type { ToolBackground } from '../tuiDisplayPrefs.js'
@@ -63,99 +64,13 @@ interface DiffRow {
 /** Replace tabs so width math and alignment hold (pi convention). */
 const expandTabs = (text: string): string => text.replaceAll('\t', '   ')
 
-// --- syntax highlighting ----------------------------------------------------
-
-// The hljs-class → theme-token map and chalkFromToken live in
-// ../cc/syntaxTheme.ts (shared with the markdown code-block renderer).
-
-/** ANSI 16-color SGR codes → rgb() strings (the dark-ansi palette path). */
-const ANSI16: Record<number, string> = {
-  30: 'rgb(0,0,0)', 31: 'rgb(128,0,0)', 32: 'rgb(0,128,0)', 33: 'rgb(128,128,0)',
-  34: 'rgb(0,0,128)', 35: 'rgb(128,0,128)', 36: 'rgb(0,128,128)', 37: 'rgb(192,192,192)',
-  90: 'rgb(128,128,128)', 91: 'rgb(255,0,0)', 92: 'rgb(0,255,0)', 93: 'rgb(255,255,0)',
-  94: 'rgb(0,0,255)', 95: 'rgb(255,0,255)', 96: 'rgb(0,255,255)', 97: 'rgb(255,255,255)',
-}
-
-/** Parse a cli-highlight ANSI string into colored runs, preserving open
- *  spans across embedded newlines (multi-line strings/comments). Handles
- *  truecolor 38;2, 256-color 38;5 (tmux / FORCE_COLOR=2, issue #250 P1-1),
- *  and single-code 16-color SGR. */
-export function parseAnsiRuns(text: string): { text: string; color?: string }[] {
-  const runs: { text: string; color?: string }[] = []
-  let color: string | undefined
-  let rest = text
-  // eslint-disable-next-line no-control-regex -- parsing SGR is the point
-  const sgr = /\x1b\[([0-9;]+)m/
-  while (rest.length > 0) {
-    const match = sgr.exec(rest)
-    const chunk = match === null ? rest : rest.slice(0, match.index)
-    if (chunk !== '') runs.push(color === undefined ? { text: chunk } : { text: chunk, color })
-    if (match === null) break
-    const codes = match[1]!.split(';').map(Number)
-    if (codes.includes(0) || codes.includes(39)) color = undefined
-    else if (codes[0] === 38 && codes[1] === 2 && codes.length >= 5) {
-      color = `rgb(${codes[2]},${codes[3]},${codes[4]})`
-    } else if (codes[0] === 38 && codes[1] === 5 && codes.length >= 3) {
-      color = `ansi256(${codes[2]})`
-    } else if (codes.length === 1 && ANSI16[codes[0]!] !== undefined) {
-      color = ANSI16[codes[0]!]
-    }
-    rest = rest.slice(match.index + match[0].length)
-  }
-  return runs
-}
-
-/** Split flat runs into per-line run arrays at embedded newlines. */
-function splitRunsToLines(runs: readonly { text: string; color?: string }[]): { text: string; color?: string }[][] {
-  const lines: { text: string; color?: string }[][] = [[]]
-  for (const run of runs) {
-    const parts = run.text.split('\n')
-    for (let i = 0; i < parts.length; i++) {
-      if (i > 0) lines.push([])
-      if (parts[i] !== '') {
-        lines[lines.length - 1]!.push(run.color === undefined ? { text: parts[i]! } : { text: parts[i]!, color: run.color })
-      }
-    }
-  }
-  return lines
-}
-
-/** Whole-hunk syntax runs per line, cached per (theme signature + language
- *  + text): one entry survives any amount of card re-rendering, and the
- *  palette change invalidates it (issue #250, P1-2 + P2-8). */
-const syntaxCache = new Map<string, readonly { text: string; color?: string }[][]>()
-const SYNTAX_CACHE_MAX = 40
-
-export function highlightLines(
-  text: string,
-  language: string | undefined,
-  hl: CliHighlight | null,
-  chTheme: Record<string, (text: string) => string> | undefined,
-  themeSig: string,
-): readonly { text: string; color?: string }[][] | undefined {
-  if (hl === null || chTheme === undefined || language === undefined) return undefined
-  if (text === '' || !hl.supportsLanguage(language)) return undefined
-  const key = `${themeSig}${language}${text}`
-  const cached = syntaxCache.get(key)
-  if (cached !== undefined) return cached
-  let lines: readonly { text: string; color?: string }[][]
-  try {
-    lines = splitRunsToLines(parseAnsiRuns(hl.highlight(text, { language, theme: chTheme })))
-  } catch {
-    return undefined
-  }
-  if (syntaxCache.size >= SYNTAX_CACHE_MAX) syntaxCache.clear()
-  syntaxCache.set(key, lines)
-  return lines
-}
-
 /**
  * Merge syntax runs with word-diff change flags over the same string: both
  * partition it, so an offset sweep yields runs carrying a syntax color AND
  * a changed flag. The render layer lets `changed` override the color.
  */
 function mergeRuns(
-  syntax: readonly { text: string; color?: string }[],
+  syntax: readonly SyntaxRun[],
   words: readonly Segment[],
 ): Segment[] {
   const out: Segment[] = []
@@ -404,23 +319,8 @@ export function SplitDiffView({
   const [themeName] = useTheme()
   // Resolved-palette signature: covers dark→light, light→dark, AND the
   // `auto` base flip where the name never changes (issue #250, P1-2).
-  const themeSig = React.useMemo(() => {
-    const theme = getTheme(themeName) as unknown as Record<string, string>
-    return Object.values(SYNTAX_CLASS_TO_TOKEN)
-      .map(key => theme[key] ?? '')
-      .join('|')
-  }, [themeName])
-  const chTheme = React.useMemo(() => {
-    const theme = getTheme(themeName) as unknown as Record<string, string>
-    const out: Record<string, (text: string) => string> = {}
-    for (const [tokenClass, tokenKey] of Object.entries(SYNTAX_CLASS_TO_TOKEN)) {
-      const value = theme[tokenKey]
-      if (value !== undefined) out[tokenClass] = chalkFromToken(value)
-    }
-    return out
-    // themeSig changes exactly when any syntax token's resolved value does.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [themeSig])
+  const syntaxTheme = React.useMemo(() => getTheme(themeName), [themeName])
+  const themeSig = React.useMemo(() => syntaxThemeSignature(syntaxTheme), [syntaxTheme])
 
   // Alignment is text-only and capped BEFORE styling: the highlighter and
   // word-diff work lands only on the visible slice (issue #250, P2-8).
@@ -447,8 +347,8 @@ export function SplitDiffView({
   const fileSyntax = diffs.map(diff => {
     const language = extname(diff.path).replace(/^\./, '') || undefined
     return {
-      old: highlightLines(expandTabs(diff.oldText ?? ''), language, hl, chTheme, themeSig),
-      next: highlightLines(expandTabs(diff.newText), language, hl, chTheme, themeSig),
+      old: highlightLines(expandTabs(diff.oldText ?? ''), language, hl, syntaxTheme, themeSig),
+      next: highlightLines(expandTabs(diff.newText), language, hl, syntaxTheme, themeSig),
     }
   })
 

--- a/src/components/SyntaxText.tsx
+++ b/src/components/SyntaxText.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Text } from '../ui.js'
+import type { Color } from '../ink/styles.js'
+import { getCliHighlightPromise, type CliHighlight } from '../cc/cliHighlight.js'
+import { highlightLines, syntaxThemeSignature, type SyntaxLines } from '../cc/syntaxRuns.js'
+import { getTheme } from '../theme.js'
+import { useTheme } from './design-system/ThemeProvider.js'
+
+type Props = {
+  readonly text: string
+  readonly language?: string
+  /** Complete payload used for lexing; text is the visible line. */
+  readonly sourceText?: string
+  readonly lineIndex?: number
+  readonly color?: Color
+  readonly dimColor?: boolean
+}
+
+/** Async nested Text renderer. Lexes the complete payload before splitting. */
+export function SyntaxText({ text, language, sourceText = text, lineIndex = 0, color, dimColor }: Props): React.ReactNode {
+  const [highlighter, setHighlighter] = React.useState<CliHighlight | null>(null)
+  const [themeName] = useTheme()
+  React.useEffect(() => {
+    let mounted = true
+    void getCliHighlightPromise().then(value => { if (mounted) setHighlighter(value) })
+    return () => { mounted = false }
+  }, [])
+  const theme = React.useMemo(() => getTheme(themeName), [themeName])
+  const themeSig = React.useMemo(() => syntaxThemeSignature(theme), [theme])
+  const syntax: SyntaxLines | undefined = React.useMemo(
+    () => highlightLines(sourceText, language, highlighter, theme, themeSig),
+    [sourceText, language, highlighter, theme, themeSig],
+  )
+  const runs = syntax?.[lineIndex]
+  if (runs === undefined || color !== undefined || dimColor) {
+    return <Text color={color} dimColor={dimColor}>{text === '' ? ' ' : text}</Text>
+  }
+  let remaining = text.length
+  const visibleRuns = runs.flatMap(run => {
+    if (remaining <= 0) return []
+    const visible = run.text.slice(0, remaining)
+    remaining -= visible.length
+    return visible === '' ? [] : [{ ...run, text: visible }]
+  })
+  return (
+    <Text>
+      {visibleRuns.length === 0 ? text : visibleRuns.map((run, index) => (
+        <Text key={index} color={run.color as Color | undefined}>{run.text}</Text>
+      ))}
+    </Text>
+  )
+}

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { extname } from 'node:path'
 import { Box, Text, useTerminalSize } from '../../ui.js'
 import { stringWidth } from '../../ink/stringWidth.js'
 import { useAnimationFrame } from '../../ink/hooks/use-animation-frame.js'
 import type { ToolCallView, ToolFileDiff, ToolResultView, ToolRow } from '../../dsh-adapter/channel.js'
 import { ToolUseLoader } from '../ToolUseLoader.js'
 import { SplitDiffView } from '../SplitDiffView.js'
+import { SyntaxText } from '../SyntaxText.js'
 import { formatDuration } from '../../cc/format.js'
 import type { ToolBackground } from '../../tuiDisplayPrefs.js'
 import type { Theme } from '../../theme.js'
@@ -54,6 +56,29 @@ function displayName(name: string): string {
   if (mapped) return mapped
   if (name.length === 0) return name
   return name[0]!.toUpperCase() + name.slice(1)
+}
+
+function parseJsonArgs(args: string): unknown {
+  try { return JSON.parse(args) } catch { return undefined }
+}
+
+function jsonArgsLanguage(args: string): 'json' | undefined {
+  return parseJsonArgs(args) === undefined ? undefined : 'json'
+}
+
+function filePathFromTool(tool: ToolRow, view: ToolCallView | ToolResultView | undefined): string | undefined {
+  if (view !== undefined && 'path' in view && typeof view.path === 'string') return view.path
+  const parsed = parseJsonArgs(tool.argsFull ?? tool.argsText)
+  if (parsed !== null && typeof parsed === 'object') {
+    const record = parsed as Record<string, unknown>
+    for (const key of ['file_path', 'path']) if (typeof record[key] === 'string') return record[key]
+  }
+  return undefined
+}
+
+function languageFromPath(path: string | undefined): string | undefined {
+  const language = path === undefined ? undefined : extname(path).slice(1).toLowerCase()
+  return language === '' ? undefined : language
 }
 
 // --- structured body lines --------------------------------------------------
@@ -204,11 +229,12 @@ function clipHeaderArgs(args: string): string {
   return `${args.slice(0, HEADER_ARGS_BUDGET)}…`
 }
 
-function HeaderTitle({ name, title, isTerminal, displayArgs, nameColor }: {
+function HeaderTitle({ name, title, isTerminal, displayArgs, argsLanguage, nameColor }: {
   name: string
   title: string | undefined
   isTerminal: boolean
   displayArgs: string
+  argsLanguage?: 'json'
   nameColor: keyof Theme
 }): React.ReactNode {
   if (title === undefined) {
@@ -219,7 +245,9 @@ function HeaderTitle({ name, title, isTerminal, displayArgs, nameColor }: {
         </Box>
         {displayArgs !== '' && (
           <Box flexWrap="nowrap">
-            <Text>({clipHeaderArgs(displayArgs)})</Text>
+            <Text>(</Text>
+            <SyntaxText text={clipHeaderArgs(displayArgs)} sourceText={displayArgs} language={argsLanguage} />
+            <Text>)</Text>
           </Box>
         )}
       </>
@@ -283,6 +311,10 @@ export function AssistantToolUseMessage({
   // The settled view carries the applied diff / actual output; while running,
   // the call view already shows the pending change (CC's pending Edit diff).
   const view = tool.resultView ?? tool.callView
+  const filePath = filePathFromTool(tool, view)
+  const syntaxLanguage = view?.card === 'read' || view?.card === 'generic' || view === undefined
+    ? languageFromPath(filePath)
+    : undefined
   // presentResult may omit a title (terminal results carry output, not a
   // command) — then the call view's title stands.
   const headerTitle = tool.resultView?.title ?? tool.callView?.title
@@ -319,6 +351,8 @@ export function AssistantToolUseMessage({
     }
   }
   const cap = view?.card === 'diff' ? DIFF_BODY_MAX_LINES : TEXT_BODY_MAX_LINES
+  const bodySource = body.map(line => line.text).join('\n')
+  const argsLanguage = jsonArgsLanguage(displayArgs)
   // The footnote rides OUTSIDE the cap: it is a pointer, not content, and a
   // long error body must not be the reason it disappears.
   const lines = capLines(body, cap, verbose)
@@ -352,7 +386,7 @@ export function AssistantToolUseMessage({
             isError={isError}
             toolName={tool.name}
           />
-          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} nameColor={toolNameColor(tool.name)} />
+          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} argsLanguage={argsLanguage} nameColor={toolNameColor(tool.name)} />
           {!isRunning && (
             <Box flexWrap="nowrap">
               <Text dimColor>{elapsedText}</Text>
@@ -409,7 +443,11 @@ export function AssistantToolUseMessage({
                   dimColor={line.tone === 'dim'}
                   wrap="wrap"
                 >
-                  {line.text === '' ? ' ' : line.text}
+                  {line.tone === 'plain' && syntaxLanguage !== undefined ? (
+                    <SyntaxText text={line.text} sourceText={bodySource} lineIndex={index} language={syntaxLanguage} />
+                  ) : (
+                    line.text === '' ? ' ' : line.text
+                  )}
                 </Text>
               </Box>
             </Box>

--- a/src/components/messages/UserPromptMessage.tsx
+++ b/src/components/messages/UserPromptMessage.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { Box, Text } from '../../ui.js'
+import { Box, Text, useTerminalSize } from '../../ui.js'
 import { POINTER } from '../../cc/figures.js'
+import { stringWidth } from '../../ink/stringWidth.js'
+import { wrapWidth } from '../../sessions/format.js'
 
 type Props = {
   text: string
@@ -22,6 +24,18 @@ export function UserPromptMessage({
   isSelected = false,
   onClick,
 }: Props): React.ReactNode {
+  const { columns } = useTerminalSize()
+  const promptPrefix = `${POINTER} `
+  const prefixWidth = stringWidth(promptPrefix)
+  // Wrap here instead of letting Ink wrap the whole Text node. Ink starts an
+  // automatic continuation at column zero, while a prompt needs a hanging
+  // indent for both explicit newlines and width-based visual lines.
+  // Leave a small safety margin for the ScrollBox edge/scrollbar. The Text
+  // nodes below are explicitly wrapped, so they must never be wrapped again by
+  // Ink; a second wrap would move the continuation back to column zero.
+  const lines = wrapWidth(text, Math.max(1, columns - prefixWidth - 3))
+  const continuationIndent = ' '.repeat(prefixWidth)
+
   return (
     <Box
       flexDirection="column"
@@ -30,9 +44,12 @@ export function UserPromptMessage({
       paddingRight={1}
       onClick={onClick}
     >
-      <Text color="briefLabelYou" bold>
-        {POINTER} {text}
-      </Text>
+      {lines.map((line, index) => (
+        <Text key={index} color="briefLabelYou" bold wrap="truncate-end">
+          {index === 0 ? `${POINTER} ` : continuationIndent}
+          {line}
+        </Text>
+      ))}
     </Box>
   )
 }

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -102,6 +102,10 @@ export default class Ink {
   private backFrame: Frame;
   private lastPoolResetTime = performance.now();
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  // Every scheduled microtask carries the generation that created it. Immediate
+  // renders invalidate older trailing work before it can append an old frame.
+  private renderGeneration = 0;
+  private pendingRenderGeneration: number | null = null;
   private lastYogaCounters: {
     ms: number;
     visited: number;
@@ -231,8 +235,18 @@ export default class Ink {
     // effects have committed, so the native cursor tracks the caret without
     // a one-keystroke lag. Same event-loop tick, so throughput is unchanged.
     // Test env uses onImmediateRender (direct onRender, no throttle) so
-    // existing synchronous lastFrame() tests are unaffected.
-    const deferredRender = (): void => queueMicrotask(this.onRender);
+    // existing synchronous lastFrame() tests are unaffected. Keep a
+    // generation on the microtask: an immediate render may supersede the
+    // leading frame before its deferred callback runs.
+    const deferredRender = (): void => {
+      const generation = ++this.renderGeneration;
+      this.pendingRenderGeneration = generation;
+      queueMicrotask(() => {
+        if (this.pendingRenderGeneration !== generation || this.renderGeneration !== generation) return;
+        this.pendingRenderGeneration = null;
+        this.onRender();
+      });
+    };
     this.scheduleRender = throttle(deferredRender, FRAME_INTERVAL_MS, {
       leading: true,
       trailing: true
@@ -258,7 +272,7 @@ export default class Ink {
     this.rootNode.focusManager = this.focusManager;
     this.renderer = createRenderer(this.rootNode, this.stylePool);
     this.rootNode.onRender = this.scheduleRender;
-    this.rootNode.onImmediateRender = this.onRender;
+    this.rootNode.onImmediateRender = this.renderNow;
     this.rootNode.onComputeLayout = () => {
       // Calculate layout during React's commit phase so useLayoutEffect hooks
       // have access to fresh layout data
@@ -495,6 +509,17 @@ export default class Ink {
   reanchorViewport() {
     if (this.altScreenActive) return;
     this.log.requestViewportReanchor();
+  }
+  /** Render synchronously and invalidate older trailing/drain callbacks. */
+  private renderNow(): void {
+    this.renderGeneration++;
+    this.pendingRenderGeneration = null;
+    this.scheduleRender.cancel?.();
+    if (this.drainTimer !== null) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+    this.onRender();
   }
   onRender() {
     if (this.isUnmounted || this.isPaused) {
@@ -740,22 +765,15 @@ export default class Ink {
     // and no move is emitted.
     const decl = this.cursorDeclaration;
     const rect = decl !== null ? nodeCache.get(decl.node) : undefined;
-    // Main-screen inline mode stores node rectangles in frame coordinates,
-    // while the physical terminal only exposes the viewport tail once the
-    // frame is taller than the terminal. Convert the declared row to that
-    // visible coordinate system before emitting the relative cursor move.
-    // Without this subtraction a long streaming frame asks the terminal to
-    // move to an off-screen row; terminals clamp it at the bottom, leaving
-    // the virtual and physical cursor origins out of sync for the next diff.
-    // Offset is exactly the rows pushed into scrollback: H - V when the frame
-    // outgrows the viewport, 0 when it fits (H <= V). A +1 here would nudge a
-    // just-fitting frame (H === V) up one row, misplacing the input caret.
-    const visibleFrameOffset = this.altScreenActive
-      ? 0
-      : Math.max(0, frame.screen.height - frame.viewport.height);
+    // Keep the declared target in the same full-frame coordinate system as
+    // frame.cursor and displayCursor. Main-screen cursor moves are relative:
+    // subtracting the scrollback height from target alone makes the physical
+    // cursor climb that height on every park/preamble cycle, so later streaming
+    // diffs overwrite thinking, tool, and assistant rows. The terminal maps the
+    // full-frame relative move onto its viewport/scrollback position itself.
     const target = decl !== null && rect !== undefined ? {
       x: rect.x + decl.relativeX,
-      y: rect.y + decl.relativeY - visibleFrameOffset
+      y: rect.y + decl.relativeY
     } : null;
     const parked = this.displayCursor;
     // Diagnostics: the resolved park target per frame (DSH_TUI_DEBUG only).
@@ -846,15 +864,14 @@ export default class Ink {
     // trailing-edge throttle invocation, timerId is undefined, and lodash's
     // debounce sees timeSinceLastCall >= wait (last call was at the start
     // of this window) → leadingEdge fires IMMEDIATELY → double render ~0.1ms
-    // apart → jank. Use a plain timeout. If a wheel event arrives first,
-    // its scheduleRender path fires a render which clears this timer at
-    // the top of onRender — no double.
+    // apart → jank. Use a plain timeout. If a wheel event or immediate
+    // render arrives first, renderNow cancels this timer — no double.
     //
     // Drain frames are cheap (DECSTBM + ~10 patches, ~200 bytes) so run at
     // quarter interval (~250fps, setTimeout practical floor) for max scroll
     // speed. Regular renders stay at FRAME_INTERVAL_MS via the throttle.
     if (frame.scrollDrainPending) {
-      this.drainTimer = setTimeout(() => this.onRender(), FRAME_INTERVAL_MS >> 2);
+      this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
     }
     const yogaMs = getLastYogaMs();
     const commitMs = getLastCommitMs();
@@ -890,12 +907,12 @@ export default class Ink {
     // Flush pending React updates and render before pausing.
     // @ts-ignore -- ported CC build; type drift tolerated flushSyncFromReconciler exists in react-reconciler 0.31 but not in @types/react-reconciler
     reconciler.flushSyncFromReconciler();
-    this.onRender();
+    this.renderNow();
     this.isPaused = true;
   }
   resume(): void {
     this.isPaused = false;
-    this.onRender();
+    this.renderNow();
   }
 
   /**
@@ -937,7 +954,7 @@ export default class Ink {
       // diff sees no content. onRender resets the flag at frame end.
       this.prevFrameContaminated = true;
     }
-    this.onRender();
+    this.renderNow();
   }
 
   /**
@@ -961,7 +978,7 @@ export default class Ink {
       this.repaint();
       this.prevFrameContaminated = true;
     }
-    this.onRender();
+    this.renderNow();
   }
 
   /**
@@ -1067,7 +1084,7 @@ export default class Ink {
       // cursor position. Idempotent when nothing drifted — the user sees
       // no change, at O(viewport) bytes once per >5s idle gap.
       this.log.requestViewportReanchor();
-      this.onRender();
+      this.renderNow();
       return;
     }
     // Mouse tracking — idempotent, safe to re-assert on every stdin gap.
@@ -1237,7 +1254,7 @@ export default class Ink {
       // Raw OSC 52, or DCS-passthrough-wrapped OSC 52 inside tmux (tmux
       // drops it silently unless allow-passthrough is on — no regression).
       void setClipboard(text).then(raw => {
-        if (raw) this.options.stdout.write(raw);
+        if (raw) this.writeRaw(raw);
       });
     }
     return text;
@@ -1463,7 +1480,7 @@ export default class Ink {
     return () => this.selectionListeners.delete(cb);
   }
   private notifySelectionChange(): void {
-    this.onRender();
+    this.renderNow();
     for (const cb of this.selectionListeners) cb();
   }
 
@@ -1691,7 +1708,7 @@ export default class Ink {
     if (this.isUnmounted) {
       return;
     }
-    this.onRender();
+    this.renderNow();
     this.unsubscribeExit();
     if (typeof this.restoreConsole === 'function') {
       this.restoreConsole();

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -53,6 +53,7 @@ import { RewindPicker } from '../components/RewindPicker.js'
 import { BtwPanel } from '../components/BtwPanel.js'
 import { TipsPanel } from '../components/TipsPanel.js'
 import { setClipboard } from '../ink/termio/osc.js'
+import { TerminalWriteContext } from '../ink/useTerminalNotification.js'
 import instances from '../ink/instances.js'
 import { useAnimationFrame } from '../ink/hooks/use-animation-frame.js'
 import { TrajectoryScene } from './TrajectoryScene.js'
@@ -202,6 +203,7 @@ export function Chat({
    */
   trajectorySeen?: boolean
 }) {
+  const writeRaw = React.useContext(TerminalWriteContext)
   // Re-render whenever the channel mutates; rows/status are read fresh below.
   React.useSyncExternalStore(channel.subscribe, () => channel.version)
   // Re-render on language switches so the whole UI hot-swaps its strings.
@@ -2212,7 +2214,7 @@ export function Chat({
               streaming={!btw.done}
               onClose={closeBtw}
               onCopy={() => {
-                void setClipboard(btw.answer ?? '').then(raw => { if (raw) process.stdout.write(raw) })
+                void setClipboard(btw.answer ?? '').then(raw => { if (raw) writeRaw?.(raw) })
                 channel.notify(t('copied-chars', { n: (btw.answer ?? '').length }), { timeoutMs: 1500 })
               }}
             />

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -210,16 +210,16 @@ const darkTheme: Theme = {
   toolDotWrite: rgb('#B3A0D4'), // soft violet — edit/write
   toolDotWeb: rgb('#7DA1DE'), // mist blue — web search/fetch
   toolDotTask: rgb('#D194AE'), // mist rose — subagent/jobs
-  syntaxKeyword: rgb('#82AAFF'), // vivid blue (theme anchor)
-  syntaxString: rgb('#E5C07B'), // gold - echoes the user-message gold accent
-  syntaxComment: rgb('#6B7280'), // neutral grey
-  syntaxNumber: rgb('#D19A66'), // warm orange
-  syntaxFunction: rgb('#56B6C2'), // vivid cyan
-  syntaxType: rgb('#C678DD'), // vivid violet
+  syntaxKeyword: rgb('#78A0D6'), // muted anchor blue
+  syntaxString: rgb('#79AD91'), // mist green, distinct without neon saturation
+  syntaxComment: rgb('#74808D'), // neutral blue-grey
+  syntaxNumber: rgb('#C89B70'), // softened warm amber
+  syntaxFunction: rgb('#6FAEB5'), // muted cyan
+  syntaxType: rgb('#A98FBF'), // softened violet
   syntaxVariable: rgb('#C9D1D9'), // near-text
   syntaxOperator: rgb('#93A1B0'), // blue grey
   syntaxPunctuation: rgb('#7A8694'), // dim blue grey
-  syntaxConstant: rgb('#E48A9B'), // soft rose
+  syntaxConstant: rgb('#C98291'), // softened rose
   red_FOR_SUBAGENTS_ONLY: rgb('#D4685E'),
   blue_FOR_SUBAGENTS_ONLY: rgb('#7496D6'),
   green_FOR_SUBAGENTS_ONLY: rgb('#66B285'),
@@ -307,16 +307,16 @@ const lightTheme: Theme = {
   toolDotWrite: rgb('#7A5CA8'),
   toolDotWeb: rgb('#4A63A8'),
   toolDotTask: rgb('#B04A5A'),
-  syntaxKeyword: rgb('#2557C7'),
-  syntaxString: rgb('#8A6A00'),
-  syntaxComment: rgb('#8A8F98'),
-  syntaxNumber: rgb('#B25E1E'),
-  syntaxFunction: rgb('#0F7A8A'),
-  syntaxType: rgb('#8A3FC7'),
+  syntaxKeyword: rgb('#3F68B5'), // clear primary blue without neon saturation
+  syntaxString: rgb('#3F805F'), // readable muted green
+  syntaxComment: rgb('#7D858F'), // neutral blue-grey
+  syntaxNumber: rgb('#A7652B'), // warm amber accent
+  syntaxFunction: rgb('#2E7E8A'), // muted cyan
+  syntaxType: rgb('#7E55A4'), // softened violet
   syntaxVariable: rgb('#343945'),
   syntaxOperator: rgb('#5B6672'),
   syntaxPunctuation: rgb('#9AA0A8'),
-  syntaxConstant: rgb('#C2186B'),
+  syntaxConstant: rgb('#A84472'), // muted rose accent
   red_FOR_SUBAGENTS_ONLY: rgb('#BE5A52'),
   blue_FOR_SUBAGENTS_ONLY: rgb('#3F6CC4'),
   green_FOR_SUBAGENTS_ONLY: rgb('#4E9675'),


### PR DESCRIPTION
## Summary

- fix streaming assistant rows missing the shared measurement ref, so long streaming content uses real Yoga heights instead of the default estimate
- invalidate stale throttled, drain, and microtask renders with a render generation before synchronous redraws
- keep inline native cursor declarations in one full-frame coordinate system
- route clipboard OSC output through the Ink terminal writer instead of bypassing the render boundary
- extend the inline scrollback regression with streaming reasoning/tool/assistant, caret, border, semantic-row, and duplicate-frame checks

## Validation

- `node --import tsx/esm scripts/repro-inline-scrollback.tsx`
- `node --import tsx/esm scripts/repro-collapse-shrink.tsx`
- `node --import tsx/esm scripts/verify-resize-reflow.tsx`
- `node --import tsx/esm scripts/verify-ime-cursor.tsx`
- `node --import tsx/esm scripts/repro-inline-thirdparty.tsx`
- `node --import tsx/esm scripts/verify-extension-events.tsx`
- `node --import tsx/esm scripts/verify-message-measure-depth.tsx`
- `node --import tsx/esm scripts/verify-clipboard.mjs`
- `node --import tsx/esm scripts/verify-copy-on-select.mjs`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm run compile`
- `git diff --check`

`verify-jediterm.tsx` still has four fallback-harness failures because the bundled JediTerm jar is unavailable; its sync/BSU/ESU/DECSTBM capability checks pass.
