### PR TITLE
feat(ui): add hidden /deepseek easter egg replay

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -122,6 +122,30 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
 ]
 
 /**
+ * Hidden slash commands: intentionally not exposed in the `/` suggestion
+ * menu or Help, but still recognized as local commands when typed. They are
+ * kept out of `LOCAL_COMMANDS` so `filterCommands`/`completeCommands` never
+ * surface them; dispatch recognizes them via {@link HIDDEN_COMMAND_NAMES}.
+ */
+export const HIDDEN_COMMANDS: readonly LocalCommand[] = [
+  { name: 'deepseek', description: 'Hidden DeepSeek easter egg' },
+]
+
+/** Names of hidden commands, for fast dispatch/lookup. */
+export const HIDDEN_COMMAND_NAMES: ReadonlySet<string> = new Set(
+  HIDDEN_COMMANDS.map(command => command.name),
+)
+
+/**
+ * Whether the input names a hidden command (same slash-optional trimming
+ * rules as {@link isLocalCommandName}).
+ */
+export function isHiddenCommandName(input: string): boolean {
+  const name = input.replace(/^\//, '').trim()
+  return HIDDEN_COMMAND_NAMES.has(name)
+}
+
+/**
  * Resolve a command's description in the active UI language. The en text in
  * `LOCAL_COMMANDS` (and the registry's own text for external commands) is
  * the fallback; zh translations live in the i18n dict under
@@ -166,7 +190,7 @@ export function isLocalCommandName(
   // Trailing whitespace is legal (Tab completion leaves a space after the
   // name so the user can type arguments).
   const name = input.replace(/^\//, '').trim()
-  return list.some(command => command.name === name)
+  return HIDDEN_COMMAND_NAMES.has(name) || list.some(command => command.name === name)
 }
 
 /**

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -12,7 +12,7 @@ import { stringWidth } from '../ink/stringWidth.js'
 import { formatClipboardInsert, readClipboard } from '../utils/clipboard.js'
 import { editInExternalEditor } from '../utils/externalEditor.js'
 import type { Channel } from '../dsh-adapter/channel.js'
-import { parseCommandName } from '../commands.js'
+import { isHiddenCommandName, parseCommandName } from '../commands.js'
 import { appendHistory } from '../history.js'
 import { mentionAtCaret } from '../utils/mentions.js'
 import { isMod } from '../utils/modifiers.js'
@@ -364,16 +364,19 @@ export function PromptInput({
   }
 
   /**
-   * Execute a slash command (built-in or plugin-registered) when the input
-   * resolves to one: the name parses as the first token so `/plan off`
-   * dispatches `plan` with its argument text, and the merged command list
-   * (locals + registry) decides whether the line is a command at all.
+   * Execute a slash command (built-in, plugin-registered, or hidden) when
+   * the input resolves to one: the name parses as the first token so
+   * `/plan off` dispatches `plan` with its argument text, and the merged
+   * command list (locals + registry) decides whether the line is a command
+   * at all. Hidden commands are recognized even though they are intentionally
+   * absent from the suggestion/help catalogs.
    */
   const tryRunCommand = (text: string): boolean => {
     if (!text.startsWith('/')) return false
     const parsed = parseCommandName(text)
     if (parsed === undefined) return false
     const known = channel.commandList.some(command => command.name === parsed.name)
+      || isHiddenCommandName(parsed.name)
     if (!known) return false
     const handled = onRunCommand(parsed.name, parsed.rawInput)
     if (handled) {
@@ -571,10 +574,15 @@ export function PromptInput({
       }
       if (channel.working && value.trim() !== '') {
         // CC's immediate-command semantics: /btw is exempt from steering —
-        // the side question never interrupts the running turn. Every other
-        // input keeps the steer behavior so /new /model etc. stay idle-only.
+        // the side question never interrupts the running turn. Hidden
+        // UI-only easter eggs (e.g. /deepseek) are also safe to run while
+        // streaming. Every other input keeps the steer behavior so /new
+        // /model etc. stay idle-only.
         const parsed = value.startsWith('/') ? parseCommandName(value) : undefined
-        if (parsed?.name === 'btw' && channel.commandList.some(c => c.name === 'btw')) {
+        if (parsed !== undefined && (
+          (parsed.name === 'btw' && channel.commandList.some(c => c.name === 'btw'))
+          || isHiddenCommandName(parsed.name)
+        )) {
           tryRunCommand(value)
           return
         }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -22,7 +22,7 @@ import { renderContextSections, renderPrompt } from '@deepseek-ai/dsh-system-pro
 import { loadBaselineInstructions } from '@deepseek-ai/dsh-agent-instructions'
 import type { Context } from '@deepseek-ai/cordis'
 import { extname, isAbsolute, join } from 'node:path'
-import { completeCommands, isLocalCommandName, LOCAL_COMMANDS, parseCommandName, type CommandCompletion, type CommandCompletionNode, type LocalCommand } from '../commands.js'
+import { completeCommands, HIDDEN_COMMAND_NAMES, isLocalCommandName, LOCAL_COMMANDS, parseCommandName, type CommandCompletion, type CommandCompletionNode, type LocalCommand } from '../commands.js'
 import { clearResumeTarget, forgetSession, readResumeTarget, touchSession, writeResumeTarget } from '../sessionHistory.js'
 import { appendSessionTitle, deleteSessionLog, ensureLegacySessionEventTypes, sessionsRoots } from './compat/index.js'
 import {
@@ -3863,6 +3863,9 @@ export function createChannel(
     const merged: LocalCommand[] = [...LOCAL_COMMANDS]
     if (commandService) {
       for (const descriptor of commandService.list(target)) {
+        // Hidden TUI commands (e.g. /deepseek) stay out of the public
+        // command catalog even if a plugin/skill happens to share the name.
+        if (HIDDEN_COMMAND_NAMES.has(descriptor.name)) continue
         if (merged.some(command => command.name === descriptor.name)) continue
         const descriptions = commandTrees?.descriptions(descriptor.name)
         merged.push({

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -348,6 +348,11 @@ export function Chat({
   }
   /** /tips usage-tips overlay: pure UI state, no session side effects. */
   const [tipsOpen, setTipsOpen] = React.useState(false)
+  /**
+   * Hidden `/deepseek` easter egg: each invocation bumps this key so the
+   * logo header remounts and replays the whale spout + text shimmer.
+   */
+  const [logoNonce, setLogoNonce] = React.useState(0)
   React.useEffect(() => () => btwAbortRef.current?.abort(), [])
   /**
    * The trajectory scene (issue #80 evolution). Unlike every other overlay
@@ -1166,6 +1171,18 @@ export function Chat({
           if (controller.signal.aborted) return
           setBtw(prev => (prev ? { ...prev, answer: result.answer ?? prev.answer, error: result.error, done: true } : prev))
         })
+        return true
+      }
+      case 'deepseek': {
+        // Hidden easter egg: replay the logo header's whale spout + text
+        // shimmer. The command is intentionally not in the suggestion/help
+        // catalogs; PromptInput recognizes it through HIDDEN_COMMAND_NAMES.
+        setHelpOpen(false)
+        setLogoNonce(n => n + 1)
+        // Bring the logo back into view if the transcript has scrolled.
+        setTimeout(() => {
+          handle?.scrollTo(0)
+        }, 0)
         return true
       }
       case 'tips':
@@ -2089,6 +2106,7 @@ export function Chat({
       )}
       <ScrollBox ref={setHandle} flexDirection="column" flexGrow={1} flexShrink={1} stickyScroll>
         <LogoHeader
+          key={logoNonce}
           model={channel.model}
           effort={channel.reasoningEffort}
           cwd={channel.displayCwd}


### PR DESCRIPTION
## Summary

Add a hidden `/deepseek` easter egg command.

- Not shown in the slash-command suggestions, Tab completion, or `/help`.
- Typing `/deepseek` replays the logo header's whale spout animation and the DEEPSEEK/HARNESS text shimmer.
- The view scrolls back to the top so the logo animation is visible.
- Works even while the model is streaming (UI-only command).
- Hidden names are filtered from plugin/skill command catalogs so the command stays out of the public command list.

## Verification

- `tsc` compile passes
- `verify-tips` passes
- `header-probe` passes
- `verify-adapter-boundary` passes