### PR TITLE
fix(render): wheel scroll translates text selection with content (#438)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prompt:debug": "node scripts/read-prompt-debug.mjs",
     "tui": "node --import tsx/esm scripts/run.ts",
     "smoke": "node --import tsx/esm scripts/smoke.tsx",
-    "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:herdr && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:web-coexistence && npm run verify:plugin-spec && npm run verify:plugin-grants && npm run verify:plugin-storage && npm run verify:plugin-messages && npm run verify:plugin-ledger && npm run verify:plugin-commands && npm run verify:plugin-negotiation && npm run verify:plugin-lifecycle && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap",
+    "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:herdr && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:web-coexistence && npm run verify:plugin-spec && npm run verify:plugin-grants && npm run verify:plugin-storage && npm run verify:plugin-messages && npm run verify:plugin-ledger && npm run verify:plugin-commands && npm run verify:plugin-negotiation && npm run verify:plugin-lifecycle && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap && npm run verify:wheel-selection",
     "verify:boundary": "node --import tsx/esm scripts/verify-adapter-boundary.ts",
     "verify:contract": "node --import tsx/esm scripts/verify-upstream-contract.ts",
     "verify:herdr": "node --import tsx/esm scripts/verify-herdr-integration.ts",
@@ -118,6 +118,7 @@
     "verify:plugin-lifecycle": "node --import tsx/esm scripts/verify-plugin-lifecycle.ts",
     "verify:tips": "node --import tsx/esm scripts/verify-tips.tsx",
     "verify:thinking-preview": "node --import tsx/esm scripts/verify-thinking-preview.tsx",
+    "verify:wheel-selection": "node --import tsx/esm scripts/verify-wheel-selection.ts",
     "sync:profile": "node scripts/sync-profile.mjs",
     "sync:profile:check": "node scripts/sync-profile.mjs --check"
   },

