### PR TITLE
docs: 修复 dshfind 插件页链接——目录改版后旧路径 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@
   <img src="screenshots/wechat-official.png" alt="DeepSeek Harness 官方公众号推文收录 dsh-TUI" width="560">
 </p>
 
-同时也被 [dshfind](https://dshfind.com/ccch1mneyyy/dsh-TUI) 插件目录收录：
+同时也被 [dshfind](https://dshfind.com/zh/plugins/ccch1mneyyy/dsh-TUI) 插件目录收录：
 
 <p align="center">
-  <a href="https://dshfind.com/ccch1mneyyy/dsh-TUI"><img src="https://dshfind.com/api/card/ccch1mneyyy/dsh-TUI?lang=zh" alt="dsh-TUI on dshfind"></a>
+  <a href="https://dshfind.com/zh/plugins/ccch1mneyyy/dsh-TUI"><img src="https://dshfind.com/api/card/ccch1mneyyy/dsh-TUI?lang=zh" alt="dsh-TUI on dshfind"></a>
 </p>
 
 ## 核心能力

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,7 +34,7 @@ the interface, and removing it leaves no core modifications behind.
 > permission model or terminal-specific behavior.
 
 <p align="center">
-  <a href="https://dshfind.com/ccch1mneyyy/dsh-TUI"><img src="https://dshfind.com/api/card/ccch1mneyyy/dsh-TUI?lang=en" alt="dsh-TUI on dshfind"></a>
+  <a href="https://dshfind.com/en/plugins/ccch1mneyyy/dsh-TUI"><img src="https://dshfind.com/api/card/ccch1mneyyy/dsh-TUI?lang=en" alt="dsh-TUI on dshfind"></a>
 </p>
 
 ## Highlights


### PR DESCRIPTION
## 问题

dshfind.com 目录改版后插件页路径结构变为 `/<lang>/plugins/<owner>/<repo>`，README 里的旧链接 `https://dshfind.com/ccch1mneyyy/dsh-TUI` 已 **404**（实测）。

## 改动

- `README.md` 两处（正文收录链接 + zh badge 外链）→ `https://dshfind.com/zh/plugins/ccch1mneyyy/dsh-TUI`（实测 200）
- `README_EN.md` 一处（en badge 外链）→ `https://dshfind.com/en/plugins/ccch1mneyyy/dsh-TUI`（实测 200）
- badge 卡片 API（`/api/card/...`）路径未变（实测 200），无需调整
- `docs/links.md` 指向站点根域，不受影响

纯链接修正，无代码变更。