### PR TITLE
fix(render): sticky 视角 resize 塌缩帧不再整屏空白（issue #421）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
       - run: node --import tsx/esm scripts/repro-settings.tsx
       - run: node --import tsx/esm scripts/repro-inline-scrollback.tsx
       - run: node --import tsx/esm scripts/repro-inline-thirdparty.tsx
+      # 全屏 resize 空白回归：宽度变化清空行高缓存 → scrollHeight 估算塌缩，
+      # shrunk 帧冻结的旧 scrollTop 与失准的 clamp 边界越过内容底，整屏裁剪
+      # 成"只剩输入框"（Orca pane 宽度抖动的现场取证复现）。
+      - run: node --import tsx/esm scripts/repro-resize-blank.tsx
 
       # 消息列表虚拟化回归：连续高度校正的嵌套更新上限（#129, React #185）、
       # 滚动窗口与 shrink 边界。measure-depth 需生产模式（minified #185）。

--- a/scripts/repro-resize-blank.tsx
+++ b/scripts/repro-resize-blank.tsx
@@ -1,0 +1,152 @@
+/**
+ * 全屏 resize 风暴复现（issue #421）——Orca OCKL terminal-history 取证：用户 pane 宽度
+ * 反复抖动（232→231→232→235），空白复现窗口与 resize burst 重合。
+ * 本脚本无头渲染真实 Chat（alt-screen），打 resize 事件风暴，断言每次
+ * 落定后消息区不得空白（空白 = 用户报告症状）。
+ * 运行：node --import tsx/esm scripts/repro-resize-blank.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'Orca'
+process.env.DSH_TUI_THEME = 'dark'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/ink/instances.js'),
+])
+
+let COLS = 232
+const ROWS = 71
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+let lastFlushed: Promise<void> = Promise.resolve()
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    // xterm 异步分块处理写入：密度测量必须等本帧 flush 完，
+    // 否则会量到"已擦除未重绘"的中间态（测量误差，非应用行为）。
+    lastFlushed = new Promise<void>(res => term.write(String(chunk), () => { cb(); res() }))
+  }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough { isTTY = true; setRawMode() { return this }; ref() { return this }; unref() { return this } }
+const stdout = new FakeStdout() as any
+const stderr = new FakeStderr() as any
+const stdin = new FakeStdin() as any
+
+function screenLines(): string[] {
+  const buf = term.buffer.active
+  const out: string[] = []
+  for (let y = 0; y < ROWS; y++) out.push((buf.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+  return out
+}
+function density(): number {
+  const body = screenLines().slice(0, ROWS - 7)
+  return body.filter(l => l.trim()).length
+}
+function dump(tag: string) {
+  console.log('--- 屏幕快照 ' + tag + ' ---')
+  screenLines().forEach((l, i) => console.log(String(i).padStart(2) + '|' + l.slice(0, 70)))
+}
+function assertVisible(tag: string) {
+  const d = density()
+  check('[' + tag + '] 消息区非空', d >= 3, 'density=' + d)
+  if (d < 3) dump(tag)
+}
+
+// ---- 400 行历史（重度会话） ----
+const listeners = new Set<() => void>()
+const rows: any[] = []
+let id = 0
+for (let t = 0; t < 200; t++) {
+  rows.push({ id: id++, kind: 'user', text: '问题 ' + t + '：分析因子 ' + t + ' 的表现与回撤' })
+  rows.push({ id: id++, kind: 'reasoning', text: ('思考 ' + t + '：先检查数据。').repeat(12), streaming: false, durationMs: 900 })
+  rows.push({
+    id: id++, kind: 'tool', text: '',
+    tool: {
+      callId: 't' + t, name: 'Bash', argsText: '{"command": "analyze ' + t + '"}', argsFull: '{}',
+      status: 'ok', startedAt: 0, durationMs: 30,
+      resultText: Array.from({ length: 8 }, (_, i) => '结果 ' + t + '-' + i).join('\n'),
+    },
+  })
+  rows.push({ id: id++, kind: 'assistant', text: '回答 ' + t + '：\n\n- 因子 IC 稳定\n- 回撤可控\n- 与动量低相关', streaming: false })
+}
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'resize-stress', agentId: 'x',
+  model: 'deepseek-v4-flash', reasoningEffort: 'max',
+  tokens: { input: 100, output: 40 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo',
+  gitBranch: 'main', working: false, spinnerMode: 'requesting', responseChars: 0,
+  activeToolCount: 0, turnStart: 0, lastUserText: rows[rows.length - 4].text,
+  pending: [], commandList: [], notifications: [],
+  mode: { plan: false }, effortLevels: undefined,
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => [],
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) (cb as () => void)() }
+
+await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} />
+  </AlternateScreen>,
+  { stdout, stdin, stderr, exitOnCtrlC: false, patchConsole: false },
+)
+// AlternateScreen 用 instances.get(process.stdout) 找实例（本无头环境注册在
+// FakeStdout 下），手动补上 alt-screen 激活，走真实全屏渲染路径。
+const ink: any = instances.get(stdout)
+if (!ink) { console.log('FAIL 未找到 Ink 实例'); process.exit(1) }
+ink.setAltScreenActive(true, true)
+await sleep(1200)
+check('alt-screen 已激活', ink.isAltScreenActive === true)
+assertVisible('启动落定 400 行')
+
+function doResize(w: number, h: number) {
+  stdout.columns = w
+  stdout.rows = h
+  term.resize(w, h)
+  stdout.emit('resize')
+}
+
+// ---- 现场形态的 burst ----
+const bursts: Array<Array<[number, number]>> = [
+  [[231, 71], [232, 71]],
+  [[235, 71]],
+  [[234, 71], [233, 71], [235, 71], [232, 71]],
+  [[200, 71], [232, 71]],
+  [[232, 40], [232, 71]],
+  [[150, 50], [180, 60], [232, 71]],
+]
+for (let b = 0; b < bursts.length; b++) {
+  for (const [w, h] of bursts[b]) {
+    doResize(w, h)
+    await sleep(8)
+    await lastFlushed
+    const d = density()
+    if (d < 3) {
+      check('burst#' + b + ' resize(' + w + 'x' + h + ') +8ms 空白帧', false, 'density=' + d)
+      dump('burst#' + b + '-' + w + 'x' + h)
+    }
+  }
+  await sleep(150)
+  await lastFlushed
+  assertVisible('burst#' + b + ' 落定')
+  await sleep(500)
+  await lastFlushed
+  assertVisible('burst#' + b + ' 闲置后')
+}
+
+console.log(failed === 0 ? '\nALL PASS' : '\n' + failed + ' 项失败')
+process.exit(failed === 0 ? 0 : 1)

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -903,7 +903,18 @@ function renderNodeToOutput(
         // Keep the pre-frame position on a shrink frame (measurement
         // artifact) instead of clamping to the shrunken maxScroll — the
         // clamp would persist the yank even after content grows back.
-        let scrollTop = shrunk ? cur : Math.max(0, Math.min(cur, maxScroll))
+        // Exception: a STICKY view must stay pinned to the bottom. A width
+        // change clears MessageList's row-height cache, collapsing the
+        // estimated scrollHeight; freezing the pre-shrink scrollTop then
+        // parks it PAST the whole shrunken content — every child culls and
+        // the frame paints only the bottom chrome. With the resize erase
+        // (needsEraseBeforePaint) that lands as a pure blank screen with
+        // just the input box, and an idle app produces no follow-up frame
+        // to heal it (user-reported full-screen loss on pane-width jitter —
+        // issue #421; repro-resize-blank). Clamping a sticky view to the shrunken
+        // maxScroll is exactly its contract — show the bottom.
+        let scrollTop =
+          shrunk && !sticky ? cur : Math.max(0, Math.min(cur, maxScroll))
         // Virtual-scroll clamp: if scrollTop raced past the currently-mounted
         // range (burst PageUp before React re-renders), render at the EDGE of
         // the mounted children instead of blank spacer. Do NOT write back to
@@ -912,9 +923,17 @@ function renderNodeToOutput(
         // the right range. Not scheduling scrollDrainNode here keeps the
         // clamp passive — React's commit → resetAfterCommit → onRender will
         // paint again with fresh bounds.
+        // Cap both bounds at maxScroll: the clamp bounds come from
+        // MessageList's height ESTIMATES while maxScroll comes from the
+        // frame's actual Yoga height. A width change resets the estimates
+        // (row-height cache clear), and a stale bound can point PAST the
+        // shrunken content bottom — the painted viewport then sits entirely
+        // below the content and every child culls to blank (the sticky
+        // full-screen loss — issue #421; repro-resize-blank). Nothing renderable exists
+        // below maxScroll regardless of what the estimates claim.
         const clamped = Math.max(
-          cMin ?? -Infinity,
-          Math.min(scrollTop, cMax ?? Infinity),
+          Math.min(cMin ?? -Infinity, maxScroll),
+          Math.min(scrollTop, Math.min(cMax ?? Infinity, maxScroll)),
         )
         node.scrollTop = scrollTop
         // Clamp hitting top/bottom consumes any remainder. Set drainPending


### PR DESCRIPTION
Fixes #421

全屏模式 pane 宽度变化后整屏变黑只剩输入框——sticky 视角下 shrunk 帧的旧 scrollTop 与失准的 clamp 边界越过塌缩后的内容底，整屏被裁剪，叠加 resize 清屏即用户报告的纯黑屏（Orca 终端 pane 宽度抖动的现场字节取证 + 无头复现）。

**改动**（src/ink/render-node-to-output.ts，两处最小修改）：

- shrunk 帧对 **sticky 视角**不再冻结 scrollTop，钳制到（塌缩后的）maxScroll——sticky 契约即钉底；非 sticky 的手动位置保护原样保留（verify-scroll 的 mid-scroll shrink 断言仍过）；
- 虚拟滚动 clamp 上下界加 maxScroll 上限——clamp 边界来自行高估算、maxScroll 来自当帧 Yoga 实高，估算失准时视角不能被推到内容底部以下（那里本就无可渲染内容）。

**验证**：

- 新增 repro-resize-blank.tsx（真实 Chat 树 + alt-screen + 现场形态的 resize 风暴）：修复前 resize 首帧 density 64→0（只剩输入框），修复后首帧即含内容，ALL PASS；已挂 CI；
- 既有回归全过：repro-fullscreen-ghost / repro-collapse-shrink / repro-inline-scrollback / verify-resize-reflow / verify-shrink / verify-scroll / verify-resticky / verify-ctrl-t-scope / verify-help-scroll / repro-inline-thirdparty / verify-unseen-report-once；
- tsc 干净。