--- a/scripts/verify-wheel-selection.ts
+++ b/scripts/verify-wheel-selection.ts
@@ -1,0 +1,215 @@
+/**
+ * verify-wheel-selection — regression test for issue #438.
+ *
+ * 选中文字后滚轮滚动，选区必须跟随内容平移而不是钉在屏幕行上；
+ * 滚出视口的行经 captureScrolledRows 进入累加器，复制结果仍完整。
+ *
+ * Exercises the pure selection primitives the wheel-drain translate path
+ * drives (render-node-to-output.ts records a SIGNED followScroll delta for
+ * pendingScrollDelta drains; ink.tsx consumes it):
+ *   - captureScrolledRows + shiftSelectionForFollow with delta > 0
+ *     (content up: wheel-down / streaming follow) and delta < 0
+ *     (content down: wheel-up — capture window mirrors to the bottom edge)
+ *   - virtual-row accumulation across multi-frame drains
+ *   - symmetric auto-clear when BOTH ends fully exit the viewport
+ *   - partial straddle must NOT clear
+ *
+ * The direction math below mirrors the ink.tsx consumeFollowScroll block
+ * (firstRow/lastRow/side/shift). If that block changes, update here.
+ */
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  createScreen,
+  setCellAt,
+  type Screen,
+} from '../src/ink/screen.js'
+import {
+  captureScrolledRows,
+  getSelectedText,
+  hasSelection,
+  shiftSelectionForFollow,
+  type SelectionState,
+} from '../src/ink/selection.js'
+
+const W = 20
+const H = 12
+const VIEWPORT_TOP = 2
+const VIEWPORT_BOTTOM = 11
+
+let failures = 0
+
+function check(name: string, actual: unknown, expected: unknown): void {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a !== e) {
+    failures++
+    console.error(`FAIL ${name}`)
+    console.error(`      expected: ${e}`)
+    console.error(`      actual:   ${a}`)
+  } else {
+    console.log(`ok   ${name}`)
+  }
+}
+
+function rowText(row: number): string {
+  return `row-${String(row).padStart(2, '0')} content`
+}
+
+function buildScreen(): Screen {
+  const styles = new StylePool()
+  const screen = createScreen(W, H, styles, new CharPool(), new HyperlinkPool())
+  for (let row = 0; row < H; row++) {
+    const text = rowText(row).padEnd(W, ' ')
+    for (let col = 0; col < W; col++) {
+      setCellAt(screen, col, row, {
+        char: text[col]!,
+        styleId: screen.emptyStyleId,
+        width: CellWidth.Narrow,
+        hyperlink: undefined,
+      })
+    }
+  }
+  return screen
+}
+
+function makeSelection(
+  anchor: { col: number; row: number },
+  focus: { col: number; row: number },
+): SelectionState {
+  // Post-drag released state: anchor+focus set, isDragging false.
+  return {
+    anchor: { ...anchor },
+    focus: { ...focus },
+    isDragging: false,
+    anchorSpan: null,
+    scrolledOffAbove: [],
+    scrolledOffBelow: [],
+    scrolledOffAboveSW: [],
+    scrolledOffBelowSW: [],
+    lastPressHadAlt: false,
+  }
+}
+
+/** One frame of the ink.tsx consumeFollowScroll translation. */
+function applyScroll(
+  sel: SelectionState,
+  screen: Screen,
+  delta: number,
+): boolean {
+  const rows = Math.abs(delta)
+  const up = delta > 0
+  const firstRow = up ? VIEWPORT_TOP : VIEWPORT_BOTTOM - rows + 1
+  const lastRow = up ? VIEWPORT_TOP + rows - 1 : VIEWPORT_BOTTOM
+  const side: 'above' | 'below' = up ? 'above' : 'below'
+  const shift = up ? -rows : rows
+  if (hasSelection(sel)) {
+    captureScrolledRows(sel, screen, firstRow, lastRow, side)
+  }
+  return shiftSelectionForFollow(sel, shift, VIEWPORT_TOP, VIEWPORT_BOTTOM)
+}
+
+// ── Test 1: wheel-down (delta > 0) — capture top rows, shift up ──
+{
+  const screen = buildScreen()
+  const sel = makeSelection({ col: 1, row: 4 }, { col: 6, row: 8 })
+  const cleared = applyScroll(sel, screen, +3)
+  check('T1 not cleared', cleared, false)
+  check('T1 anchor clamped to viewport top, col reset by capture', sel.anchor, {
+    col: 0,
+    row: 2,
+  })
+  check('T1 virtual anchor row tracks pre-clamp position', sel.virtualAnchorRow, 1)
+  check('T1 focus shifted up', sel.focus, { col: 6, row: 5 })
+  check('T1 scrolledOffAbove captured anchor row (col-constrained)', sel.scrolledOffAbove, [
+    'ow-04 content',
+  ])
+  check(
+    'T1 copy includes captured row + on-screen rows',
+    getSelectedText(sel, screen),
+    [
+      'ow-04 content',
+      'row-02 content',
+      'row-03 content',
+      'row-04 content',
+      'row-05',
+    ].join('\n'),
+  )
+}
+
+// ── Test 2: wheel-up (delta < 0) — capture bottom rows, shift down,
+//    round-trip restores the pre-scroll positions ──
+{
+  const screen = buildScreen()
+  const sel = makeSelection({ col: 1, row: 4 }, { col: 6, row: 8 })
+  applyScroll(sel, screen, +3)
+  const cleared = applyScroll(sel, screen, -3)
+  check('T2 not cleared', cleared, false)
+  check('T2 anchor restored (virtual debt popped)', sel.anchor, { col: 0, row: 4 })
+  check('T2 virtual anchor cleared', sel.virtualAnchorRow, undefined)
+  check('T2 focus restored', sel.focus, { col: 6, row: 8 })
+  check('T2 below accumulator empty (selection never reached bottom edge)', sel.scrolledOffBelow, [])
+}
+
+// ── Test 3: multi-frame drain (2 frames of +2) accumulates like one +4 ──
+{
+  const screen = buildScreen()
+  const sel = makeSelection({ col: 1, row: 4 }, { col: 6, row: 8 })
+  applyScroll(sel, screen, +2)
+  const cleared = applyScroll(sel, screen, +2)
+  check('T3 not cleared', cleared, false)
+  check('T3 anchor', sel.anchor, { col: 0, row: 2 })
+  check('T3 virtual anchor', sel.virtualAnchorRow, 0)
+  check('T3 focus', sel.focus, { col: 6, row: 4 })
+  check('T3 captured rows 2-3 across drain frames', sel.scrolledOffAbove, [
+    'ow-02 content',
+    'row-03 content',
+  ])
+}
+
+// ── Test 4: wheel-up scrolls selection fully off the bottom → clear ──
+{
+  const screen = buildScreen()
+  const sel = makeSelection({ col: 0, row: 9 }, { col: 3, row: 11 })
+  const cleared = applyScroll(sel, screen, -4)
+  check('T4 cleared when both ends exit bottom', cleared, true)
+  check('T4 anchor nulled', sel.anchor, null)
+  check('T4 no selection after clear', hasSelection(sel), false)
+}
+
+// ── Test 5: wheel-down scrolls selection fully off the top → clear
+//    (pre-existing follow behavior — regression guard) ──
+{
+  const screen = buildScreen()
+  const sel = makeSelection({ col: 1, row: 2 }, { col: 3, row: 4 })
+  const cleared = applyScroll(sel, screen, +4)
+  check('T5 cleared when both ends exit top', cleared, true)
+  check('T5 anchor nulled', sel.anchor, null)
+}
+
+// ── Test 6: partial straddle (one end clamps, other stays) → NO clear ──
+{
+  const screen = buildScreen()
+  const sel = makeSelection({ col: 1, row: 3 }, { col: 2, row: 6 })
+  const cleared = applyScroll(sel, screen, +4)
+  check('T6 not cleared on partial exit', cleared, false)
+  check('T6 anchor clamped with virtual debt', [sel.anchor, sel.virtualAnchorRow], [
+    { col: 0, row: 2 },
+    -1,
+  ])
+  check('T6 focus still in viewport', sel.focus, { col: 2, row: 2 })
+  check('T6 copy still has full text via accumulator', getSelectedText(sel, screen), [
+    'ow-03 content',
+    'row-04 content',
+    'row-05 content',
+    'row',
+  ].join('\n'))
+}
+
+if (failures > 0) {
+  console.error(`\nverify-wheel-selection: ${failures} failure(s)`)
+  process.exit(1)
+}
+console.log('\nverify-wheel-selection: all checks passed')

