### PR TITLE
feat(input): 输入框可视行预算 5→10，按终端高度钳制

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
       # 三种到达形态、CSI-u 与 modifyOtherKeys 的 Shift/Ctrl/Meta+Enter。
       - run: node --import tsx/esm scripts/verify-keys.tsx
 
+      # 输入框高度回归（feat/prompt-max-10）：终端钳制预算下高度单调、
+      # 封顶恒定、小终端钳制生效。
+      - run: node --import tsx/esm scripts/verify-prompt-height.tsx
+
       # 终端能力探测回归：延迟 OSC/XTVERSION 回复期间保持 raw mode，
       # 回复只进 querier，不回显成终端残影。
       - run: node --import tsx/esm scripts/verify-terminal-queries.tsx

--- a/scripts/verify-prompt-height.tsx
+++ b/scripts/verify-prompt-height.tsx
@@ -1,0 +1,153 @@
+/**
+ * 输入框高度回归（feat/prompt-max-10）：可视行预算从常量 5 升为
+ * min(10, terminalRows - 10) 的终端钳制预算后，锁定三条不变量：
+ *   1. 高度 = min(视觉行数, 预算) + 2 边框，逐行单调、无相邻帧震荡
+ *   2. 超预算后高度封顶恒定（30 行终端 = 12），窗口随光标平移不跳变
+ *   3. 小终端钳制生效：16 行终端预算 6（封顶 8）、13 行终端预算 3
+ * 运行：node --import tsx/esm scripts/verify-prompt-height.tsx
+ */
+export {} // 模块边界：避免顶层 await/全局名与其他 verify 脚本冲突
+
+process.env.FORCE_COLOR = '3'
+
+const [{ Writable, PassThrough }, React, { Terminal: XTerm }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+])
+const { render, Box, Text } = await import('../src/ui.js')
+const { PromptInput } = await import('../src/components/PromptInput.js')
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+function makeHarness(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 0, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _e: Buffer.Encoding, cb: () => void) { term.write(String(chunk), cb) }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode() { return this }
+    ref() { return this }
+    unref() { return this }
+  }
+  return {
+    term,
+    stdout: new FakeStdout() as never,
+    stdin: new FakeStdin() as never,
+  }
+}
+
+const channel = {
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  cycleMode() {},
+  commandList: [],
+  commandCompletions: () => [],
+  notifications: [],
+  pending: [],
+  working: false,
+  notify() {},
+  submit() {},
+  steer() {},
+  interruptAndDeliver() {},
+  removePending() {},
+  stageImage() {},
+  listFiles: async () => [],
+}
+
+let failures = 0
+const check = (name: string, ok: boolean, detail = '') => {
+  if (ok) process.stdout.write(`PASS  ${name}\n`)
+  else { failures++; process.stdout.write(`FAIL  ${name} — ${detail}\n`) }
+}
+
+/** 挂载 FILLER 转录 + PromptInput + 状态行，返回帧指标采集器。 */
+async function mount(cols: number, rows: number) {
+  const { term, stdout, stdin } = makeHarness(cols, rows)
+  const App = () =>
+    React.createElement(Box, { flexDirection: 'column', height: rows, width: '100%' },
+      React.createElement(Box, { flexDirection: 'column', flexGrow: 1, flexShrink: 1, overflow: 'hidden' },
+        ...Array.from({ length: rows }, (_, i) =>
+          React.createElement(Text, { key: `f${i}` }, `FILLER-${String(i).padStart(2, '0')} ${'x'.repeat(30)}`))),
+      React.createElement(Box, { flexDirection: 'column', flexShrink: 0 },
+        React.createElement(PromptInput, {
+          channel, helpOpen: false, onToggleHelp() {}, onRunCommand: () => false, selectionActive: false,
+        }),
+        React.createElement(Text, null, 'STATUSLINE')))
+  const instance = await render(React.createElement(App), {
+    stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false,
+  })
+  await sleep(500)
+  const frame = () => {
+    const lines = Array.from({ length: rows }, (_, y) =>
+      term.buffer.active.getLine(y)?.translateToString(true) ?? '')
+    const top = lines.findIndex(l => l.includes('╭'))
+    const bottom = lines.findIndex(l => l.includes('╰'))
+    const firstInput = lines.find(l => /L\d\d/.test(l))?.match(/L\d\d/)?.[0] ?? '-'
+    return { height: top >= 0 && bottom >= 0 ? bottom - top + 1 : -1, firstInput }
+  }
+  const feed = async (seq: string) => { stdin.write(seq); await sleep(130) }
+  return { frame, feed, unmount: async () => { instance.unmount(); await sleep(150) } }
+}
+
+// ── 场景 1：30 行终端逐行 1→12，单调爬升后封顶恒 12，窗口从第 11 行起滚 ──
+{
+  const m = await mount(100, 30)
+  const heights: number[] = []
+  await m.feed('L01 ')
+  heights.push(m.frame().height)
+  for (let n = 2; n <= 12; n++) {
+    await m.feed('\n')
+    await m.feed(`L${String(n).padStart(2, '0')} `)
+    heights.push(m.frame().height)
+  }
+  // 预算 10：高度应为 3,4,...,12（12 个值）再恒 12
+  const expected = Array.from({ length: 11 }, (_, i) => Math.min(i + 1, 10) + 2).concat([12])
+  check('30 行终端：逐行高度单调且等于 min(行数,10)+2',
+    JSON.stringify(heights) === JSON.stringify(expected), JSON.stringify(heights))
+  let monotonic = true
+  for (let i = 1; i < heights.length; i++) if (heights[i]! - heights[i - 1]! < 0) monotonic = false
+  check('逐行输入全程无高度回落（相邻帧不震荡）', monotonic, JSON.stringify(heights))
+  check('12 行文本窗口 [2,12)（首行 L03，光标贴底）', m.frame().firstInput === 'L03', m.frame().firstInput)
+
+  // 光标顶/底往返：高度恒 12
+  for (let i = 0; i < 11; i++) await m.feed('\x1b[A')
+  const atTop = m.frame()
+  for (let i = 0; i < 11; i++) await m.feed('\x1b[B')
+  const atBottom = m.frame()
+  check('光标顶/底往返高度恒定（封顶 12）',
+    atTop.height === 12 && atBottom.height === 12, `${atTop.height}/${atBottom.height}`)
+  await m.unmount()
+}
+
+// ── 场景 2：16 行终端钳制预算 6（封顶高 8）──
+{
+  const m = await mount(100, 16)
+  for (let n = 1; n <= 8; n++) {
+    if (n > 1) await m.feed('\n')
+    await m.feed(`L${String(n).padStart(2, '0')} `)
+  }
+  check('16 行终端：8 行文本钳制在预算 6（封顶高 8）', m.frame().height === 8, String(m.frame().height))
+  await m.unmount()
+}
+
+// ── 场景 3：13 行终端钳制预算 3（封顶高 5）──
+{
+  const m = await mount(100, 13)
+  for (let n = 1; n <= 5; n++) {
+    if (n > 1) await m.feed('\n')
+    await m.feed(`L${String(n).padStart(2, '0')} `)
+  }
+  check('13 行终端：5 行文本钳制在预算 3（封顶高 5）', m.frame().height === 5, String(m.frame().height))
+  await m.unmount()
+}
+
+if (failures > 0) {
+  process.stdout.write(`verify-prompt-height: ${failures} assertion(s) failed\n`)
+  process.exit(1)
+}
+process.stdout.write('verify-prompt-height OK\n')

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -58,8 +58,13 @@ function wordBoundaryRight(text: string, cursor: number): number {
  */
 
 /** Max input rows before the visible viewport starts scrolling (CC's
- *  maxVisibleLines behavior — the box keeps a stable height). */
-const MAX_VISIBLE_LINES = 5
+ *  maxVisibleLines behavior — the box keeps a stable height). Terminal-height
+ *  clamp keeps ≥6 transcript rows on small terminals: content rows + 2 border
+ *  + 1 marginTop + 1 status + 6 transcript floor ≤ terminalRows. */
+const MAX_INPUT_ROWS = 10
+/** Visible-row budget for the input viewport at a given terminal height. */
+const maxVisibleLines = (terminalRows: number): number =>
+  Math.max(3, Math.min(MAX_INPUT_ROWS, terminalRows - 10))
 
 /**
  * Imperative handle for the Chat-level Ctrl+C rule: Chat's useInput listener
@@ -111,7 +116,7 @@ export interface PromptInputProps {
  * Multi-line: Shift+Enter inserts a newline; ↑/↓ move between lines while
  * the input spans multiple lines (history/command selection otherwise); the
  * visible window scrolls to keep the caret row on screen past
- * MAX_VISIBLE_LINES. Enter submits, backspace/delete edit, ←/→ move the
+ * maxVisibleLines budget. Enter submits, backspace/delete edit, ←/→ move the
  * cursor, Tab completes the selected command, Ctrl+G opens the draft in the
  * external editor ($VISUAL/$EDITOR), Escape clears (or closes the help
  * menu), `?` toggles the help menu. Windows ConPTY pipelines deliver
@@ -195,10 +200,13 @@ export function PromptInput({
   }, [])
   const { columns, rows: terminalRows } = useTerminalSize()
   const helpScrollRef = React.useRef<ScrollBoxHandle | null>(null)
-  // OverlayAbove reserves six terminal rows for the composer/status chrome;
-  // the help block also keeps one row below it. Its own final row is a
-  // persistent navigation hint, leaving the remainder to ScrollBox.
-  const helpViewportHeight = Math.max(3, Math.max(terminalRows - 6, 4) - 1)
+  // OverlayAbove reserves the composer/status chrome below the help float;
+  // the help block also keeps one row of its own. The composer budget scales
+  // with the terminal (maxVisibleLines content rows + 2 border rows), so a
+  // full-height input cannot push the help float past the frame top — the
+  // overlay's own top clamp still guards the residual rounding.
+  const composerMaxRows = maxVisibleLines(terminalRows) + 2
+  const helpViewportHeight = Math.max(3, terminalRows - composerMaxRows - 4)
 
   const suggestions = value.startsWith('/') ? channel.commandCompletions(value) : []
   const overlayOpen =
@@ -934,16 +942,17 @@ export function PromptInput({
   const inputWidth = Math.max(10, columns - 3)
   const visualLines = wrapToWidth(value, inputWidth)
   const caretVisualLine = wrapToWidth(value.slice(0, cursor), inputWidth).length - 1
+  const visibleBudget = maxVisibleLines(terminalRows)
   const windowStart = Math.max(
     0,
     Math.min(
-      caretVisualLine - MAX_VISIBLE_LINES + 1,
-      visualLines.length - MAX_VISIBLE_LINES,
+      caretVisualLine - visibleBudget + 1,
+      visualLines.length - visibleBudget,
     ),
   )
   const visibleLines = visualLines.slice(
     windowStart,
-    windowStart + MAX_VISIBLE_LINES,
+    windowStart + visibleBudget,
   )
 
   // Caret position in the caret's visual row, in two units:
@@ -1016,7 +1025,7 @@ export function PromptInput({
           帧高不随面板开关涨落——否则帧顶行会被滚进 scrollback 并在关闭
           重绘时二次写入（/model 切换多一份启动画的根因，见 OverlayAbove）。 */}
       {floatersOpen && (
-      <OverlayAbove maxHeight={Math.max(terminalRows - 6, 4)}>
+      <OverlayAbove maxHeight={Math.max(terminalRows - composerMaxRows - 3, 4)}>
         {helpOpen && (
           <Box marginBottom={1}>
             <HelpMenu


### PR DESCRIPTION
## 动机

输入框可视区此前恒为 5 行（`MAX_VISIBLE_LINES = 5`），长粘贴/多行编辑可视范围不足；本 PR 升为**内容区最多 10 行**，并按终端高度钳制。

## 改动

1. `PromptInput.tsx`：常量 5 → 模块级纯函数 `maxVisibleLines(terminalRows) = max(3, min(10, terminalRows - 10))`。30 行终端总高最多 12 行（10 内容 + 2 边框）；小终端保底 3 行内容且**至少保留 6 行转录**（内容 + 边框 2 + marginTop 1 + 状态 1 + 转录 6 ≤ 终端高）。
2. `helpViewportHeight` 与瞬态浮层（帮助/队列/补全）`OverlayAbove maxHeight` 的 chrome 预留随 composer 预算同步缩放——旧值 `terminalRows - 6` 建立在 composer 最大 7 行的假设上。
3. 新增 `scripts/verify-prompt-height.tsx`（接入 CI）：断言高度 = min(视觉行数, 预算)+2 **逐行单调、相邻帧无震荡**；超预算封顶恒定（30 行终端恒 12）；窗口随光标平移；16 行终端钳制预算 6、13 行终端钳制预算 3。

## 实测依据（xterm-headless 完整挂载结构）

| 场景 | 行为 |
|---|---|
| 逐行输入 1→12 行（30 行终端） | 高度 3→12 单调，每步 +1，>10 行恒 12 |
| 12 行文本光标 顶↔底 往返 | 高度恒 12，窗口逐行平移 |
| CJK 折行 / 60 列窄终端 ±1 字交替 | 高度无震荡（0.8.6 全场景单调；历史上的高度跳动为 0.7.x 边框 Yoga 换行漂移，已由 #402 修复） |
| 16 / 13 行终端 | 钳制预算 6 / 3，转录保底 |

## 取舍说明

- `Chat.tsx` picker 浮层 maxHeight（`terminalRows - 8`）**未动**：OverlayAbove 自带 y<0 顶部 clamp（超高从顶裁整行），且 picker 打开时 composer 内容通常为一条短命令，实际探顶概率极低。
- `repro-model-switch-scrollback` 在本分支与干净 main 上均有偶发失败（各 3 次中 1-2 次，boot 断言时序依赖），与本改动无关——根因是该脚本族固定 sleep 的既有 flaky，可另行处理。

## 验证

- `verify-prompt-height` 7/7、`verify-ime-cursor` / `verify-resize-reflow` / `repro-picker-windowing` 全绿；`tsc --noEmit` 通过。