### PR TITLE
feat(input): Alt+V 剪贴板粘贴别名——终端吞掉 Ctrl+V 时的兜底键

### DIFF
--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -265,7 +265,8 @@ export function PromptInput({
   // Double-tap Esc to clear (CC semantics).
   const escPendingRef = React.useRef(false)
   const escTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-  /** True while a Ctrl+V clipboard read is in flight (ignore repeat keys). */
+  /** True while a clipboard paste read is in flight — guards both Ctrl+V
+   *  and Alt+V (ignore repeat keys). */
   const clipboardBusyRef = React.useRef(false)
   /** True while the external editor owns the terminal (Ctrl+G round-trip). */
   const editorBusyRef = React.useRef(false)
@@ -546,10 +547,11 @@ export function PromptInput({
       return
     }
 
-    // Ctrl+V / Cmd+V: raw mode hands the key to the app, so the clipboard is
-    // read here — text, file paths when the file manager copied files, or an
-    // exported temp-file path when the clipboard holds a raw image.
-    if (isMod(key) && input === 'v') {
+    // Clipboard paste, shared by Ctrl+V and Alt+V. Raw mode hands the key
+    // to the app, so the clipboard is read here — text, file paths when the
+    // file manager copied files, or an exported temp-file path when the
+    // clipboard holds a raw image (staged as an image attachment).
+    const pasteClipboard = () => {
       if (clipboardBusyRef.current) return
       // Match insertAtCaret's overlay/selection dismissal up front: the
       // async continuation below only sets value/cursor, so a paste landing
@@ -596,15 +598,32 @@ export function PromptInput({
           channel.notify(t('input-clipboard-read-failed'), { color: 'warning' })
         })
         .finally(() => {
-          // A rejected read must never wedge Ctrl+V for the rest of the
-          // session.
+          // A rejected read must never wedge clipboard paste for the rest
+          // of the session.
           clipboardBusyRef.current = false
         })
+    }
+
+    // Ctrl+V / Cmd+V: the primary clipboard-paste binding.
+    if (isMod(key) && input === 'v') {
+      pasteClipboard()
       return
     }
 
-    // Help is modal for modified keys and every Enter variant. Ctrl+V above
-    // is the intentional exception: paste closes Help and inserts visibly.
+    // Alt+V: same paste, alternate binding. Desktop terminals commonly own
+    // Ctrl+V themselves (Windows Terminal binds it to a text-only paste, so
+    // an image-only clipboard produces NO event at all — the keystroke never
+    // reaches the app), and Cmd+V is the macOS system paste. Alt+V passes
+    // through everywhere, so a clipboard image stays reachable even where
+    // Ctrl+V is swallowed. Pure alias: behavior is identical to Ctrl+V.
+    if (key.meta && input === 'v') {
+      pasteClipboard()
+      return
+    }
+
+    // Help is modal for modified keys and every Enter variant. Ctrl+V/Alt+V
+    // above are the intentional exception: paste closes Help and inserts
+    // visibly.
     // Swallow here before editor/submit/interrupt branches can mutate hidden
     // composer or working-turn state; plain typing still dismisses Help below.
     if (helpOpen && !key.escape && (key.ctrl || key.meta || key.super || key.return || input.includes('\n') || input.includes('\r'))) {

--- a/src/dsh-adapter/shortcuts.ts
+++ b/src/dsh-adapter/shortcuts.ts
@@ -127,6 +127,7 @@ const RESERVED_COMBOS = new Set([
   'ctrl+shift+return', // shift+Enter newline (CSI 13;6u) — same editor binding
   'alt+return', // newline fallback on terminals without shift reporting
   'alt+up', // pull the last pending message back for editing
+  'alt+v', // clipboard paste fallback for terminals that swallow Ctrl+V
   'escape', // pickers / interrupt / rewind double-tap
   'tab', // command completion
   'shift+tab', // session-mode cycle

--- a/src/tips.ts
+++ b/src/tips.ts
@@ -145,8 +145,8 @@ export const TIPS: readonly Tip[] = [
   {
     id: 'keys-paste',
     group: 'keys',
-    zh: 'Ctrl+V 粘贴文本、文件路径或图片附件',
-    en: 'Ctrl+V pastes text, file paths, or image attachments',
+    zh: 'Ctrl+V 粘贴文本、文件路径或图片附件；终端吞掉 Ctrl+V 时（如 Windows Terminal）用 Alt+V',
+    en: 'Ctrl+V pastes text, file paths, or image attachments; if the terminal swallows Ctrl+V (e.g. Windows Terminal), use Alt+V',
   },
   {
     id: 'keys-slash-search',


### PR DESCRIPTION
## 问题

桌面终端普遍把 Ctrl+V 占为自己的粘贴绑定：Windows Terminal 默认把 Ctrl+V 绑成**纯文本粘贴**，剪贴板只有图片时终端侧无文本可贴，**按键事件根本到不了应用**——TUI 的 Ctrl+V 图片粘贴在这类终端上完全不可达，且无任何提示，表现为"按了没反应"。macOS 的 Cmd+V 同理是系统级粘贴。已在 Windows Terminal + Win10/Win11 实机复现并定位：应用代码无问题，是终端层拦截（Claude Code、opencode 有同款 issue）。

## 方案

新增 **Alt+V** 作为剪贴板粘贴的备用键：走与 Ctrl+V **完全相同**的代码路径（纯别名），Alt+V 在各种终端协议下都能透传到应用（legacy `ESC+v` / win32-input-mode / kitty CSI-u 均已实测解析为 `meta+v`）。

- Ctrl+V **行为零改动**：原 handler 函数体逐字提取为 `pasteClipboard()` 闭包，busy 锁、help 浮层先关、选择器复位等保护原样
- `alt+v` 登记 `RESERVED_COMBOS`，插件不可抢占（与 ctrl+v 同级）
- tips 中英文同步更新，注明 Windows Terminal 的解法（settings.json 加 `{"command":"unbound","keys":"ctrl+v"}` 可让 Ctrl+V 也透传）

## 验证

- `tsc --noEmit` 零错误；`verify:build` 全量 20 组门禁通过；`verify-clipboard` / `verify-clipboard-image` 回归通过
- 键位冲突排查：全仓库唯一 `meta+v` 绑定，Chat/SessionBrowser 等处对 meta 键均显式排除
- 实机（Windows 11 + Windows Terminal，WT 默认配置）：截图 → Alt+V 出 `[Image #N]` 附件 token；Ctrl+V 解除 WT 拦截后行为与官方一致