--- a/scripts/verify-wheel-selection.ts
+++ b/scripts/verify-wheel-selection.ts
@@ -30,6 +30,7 @@ import {
   captureScrolledRows,
   getSelectedText,
   hasSelection,
+  pickFollowForSelection,
   shiftSelectionForFollow,
   type SelectionState,
 } from '../src/ink/selection.js'
@@ -206,6 +207,35 @@ function applyScroll(
     'row-05 content',
     'row',
   ].join('\n'))
+}
+
+// ── Test 7: multi-box attribution — innermost viewport containing the
+//    anchor wins; a selection outside every viewport follows nothing ──
+{
+  const transcript = { delta: 3, viewportTop: 0, viewportBottom: 29 }
+  const panel = { delta: -2, viewportTop: 10, viewportBottom: 18 }
+  check(
+    'T7 anchor in overlap rows picks the panel (innermost viewport)',
+    pickFollowForSelection([transcript, panel], 12),
+    panel,
+  )
+  check(
+    'T7 anchor above the panel picks the transcript',
+    pickFollowForSelection([transcript, panel], 5),
+    transcript,
+  )
+  check(
+    'T7 order-independent: same pick with events swapped',
+    pickFollowForSelection([panel, transcript], 12),
+    panel,
+  )
+  check(
+    'T7 anchor outside every viewport follows nothing',
+    pickFollowForSelection([transcript, panel], 31),
+    null,
+  )
+  check('T7 no events -> null', pickFollowForSelection([], 5), null)
+  check('T7 null anchor -> null', pickFollowForSelection([transcript], null), null)
 }
 
 if (failures > 0) {

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -33,7 +33,7 @@ import { applyPositionedHighlight, type MatchPosition, scanPositions } from './r
 import createRenderer, { type Renderer } from './renderer.js';
 import { CellWidth, CharPool, cellAt, createScreen, HyperlinkPool, isEmptyCellAt, migrateScreenPools, StylePool } from './screen.js';
 import { applySearchHighlight } from './searchHighlight.js';
-import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection.js';
+import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, pickFollowForSelection, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection.js';
 import { isDecstbmSafe, SYNC_OUTPUT_SUPPORTED, supportsExtendedKeys, supportsWin32InputMode, type Terminal, writeDiffToTerminal } from './terminal.js';
 import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ENABLE_WIN32_INPUT_MODE, ERASE_SCREEN, ERASE_SCROLLBACK, SGR_RESET } from './termio/csi.js';
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
@@ -552,8 +552,8 @@ export default class Ink {
     });
     const rendererMs = performance.now() - renderStart;
 
