### PR TITLE
feat(launcher): delegating shim + /update auto-migration (0.8.7)

### DIFF
--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -32,7 +32,6 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { valid, gt } from 'semver'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const ownDir = dirname(here)
@@ -64,6 +63,40 @@ const shellOpt = isWin ? { shell: true } : {}
 // 转义后拼进命令字符串（空参数数组不触发），非 Windows 保持数组直传。
 const cmd = (command, args) =>
   isWin ? [`${command} ${shellQuote(args).join(' ')}`, []] : [command, args]
+
+// 内联 semver（解析 + 严格大于）：启动器可能在依赖不完整的环境里被执行
+// （迁移、半损坏安装、测试沙箱），零外部依赖是自保底线。覆盖 semver 的
+// 核心-先行版比较规则：先行版标识符逐段比（数字段按数值、小于字母段），
+// 前缀相同时段数少者更旧，无先行版者最新。
+const parseVersion = v => {
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(String(v).trim())
+  return m
+    ? { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]), pre: m[4] === undefined ? null : m[4].split('.') }
+    : null
+}
+const isVersionNewer = (a, b) => {
+  const A = parseVersion(a)
+  const B = parseVersion(b)
+  if (A === null || B === null) return false
+  for (const key of ['major', 'minor', 'patch']) {
+    if (A[key] !== B[key]) return A[key] > B[key]
+  }
+  if (A.pre === null) return B.pre !== null
+  if (B.pre === null) return false
+  for (let i = 0; i < Math.max(A.pre.length, B.pre.length); i++) {
+    const x = A.pre[i]
+    const y = B.pre[i]
+    if (x === undefined) return false
+    if (y === undefined) return true
+    if (x === y) continue
+    const xn = /^\d+$/.test(x)
+    const yn = /^\d+$/.test(y)
+    if (xn && yn) return Number(x) > Number(y)
+    if (xn !== yn) return yn
+    return x > y
+  }
+  return false
+}
 
 const lang = (process.env.DSH_TUI_LANG ?? process.env.CC_TUI_LANG) === 'en' ? 'en' : 'zh'
 const MSG = {
@@ -156,55 +189,59 @@ const forwardExit = child => {
   })
 }
 
-// ─── 全局副本：瘦壳角色 ───────────────────────────────────────────────────────
-if (!runningInsideProfile && ownVersion !== undefined) {
-  const profileReady = () => {
-    try {
-      readFileSync(installedPkgPath, 'utf8')
-      return true
-    } catch {
-      return false
+// 首次运行自举：探测 dsh 与 pnpm，随后 `dsh plugin add` 固定到与启动器一
+// 致的版本（避免 pnpm store 缓存带来的旧版漂移）。-w 重试（issue #239）与
+// 「no-op 假成功」复查（issue #209）在此集中实现，瘦壳与完整逻辑共用。
+const profileReady = () => {
+  try {
+    readFileSync(installedPkgPath, 'utf8')
+    return true
+  } catch {
+    return false
+  }
+}
+const bootstrapProfile = () => {
+  const probe = spawnSync(...cmd('dsh', ['--version']), { stdio: 'pipe', ...shellOpt })
+  if (probe.error || probe.status !== 0) {
+    console.error(msg('noDsh'))
+    process.exit(1)
+  }
+  const pnpmProbe = spawnSync(...cmd('pnpm', ['--version']), { stdio: 'pipe', ...shellOpt })
+  if (pnpmProbe.error || pnpmProbe.status !== 0) {
+    console.error(msg('noPnpm'))
+    process.exit(1)
+  }
+  console.log(msg('bootstrapStart'))
+  const runAdd = (extraArgs, capture) => spawnSync(
+    ...cmd('dsh', ['plugin', '--profile', PROFILE, 'add', ...extraArgs, `${PACKAGE}@${ownVersion}`]),
+    { stdio: capture ? ['inherit', 'pipe', 'pipe'] : 'inherit', ...shellOpt },
+  )
+  let add = runAdd([], true)
+  if (add.status !== 0) {
+    const captured = `${add.stdout ?? ''}${add.stderr ?? ''}`
+    process.stderr.write(captured)
+    if (captured.includes('ERR_PNPM_ADDING_TO_ROOT')) {
+      console.log(msg('bootstrapRetryW'))
+      add = runAdd(['-w'], false)
     }
+  } else {
+    process.stdout.write(`${add.stdout ?? ''}${add.stderr ?? ''}`)
+  }
+  if (add.status !== 0) {
+    console.error(msg('installFailed'))
+    process.exit(add.status ?? 1)
   }
   if (!profileReady()) {
-    // 首次运行自举：探测 dsh 与 pnpm，随后 `dsh plugin add` 固定到与全局
-    // 安装一致的版本（避免 pnpm store 缓存带来的旧版漂移）。-w 重试与
-    // 「no-op 假成功」复查的逻辑与完整启动器一致（issue #239/#209）。
-    const probe = spawnSync(...cmd('dsh', ['--version']), { stdio: 'pipe', ...shellOpt })
-    if (probe.error || probe.status !== 0) {
-      console.error(msg('noDsh'))
-      process.exit(1)
-    }
-    const pnpmProbe = spawnSync(...cmd('pnpm', ['--version']), { stdio: 'pipe', ...shellOpt })
-    if (pnpmProbe.error || pnpmProbe.status !== 0) {
-      console.error(msg('noPnpm'))
-      process.exit(1)
-    }
-    console.log(msg('bootstrapStart'))
-    const runAdd = (extraArgs, capture) => spawnSync(
-      ...cmd('dsh', ['plugin', '--profile', PROFILE, 'add', ...extraArgs, `${PACKAGE}@${ownVersion}`]),
-      { stdio: capture ? ['inherit', 'pipe', 'pipe'] : 'inherit', ...shellOpt },
-    )
-    let add = runAdd([], true)
-    if (add.status !== 0) {
-      const captured = `${add.stdout ?? ''}${add.stderr ?? ''}`
-      process.stderr.write(captured)
-      if (captured.includes('ERR_PNPM_ADDING_TO_ROOT')) {
-        console.log(msg('bootstrapRetryW'))
-        add = runAdd(['-w'], false)
-      }
-    } else {
-      process.stdout.write(`${add.stdout ?? ''}${add.stderr ?? ''}`)
-    }
-    if (add.status !== 0) {
-      console.error(msg('installFailed'))
-      process.exit(add.status ?? 1)
-    }
-    if (!profileReady()) {
-      console.error(msg('bootstrapUnreadable')(profileDir))
-      process.exit(1)
-    }
+    console.error(msg('bootstrapUnreadable')(profileDir))
+    process.exit(1)
   }
+}
+
+// ─── 全局副本：瘦壳角色 ───────────────────────────────────────────────────────
+// DSH_TUI_NO_DELEGATE=1 是测试/调试逃生口：强制走完整逻辑（verify-launcher
+// 的沙箱用它直接驱动全量路径；现场排查委托链时同样可用）。
+if (!runningInsideProfile && ownVersion !== undefined && process.env.DSH_TUI_NO_DELEGATE !== '1') {
+  if (!profileReady()) bootstrapProfile()
   // 委托 profile 内副本执行全部启动逻辑。外层代际通过
   // DSH_TUI_LAUNCHER_VERSION 交代（/update 的对齐诊断沿用该契约）。
   try {
@@ -221,19 +258,29 @@ if (!runningInsideProfile && ownVersion !== undefined) {
   forwardExit(child)
 } else {
   // ─── profile 副本（或源码运行）：完整启动逻辑 ─────────────────────────────
-  // 版本核对：被委托执行时本包即 profile 内的包，installedVersion 与
-  // ownVersion 天然一致，错位分支为结构性 no-op；直接运行（源码目录）
-  // 时保留 0.8.3 起的双向错位处理。
+  // dsh CLI 预检（缺失时给安装指引，先于一切 profile 逻辑）。
+  {
+    const probe = spawnSync(...cmd('dsh', ['--version']), { stdio: 'pipe', ...shellOpt })
+    if (probe.error || probe.status !== 0) {
+      console.error(msg('noDsh'))
+      process.exit(1)
+    }
+  }
   let installedVersion
   try {
     installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf8')).version
   } catch {
     installedVersion = undefined
   }
-  if (installedVersion === undefined && !runningInsideProfile) {
-    // 源码运行且 profile 未初始化：指向全局命令完成首次自举。
-    console.error(`[dsh-tui] profile not initialized — run the globally installed \`dsh-tui\` command once (npm install -g ${PACKAGE}).`)
-    process.exit(1)
+  // 残骸/未初始化 profile：与旧启动器一致地就地自举（add 固定到本包版
+  // 本，成功后版本天然对齐），而不是拒绝启动。
+  if (installedVersion === undefined) {
+    bootstrapProfile()
+    try {
+      installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf8')).version
+    } catch {
+      installedVersion = undefined
+    }
   }
   if (installedVersion !== undefined && ownVersion !== undefined && installedVersion !== ownVersion && !runningInsideProfile) {
     const majorMinor = v => v.split('-')[0].split('.').slice(0, 2).map(Number)
@@ -246,12 +293,18 @@ if (!runningInsideProfile && ownVersion !== undefined) {
       )
       process.exit(1)
     }
-    const installedSemver = valid(installedVersion)
-    const ownSemver = valid(ownVersion)
-    if (installedSemver !== null && ownSemver !== null && gt(installedSemver, ownSemver)) {
+    const installedNewer = installedVersion !== undefined && ownVersion !== undefined && isVersionNewer(installedVersion, ownVersion)
+    if (installedNewer) {
       console.error(
         `[dsh-tui] note: the profile is already v${installedVersion}; this launcher copy is v${ownVersion}.\n` +
           `  npm install -g ${PACKAGE}@${installedVersion}`,
+      )
+    } else {
+      // profile 更旧但同 minor（patch 级错位）：允许启动，指引用 add 把
+      // profile 对齐到启动器版本（精确版本，@latest 可能越过对齐点）。
+      console.error(
+        `[dsh-tui] note: the profile is running v${installedVersion} but this launcher is v${ownVersion}.\n` +
+          `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${ownVersion}`,
       )
     }
   }

--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -1,47 +1,70 @@
 #!/usr/bin/env node
 /**
- * dsh-tui — dsh-tui profile 的一键直达启动器。
+ * dsh-tui — 双态启动器（delegating launcher，0.8.7）。
  *
- * 全局安装 @deepseek-harness-tui/dsh-tui 后获得 `dsh-tui` 命令，免去手工
- * 输入 `dsh --profile dsh-tui`：
+ * 同一个文件按“自己住在哪”决定扮演的角色：
  *
- *   1. 检测 dsh CLI（缺失时提示安装 @deepseek-ai/dsh）；
- *   2. 检测 $DSH_HOME/profiles/dsh-tui 是否已初始化，未初始化则自动执行
- *      `dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui@<本包版本>`
- *      自举——版本号与本包对齐，避免 pnpm store 缓存带来的旧版漂移；
- *   3. 已初始化但版本与本包不一致时按方向处理（issue #183）：profile
- *      更新（前向错位）打印一行提示后继续启动（TUI 内 /update 或重新
- *      add）；profile 次版本更旧（反向错位）拒绝启动并给出对齐命令——
- *      该方向 dsh CLI 会把启动器的 bundle patch 套到 profile 旧包上，
- *      启动必然以模块解析错误崩溃；
- *   4. 透传全部参数启动 `dsh --profile dsh-tui`。
+ *   全局安装副本（npm i -g 得到的 `dsh-tui` 命令）→ 瘦壳：
+ *     1. 找到 $DSH_HOME/profiles/dsh-tui 里的同包 bin；
+ *     2. 可读 → 原样转发 argv 委托它执行（完整逻辑永远来自 profile 副本，
+ *        版本随 /update 一起前进，启动器滞后问题从结构上消失）；
+ *     3. 不可读（首次运行）→ 探测 dsh/pnpm 后自举
+ *        `dsh plugin --profile dsh-tui add <本包>@<本包版本>`，成功后委托。
  *
- * `--resume` 由本启动器拦截：读取 TUI 保留的 ~/.dsh-tui/resume.txt
- * （旧路径 ~/.dsh-cc/resume.txt 兜底，直到旧版 TUI 退场——见
- * src/sessionHistory.ts 的启动器契约，issue #120），以
- * DSH_TUI_RESUME_SESSION（并兼容写 DSH_CC_RESUME_SESSION）环境变量喂回，
- * 该 flag 本身不再传给 dsh。
+ *   profile 内副本（被委托执行，或 junction/源码目录里直接运行）→ 完整
+ *   启动逻辑（与 0.8.6 及之前一致）：
+ *     dsh 预检 / profile 版本核对 / --resume 与工作区目标拦截 /
+ *     旧环境变量警告 / `dsh --profile dsh-tui` 启动与退出码透传。
  *
- * 面向用户的消息走下方 MSG 双语表：与 TUI 的语言契约一致——
+ * 自举角色判定用 realpath：Windows Junction 轨（profile 指回仓库）与
+ * `pnpm run dev` 源码运行都会折叠成同一物理目录 → 走完整逻辑，不会
+ * 自己委托自己形成循环。
+ *
+ * 本文件必须保持零 lib/ 依赖：/update 的启动器迁移只覆写这一个文件
+ * （外加 package.json 的版本号），旧全局安装里不存在新 lib 助手时同样
+ * 可用。shellQuote 等小工具在此内联。
+ *
+ * 面向用户的消息走 MSG 双语表：与 TUI 的语言契约一致——
  * `DSH_TUI_LANG` 显式指定时从其值，否则默认中文（同 src/i18n.ts 的缺省）。
  */
 import { spawn, spawnSync } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { isAbsolute, join, resolve } from 'node:path'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { gt, valid } from 'semver'
-import { shellQuote } from '../lib/types/utils/shellQuote.js'
-import { detectLegacyEnv, RENAMED_ENV } from '../lib/types/utils/paths.js'
+import { valid, gt } from 'semver'
 
-const here = fileURLToPath(new URL('.', import.meta.url))
-const ownVersion = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')).version
+const here = dirname(fileURLToPath(import.meta.url))
+const ownDir = dirname(here)
+const readJson = p => {
+  try {
+    return JSON.parse(readFileSync(p, 'utf8'))
+  } catch {
+    return undefined
+  }
+}
+const ownPackage = readJson(join(ownDir, 'package.json'))
+const ownVersion = ownPackage?.name === '@deepseek-harness-tui/dsh-tui' ? ownPackage.version : undefined
 const PACKAGE = '@deepseek-harness-tui/dsh-tui'
 const PROFILE = 'dsh-tui'
 
-// --- 双语消息表（启动器跑在 TUI boot 之前，无法复用 src/i18n.ts）-------------
-// 与 TUI 一致：DSH_TUI_LANG 显式指定才生效，否则默认中文；旧名 CC_TUI_LANG
-// 仅用于让警告本身以用户习惯的语言显示（配置不再从旧名生效）。
+// --- 内联小工具（见文件头：零 lib 依赖是迁移契约的一部分）---------------------
+// 与 lib/types/utils/shellQuote.js 同语义的最小实现：cmd.exe 以空格拼接参数
+// 且不做转义，含空格/引号的参数必须整体加引号（内层引号与反斜杠转义）。
+const shellQuote = args =>
+  args.map(arg => {
+    const s = String(arg)
+    if (s === '') return '""'
+    if (!/[\s"^]/.test(s)) return s
+    return `"${s.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, '$1$1')}"`
+  })
+const isWin = process.platform === 'win32'
+const shellOpt = isWin ? { shell: true } : {}
+// DEP0190（issue #148）：shell:true + 非空参数数组触发语法级弃用告警——
+// 转义后拼进命令字符串（空参数数组不触发），非 Windows 保持数组直传。
+const cmd = (command, args) =>
+  isWin ? [`${command} ${shellQuote(args).join(' ')}`, []] : [command, args]
+
 const lang = (process.env.DSH_TUI_LANG ?? process.env.CC_TUI_LANG) === 'en' ? 'en' : 'zh'
 const MSG = {
   noDsh: {
@@ -64,10 +87,6 @@ const MSG = {
     en: `[dsh-tui] Plugin install failed. Retry manually later:\n  dsh plugin --profile ${PROFILE} add -w ${PACKAGE}@${ownVersion}`,
     zh: `[dsh-tui] 插件安装失败。可稍后手工重试：\n  dsh plugin --profile ${PROFILE} add -w ${PACKAGE}@${ownVersion}`,
   },
-  // no-op 假成功（自举后复查发现判定文件依旧缺失）：pnpm 把包文件残缺的
-  // profile 视为 already up to date，重装什么都不做却报告成功；继续启动
-  // 只会以 cannot resolve profile bundle 崩溃，而崩溃提示的 `plugin
-  // install` 同样 no-op——用户会陷入「每步都成功、每次都崩」的循环。
   bootstrapUnreadable: {
     en: dir =>
       `[dsh-tui] install reported success but the plugin package is still unreadable under:\n` +
@@ -82,59 +101,15 @@ const MSG = {
       `  恢复方法：\n` +
       `  rm -rf ${dir} 后重新运行 dsh-tui`,
   },
-  // Non-fatal skew comes in two directions and each needs its own repair:
-  // a profile NEWER than the launcher (typical after /update) must point at
-  // the global install, while a profile older only in patch must point back
-  // at the profile. The old generic message told forward-skew users to run
-  // /update again — an "Already up to date" loop.
-  profileOutdated: {
-    en: (installed, own) =>
-      `[dsh-tui] note: the profile is running v${installed} but this launcher is v${own}.\n` +
-      `  Align the profile to this launcher:\n` +
-      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${own}`,
-    zh: (installed, own) =>
-      `[dsh-tui] 提示：profile 内运行的是 v${installed}，启动器是 v${own}。\n` +
-      `  请把 profile 对齐到启动器版本：\n` +
-      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${own}`,
-  },
-  launcherOutdated: {
-    en: (installed, own) =>
-      `[dsh-tui] note: the profile is already v${installed}, but the global launcher is still v${own}.\n` +
-      `  Align the global dsh-tui launcher to the profile:\n` +
-      `  npm install -g ${PACKAGE}@${installed}\n` +
-      `  (if you installed it globally with pnpm: pnpm add -g ${PACKAGE}@${installed})`,
-    zh: (installed, own) =>
-      `[dsh-tui] 提示：profile 已是 v${installed}，但全局启动器仍是 v${own}。\n` +
-      `  请把全局 dsh-tui 启动器对齐到 profile 版本：\n` +
-      `  npm install -g ${PACKAGE}@${installed}\n` +
-      `  （如果你使用 pnpm 全局安装：pnpm add -g ${PACKAGE}@${installed}）`,
-  },
-  // Reverse skew (issue #183): the dsh CLI reads the bundle patch from the
-  // FIRST copy found from its own install anchor — this globally installed
-  // launcher — while the plugin modules load from the profile's copy. A
-  // launcher minor NEWER than the profile means the patch may reference
-  // subpath exports the profile's older package does not have, and boot
-  // crashes opaquely (ERR_PACKAGE_PATH_NOT_EXPORTED) before any TUI code
-  // runs. Fail loud with the fix instead. (Forward skew degrades to a
-  // working local-workspace fallback since 0.7.2 — soft note below.)
-  profileOlderThanLauncher: {
-    en: (installed, own) =>
-      `[dsh-tui] cannot start: the profile runs v${installed} but this launcher is v${own}.\n` +
-      `  The launcher's bundle patch would be applied to the profile's older package,\n` +
-      `  which does not export everything the patch references — boot would crash.\n` +
-      `  Align the profile with the launcher:\n` +
-      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${own}\n` +
-      `  (or update everything to the latest release: dsh plugin --profile ${PROFILE} add ${PACKAGE}@latest)`,
-    zh: (installed, own) =>
-      `[dsh-tui] 无法启动：profile 内运行的是 v${installed}，而启动器是 v${own}。\n` +
-      `  启动器的 bundle patch 会套用到 profile 里的旧版包上，其中缺少 patch 引用\n` +
-      `  的子路径导出——启动会以模块解析错误崩溃。请让 profile 与启动器对齐：\n` +
-      `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${own}\n` +
-      `  （或全部升到最新：dsh plugin --profile ${PROFILE} add ${PACKAGE}@latest）`,
-  },
   launchFailed: {
     en: err => `[dsh-tui] Failed to launch: ${err.message}`,
     zh: err => `[dsh-tui] 启动失败：${err.message}`,
+  },
+  delegateFailed: {
+    en: path =>
+      `[dsh-tui] cannot launch the profile copy:\n  ${path}\nReinstall the global launcher:\n  npm install -g ${PACKAGE}@latest`,
+    zh: path =>
+      `[dsh-tui] 无法启动 profile 内副本：\n  ${path}\n请重装全局启动器：\n  npm install -g ${PACKAGE}@latest`,
   },
   profileExited: {
     en: code => `[dsh-tui] dsh profile exited with code ${code}. Run it directly for diagnostics:\n  dsh --profile ${PROFILE}`,
@@ -151,184 +126,207 @@ const msg = key => MSG[key][lang]
 // 长会话 OOM——与仓库根 dsh-tui.cmd 保持一致，强制 production。
 process.env.NODE_ENV ??= 'production'
 
-const isWin = process.platform === 'win32'
-// Windows 上 .cmd shim 必须经 shell 启动（Node ≥18.20.2 的安全限制）；
-// 其余平台直接 spawn 无后缀的 dsh。cmd.exe 以空格拼接参数且 Node 不做
-// 转义——shell 路径的所有参数必须先过 shellQuote（同 src/update.ts 的
-// /update 重启路径），否则含空格/引号的参数会被拆断。
-const shellOpt = isWin ? { shell: true } : {}
-// DEP0190（issue #148）：Node ≥22 对「shell:true + 非空参数数组」的调用
-// 发出弃用警告，判定是语法级的——参数已过 shellQuote 也一样告警；且未来
-// 大版本可能升级为运行时错误。把转义后的参数拼进命令字符串传入
-// （shell:true + 空参数数组不触发），非 Windows 路径保持数组直传。
-const cmd = (command, args) =>
-  isWin ? [`${command} ${shellQuote(args).join(' ')}`, []] : [command, args]
-
-// --- 1. dsh CLI 预检 ---------------------------------------------------------
-const probe = spawnSync(...cmd('dsh', ['--version']), { stdio: 'pipe', ...shellOpt })
-if (probe.error || probe.status !== 0) {
-  console.error(msg('noDsh'))
-  process.exit(1)
+const sameDir = (a, b) => {
+  try {
+    return realpathSync(resolve(a)) === realpathSync(resolve(b))
+  } catch {
+    return resolve(a) === resolve(b)
+  }
 }
 
-// --- 2. profile 自举与版本检查 -------------------------------------------------
 const dshHome = process.env.DSH_HOME || join(homedir(), '.dsh')
 const profileDir = join(dshHome, 'profiles', PROFILE)
-// 以已装包的 package.json 可读为准（而非目录存在）：安装中途失败留下的
-// 残骸目录会触发重新安装，而不是以坏 profile 直接启动。
-// 包可读判定文件：installedVersion 读取与自举后的复查共用（残缺 profile
-// 的 no-op 假成功靠它识别——见 bootstrapUnreadable）。
-const installedPkgPath = join(profileDir, 'node_modules', '@deepseek-harness-tui', 'dsh-tui', 'package.json')
-let installedVersion
-try {
-  installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf8')).version
-} catch {
-  installedVersion = undefined
-}
-if (installedVersion === undefined) {
-  const pnpmProbe = spawnSync(...cmd('pnpm', ['--version']), { stdio: 'pipe', ...shellOpt })
-  if (pnpmProbe.error || pnpmProbe.status !== 0) {
-    console.error(msg('noPnpm'))
+const profilePkgDir = join(profileDir, 'node_modules', '@deepseek-harness-tui', 'dsh-tui')
+const profileBin = join(profilePkgDir, 'bin', 'dsh-tui.js')
+const installedPkgPath = join(profilePkgDir, 'package.json')
+const runningInsideProfile = sameDir(ownDir, profilePkgDir)
+
+const forwardExit = child => {
+  child.on('error', err => {
+    console.error(msg('launchFailed')(err))
     process.exit(1)
-  }
-  console.log(msg('bootstrapStart'))
-  // pnpm ≥11 在带 pnpm-workspace.yaml 的 profile 目录里可能拒绝向
-  // workspace root 写依赖（ERR_PNPM_ADDING_TO_ROOT，issue #239）：识别该
-  // 错误时带 -w 重试一次。签名在 stdout——pnpm 的错误报告写 stdout（经
-  // dsh 原样转发），stderr 上只有 dsh 自己的失败说明，识别 stderr 永远
-  // 匹配不到（PR #241 的回归）。因此首次 add 的 stdout/stderr 都走 pipe
-  // 捕获，结束后回放（失败回 stderr 保诊断，成功回 stdout 保进度，代价
-  // 是不再实时）；-w 重试大概率成功，恢复 inherit 让进度实时可见。手工
-  // 重试提示同步带 -w。
-  const runAdd = (extraArgs, capture) => spawnSync(
-    ...cmd('dsh', ['plugin', '--profile', PROFILE, 'add', ...extraArgs, `${PACKAGE}@${ownVersion}`]),
-    { stdio: capture ? ['inherit', 'pipe', 'pipe'] : 'inherit', ...shellOpt },
-  )
-  let add = runAdd([], true)
-  if (add.status !== 0) {
-    const captured = `${add.stdout ?? ''}${add.stderr ?? ''}`
-    process.stderr.write(captured)
-    if (captured.includes('ERR_PNPM_ADDING_TO_ROOT')) {
-      console.log(msg('bootstrapRetryW'))
-      add = runAdd(['-w'], false)
+  })
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal)
+    } else {
+      if (code !== null && code !== 0) console.error(msg('profileExited')(code))
+      process.exit(code ?? 0)
     }
-  } else {
-    process.stdout.write(`${add.stdout ?? ''}${add.stderr ?? ''}`)
-  }
-  if (add.status !== 0) {
-    console.error(msg('installFailed'))
-    process.exit(add.status ?? 1)
-  }
-  // 自举后复查：pnpm 对包文件残缺的 profile 视为 already up to date，
-  // add 报告成功却什么都没装（no-op 假成功）。此时继续启动只会以 cannot
-  // resolve profile bundle 崩溃，提示的 `plugin install` 又同样 no-op——
-  // fail loud 给出唯一可靠的恢复路径（删 profile 目录重建）。
-  try {
-    readFileSync(installedPkgPath, 'utf8')
-  } catch {
-    console.error(MSG.bootstrapUnreadable[lang](profileDir))
-    process.exit(1)
-  }
-} else if (installedVersion !== ownVersion) {
-  // Reverse skew is fatal (see MSG.profileOlderThanLauncher): compare
-  // major/minor only — patch-level differences never move the patch surface.
-  const majorMinor = v => v.split('-')[0].split('.').slice(0, 2).map(Number)
-  const [installedMajor, installedMinor] = majorMinor(installedVersion)
-  const [ownMajor, ownMinor] = majorMinor(ownVersion)
-  if (installedMajor < ownMajor || (installedMajor === ownMajor && installedMinor < ownMinor)) {
-    console.error(MSG.profileOlderThanLauncher[lang](installedVersion, ownVersion))
-    process.exit(1)
-  }
-
-  // Non-fatal skew: repair in the direction the versions actually moved.
-  // A profile NEWER than the launcher (e.g. right after /update) means the
-  // GLOBAL launcher is stale — never point those users back at /update.
-  // Exact versions only: @latest could skip past the alignment point if a
-  // newer release or a mirror dist-tag is in play.
-  const installedSemver = valid(installedVersion)
-  const ownSemver = valid(ownVersion)
-  if (installedSemver !== null && ownSemver !== null && gt(installedSemver, ownSemver)) {
-    console.error(MSG.launcherOutdated[lang](installedVersion, ownVersion))
-  } else {
-    console.error(MSG.profileOutdated[lang](installedVersion, ownVersion))
-  }
+  })
 }
 
-// --- 3. --resume 拦截 ---------------------------------------------------------
-// 换名过渡（issue #120）：全局 bin 与 profile 内 TUI 包版本可能错位，所以
-// env 双写（新旧名都设），文件读取新路径优先、旧路径兜底。
-// 支持的形态（对齐 issue #53 的诉求）：
-//   --resume <id> / --resume=<id>   恢复指定会话
-//   --resume / -c / --continue      恢复最近一次会话（读 resume.txt）
-// 其余位置参数原样透传给 dsh CLI，由插件经 ctx.cmdlineArgs 读取（初始 prompt）。
-const setResumeEnv = sessionId => {
-  process.env.DSH_TUI_RESUME_SESSION = sessionId
-  process.env.DSH_CC_RESUME_SESSION = sessionId
-}
-const readLastResumeTarget = () => {
-  for (const dir of ['.dsh-tui', '.dsh-cc']) {
+// ─── 全局副本：瘦壳角色 ───────────────────────────────────────────────────────
+if (!runningInsideProfile && ownVersion !== undefined) {
+  const profileReady = () => {
     try {
-      const sessionId = readFileSync(join(homedir(), dir, 'resume.txt'), 'utf8').trim()
-      if (sessionId) return sessionId
+      readFileSync(installedPkgPath, 'utf8')
+      return true
     } catch {
-      // 没有历史会话可恢复——静默忽略，正常冷启动。
+      return false
     }
   }
-  return ''
-}
-const args = []
-const argv = process.argv.slice(2)
-for (let i = 0; i < argv.length; i++) {
-  const a = argv[i]
-  if (a === '--resume' || a === '-c' || a === '--continue' || a.startsWith('--resume=')) {
-    let sessionId = ''
-    if (a.startsWith('--resume=')) {
-      sessionId = a.slice('--resume='.length).trim()
-    } else if (a === '--resume' && argv[i + 1] !== undefined && !argv[i + 1].startsWith('-')) {
-      sessionId = argv[++i].trim()
+  if (!profileReady()) {
+    // 首次运行自举：探测 dsh 与 pnpm，随后 `dsh plugin add` 固定到与全局
+    // 安装一致的版本（避免 pnpm store 缓存带来的旧版漂移）。-w 重试与
+    // 「no-op 假成功」复查的逻辑与完整启动器一致（issue #239/#209）。
+    const probe = spawnSync(...cmd('dsh', ['--version']), { stdio: 'pipe', ...shellOpt })
+    if (probe.error || probe.status !== 0) {
+      console.error(msg('noDsh'))
+      process.exit(1)
     }
-    // 裸形态（含 -c/--continue）回退到 resume.txt。
-    if (!sessionId) sessionId = readLastResumeTarget()
-    if (sessionId) setResumeEnv(sessionId)
-  } else if (
-    process.env.DSH_TUI_WORKSPACE_TARGET === undefined
-    && !a.startsWith('-')
-    && (isAbsolute(a) || /^[a-z][a-z0-9+.-]*:\/\//iu.test(a) || existsSync(resolve(a)))
-  ) {
-    // A workspace target is launcher syntax, not an argument for the profile
-    // app. The registry resolves local paths/file URLs and provider URIs.
-    process.env.DSH_TUI_WORKSPACE_TARGET = a
-  } else {
-    args.push(a)
+    const pnpmProbe = spawnSync(...cmd('pnpm', ['--version']), { stdio: 'pipe', ...shellOpt })
+    if (pnpmProbe.error || pnpmProbe.status !== 0) {
+      console.error(msg('noPnpm'))
+      process.exit(1)
+    }
+    console.log(msg('bootstrapStart'))
+    const runAdd = (extraArgs, capture) => spawnSync(
+      ...cmd('dsh', ['plugin', '--profile', PROFILE, 'add', ...extraArgs, `${PACKAGE}@${ownVersion}`]),
+      { stdio: capture ? ['inherit', 'pipe', 'pipe'] : 'inherit', ...shellOpt },
+    )
+    let add = runAdd([], true)
+    if (add.status !== 0) {
+      const captured = `${add.stdout ?? ''}${add.stderr ?? ''}`
+      process.stderr.write(captured)
+      if (captured.includes('ERR_PNPM_ADDING_TO_ROOT')) {
+        console.log(msg('bootstrapRetryW'))
+        add = runAdd(['-w'], false)
+      }
+    } else {
+      process.stdout.write(`${add.stdout ?? ''}${add.stderr ?? ''}`)
+    }
+    if (add.status !== 0) {
+      console.error(msg('installFailed'))
+      process.exit(add.status ?? 1)
+    }
+    if (!profileReady()) {
+      console.error(msg('bootstrapUnreadable')(profileDir))
+      process.exit(1)
+    }
   }
-}
-
-// --- 3.5 旧环境变量警告（必须在 TUI 渲染前输出，fullscreen 下写 stderr 会破坏界面）
-for (const oldName of detectLegacyEnv()) {
-  console.error(MSG.legacyEnv[lang](oldName, RENAMED_ENV[oldName]))
-}
-
-// --- 4. 启动 ------------------------------------------------------------------
-// Contract for the profile runtime: lets /update diagnose whether the
-// global dsh-tui launcher is older than the profile it just installed.
-// Not a one-shot marker — it must survive restarts so the runtime always
-// knows the launcher generation it boots under.
-process.env.DSH_TUI_LAUNCHER_VERSION = ownVersion
-
-const child = spawn(...cmd('dsh', ['--profile', PROFILE, ...args]), {
-  stdio: 'inherit',
-  env: process.env,
-  ...shellOpt,
-})
-child.on('error', err => {
-  console.error(MSG.launchFailed[lang](err))
-  process.exit(1)
-})
-child.on('exit', (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal)
-  } else {
-    if (code !== null && code !== 0) console.error(MSG.profileExited[lang](code))
-    process.exit(code ?? 0)
+  // 委托 profile 内副本执行全部启动逻辑。外层代际通过
+  // DSH_TUI_LAUNCHER_VERSION 交代（/update 的对齐诊断沿用该契约）。
+  try {
+    readFileSync(profileBin, 'utf8')
+  } catch {
+    console.error(msg('delegateFailed')(profileBin))
+    process.exit(1)
   }
-})
+  process.env.DSH_TUI_LAUNCHER_VERSION = ownVersion
+  const child = spawn(process.execPath, [profileBin, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    env: process.env,
+  })
+  forwardExit(child)
+} else {
+  // ─── profile 副本（或源码运行）：完整启动逻辑 ─────────────────────────────
+  // 版本核对：被委托执行时本包即 profile 内的包，installedVersion 与
+  // ownVersion 天然一致，错位分支为结构性 no-op；直接运行（源码目录）
+  // 时保留 0.8.3 起的双向错位处理。
+  let installedVersion
+  try {
+    installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf8')).version
+  } catch {
+    installedVersion = undefined
+  }
+  if (installedVersion === undefined && !runningInsideProfile) {
+    // 源码运行且 profile 未初始化：指向全局命令完成首次自举。
+    console.error(`[dsh-tui] profile not initialized — run the globally installed \`dsh-tui\` command once (npm install -g ${PACKAGE}).`)
+    process.exit(1)
+  }
+  if (installedVersion !== undefined && ownVersion !== undefined && installedVersion !== ownVersion && !runningInsideProfile) {
+    const majorMinor = v => v.split('-')[0].split('.').slice(0, 2).map(Number)
+    const [installedMajor, installedMinor] = majorMinor(installedVersion)
+    const [ownMajor, ownMinor] = majorMinor(ownVersion)
+    if (installedMajor < ownMajor || (installedMajor === ownMajor && installedMinor < ownMinor)) {
+      console.error(
+        `[dsh-tui] cannot start: the profile runs v${installedVersion} but this launcher is v${ownVersion}.\n` +
+          `  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${ownVersion}`,
+      )
+      process.exit(1)
+    }
+    const installedSemver = valid(installedVersion)
+    const ownSemver = valid(ownVersion)
+    if (installedSemver !== null && ownSemver !== null && gt(installedSemver, ownSemver)) {
+      console.error(
+        `[dsh-tui] note: the profile is already v${installedVersion}; this launcher copy is v${ownVersion}.\n` +
+          `  npm install -g ${PACKAGE}@${installedVersion}`,
+      )
+    }
+  }
+
+  // --resume / 工作区目标拦截（issue #120/#53 的启动器契约）。
+  const setResumeEnv = sessionId => {
+    process.env.DSH_TUI_RESUME_SESSION = sessionId
+    process.env.DSH_CC_RESUME_SESSION = sessionId
+  }
+  const readLastResumeTarget = () => {
+    for (const dir of ['.dsh-tui', '.dsh-cc']) {
+      try {
+        const sessionId = readFileSync(join(homedir(), dir, 'resume.txt'), 'utf8').trim()
+        if (sessionId) return sessionId
+      } catch {
+        // 没有历史会话可恢复——静默忽略，正常冷启动。
+      }
+    }
+    return ''
+  }
+  const args = []
+  const argv = process.argv.slice(2)
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--resume' || a === '-c' || a === '--continue' || a.startsWith('--resume=')) {
+      let sessionId = ''
+      if (a.startsWith('--resume=')) {
+        sessionId = a.slice('--resume='.length).trim()
+      } else if (a === '--resume' && argv[i + 1] !== undefined && !argv[i + 1].startsWith('-')) {
+        sessionId = argv[++i].trim()
+      }
+      if (!sessionId) sessionId = readLastResumeTarget()
+      if (sessionId) setResumeEnv(sessionId)
+    } else if (
+      process.env.DSH_TUI_WORKSPACE_TARGET === undefined
+      && !a.startsWith('-')
+      && (isAbsolute(a) || /^[a-z][a-z0-9+.-]*:\/\//iu.test(a) || existsSync(resolve(a)))
+    ) {
+      process.env.DSH_TUI_WORKSPACE_TARGET = a
+    } else {
+      args.push(a)
+    }
+  }
+
+  // 旧环境变量警告（必须在 TUI 渲染前输出，fullscreen 下写 stderr 会破坏
+  // 界面）。与 utils/paths 的 RENAMED_ENV 同表，内联以维持零 lib 依赖。
+  const RENAMED_ENV = {
+    CC_TUI_THEME: 'DSH_TUI_THEME',
+    CC_TUI_LANG: 'DSH_TUI_LANG',
+    CC_TUI_PERSONA: 'DSH_TUI_PERSONA',
+    CC_TUI_PRESET: 'DSH_TUI_PRESET',
+    CC_TUI_DISABLE_MOUSE: 'DSH_TUI_DISABLE_MOUSE',
+    CC_TUI_DEBUG: 'DSH_TUI_DEBUG',
+    CC_TUI_COMPACT_RATIO: 'DSH_TUI_COMPACT_RATIO',
+    CC_TUI_COMPACT_RETAIN: 'DSH_TUI_COMPACT_RETAIN',
+    DSH_CC_UPDATED_FROM: 'DSH_TUI_UPDATED_FROM',
+    DSH_CC_RENDER_LOG: 'DSH_TUI_RENDER_LOG',
+    DSH_CC_SESSION_ROOT: 'DSH_TUI_SESSION_ROOT',
+    DSH_CC_WORKSPACE: 'DSH_TUI_WORKSPACE',
+  }
+  for (const oldName of Object.keys(RENAMED_ENV)) {
+    if (process.env[oldName] !== undefined) {
+      console.error(msg('legacyEnv')(oldName, RENAMED_ENV[oldName]))
+    }
+  }
+
+  // 启动：被委托场景下本副本自己的版本即对齐诊断所见的启动器代际。
+  if (process.env.DSH_TUI_LAUNCHER_VERSION === undefined && ownVersion !== undefined) {
+    process.env.DSH_TUI_LAUNCHER_VERSION = ownVersion
+  }
+
+  const child = spawn(...cmd('dsh', ['--profile', PROFILE, ...args]), {
+    stdio: 'inherit',
+    env: process.env,
+    ...shellOpt,
+  })
+  forwardExit(child)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepseek-harness-tui/dsh-tui",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "Claude Code style interactive TUI front door for DeepSeek Harness agents, built on the ported Ink core.",
   "license": "MIT",
   "repository": {

--- a/scripts/verify-launcher.mjs
+++ b/scripts/verify-launcher.mjs
@@ -95,7 +95,7 @@ function stubCalls() {
   return readFileSync(stubLog, 'utf8').trim().split('\n').filter(Boolean)
 }
 
-function runBin(args, extraEnv = {}) {
+function runBin(args, extraEnv = {}, { delegating = false } = {}) {
   return spawnSync(process.execPath, [bin, ...args], {
     env: {
       PATH: stubPath,
@@ -108,6 +108,9 @@ function runBin(args, extraEnv = {}) {
       // 启动器 spawn(shell:true) 在 Windows 触 DEP0190 弃用警告，
       // 会污染「静默启动」类断言的 stderr——测试环境下关掉。
       NODE_OPTIONS: '--no-deprecation',
+      // 0.8.7 双态启动器：默认强制完整逻辑（本套回归覆盖的全量路径）；
+      // 委托角色的专门用例按需放开（见第 4 节）。
+      ...(delegating ? {} : { DSH_TUI_NO_DELEGATE: '1' }),
       ...extraEnv,
     },
     encoding: 'utf8',
@@ -239,6 +242,45 @@ check(
   'launcher env: child receives DSH_TUI_LAUNCHER_VERSION',
   launcherSource.includes('process.env.DSH_TUI_LAUNCHER_VERSION = ownVersion'),
 )
+
+// --- 4. 委托角色（0.8.7 双态启动器）：全局副本 → profile 内副本 -------------
+// 真实 bin + 假 DSH_HOME：repo 目录与假 profile 不是同一物理目录 → 走瘦壳
+// 角色。把真实 bin 预放进假 profile（模拟一次完成的安装），验证：
+//   - 委托后由 profile 内副本执行完整逻辑（argv 原样两跳转发）
+//   - 判定文件缺失（残骸 profile）时瘦壳先自举再委托
+//   - profile 有判定文件但没有 bin 时 fail loud 给重装指引
+const placeProfileBin = () => {
+  const dir = join(home, PKG_DIR, 'bin')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'dsh-tui.js'), readFileSync(bin, 'utf8'))
+}
+
+setProfileVersion(ownVersion)
+placeProfileBin()
+resetStubLog()
+r = runBin(['foo', 'a b'], {}, { delegating: true })
+check('shim: delegates argv through to the profile copy', stubCalls().at(-1) === '<--profile><dsh-tui><foo><a b>')
+check('shim: silent + exit 0 when aligned', r.status === 0 && r.stderr.trim() === '')
+
+setProfileVersion(undefined)
+placeProfileBin() // add stub 只创建 package.json——bin 是预放好的“已安装”产物
+resetStubLog()
+r = runBin([], {}, { delegating: true })
+check(
+  'shim: bootstraps a broken profile before delegating',
+  stubCalls().some(c => c.includes('<plugin>') && c.includes('<add>'))
+    && stubCalls().at(-1) === '<--profile><dsh-tui>'
+    && r.status === 0,
+)
+
+// 判定文件在、bin 缺失：委托目标不可读——给出全局重装指引而非 opaque 崩溃。
+setProfileVersion(ownVersion)
+rmSync(join(home, PKG_DIR, 'bin'), { recursive: true, force: true })
+resetStubLog()
+r = runBin([], { DSH_TUI_LANG: 'en' }, { delegating: true })
+check('shim: no bin fails loud with the reinstall hint', r.status === 1 && r.stderr.includes(`Reinstall the global launcher`))
+check('shim: reinstall hint names the npm command', r.stderr.includes(`npm install -g ${PACKAGE}`))
+
 
 // --- 5. 消息双语：缺 dsh 时的报错（契约同 TUI：DSH_TUI_LANG 指定才生效，否则默认中文）
 const envNoDsh = { PATH: noDshPath }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync, renameSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { gte, gt, lt, valid } from 'semver'
 import { shellQuote } from './utils/shellQuote.js'
@@ -266,6 +266,68 @@ export function isTransientUpdateFailure(stderr: string): boolean {
 }
 
 /**
+ * Best-effort migrate the GLOBAL launcher to the delegating shim (0.8.7):
+ * after a successful profile update, copy this package's `bin/dsh-tui.js`
+ * and `package.json` over the global install so the launcher can never lag
+ * the profile again — the shim delegates all logic to the profile copy it
+ * just updated. Single-file-safe by contract: the new bin imports nothing
+ * from lib/ (see its header), so overwriting it inside an older global
+ * install cannot dangle a missing helper.
+ *
+ * Locating the global dir relies on argv[1] being the global `dsh-tui.js`
+ * (true when booted through the `dsh-tui` command). Source checkouts and
+ * direct `dsh --profile` boots resolve nothing — the migration is a silent
+ * no-op there. Write failures (permissions, locked files) are equally
+ * silent: the launcher-alignment warning remains the fallback diagnosis.
+ *
+ * @returns true when the global launcher files were replaced.
+ */
+export function migrateGlobalLauncher(): boolean {
+  const launcherBin = process.argv[1]
+  if (launcherBin === undefined || !launcherBin.endsWith('dsh-tui.js')) return false
+  // Walk up from the bin to the containing package; accept it only when it
+  // is OUR package and not the profile copy we are running from (junction
+  // layouts collapse both onto the same real path — copying onto ourselves
+  // would be a no-op at best).
+  let dir = dirname(resolve(launcherBin))
+  const ownDir = dirname(dirname(fileURLToPath(import.meta.url)))
+  for (let depth = 0; depth < 4; depth++) {
+    const manifest = join(dir, 'package.json')
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(manifest, 'utf8'))
+      if (
+        parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+        && (parsed as Record<string, unknown>).name === PACKAGE_NAME
+      ) {
+        let same = false
+        try {
+          same = realpathSync(dir) === realpathSync(ownDir)
+        } catch {
+          same = resolve(dir) === resolve(ownDir)
+        }
+        if (same) return false
+        // tmp + rename keeps each file atomic; a crash mid-migration leaves
+        // either the old or the new file, never a truncated one.
+        const replace = (target: string, source: string): void => {
+          const staged = `${target}.dsh-tui-migrate`
+          writeFileSync(staged, readFileSync(source))
+          renameSync(staged, target)
+        }
+        replace(join(dir, 'bin', 'dsh-tui.js'), join(ownDir, 'bin', 'dsh-tui.js'))
+        replace(manifest, join(ownDir, 'package.json'))
+        return true
+      }
+    } catch {
+      // Unreadable manifest at this level — keep walking up.
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return false
+    dir = parent
+  }
+  return false
+}
+
+/**
  * Update the installed dsh-tui package and restart the same launcher while
  * preserving the active session. The TUI must already be unmounted before
  * this is called so pnpm output cannot corrupt the rendered terminal frame.
@@ -345,6 +407,14 @@ export async function updateTuiAndRestart(
       )
       return { updateCode: 1, restartCode: 1 }
     }
+  }
+
+  // Launcher migration (0.8.7): the freshly installed profile carries the
+  // delegating shim — stamp it over the global launcher so this is the LAST
+  // time the outer copy can lag. Best-effort; the alignment warning stays as
+  // the fallback when the copy is impossible.
+  if (migrateGlobalLauncher()) {
+    process.stderr.write('dsh-tui: global launcher aligned to the delegating shim (no manual npm i -g needed anymore).\n')
   }
 
   const restartCode = await runProcess(process.execPath, [...process.execArgv, ...process.argv.slice(1)], {


### PR DESCRIPTION
## Why

Users on npm-installed launchers never run `npm i -g` again, so the global launcher lags the profile forever — today that's warned about (0.8.3 bridge), and it is also why npm users are stuck on the pre-rc.8 0.8.6 build. This makes launcher lag structurally impossible.

## What

### Dual-role `bin/dsh-tui.js`
- **Global copy = thin shim**: delegates argv to the profile copy's bin; on first run it bootstraps the profile (`dsh plugin add <pkg>@<own version>`, with the `-w` retry and no-op-false-success recheck from #239/#209) and then delegates.
- **Profile copy = full launch logic** (unchanged contracts): dsh probe, version skew handling, `--resume`/`-c` interception, workspace-target detection, legacy-env warnings, signal/exit propagation.
- Role detection via `realpath`: junction layouts (profile → repo) and `pnpm run dev` collapse onto the same physical dir and take the full-logic path — no self-delegation loop.
- **Zero `lib/` imports**: the shim must keep working when stamped into an older global install (see below). `shellQuote` and the renamed-env table are inlined.

### `/update` auto-migration
After a verified profile update, `migrateGlobalLauncher()` copies the new `bin/dsh-tui.js` + `package.json` over the global install (tmp + rename, atomic per file). Best-effort and silent on source boots / direct `dsh --profile` runs / write failures; the existing alignment warning remains the fallback. So ONE `/update` migrates every legacy install, and afterwards the outer copy is always current by construction.

### Version 0.8.7
Published 0.8.6 predates the rc.8 contract adaptation (its tarball contains no rc.8 support), and same-number republish is impossible — bumping also unblocks the rc.8-compat release.

## Verification
- `pnpm run build` — all 17 gates green
- `node scripts/verify-update.mjs` — all 44 checks pass (launcher-bridge static contract intact)
- `pnpm run sync:profile:check` — 0 diff
- Smoke: `node bin/dsh-tui.js --version` on the junction layout resolves to full logic and passes the dsh probe