-    // Sticky/auto-follow or wheel-drain scrolled the ScrollBox this
-    // frame. Translate the selection by the same delta so the highlight
+    // Sticky/auto-follow or wheel-drain scrolled one or more ScrollBoxes
+    // this frame. Translate the selection by the same delta so the highlight
     // stays anchored to the TEXT (native terminal behavior — the
     // selection walks up the screen as content scrolls, eventually
     // clipping at the top). frontFrame
@@ -564,15 +564,18 @@ export default class Ink {
     // (screen-local) so only anchor shifts — selection grows toward the
     // mouse as the anchor walks up. After release, both ends are text-
     // anchored and move as a block.
-    const follow = consumeFollowScroll();
-    if (follow && this.selection.anchor &&
-    // Only translate if the selection is ON scrollbox content. Selections
-    // in the footer/prompt/StickyPromptHeader are on static text — the
-    // scroll doesn't move what's under them. Without this guard, a
-    // footer selection would be shifted then clamped into the viewport,
-    // teleporting it into the scrollbox. Mirror the bounds check the
-    // deleted check() in ScrollKeybindingHandler had.
-    this.selection.anchor.row >= follow.viewportTop && this.selection.anchor.row <= follow.viewportBottom) {
+    const follow = pickFollowForSelection(
+      consumeFollowScroll(),
+      this.selection.anchor?.row ?? null,
+    );
+    // pickFollowForSelection already checked anchor-in-viewport (that IS
+    // the "selection is on scrollbox content" guard — footer/prompt
+    // selections on static text match no viewport and follow nothing).
+    // Innermost-viewport wins attributes correctly when several boxes
+    // scrolled this frame (transcript draining while an overlay panel's
+    // box scrolls): panels render on top, so overlap-row selections
+    // belong to the panel, not the covered transcript.
+    if (follow && this.selection.anchor) {
       const {
         delta,
         viewportTop,

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -552,10 +552,11 @@ export default class Ink {
     });
     const rendererMs = performance.now() - renderStart;
 
-    // Sticky/auto-follow scrolled the ScrollBox this frame. Translate the
-    // selection by the same delta so the highlight stays anchored to the
-    // TEXT (native terminal behavior — the selection walks up the screen
-    // as content scrolls, eventually clipping at the top). frontFrame
+    // Sticky/auto-follow or wheel-drain scrolled the ScrollBox this
+    // frame. Translate the selection by the same delta so the highlight
+    // stays anchored to the TEXT (native terminal behavior — the
+    // selection walks up the screen as content scrolls, eventually
+    // clipping at the top). frontFrame
     // still holds the PREVIOUS frame's screen (swap is at ~500 below), so
     // captureScrolledRows reads the rows that are about to scroll out
     // before they're overwritten — the text stays copyable until the
@@ -568,15 +569,27 @@ export default class Ink {
     // Only translate if the selection is ON scrollbox content. Selections
     // in the footer/prompt/StickyPromptHeader are on static text — the
     // scroll doesn't move what's under them. Without this guard, a
-    // footer selection would be shifted by -delta then clamped to
-    // viewportBottom, teleporting it into the scrollbox. Mirror the
-    // bounds check the deleted check() in ScrollKeybindingHandler had.
+    // footer selection would be shifted then clamped into the viewport,
+    // teleporting it into the scrollbox. Mirror the bounds check the
+    // deleted check() in ScrollKeybindingHandler had.
     this.selection.anchor.row >= follow.viewportTop && this.selection.anchor.row <= follow.viewportBottom) {
       const {
         delta,
         viewportTop,
         viewportBottom
       } = follow;
+      // Signed delta: >0 = content moved up (at-bottom follow or
+      // wheel-down drain); <0 = content moved down (wheel-up drain, #438).
+      // The capture window is the viewport-edge rows about to scroll out
+      // (top edge when content moves up, bottom edge when it moves down),
+      // and the shift re-anchors the endpoints by the same amount in the
+      // OPPOSITE direction so they track the text, not the screen.
+      const rows = Math.abs(delta);
+      const up = delta > 0;
+      const firstRow = up ? viewportTop : viewportBottom - rows + 1;
+      const lastRow = up ? viewportTop + rows - 1 : viewportBottom;
+      const side: 'above' | 'below' = up ? 'above' : 'below';
+      const shift = up ? -rows : rows;
       // captureScrolledRows and shift* are a pair: capture grabs rows about
       // to scroll off, shift moves the selection endpoint so the same rows
       // won't intersect again next frame. Capturing without shifting leaves
@@ -586,9 +599,9 @@ export default class Ink {
       // each shift branch so the pairing can't be broken by a new guard.
       if (this.selection.isDragging) {
         if (hasSelection(this.selection)) {
-          captureScrolledRows(this.selection, this.frontFrame.screen, viewportTop, viewportTop + delta - 1, 'above');
+          captureScrolledRows(this.selection, this.frontFrame.screen, firstRow, lastRow, side);
         }
-        shiftAnchor(this.selection, -delta, viewportTop, viewportBottom);
+        shiftAnchor(this.selection, shift, viewportTop, viewportBottom);
       } else if (
       // Flag-3 guard: the anchor check above only proves ONE endpoint is
       // on scrollbox content. A drag from row 3 (scrollbox) into the
@@ -604,14 +617,16 @@ export default class Ink {
       // is correct there even when focus is in the footer).
       !this.selection.focus || this.selection.focus.row >= viewportTop && this.selection.focus.row <= viewportBottom) {
         if (hasSelection(this.selection)) {
-          captureScrolledRows(this.selection, this.frontFrame.screen, viewportTop, viewportTop + delta - 1, 'above');
+          captureScrolledRows(this.selection, this.frontFrame.screen, firstRow, lastRow, side);
         }
-        const cleared = shiftSelectionForFollow(this.selection, -delta, viewportTop, viewportBottom);
-        // Auto-clear (both ends overshot minRow) must notify React-land
-        // so useHasSelection re-renders and the footer copy/escape hint
-        // disappears. notifySelectionChange() would recurse into onRender;
-        // fire the listeners directly — they schedule a React update for
-        // LATER, they don't re-enter this frame.
+        const cleared = shiftSelectionForFollow(this.selection, shift, viewportTop, viewportBottom);
+        // Auto-clear (both ends overshot an edge — off the top via
+        // follow/wheel-down, off the bottom via wheel-up) must notify
+        // React-land so useHasSelection re-renders and the footer
+        // copy/escape hint disappears. notifySelectionChange() would
+        // recurse into onRender; fire the listeners directly — they
+        // schedule a React update for LATER, they don't re-enter this
+        // frame.
         if (cleared) for (const cb of this.selectionListeners) cb();
       }
     }

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -112,6 +112,12 @@ export function getScrollDrainNode(): DOMElement | null {
 // scrolls, eventually clipping at the top). The frontFrame screen buffer
 // still holds the old content at that point — captureScrolledRows reads
 // from it before the front/back swap to preserve the text for copy.
+// Wheel drains report here too (issue #438): the pendingScrollDelta drain
+// below records its SIGNED per-frame delta (negative = content moved
+// down, wheel-up) so the selection follows wheel scrolls as well. Only
+// one event per frame — a frame that both follows AND drains reports the
+// follow (the follow branch clears pending first, so the drain
+// contributes nothing that frame).
 /**
  * At-bottom follow scroll recorded this frame: the scroll delta and
  * viewport bounds, consumed by ink.tsx to translate the active text
@@ -921,6 +927,28 @@ function renderNodeToOutput(
         // only after clamp so a wasted no-op frame isn't scheduled.
         if (scrollTop !== cur) node.pendingScrollDelta = undefined
         if (node.pendingScrollDelta !== undefined) scrollDrainNode = node
+        // Wheel-drain selection translate (#438): the drain moved content
+        // by (scrollTop - scrollTopBeforeFollow) rows this frame, minus
+        // what at-bottom follow already reported above (followDelta is 0
+        // unless the follow branch fired — and when it did, it cleared
+        // pendingScrollDelta, so the drain contributed nothing). Record
+        // the remainder as a follow-scroll event with a SIGNED delta so
+        // ink.tsx re-anchors any active selection to the text. Without
+        // this, wheel scrolling leaves the highlight pinned to screen
+        // rows and copy-on-select grabs whatever scrolled under it.
+        // scrollTo/scrollToElement jumps never contribute: they write
+        // scrollTop before scrollTopBeforeFollow is captured. Multi-frame
+        // drains record per-frame portions; the selection's virtual-row
+        // tracking accumulates the clamp overshoot across frames.
+        const wheelDelta = scrollTop - scrollTopBeforeFollow - followDelta
+        if (wheelDelta !== 0 && !followScroll) {
+          const wheelVpTop = node.scrollViewportTop ?? 0
+          followScroll = {
+            delta: wheelDelta,
+            viewportTop: wheelVpTop,
+            viewportBottom: wheelVpTop + innerHeight - 1
+          }
+        }
         // A manual scroll that lands exactly on the bottom re-pins sticky
         // IMMEDIATELY on this frame — the follow-block restore above only
         // fires when a later frame happens, but an idle stream (turn done,

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -114,10 +114,10 @@ export function getScrollDrainNode(): DOMElement | null {
 // from it before the front/back swap to preserve the text for copy.
 // Wheel drains report here too (issue #438): the pendingScrollDelta drain
 // below records its SIGNED per-frame delta (negative = content moved
-// down, wheel-up) so the selection follows wheel scrolls as well. Only
-// one event per frame — a frame that both follows AND drains reports the
-// follow (the follow branch clears pending first, so the drain
-// contributes nothing that frame).
+// down, wheel-up) so the selection follows wheel scrolls as well. One
+// event per ScrollBox per frame; when several boxes scroll in the same
+// frame, ink.tsx attributes the selection to the innermost viewport
+// containing it (see pickFollowForSelection).
 /**
  * At-bottom follow scroll recorded this frame: the scroll delta and
  * viewport bounds, consumed by ink.tsx to translate the active text
@@ -128,15 +128,18 @@ export type FollowScroll = {
   viewportTop: number
   viewportBottom: number
 }
-let followScroll: FollowScroll | null = null
+let followScrolls: FollowScroll[] = []
 
 /**
- * Read and clear the follow-scroll event recorded this frame.
- * @returns the follow-scroll delta and viewport bounds, or null.
+ * Read and clear the follow-scroll events recorded this frame. At most one
+ * per ScrollBox (a box that follows AND drains reports only the follow —
+ * the follow branch clears pendingScrollDelta before the drain runs);
+ * several boxes may each report when they scroll in the same frame.
+ * @returns this frame's follow-scroll events; empty when none.
  */
-export function consumeFollowScroll(): FollowScroll | null {
-  const f = followScroll
-  followScroll = null
+export function consumeFollowScroll(): FollowScroll[] {
+  const f = followScrolls
+  followScrolls = []
   return f
 }
 
@@ -861,11 +864,11 @@ function renderNodeToOutput(
         const followDelta = (node.scrollTop ?? 0) - scrollTopBeforeFollow
         if (followDelta > 0) {
           const vpTop = node.scrollViewportTop ?? 0
-          followScroll = {
+          followScrolls.push({
             delta: followDelta,
             viewportTop: vpTop,
             viewportBottom: vpTop + innerHeight - 1,
-          }
+          })
         }
         // Drain pendingScrollDelta. Native terminals (proportional burst
         // events) use proportional drain; xterm.js (VS Code, sparse events +
@@ -939,15 +942,16 @@ function renderNodeToOutput(
         // scrollTo/scrollToElement jumps never contribute: they write
         // scrollTop before scrollTopBeforeFollow is captured. Multi-frame
         // drains record per-frame portions; the selection's virtual-row
-        // tracking accumulates the clamp overshoot across frames.
+        // tracking accumulates the clamp overshoot across frames. Multiple
+        // boxes may each record; ink.tsx attributes by viewport containment.
         const wheelDelta = scrollTop - scrollTopBeforeFollow - followDelta
-        if (wheelDelta !== 0 && !followScroll) {
+        if (wheelDelta !== 0) {
           const wheelVpTop = node.scrollViewportTop ?? 0
-          followScroll = {
+          followScrolls.push({
             delta: wheelDelta,
             viewportTop: wheelVpTop,
             viewportBottom: wheelVpTop + innerHeight - 1
-          }
+          })
         }
         // A manual scroll that lands exactly on the bottom re-pins sticky
         // IMMEDIATELY on this frame — the follow-block restore above only

--- a/src/ink/selection.ts
+++ b/src/ink/selection.ts
@@ -676,10 +676,12 @@ export function shiftAnchor(
  * the selection is text-anchored at both ends — both must move. The
  * isDragging check in ink.tsx picks which shift to apply.
  *
- * If both ends would shift strictly BELOW minRow (unclamped), the selected
- * text has scrolled entirely off the top. Clear it — otherwise a single
- * inverted cell lingers at the viewport top as a ghost (native terminals
- * drop the selection when it leaves scrollback). Landing AT minRow is
+ * If both ends would shift strictly BELOW minRow or strictly ABOVE maxRow
+ * (unclamped), the selected text has scrolled entirely off the viewport —
+ * off the top via streaming follow / wheel-down, off the bottom via
+ * wheel-up. Clear it — otherwise a single inverted cell lingers at the
+ * edge as a ghost (native terminals drop the selection when it leaves
+ * scrollback). Landing AT the edge row is
  * still valid: that cell holds the correct text. Returns true if the
  * selection was cleared so the caller can notify React-land subscribers
  * (useHasSelection) — the caller is inside onRender so it can't use
@@ -710,7 +712,13 @@ export function shiftSelectionForFollow(
   const rawFocus = s.focus
     ? (s.virtualFocusRow ?? s.focus.row) + dRow
     : undefined
-  if (rawAnchor < minRow && rawFocus !== undefined && rawFocus < minRow) {
+  // Both ends strictly past the same edge = selection fully scrolled off
+  // (top: follow/wheel-down; bottom: wheel-up). Symmetric clear — a
+  // clamped-to-edge pair would render as a 1-row ghost highlight.
+  if (
+    (rawAnchor < minRow && rawFocus !== undefined && rawFocus < minRow) ||
+    (rawAnchor > maxRow && rawFocus !== undefined && rawFocus > maxRow)
+  ) {
     clearSelection(s)
     return true
   }

--- a/src/ink/selection.ts
+++ b/src/ink/selection.ts
@@ -750,6 +750,47 @@ export function shiftSelectionForFollow(
   return false
 }
 
+/** A scroll event reported by a ScrollBox this frame (follow or wheel
+ *  drain): signed delta plus the box's viewport bounds. Structurally
+ *  identical to FollowScroll in render-node-to-output. */
+export type ScrollEvent = {
+  delta: number
+  viewportTop: number
+  viewportBottom: number
+}
+
+/**
+ * Pick which scroll event a selection belongs to when several ScrollBoxes
+ * scrolled in the same frame (e.g., the transcript still draining a wheel
+ * burst while an overlay panel's box scrolls). The selection follows the
+ * INNERMOST viewport containing the anchor: overlay panels render on top
+ * of the transcript, so a selection inside the overlap rows belongs to
+ * the panel, not the covered transcript beneath it. A selection outside
+ * every viewport (footer/prompt, static text) follows nothing — scrolling
+ * doesn't move the content under it.
+ * @param events - this frame's scroll events (signed deltas).
+ * @param anchorRow - the selection anchor's screen row, or null when no
+ *   selection is active.
+ * @returns the event the selection should be translated by, or null.
+ */
+export function pickFollowForSelection(
+  events: ScrollEvent[],
+  anchorRow: number | null,
+): ScrollEvent | null {
+  if (anchorRow === null) return null
+  let best: ScrollEvent | null = null
+  let bestHeight = Infinity
+  for (const e of events) {
+    if (anchorRow < e.viewportTop || anchorRow > e.viewportBottom) continue
+    const height = e.viewportBottom - e.viewportTop
+    if (best === null || height < bestHeight) {
+      best = e
+      bestHeight = height
+    }
+  }
+  return best
+}
+
 /**
  * True when a selection is active, meaning both anchor and focus are set.
  * @param s - the selection state to inspect.


### PR DESCRIPTION
## 问题

Closes #438

全屏模式下用鼠标选中一段文字后滚动滚轮：

1. 被选中的文字随内容滚走了，但蓝色高亮**停留在原来的屏幕行**上——变成现在滚到这个位置的字被高亮
2. 此时复制（copy-on-select），拿到的只是最后停在高亮下的那点内容，而不是最初选中的文字

## 根因

选区存的是屏幕缓冲区坐标。renderer 里已有完整的选区跟随内容机制（`captureScrolledRows` + `shiftSelectionForFollow`，由 `followScroll` 事件驱动），但只有**流式 at-bottom 跟随**会记录该事件（`render-node-to-output.ts`）。滚轮走的另一条路——`Chat.tsx` → `ScrollBox.scrollBy()` → `pendingScrollDelta` 分帧 drain——从不设置 `followScroll`，选区平移完全不触发；复制按旧坐标读当前屏幕缓冲区，自然错位。

## 修复

**`src/ink/render-node-to-output.ts`**
- drain 落账后计算本帧实际位移 `wheelDelta`（= clamp 后 scrollTop 变化量 − at-bottom follow 已上报的部分），以**带符号** delta 写入 follow-scroll 事件（负 = 内容下移/wheel-up）
- follow 与 drain 同一 ScrollBox 内互斥（follow 分支先清 `pendingScrollDelta`，该帧 drain 贡献为 0）
- `followScroll` 单槽改为 `followScrolls` 数组：多个 ScrollBox 同帧滚动时各自上报，不再先到先得

**`src/ink/ink.tsx`**
- 消费端泛化为双向：wheel-up 时捕获窗口镜像到视口**底部**边缘（capture `below`），平移方向取反
- 通过 `pickFollowForSelection` 归因：选区跟随**包含锚点的最内层视口**（覆盖面板在上层，重叠行的选区属于面板；视口外的静态文本选区跟随无）

**`src/ink/selection.ts`**
- 新增 `pickFollowForSelection`（多盒归因，见上）
- `shiftSelectionForFollow` 补对称的整体滚出**底部**自动清除（原先只有滚出顶部；避免边缘 1 行幽灵高亮）

**`scripts/verify-wheel-selection.ts`**（新）
- 31 项回归检查：双向平移/捕获、多帧 drain 累积、往返恢复、双侧边缘自动清除、半跨界不清除、多盒归因（最内层胜出/顺序无关/视口外为 null）
- 已接入 `verify:build` 门禁链

## 边界说明（如实披露）

- `scrollTo` / `scrollToElement` 跳转仍不平移选区（修复前亦如此，#438 只涉及滚轮；原生终端对跳转也无此保证）
- burst 滚动触发虚拟滚动 clamp 时，绘制位置可能滞后逻辑位置 1–2 帧，React 提交后自愈（既有行为）

## 验证

- `pnpm run build` 全绿：tsc + 全部 18 项 verify 门禁（含新增 `verify:wheel-selection` 31 项检查）
- 本机 Junction 轨实测就绪（`sync:profile:check` 0 差异）