### PR TITLE
fix(render): 渲染审计 P0/P1 修复——错位/重复/Unicode caret/陈旧行高 + 一致性验证器

### DIFF
--- a/scripts/repro-bottom-drift.tsx
+++ b/scripts/repro-bottom-drift.tsx
@@ -1,0 +1,137 @@
+/** Minimal: which event appends the extra blank row below the statusline? */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+  import('node:stream'), import('react'), import('@xterm/headless'),
+  import('../src/ui.js'), import('../src/screens/Chat.js'), import('../src/dsh-adapter/questions.js'),
+])
+const COLS = 100, ROWS = 24
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 2000, allowProposedApi: true })
+const rawChunks: string[] = []
+let recording = false
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(c: unknown, _e: BufferEncoding, cb: () => void) {
+    const s = String(c)
+    if (recording) rawChunksSaved.push(s)
+    const before = recording ? term.buffer.active.length : -1
+    term.write(s, () => {
+      if (recording) {
+        const grow = term.buffer.active.length - before
+        const lfs = (s.match(/\n/g) ?? []).length
+        frameStats.push({ bytes: s.length, grow, lfs })
+      }
+      cb()
+    })
+  }
+}
+const rawChunksSaved: string[] = []
+const frameStats: Array<{ bytes: number; grow: number; lfs: number }> = []
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough { isTTY = true; setRawMode() { return this } ref() { return this } unref() { return this } }
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows: [] as any[], status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', mode: { plan: false }, reasoningEffort: 'max', tokens: { input: 120, output: 45 },
+  cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main', working: false, spinnerMode: 'requesting',
+  responseChars: 0, activeToolCount: 0, turnStart: Date.now(), lastUserText: '',
+  pending: [], commandList: [], notifications: [],
+  _ls: listeners,
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => [], setResumeTarget: () => {},
+  loadOlder: () => {}, mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) cb() }
+
+const instance = await render(
+  <Chat channel={channel} questionStore={new QuestionStore()} />,
+  { stdout: new FakeStdout() as any, stdin: new FakeStdin() as any, stderr: new FakeStderr() as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(3500)
+
+/** buffer 末尾：statusline 位置 + 下方空行数。 */
+function tailInfo(): { bufLen: number; statusY: number; blanksBelow: number } {
+  const buf = term.buffer.active
+  const lines: string[] = []
+  for (let y = 0; y < buf.length; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
+  let statusY = -1
+  for (let y = lines.length - 1; y >= 0; y--) {
+    if (lines[y]!.includes('deepseek-v4-flash')) { statusY = y; break }
+  }
+  let blanks = 0
+  for (let y = lines.length - 1; y > statusY; y--) blanks++
+  return { bufLen: buf.length, statusY, blanksBelow: blanks }
+}
+const report = (label: string) => {
+  const t = tailInfo()
+  console.log(`${label}: buffer=${t.bufLen} statusline@${t.statusY} 下方空行=${t.blanksBelow}`)
+  return t
+}
+
+let id = 0
+// 阶段 1：只长 assistant 流式（working=false，无 spinner 行）
+report('基线（空会话）')
+{
+  channel.rows.push({ id: id++, kind: 'user', text: 'Q1' })
+  const a = { id: id++, kind: 'assistant', text: '', streaming: true }
+  channel.rows.push(a); bump()
+  for (let i = 0; i < 30; i++) { a.text += `- L1 行 ${i}\n`; bump(); await sleep(60) }
+  a.streaming = false; bump(); await sleep(500)
+  report('阶段1 纯 assistant 流式（无 working 切换）')
+}
+// 阶段 2：working true→false（spinner 行挂载→卸载 = 收缩）
+{
+  channel.rows.push({ id: id++, kind: 'user', text: 'Q2' })
+  channel.working = true
+  rawChunks.length = 0; recording = true
+  bump(); await sleep(200)
+  const a = { id: id++, kind: 'assistant', text: '', streaming: true }
+  channel.rows.push(a); bump()
+  for (let i = 0; i < 30; i++) { a.text += `- L2 行 ${i}\n`; bump(); await sleep(60) }
+  a.streaming = false
+  channel.working = false
+  bump(); await sleep(500)
+  recording = false
+  // 解码收缩帧尾部的转义序列
+  const decode = (s: string) => s
+    .replace(/\x1b\[\?2026h/g, '[BSU]').replace(/\x1b\[\?2026l/g, '[ESU]')
+    .replace(/\x1b\[(\d*)A/g, (_, n) => `[CUU${n || 1}]`)
+    .replace(/\x1b\[(\d*)B/g, (_, n) => `[CUD${n || 1}]`)
+    .replace(/\x1b\[(\d*)K/g, (_, n) => `[EL${n || 0}]`)
+    .replace(/\x1b\[2J/g, '[ED2]').replace(/\x1b\[J/g, '[ED0]')
+    .replace(/\x1b\[H/g, '[HOME]').replace(/\r/g, '[CR]').replace(/\n/g, '[LF]')
+    .replace(/\x1b\[\?25l/g, '[HIDE]').replace(/\x1b\[m/g, '[SGR0]')
+  let growFrames = 0
+  frameStats.forEach((st, i) => {
+    if (st.grow > 0) {
+      growFrames++
+      const d = decode(rawChunksSaved[i] ?? '')
+      console.log(`  涨行帧#${i}(${st.bytes}B, LF×${st.lfs}) buffer+${st.grow} 尾: …${d.slice(-70)}`)
+    }
+  })
+  const totalGrow = frameStats.reduce((s, f) => s + f.grow, 0)
+  console.log(`  [阶段2录制] 共 ${frameStats.length} 帧，涨行帧 ${growFrames} 个，buffer 总涨 ${totalGrow}`)
+  report('阶段2 含 working 切换（spinner 收缩）')
+}
+// 阶段 3：reasoning 流式→折叠（thinking fold 收缩）
+{
+  channel.rows.push({ id: id++, kind: 'user', text: 'Q3' })
+  channel.working = true; bump(); await sleep(200)
+  const r = { id: id++, kind: 'reasoning', text: '', streaming: true }
+  channel.rows.push(r); bump()
+  for (let i = 0; i < 12; i++) { r.text += `推理 ${i} `.repeat(8); bump(); await sleep(60) }
+  r.streaming = false; r.durationMs = 500; bump(); await sleep(200)
+  const a = { id: id++, kind: 'assistant', text: '', streaming: true }
+  channel.rows.push(a); bump()
+  for (let i = 0; i < 20; i++) { a.text += `- L3 行 ${i}\n`; bump(); await sleep(60) }
+  a.streaming = false; channel.working = false; bump(); await sleep(500)
+  report('阶段3 含 reasoning 折叠')
+}
+await instance.unmount()
+process.exit(0)

--- a/scripts/repro-composer-ghost.tsx
+++ b/scripts/repro-composer-ghost.tsx
@@ -1,0 +1,268 @@
+/**
+ * inline 模式 scrollback 输入框残影复现（用户报告："往上翻页经常看到
+ * 输入框在上面"）：
+ *
+ * 终端原生 scrollback 是不可变的。任何一帧把 composer（输入框边框
+ * ╭─╰─/❯）画到了错误的高度、随后又被滚动推出视口，那行残影就永久
+ * 冻在 scrollback 里——用户上翻就会看到"多余的输入框"。
+ *
+ * 场景：多轮完整对话（用户 → reasoning 流式 → 折叠 → tool 卡片 →
+ * assistant 流式 → 收尾收缩 → 下一轮），帧高反复涨落，正是残影最
+ * 容易沉积的路径。跑完后逐行扫描整个 buffer（scrollback + 视口），
+ * 统计 composer 边框行（╭…╮ / ╰…╯）出现的位置：
+ *  - 视口内最后一份 = 正常（真正的 composer）；
+ *  - 视口上方任何一份 = 残影（FAIL，报出所在行号和内容）。
+ * 运行：node --import tsx/esm scripts/repro-composer-ghost.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+])
+
+const COLS = 100
+const ROWS = 24
+const SCROLLBACK = 3000
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: SCROLLBACK, allowProposedApi: true })
+
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+function fullBufferLines(): string[] {
+  const buf = term.buffer.active
+  const out: string[] = []
+  for (let y = 0; y < buf.length; y++) out.push(buf.getLine(y)?.translateToString(true) ?? '')
+  return out
+}
+
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows: [] as any[], status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash',
+  mode: { plan: false }, reasoningEffort: 'max', tokens: { input: 120, output: 45 },
+  cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main', working: false, spinnerMode: 'requesting',
+  responseChars: 0, activeToolCount: 0, turnStart: Date.now(), lastUserText: '',
+  pending: [], commandList: [], notifications: [],
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => [], setResumeTarget: () => {},
+  loadOlder: () => {}, mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) cb() }
+
+let id = 0
+const stdoutObj = new FakeStdout()
+const stdin = new FakeStdin()
+const instance = await render(
+  <Chat channel={channel} questionStore={new QuestionStore()} />,
+  { stdout: stdoutObj, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(3500) // 鲸鱼启动动画定格
+
+// ---- 多轮完整对话：每轮都经历 grow → stream → fold 收缩 → settle ----
+const TURNS = 4
+for (let turn = 0; turn < TURNS; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `第 ${turn} 轮：分析这个模块的设计 ${'细节' .repeat(turn + 1)}` })
+  channel.working = true
+  channel.lastUserText = `第 ${turn} 轮`
+  bump(); await sleep(150)
+
+  const reasoning = { id: id++, kind: 'reasoning', text: '', streaming: true }
+  channel.rows.push(reasoning); bump()
+  for (let i = 0; i < 8; i++) {
+    reasoning.text += `思考片段 ${turn}-${i}：先看结构再下手，考虑边界与错误路径。`
+    bump(); await sleep(60)
+  }
+  reasoning.streaming = false
+  reasoning.durationMs = 900
+  bump(); await sleep(120)
+
+  const tool = {
+    id: id++, kind: 'tool', text: '',
+    tool: {
+      callId: `t${turn}`, name: 'Read', argsText: '{"file_path":"/home/demo/mod.dart"}', argsFull: '{}',
+      status: 'running', startedAt: Date.now(), durationMs: undefined as number | undefined,
+      resultText: undefined as string | undefined,
+    },
+  }
+  channel.rows.push(tool); bump(); await sleep(200)
+  tool.tool.status = 'ok'
+  tool.tool.durationMs = 40
+  tool.tool.resultText = Array.from({ length: 10 }, (_, i) => `结果行 ${turn}-${i}`).join('\n')
+  bump(); await sleep(150)
+
+  const answer = { id: id++, kind: 'assistant', text: '', streaming: true }
+  channel.rows.push(answer); bump()
+  for (let i = 0; i < 14; i++) {
+    answer.text += `- 回答要点 ${turn}-${i}：模块划分、依赖方向、错误处理、性能与可测性。\n`
+    bump(); await sleep(70)
+  }
+  answer.streaming = false
+  channel.working = false
+  channel.activeToolCount = 0
+  bump()
+  await sleep(400) // 收尾收缩帧（thinking 折叠 / spinner 卸载）
+}
+
+await sleep(600)
+
+// ---- 扫描整个 buffer：composer 边框行只允许出现在视口内 ----
+const lines = fullBufferLines()
+const total = lines.length
+const viewportStart = total - ROWS
+const isTopBorder = (l: string) => /^ *╭─+╮/.test(l)
+const isBottomBorder = (l: string) => /^ *╰─+╯/.test(l)
+const ghosts: Array<{ y: number; kind: string; text: string }> = []
+for (let y = 0; y < viewportStart; y++) {
+  const l = lines[y]!
+  if (isTopBorder(l)) ghosts.push({ y, kind: 'top', text: l.trim().slice(0, 50) })
+  else if (isBottomBorder(l)) ghosts.push({ y, kind: 'bottom', text: l.trim().slice(0, 50) })
+}
+const inViewport = lines.slice(viewportStart).filter(l => isTopBorder(l) || isBottomBorder(l)).length
+
+console.log(`buffer=${total} 行，viewportStart=${viewportStart}，视口内边框行=${inViewport}，scrollback 残影=${ghosts.length}`)
+for (const g of ghosts.slice(0, 12)) console.log(`  残影 行${g.y} [${g.kind}] ${g.text}`)
+check('scrollback 无输入框残影', ghosts.length === 0, `残影 ${ghosts} 处 / buffer ${total} 行`)
+check('视口内恰有一份 composer', inViewport >= 2, `边框行 ${inViewport}`)
+
+// ---- 转录行完整性：每个要点在 buffer 中恰一份 ----
+let missing = 0
+for (let t = 0; t < TURNS; t++) {
+  for (let i = 0; i < 14; i++) {
+    const marker = `回答要点 ${t}-${i}：` // 带冒号终止符，避免 0-1 匹配 0-10
+    const count = lines.filter(l => l.includes(marker)).length
+    if (count !== 1) { missing++; console.log(`  要点异常 ${marker} ×${count}`) }
+  }
+}
+check('每个流式要点在 buffer 中恰出现一次', missing === 0, `${missing} 处异常`)
+
+// ---- 场景 B：用户上翻阅读（终端原生 scrollback）+ 后台继续流式 ----
+// inline 模式没有鼠标跟踪，上翻 = 终端自己滚 scrollback；此时流式继续、
+// 帧继续渲染。任何一帧把 composer 画错高度，残影永久冻进 scrollback。
+const SCROLL_TURNS = 2
+for (let turn = 0; turn < SCROLL_TURNS; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `上翻轮 ${turn}：继续流式输出` })
+  channel.working = true
+  bump(); await sleep(150)
+  const answer = { id: id++, kind: 'assistant', text: '', streaming: true }
+  channel.rows.push(answer); bump()
+  for (let i = 0; i < 16; i++) {
+    answer.text += `- 上翻要点 ${turn}-${i}：边滚边流的行。\n`
+    bump(); await sleep(70)
+    if (i === 4 || i === 9 || i === 13) {
+      term.scrollLines(-80) // 用户往上翻页
+      await sleep(40)
+    }
+  }
+  answer.streaming = false
+  channel.working = false
+  bump(); await sleep(300)
+}
+await sleep(400)
+
+// ---- 场景 C：输入草稿多行（composer 变高）期间流式 + 收缩 ----
+const draft = { id: -1, kind: 'assistant', text: '', streaming: true }
+channel.rows.push({ id: id++, kind: 'user', text: '输入期间流式' })
+channel.working = true
+bump(); await sleep(120)
+channel.rows.push(draft); bump()
+// 边打字（composer 高度 1→5 行）边流式
+const typing = ['多行草稿第一行', '第二行内容追加', '第三行继续写', '第四行', '第五行收尾']
+for (let i = 0; i < typing.length; i++) {
+  stdin.write(typing[i]!)
+  await sleep(60)
+  stdin.write('\u001b[13;2u') // Shift+Enter (kitty CSI-u)
+  await sleep(60)
+  draft.text += `- 输入期要点 ${i}：composer 变高时的流式行。\n`
+  bump(); await sleep(90)
+}
+for (let i = typing.length; i < 10; i++) {
+  draft.text += `- 输入期要点 ${i}：composer 变高时的流式行。\n`
+  bump(); await sleep(90)
+}
+// 清空草稿（一次 Backspace 链 / Ctrl+U）—— composer 5 行收缩回 1 行
+const beforeClear = fullBufferLines().slice(-ROWS)
+const draftVisible = beforeClear.filter(l => l.includes('多行草稿') || l.includes('第二行') || l.includes('第五行')).length
+console.log(`[诊断] Ctrl+U 前视口内草稿行数 = ${draftVisible}（0 = 键盘注入未生效）`)
+stdin.write('\u0015') // Ctrl+U 清行
+await sleep(200)
+draft.streaming = false
+channel.working = false
+bump(); await sleep(500)
+
+// 再次扫描
+const lines2 = fullBufferLines()
+const total2 = lines2.length
+const viewportStart2 = total2 - ROWS
+const ghosts2: Array<{ y: number; text: string }> = []
+for (let y = 0; y < viewportStart2; y++) {
+  const l = lines2[y]!
+  if (/^ *╭─+╮/.test(l) || /^ *╰─+╯/.test(l)) ghosts2.push({ y, text: l.trim().slice(0, 50) })
+}
+console.log(`[上翻场景] buffer=${total2} 行，scrollback 残影=${ghosts2.length}`)
+for (const g of ghosts2.slice(0, 12)) console.log(`  残影 行${g.y} ${g.text}`)
+check('上翻+流式：scrollback 无输入框残影', ghosts2.length === 0, `残影 ${ghosts2.length} 处`)
+
+let missing2 = 0
+for (let t = 0; t < SCROLL_TURNS; t++) {
+  for (let i = 0; i < 16; i++) {
+    const marker = `上翻要点 ${t}-${i}：`
+    const count = lines2.filter(l => l.includes(marker)).length
+    if (count !== 1) { missing2++; console.log(`  要点异常 ${marker} ×${count}`) }
+  }
+}
+check('上翻+流式：每个要点恰出现一次', missing2 === 0, `${missing2} 处异常`)
+
+// 场景 C 后再扫一次（输入收缩是残影最危险的时刻）
+const lines3 = fullBufferLines()
+const viewportStart3 = lines3.length - ROWS
+const ghosts3: Array<{ y: number; text: string }> = []
+for (let y = 0; y < viewportStart3; y++) {
+  const l = lines3[y]!
+  if (/^ *╭─+╮/.test(l) || /^ *╰─+╯/.test(l)) ghosts3.push({ y, text: l.trim().slice(0, 50) })
+}
+console.log(`[输入收缩场景] buffer=${lines3.length} 行，scrollback 残影=${ghosts3.length}`)
+for (const g of ghosts3.slice(0, 12)) console.log(`  残影 行${g.y} ${g.text}`)
+check('多行输入收缩：scrollback 无输入框残影', ghosts3.length === 0, `残影 ${ghosts3.length} 处`)
+{
+  let missing3 = 0
+  for (let i = 0; i < 10; i++) {
+    const marker = `输入期要点 ${i}：`
+    const count = lines3.filter(l => l.includes(marker)).length
+    if (count !== 1) { missing3++; console.log(`  要点异常 ${marker} ×${count}`) }
+  }
+  check('多行输入+流式：每个要点恰出现一次', missing3 === 0, `${missing3} 处异常`)
+}
+
+console.log(failed === 0 ? '\nALL PASS（scrollback 干净，无输入框残影）' : `\n${failed} 项失败`)
+await instance.unmount()
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-frame-invariants.tsx
+++ b/scripts/verify-frame-invariants.tsx
@@ -1,0 +1,272 @@
+/**
+ * 三层真相一致性验证（React 状态 / Yoga 布局 / 终端物理层）：
+ *
+ * 核心不变量：对同一份最终状态，**经过一长串增量帧渲染出来的终端**，
+ * 必须与**全新挂载一次渲染出来的终端**逐行一致。任何一层的三相
+ * 账本（行高缓存 / nodeCache blit / scrollback viewportY / 光标记账）
+ * 漂移，都会在这条断言下现形——这是比"marker 恰好一份"更强的
+ * 端到端性质，直接锁定"增量管线最终漂移"这一整类 bug。
+ *
+ * 场景（共用一个增量实例，对照多个 fresh 实例）：
+ *  A. 多轮流式（reasoning 流式→折叠、tool running→ok、assistant 流式
+ *     →settle 收缩）后的视口 vs fresh；
+ *  B. Ctrl+O 全局展开后的视口 vs fresh（同发按键）；
+ *  C. Help 浮层开→关后的视口 vs fresh（浮层关闭恢复底层 cells）；
+ *  D. 增量实例整个 buffer（scrollback+视口）中每条内容恰一份。
+ *
+ * 时间相关文本（耗时/时钟）归一化为 T 后再比较。
+ * 运行：node --import tsx/esm scripts/verify-frame-invariants.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+])
+
+const COLS = 100
+const ROWS = 24
+const SCROLLBACK = 2000
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  constructor(private term: XTerm.Terminal) { super() }
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { this.term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+
+interface Harness {
+  term: XTerm.Terminal
+  stdin: FakeStdin
+  instance: { unmount(): Promise<void> | void }
+}
+
+function makeChannel(): any {
+  const listeners = new Set<() => void>()
+  return {
+    version: 0, rows: [] as any[], status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    mode: { plan: false }, reasoningEffort: 'max', tokens: { input: 120, output: 45 },
+    cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main', working: false, spinnerMode: 'requesting',
+    responseChars: 0, activeToolCount: 0, turnStart: Date.now(), lastUserText: '',
+    pending: [], commandList: [], notifications: [],
+    _ls: listeners,
+    subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+    submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+    listModels: () => Promise.resolve([]), listSessions: () => [], setResumeTarget: () => {},
+    loadOlder: () => {}, mcpStatus: () => [],
+  }
+}
+
+/** Notify one channel's subscribers (its mounted Chat re-renders). */
+function bumpOf(ch: any): void {
+  ch.version++
+  for (const cb of ch._ls as Set<() => void>) cb()
+}
+
+/** Mount a Chat into its own xterm; returns the harness. */
+async function mountChat(channel: any): Promise<Harness> {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: SCROLLBACK, allowProposedApi: true })
+  const stdout = new FakeStdout(term)
+  const stdin = new FakeStdin()
+  const instance = await render(
+    <Chat channel={channel} questionStore={new QuestionStore()} />,
+    { stdout: stdout as any, stdin: stdin as any, stderr: new FakeStderr() as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  return { term, stdin, instance }
+}
+
+function viewportLines(term: XTerm.Terminal): string[] {
+  const buf = term.buffer.active
+  const out: string[] = []
+  for (let y = Math.max(0, buf.length - ROWS); y < buf.length; y++) {
+    out.push(buf.getLine(y)?.translateToString(true) ?? '')
+  }
+  return out
+}
+
+function fullBufferLines(term: XTerm.Terminal): string[] {
+  const buf = term.buffer.active
+  const out: string[] = []
+  for (let y = 0; y < buf.length; y++) out.push(buf.getLine(y)?.translateToString(true) ?? '')
+  return out
+}
+
+/** Normalize time-varying tokens (durations, clocks) to T. */
+function norm(line: string): string {
+  return line
+    .replace(/\d+(?:\.\d+)?(?:ms|s)\b/g, 'T')
+    .replace(/\d{1,2}:\d{2}(?::\d{2})?/g, 'T')
+    .trimEnd()
+}
+
+let failed = 0
+let driftReported = false
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** Compare two viewports after normalization; print up to 8 diff rows.
+ * When every diff is explained by a uniform k-row shift (incremental
+ * content sits k rows higher, k blanks at the bottom), report it as the
+ * known bottom-drift bug instead of listing rows. */
+function assertViewportsMatch(name: string, a: XTerm.Terminal, b: XTerm.Terminal): void {
+  const va = viewportLines(a).map(norm)
+  const vb = viewportLines(b).map(norm)
+  const diffs: string[] = []
+  for (let i = 0; i < ROWS; i++) {
+    if ((va[i] ?? '') !== (vb[i] ?? '')) diffs.push(`行${i}\n  增量|${va[i]}\n  全新|${vb[i]}`)
+  }
+  if (diffs.length === 0) {
+    check(name, true)
+    return
+  }
+  // 已知漂移检测：va[i] === vb[i+k] 且 va 尾部 k 行为空
+  for (let k = 1; k <= 6; k++) {
+    let shifted = true
+    for (let i = 0; i < ROWS - k; i++) {
+      if ((va[i] ?? '') !== (vb[i + k] ?? '')) { shifted = false; break }
+    }
+    const tailBlank = va.slice(ROWS - k).every(l => l === '')
+    if (shifted && tailBlank) {
+      driftReported = true
+      check(`${name} —— 已知底部漂移 bug：增量实例整体上浮 ${k} 行，statusline 下积 ${k} 空行（见审计文档 §14）`, false, '开放 bug，非本次回归')
+      return
+    }
+  }
+  check(name, false, `${diffs.length} 行差异`)
+  for (const d of diffs.slice(0, 8)) console.log(`  ${d}`)
+}
+
+// ---- 增量实例：跑完整流式剧本 ----
+const channel = makeChannel()
+let id = 0
+const inc = await mountChat(channel)
+await sleep(3500) // 鲸鱼动画定格
+
+const TURNS = 2
+for (let turn = 0; turn < TURNS; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `不变量问题 ${turn}：审一下渲染管线` })
+  channel.working = true
+  channel.lastUserText = `不变量 ${turn}`
+  bumpOf(channel); await sleep(150)
+
+  const reasoning = { id: id++, kind: 'reasoning', text: '', streaming: true }
+  channel.rows.push(reasoning); bumpOf(channel)
+  for (let i = 0; i < 6; i++) {
+    reasoning.text += `推理段 ${turn}-${i}：增量帧与新鲜帧必须逐行一致，账本不能漂。`
+    bumpOf(channel); await sleep(60)
+  }
+  reasoning.streaming = false
+  reasoning.durationMs = 800
+  bumpOf(channel); await sleep(120)
+
+  const tool = {
+    id: id++, kind: 'tool', text: '',
+    tool: {
+      callId: `v${turn}`, name: 'Grep', argsText: '{"pattern":"viewportY"}', argsFull: '{}',
+      status: 'running', startedAt: Date.now(), durationMs: undefined as number | undefined,
+      resultText: undefined as string | undefined,
+    },
+  }
+  channel.rows.push(tool); bumpOf(channel); await sleep(180)
+  tool.tool.status = 'ok'
+  tool.tool.durationMs = 25
+  tool.tool.resultText = Array.from({ length: 6 }, (_, i) => `命中 ${turn}-${i}`).join('\n')
+  bumpOf(channel); await sleep(140)
+
+  const answer = { id: id++, kind: 'assistant', text: '', streaming: true }
+  channel.rows.push(answer); bumpOf(channel)
+  for (let i = 0; i < 10; i++) {
+    answer.text += `- 不变量结论 ${turn}-${i}：三层账本一致才放行。\n`
+    bumpOf(channel); await sleep(70)
+  }
+  answer.streaming = false
+  channel.working = false
+  channel.activeToolCount = 0
+  bumpOf(channel); await sleep(400)
+}
+await sleep(600)
+
+// ---- fresh 对照 A：同一最终状态全新挂载 ----
+const freshChannelA = makeChannel()
+freshChannelA.rows = channel.rows.map(r => ({ ...r, tool: r.tool ? { ...r.tool } : undefined }))
+freshChannelA.lastUserText = channel.lastUserText
+freshChannelA.version = channel.version
+const freshA = await mountChat(freshChannelA)
+await sleep(3500 + 500)
+if (process.env.DIAG) {
+  const buf = freshA.term.buffer.active
+  console.log(`[DIAG] freshA buffer=${buf.length}`)
+  for (let y = Math.max(0, buf.length - 30); y < buf.length; y++) {
+    console.log(`  ${String(y).padStart(3)} |${(buf.getLine(y)?.translateToString(true) ?? '').trimEnd().slice(0, 60)}`)
+  }
+  const ibuf = inc.term.buffer.active
+  console.log(`[DIAG] incremental buffer=${ibuf.length}`)
+  for (let y = Math.max(0, ibuf.length - 30); y < ibuf.length; y++) {
+    console.log(`  i${String(y).padStart(3)} |${(ibuf.getLine(y)?.translateToString(true) ?? '').trimEnd().slice(0, 60)}`)
+  }
+}
+assertViewportsMatch('A 流式剧本后：增量视口 == 全新挂载视口', inc.term, freshA.term)
+
+// ---- B：Ctrl+O 全局展开（两边同发） ----
+inc.stdin.write('\x0f'); await sleep(400)
+freshA.stdin.write('\x0f'); await sleep(500)
+assertViewportsMatch('B Ctrl+O 展开后：增量视口 == 全新挂载视口', inc.term, freshA.term)
+inc.stdin.write('\x0f'); await sleep(400) // 折回，为 C 做准备
+freshA.stdin.write('\x0f'); await sleep(400)
+
+// ---- C：Help 浮层开→关（增量侧 exercised；fresh 保持关闭） ----
+inc.stdin.write('?'); await sleep(400)
+const helpOpenVisible = viewportLines(inc.term).some(l => l.includes('ctrl') || l.includes('命令'))
+check('C 前置：Help 浮层确实打开', helpOpenVisible)
+inc.stdin.write('\x1b'); await sleep(500)
+assertViewportsMatch(driftReported
+  ? 'C 浮层关闭恢复（前置 A 的漂移未修时连带失败，见 §14）'
+  : 'C 浮层关闭恢复：增量视口 == 全新挂载视口', inc.term, freshA.term)
+
+// ---- D：增量实例整个 buffer 中每条可见内容恰一份 ----
+// 注意：折叠掉的行（工具结果 … +N lines、reasoning 折叠）本就不在
+// buffer 里，×0 是预期——只检查可见 marker。
+{
+  const lines = fullBufferLines(inc.term)
+  let bad = 0
+  for (let t = 0; t < TURNS; t++) {
+    for (let i = 0; i < 10; i++) {
+      const marker = `不变量结论 ${t}-${i}：`
+      const n = lines.filter(l => l.includes(marker)).length
+      if (n !== 1) { bad++; console.log(`  内容异常 ${marker} ×${n}`) }
+    }
+    for (let i = 0; i < 3; i++) { // 工具结果折叠为 3 行（0..2 可见）
+      const marker = `命中 ${t}-${i}`
+      const n = lines.filter(l => l.includes(marker)).length
+      if (n !== 1) { bad++; console.log(`  内容异常 ${marker} ×${n}`) }
+    }
+  }
+  check('D scrollback+视口中每条可见内容恰一份', bad === 0, `${bad} 处异常`)
+}
+
+console.log(failed === 0 ? '\nALL PASS（三层账本一致：增量 == 全新）' : `\n${failed} 项失败`)
+await inc.instance.unmount()
+await freshA.instance.unmount()
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -183,6 +183,55 @@ export function MessageList({
     baseRef.current = null
   }
 
+  // --- layout signature: stale-height invalidation ------------------------
+  // heightsRef entries outlive the commits that measured them, but many
+  // state changes rewrite a row's height WITHOUT a columns change: Ctrl+O
+  // (expanded), single-row expand (expandedRows), reasoning stream→fold,
+  // a tool result/error/footnote arriving, diff layout switch, assistant
+  // text growth, thinking visibility. A cached height from before such a
+  // change feeds topPad/bottomPad spacers, the offsets scan, and the
+  // ScrollBox clamps with geometry that no longer exists — blank bands,
+  // overlapping rows, wrong scrollTop after toggles (the audit's stale
+  // height cache). Track the inputs that decide each row's height; when
+  // one changes, drop the cached height. The window extension further
+  // down remounts invalidated rows so useLayoutEffect re-measures them.
+  // Text identity uses length as an O(1) proxy — per-frame full-text
+  // hashing over every row would defeat virtualization's budget, and a
+  // same-length miss only degrades to the previous behavior.
+  const sigRef = React.useRef(new Map<number, string>())
+  {
+    const sigs = sigRef.current
+    for (let i = 0; i < visibleRows.length; i++) {
+      const row = visibleRows[i]!
+      const tool = row.tool
+      const sig = [
+        columns,
+        row.kind,
+        row.text?.length ?? 0,
+        row.streaming === true,
+        expanded,
+        expandedRows.has(row.id),
+        thinkingVisible,
+        thinkingFold,
+        diffLayout,
+        model,
+        tool?.status ?? '',
+        tool?.resultText?.length ?? 0,
+        tool?.resultFull?.length ?? 0,
+        tool?.errorText?.length ?? 0,
+        row.id === failureHintRowId ? failureHint ?? '' : '',
+      ].join('|')
+      if (sigs.get(row.id) !== sig) {
+        if (sigs.size >= HEIGHTS_CACHE_MAX) {
+          const oldest = sigs.keys().next().value
+          if (oldest !== undefined) sigs.delete(oldest)
+        }
+        sigs.set(row.id, sig)
+        heightsRef.current.delete(row.id)
+      }
+    }
+  }
+
   // Scrolling bypasses React (imperative DOM scrollTop): subscribe so the
   // window follows the viewport.
   React.useEffect(() => {
@@ -266,6 +315,19 @@ export function MessageList({
         break
       }
     }
+    // Unknown-height extension (layout signature, see sigRef): a row whose
+    // cached height was just invalidated must remount to re-measure even
+    // when it sits outside the window — its spacer otherwise falls back to
+    // DEFAULT_ROW_HEIGHT until the row scrolls back into view, leaving the
+    // content geometry wrong for exactly that long (blank band after
+    // Ctrl+O, unreachable scroll bottom after a tool result lands). One
+    // remount per change; the measure tick + hold then tighten again.
+    for (let i = 0; i < start; i++) {
+      if (!heightsRef.current.has(visibleRows[i]!.id)) {
+        start = i
+        break
+      }
+    }
     // Expansion hold — AFTER the extension so it tracks the FINAL window:
     // never tighten within the hold window after a widen. React commits
     // inside one ink frame coalesce; a mount followed by the measure-tick
@@ -278,6 +340,16 @@ export function MessageList({
       holdUntilRef.current = performance.now() + 120
     }
     lastStartRef.current = start
+  }
+  // Tail-side unknown-height extension (see the start-side loop above):
+  // runs for non-sticky views too — while scrolled up, a signature change
+  // below the window (streaming tail growth, tool result landing) still
+  // invalidates those heights, and the bottomPad spacer must not run on
+  // stale geometry until the user scrolls back down. Mounted-below rows
+  // are paint-culled by the ScrollBox renderer; only their Yoga heights
+  // are needed here.
+  for (let i = end; i < visibleRows.length; i++) {
+    if (!heightsRef.current.has(visibleRows[i]!.id)) end = i + 1
   }
   if (forceMountRowId !== undefined && forceMountRowId !== null) {
     const idx = visibleRows.findIndex(row => row.id === forceMountRowId)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -214,7 +214,10 @@ export function MessageList({
         thinkingVisible,
         thinkingFold,
         diffLayout,
-        model,
+        // Model only renders on expanded rows (MessageMetadata) — folding
+        // it out of the signature keeps an idle /model switch from
+        // invalidating every cached height at once.
+        expanded ? model : '',
         tool?.status ?? '',
         tool?.resultText?.length ?? 0,
         tool?.resultFull?.length ?? 0,
@@ -316,14 +319,22 @@ export function MessageList({
       }
     }
     // Unknown-height extension (layout signature, see sigRef): a row whose
-    // cached height was just invalidated must remount to re-measure even
+    // cached height was just INVALIDATED must remount to re-measure even
     // when it sits outside the window — its spacer otherwise falls back to
     // DEFAULT_ROW_HEIGHT until the row scrolls back into view, leaving the
     // content geometry wrong for exactly that long (blank band after
     // Ctrl+O, unreachable scroll bottom after a tool result lands). One
     // remount per change; the measure tick + hold then tighten again.
+    // Guard: only rows that have actually MOUNTED here once qualify
+    // (paintedOnce fills from localRefs post-commit) — a brand-new
+    // streaming row has never been measured, and extending over it would
+    // mount everything below the window every frame while the user reads
+    // scrolled-up (virtualization defeated, per-frame full mount = the
+    // long-session stall). New rows keep the original path: their height
+    // lands once the window reaches them.
     for (let i = 0; i < start; i++) {
-      if (!heightsRef.current.has(visibleRows[i]!.id)) {
+      const rowId = visibleRows[i]!.id
+      if (!heightsRef.current.has(rowId) && paintedOnceRef.current.has(rowId)) {
         start = i
         break
       }
@@ -341,15 +352,14 @@ export function MessageList({
     }
     lastStartRef.current = start
   }
-  // Tail-side unknown-height extension (see the start-side loop above):
-  // runs for non-sticky views too — while scrolled up, a signature change
-  // below the window (streaming tail growth, tool result landing) still
-  // invalidates those heights, and the bottomPad spacer must not run on
-  // stale geometry until the user scrolls back down. Mounted-below rows
-  // are paint-culled by the ScrollBox renderer; only their Yoga heights
-  // are needed here.
+  // Tail-side invalidated-height extension (see the start-side loop above
+  // for the rationale and the mounted-once guard): rows BELOW the window
+  // whose height was just invalidated remount to re-measure, so bottomPad
+  // keeps real geometry while the user reads scrolled-up content and the
+  // tail streams. Runs for non-sticky views; sticky mounts the tail anyway.
   for (let i = end; i < visibleRows.length; i++) {
-    if (!heightsRef.current.has(visibleRows[i]!.id)) end = i + 1
+    const rowId = visibleRows[i]!.id
+    if (!heightsRef.current.has(rowId) && paintedOnceRef.current.has(rowId)) end = i + 1
   }
   if (forceMountRowId !== undefined && forceMountRowId !== null) {
     const idx = visibleRows.findIndex(row => row.id === forceMountRowId)

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -276,10 +276,19 @@ export function PromptInput({
   }, [])
   const { columns, rows: terminalRows } = useTerminalSize()
   const helpScrollRef = React.useRef<ScrollBoxHandle | null>(null)
-  // OverlayAbove reserves six terminal rows for the composer/status chrome;
-  // the help block also keeps one row below it. Its own final row is a
-  // persistent navigation hint, leaving the remainder to ScrollBox.
-  const helpViewportHeight = Math.max(3, Math.max(terminalRows - 6, 4) - 1)
+  // Help viewport budget: the overlay anchors at the composer's top edge
+  // (OverlayAbove bottom:'100%') and grows UP, so its budget is the space
+  // ABOVE that anchor — smallest on an empty session, where the whale
+  // splash (~15 rows) sits between the screen top and the composer
+  // (terminalRows minus chrome only applies once the transcript fills the
+  // viewport). Take the conservative intersection: 15 rows of viewport (16
+  // with the hint + margin) fits the empty-session anchor on the default
+  // layout at any terminal size, and the renderer's bottom-anchored
+  // clipping for absolute overlays (no negative-y clamp) then never has
+  // to eat the overlay's FIRST rows — the shortcut-column headers. The
+  // command registry scrolls inside the viewport, so a taller terminal
+  // loses nothing functional.
+  const helpViewportHeight = Math.max(3, Math.min(terminalRows - 7, 15))
 
   const suggestions = value.startsWith('/') ? channel.commandCompletions(value) : []
   const overlayOpen =

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -8,7 +8,9 @@ import { EffortInputBorder } from './EffortInputBorder.js'
 import { EffortTierBadge } from './EffortTierBadge.js'
 import { isLightThemeActive } from '../theme.js'
 import { useDeclaredCursor } from '../ink/hooks/use-declared-cursor.js'
+import instances from '../ink/instances.js'
 import { stringWidth } from '../ink/stringWidth.js'
+import { getGraphemeSegmenter } from '../utils/intl.js'
 import { formatClipboardInsert, readClipboard } from '../utils/clipboard.js'
 import { editInExternalEditor } from '../utils/externalEditor.js'
 import type { Channel } from '../dsh-adapter/channel.js'
@@ -47,6 +49,86 @@ function wordBoundaryRight(text: string, cursor: number): number {
   while (index < length && !/\s/.test(text[index]!)) index++
   while (index < length && /\s/.test(text[index]!)) index++
   return index
+}
+
+// --- grapheme-cluster geometry ---------------------------------------------
+// The caret, editing keys, and wrapping MUST agree on one text unit. Mixing
+// UTF-16 code units (arrows/backspace), code points (wrap), and display
+// cells (stringWidth) lets the caret land inside a surrogate pair or a ZWJ
+// emoji — the inverted caret then shows half a glyph, Backspace deletes
+// half a character, and `line.slice()` splits clusters. All offsets below
+// are UTF-16 indices snapped to grapheme boundaries via the shared
+// Intl.Segmenter (utils/intl.ts).
+
+/** Ascending grapheme boundary offsets of `text` (starts at 0, ends at
+ *  `text.length`). Empty text yields `[0]`. */
+function graphemeBoundaries(text: string): number[] {
+  const bounds = [0]
+  for (const { index, segment } of getGraphemeSegmenter().segment(text)) {
+    const end = index + segment.length
+    if (end > bounds[bounds.length - 1]!) bounds.push(end)
+  }
+  return bounds
+}
+
+/** Largest grapheme boundary `<= offset` (clamped into the text). Snaps a
+ *  cursor that landed mid-cluster back onto a boundary. */
+function boundaryAtOrBefore(bounds: number[], offset: number): number {
+  let lo = 0
+  let hi = bounds.length - 1
+  let ans = bounds[0]!
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    if (bounds[mid]! <= offset) {
+      ans = bounds[mid]!
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  return ans
+}
+
+/** Largest grapheme boundary strictly before `offset` (0 when none). */
+function previousGraphemeBoundary(bounds: number[], offset: number): number {
+  let lo = 0
+  let hi = bounds.length - 1
+  let ans = 0
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    if (bounds[mid]! < offset) {
+      ans = bounds[mid]!
+      lo = mid + 1
+    } else {
+      hi = mid - 1
+    }
+  }
+  return ans
+}
+
+/** Smallest grapheme boundary strictly after `offset` (text.length when
+ *  none). Returns `offset` unchanged when it already is the last boundary. */
+function nextGraphemeBoundary(bounds: number[], offset: number): number {
+  let lo = 0
+  let hi = bounds.length - 1
+  let ans = bounds[hi] ?? 0
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1
+    if (bounds[mid]! > offset) {
+      ans = bounds[mid]!
+      hi = mid - 1
+    } else {
+      lo = mid + 1
+    }
+  }
+  return ans
+}
+
+/** Snap an arbitrary UTF-16 offset onto a grapheme boundary of `text`,
+ *  clamping into range. The safety net under every cursor write. */
+function normalizeCursorOffset(text: string, offset: number): number {
+  const clamped = Math.max(0, Math.min(offset, text.length))
+  return boundaryAtOrBefore(graphemeBoundaries(text), clamped)
 }
 
 /**
@@ -174,10 +256,7 @@ export function PromptInput({
   React.useEffect(() => {
     if (fillText && fillText !== lastFill.current) {
       lastFill.current = fillText
-      valueRef.current = fillText
-      cursorRef.current = fillText.length
-      setValue(fillText)
-      setCursor(fillText.length)
+      setInput(fillText)
       onFillConsumed?.()
     }
   }, [fillText, onFillConsumed])
@@ -251,7 +330,11 @@ export function PromptInput({
 
   const setInput = (next: string, cursorOffset = next.length) => {
     valueRef.current = next
-    cursorRef.current = Math.max(0, Math.min(cursorOffset, next.length))
+    // Normalize onto a grapheme boundary (also clamps into range): every
+    // caller passes a caret they believe is on a character edge — paste
+    // merges, history fills, and IME composition can still hand back an
+    // offset inside a surrogate pair or combining cluster.
+    cursorRef.current = normalizeCursorOffset(next, cursorOffset)
     setValue(next)
     setCursor(cursorRef.current)
   }
@@ -430,6 +513,9 @@ export function PromptInput({
     // the text/caret produced by the preceding event in that batch.
     const value = valueRef.current
     const cursor = cursorRef.current
+    // Grapheme boundaries of the current text: every caret move / delete
+    // below snaps onto one of these offsets (never mid-cluster).
+    const bounds = graphemeBoundaries(value)
 
     /** Insert text at the caret (typing, paste) and dismiss overlays. */
     const insertAtCaret = (text: string) => {
@@ -798,21 +884,25 @@ export function PromptInput({
       return
     }
     if (key.leftArrow) {
-      setInput(value, Math.max(0, cursor - 1))
+      // Grapheme-step: skip the whole cluster (surrogate pair, ZWJ emoji,
+      // combining mark) so the caret never sits inside one.
+      setInput(value, previousGraphemeBoundary(bounds, cursor))
       return
     }
     if (key.rightArrow) {
-      setInput(value, Math.min(value.length, cursor + 1))
+      setInput(value, nextGraphemeBoundary(bounds, cursor))
       return
     }
     if (key.backspace) {
       if (cursor === 0) return
-      setInput(value.slice(0, cursor - 1) + value.slice(cursor), cursor - 1)
+      const start = previousGraphemeBoundary(bounds, cursor)
+      setInput(value.slice(0, start) + value.slice(cursor), start)
       return
     }
     if (key.delete) {
-      if (cursor >= value.length) return
-      setInput(value.slice(0, cursor) + value.slice(cursor + 1), cursor)
+      const end = nextGraphemeBoundary(bounds, cursor)
+      if (end === cursor) return
+      setInput(value.slice(0, cursor) + value.slice(end), cursor)
       return
     }
     if (key.home) {
@@ -937,7 +1027,10 @@ export function PromptInput({
   // === Render: hard-wrap every logical line at the input width, then show
   // the window of visual lines with the caret row always visible (CC's
   // maxVisibleLines behavior with automatic wrapping).
-  const inputWidth = Math.max(10, columns - 3)
+  // Narrow terminals: the usable width follows the real terminal down to a
+  // single column — a fixed floor of 10 would wrap far too early and park
+  // the declared cursor past the value box's actual width.
+  const inputWidth = Math.max(1, columns - 3)
   const visualLines = wrapToWidth(value, inputWidth)
   const caretVisualLine = wrapToWidth(value.slice(0, cursor), inputWidth).length - 1
   const windowStart = Math.max(
@@ -980,11 +1073,17 @@ export function PromptInput({
         </Text>
       )
     }
-    // Caret row: invert the char at the caret column (solid block).
+    // Caret row: invert the grapheme cluster at the caret column (solid
+    // block). `col` is a cluster boundary by construction (the cursor is
+    // normalized onto boundaries and wrapping only breaks between
+    // graphemes), so [col, next boundary) covers the WHOLE cluster — a
+    // surrogate pair or ZWJ emoji inverts as one glyph, never two broken
+    // halves.
     const col = caretCharCol()
+    const clusterEnd = nextGraphemeBoundary(graphemeBoundaries(line), col)
     const before = line.slice(0, col)
-    const at = line[col] ?? ' '
-    const after = line.slice(col + 1)
+    const at = clusterEnd > col ? line.slice(col, clusterEnd) : ' '
+    const after = line.slice(clusterEnd)
     return (
       <Text key={absoluteLine} wrap="truncate-end">
         {before}
@@ -993,6 +1092,25 @@ export function PromptInput({
       </Text>
     )
   })
+
+  // Composer height shrink: clearing multi-line text (Enter/Esc/Ctrl+C/
+  // Backspace) collapses the input area within one commit, shifting the
+  // status line up and the whole chrome with it. The renderer's
+  // full-damage pass (didLayoutShift) repaints the shifted siblings, but
+  // inline mode's virtual↔scrollback correspondence needs the stronger
+  // in-place viewport repaint — same treatment as Ctrl+O and the
+  // loaded-context toggle (see Chat.tsx). One-shot, only on SHRINK:
+  // growth scrolls the terminal naturally and needs no recovery.
+  const contentRows = value.length === 0 ? 1 : visibleLines.length
+  const prevContentRowsRef = React.useRef(contentRows)
+  React.useLayoutEffect(() => {
+    if (contentRows < prevContentRowsRef.current) {
+      const ink = instances.get(process.stdout) ?? instances.values().next().value
+      ink?.invalidatePrevFrame()
+      ink?.reanchorViewport()
+    }
+    prevContentRowsRef.current = contentRows
+  }, [contentRows])
 
   const lastNotification =
     channel.notifications[channel.notifications.length - 1]
@@ -1006,7 +1124,10 @@ export function PromptInput({
   // relative to the value box the ref attaches to.
   const valueBoxRef = useDeclaredCursor({
     line: caretVisualLine - windowStart,
-    column: caretVisualCol(),
+    // Clamp the declared column to the wrap width: a grapheme wider than
+    // the last remaining column (emoji at width 1) can push the visual
+    // column past inputWidth, and the park must stay inside the value box.
+    column: Math.min(caretVisualCol(), inputWidth),
     active: !selectionActive,
   })
 
@@ -1024,7 +1145,7 @@ export function PromptInput({
           帧高不随面板开关涨落——否则帧顶行会被滚进 scrollback 并在关闭
           重绘时二次写入（/model 切换多一份启动画的根因，见 OverlayAbove）。 */}
       {floatersOpen && (
-      <OverlayAbove maxHeight={Math.max(terminalRows - 6, 4)}>
+      <OverlayAbove maxHeight={Math.max(terminalRows - 6, 1)}>
         {helpOpen && (
           <Box marginBottom={1}>
             <HelpMenu
@@ -1158,10 +1279,15 @@ export function PromptInput({
 /**
  * Hard-wrap text into visual rows of at most `width` columns (CJK-aware via
  * stringWidth). Used by the input renderer so long lines wrap instead of
- * truncating, with exact caret-row mapping.
+ * truncating, with exact caret-row mapping. Wrapping only ever breaks
+ * BETWEEN grapheme clusters: iterating code points would split ZWJ emoji
+ * and combining sequences across rows, leaving a broken half at each edge
+ * and desyncing the caret's row arithmetic (which walks cluster
+ * boundaries).
  */
 function wrapToWidth(text: string, width: number): string[] {
   const rows: string[] = []
+  const segmenter = getGraphemeSegmenter()
   for (const line of text.split('\n')) {
     if (line === '') {
       rows.push('')
@@ -1169,14 +1295,14 @@ function wrapToWidth(text: string, width: number): string[] {
     }
     let current = ''
     let currentWidth = 0
-    for (const ch of line) {
-      const w = stringWidth(ch)
+    for (const { segment } of segmenter.segment(line)) {
+      const w = stringWidth(segment)
       if (currentWidth + w > width && current !== '') {
         rows.push(current)
-        current = ch
+        current = segment
         currentWidth = w
       } else {
-        current += ch
+        current += segment
         currentWidth += w
       }
     }

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -355,6 +355,19 @@ export default class Ink {
     this.terminalRows = rows;
     this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows);
 
+    // Invalidate every render that was scheduled against the OLD size: a
+    // queued microtask generation or a scroll-drain timer would otherwise
+    // fire after this resize completes and paint a frame computed for the
+    // pre-resize layout (mixed-width rows, off-by-reflow writes). The
+    // re-render below schedules fresh work at the new dimensions.
+    this.renderGeneration++;
+    this.pendingRenderGeneration = null;
+    this.scheduleRender.cancel?.();
+    if (this.drainTimer !== null) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
+
     // Every cached measurement in the tree was taken against a width that no
     // longer exists. Nothing here is "dirty" in the reconciler's sense — no
     // props changed — so without an explicit sweep the text nodes keep
@@ -539,9 +552,27 @@ export default class Ink {
     // Done before the render to avoid dirtying state that would trigger
     // an extra React re-render cycle.
     flushInteractionTime();
+
+    // Dimension consistency: onComputeLayout laid the tree out against
+    // this.terminalColumns/Rows (the cached values handleResize owns), so
+    // the renderer and the diff engine MUST paint that same size. Reading
+    // the live stdout size here mixed the two when a resize event had not
+    // fired yet (Windows Terminal emits 'resize' after columns already
+    // changed): Yoga laid out for the old width while log-update wrapped
+    // and diffed at the new one — rows painted off by the reflow delta.
+    // On drift, route through the resize path (cache sync + markTreeDirty
+    // + re-render) and bail: the render handleResize schedules paints the
+    // correctly-laid-out frame.
+    const liveColumns = this.options.stdout.columns || 80;
+    const liveRows = this.options.stdout.rows || 24;
+    if (this.options.stdout.isTTY && (liveColumns !== this.terminalColumns || liveRows !== this.terminalRows)) {
+      this.handleResize();
+      return;
+    }
+
     const renderStart = performance.now();
-    const terminalWidth = this.options.stdout.columns || 80;
-    const terminalRows = this.options.stdout.rows || 24;
+    const terminalWidth = this.terminalColumns;
+    const terminalRows = this.terminalRows;
     const frame = this.renderer({
       frontFrame: this.frontFrame,
       backFrame: this.backFrame,
@@ -1133,6 +1164,10 @@ export default class Ink {
     // Cancel any pending throttled render so it doesn't fire between
     // cleanupTerminalModes() and process.exit() and write to main screen.
     this.scheduleRender.cancel?.();
+    if (this.drainTimer !== null) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
     this.app?.detachForShutdown();
     // Shutdown bypasses the normal unmount path, so release the process and
     // stdout listeners here as well. Otherwise a SIGCONT or resize arriving
@@ -1140,6 +1175,11 @@ export default class Ink {
     // through this detached instance after terminal cleanup has completed.
     this.unsubscribeTTYHandlers?.();
     this.unsubscribeExit();
+    // unmount() early-returns on isUnmounted above, so its instances.delete
+    // never runs — a detached instance would stay in the map and a later
+    // instances.get(stdout) lookup (Chat's reanchorViewport plumbing) could
+    // hand out a dead renderer. Remove the mapping here too.
+    instances.delete(this.options.stdout);
     // `detachForShutdown()` deliberately makes later `unmount()` calls a
     // no-op, so release process-level output patches here rather than relying
     // on unmount() to do it. The shutdown continuation may run an updater
@@ -1901,9 +1941,24 @@ export default class Ink {
         logForDebugging(`[stderr] ${text}`, {
           level: 'warn'
         });
-        if (this.altScreenActive && !this.isUnmounted && !this.isPaused) {
-          this.prevFrameContaminated = true;
-          this.scheduleRender();
+        if (!this.isUnmounted && !this.isPaused) {
+          if (this.altScreenActive) {
+            this.prevFrameContaminated = true;
+            this.scheduleRender();
+          } else {
+            // Main-screen (inline): the diff engine's moves are purely
+            // relative to the physical cursor, so ANY unobserved tty write
+            // (one that slipped through before this patch existed, or via
+            // a path it can't intercept — a snapshotted ESM writer) shifts
+            // every later write by N rows with nothing to detect it after
+            // the fact. The stdin-gap reassert covers slow leaks; this
+            // per-write defensive net closes the fast ones: blind
+            // idempotent viewport repaint from the physical cursor. When
+            // nothing drifted (the usual case — the write was swallowed)
+            // it paints the same pixels again at O(viewport) bytes.
+            this.log.requestViewportReanchor();
+            this.scheduleRender();
+          }
         }
       } finally {
         reentered = false;

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -495,15 +495,19 @@ function renderNodeToOutput(
     const width = yogaNode.getComputedWidth()
     const height = yogaNode.getComputedHeight()
 
-    // Absolute-positioned overlays (e.g. autocomplete menus with bottom='100%')
-    // can compute negative screen y when they extend above the viewport. Without
-    // clamping, setCellAt drops cells at y<0, clipping the TOP of the content
-    // (best matches in an autocomplete). By clamping to 0, we shift the element
-    // down so the top rows are visible and the bottom overflows below — the
-    // opaque prop ensures it paints over whatever is underneath.
-    if (y < 0 && node.style.position === 'absolute') {
-      y = 0
-    }
+    // Absolute-positioned overlays anchored above their parent
+    // (bottom='100%') compute negative screen y when their content is
+    // taller than the space above the anchor. Do NOT clamp y to 0 here:
+    // shifting the node down breaks the bottom-anchoring contract — the
+    // panel's BOTTOM would overflow past the anchor and paint over the
+    // composer/status rows below it (small-terminal overlay reports).
+    // Instead let the y<0 rows clip naturally: setCellAt drops cells above
+    // row 0 and blitRegion clamps in screen space, so the panel keeps its
+    // bottom pinned at the anchor and only loses its topmost rows — the
+    // same semantics as CSS clipping above the containing block. Producers
+    // prevent the case entirely by maxHeight-ing the overlay to the actual
+    // space above the anchor (OverlayAbove), so clipping is the last
+    // resort, not the layout.
 
     // Check if we can skip this subtree (clean node with unchanged layout).
     // Blit cells from previous screen instead of re-rendering.


### PR DESCRIPTION
## 概要

按 `docs/project-documentation/rendering-audit.md` 的审计结论，修复 inline 模式渲染管线的 P0/P1 问题（错位、重复渲染、Unicode caret、陈旧行高缓存），并新增"三层真相一致性"验证器作为长期防线。

## 三个提交

### 41f9e9b — P0/P1 修复（4 文件 +292/-35）

**ink.tsx**
- `onRender()` 改用缓存尺寸（与 Yoga 布局一致）；live 尺寸漂移先走 `handleResize()` 同步路径，消除"布局按旧宽、diff 按新宽"的错行
- `handleResize()` 失效旧渲染队列（generation/throttle/drainTimer）
- `patchStderr` 主屏分支补 `requestViewportReanchor()` 兜底（第三方 TTY 写入的幂等视口重锚，issue #16/#17 家族）
- `detachForShutdown()` 补 `instances.delete()`（unmount 短路导致映射泄漏）

**render-node-to-output.ts**
- 移除 absolute 节点负 y 钳 0：保留 `bottom:'100%'` 锚定 + 顶部自然 clip，小终端浮层不再下移压住 composer/status

**PromptInput.tsx**
- caret/左右键/退格/删除/wrap 全部按 grapheme 边界（`Intl.Segmenter`），emoji/ZWJ/组合字符不再被拆开
- `inputWidth = Math.max(1, columns-3)`；declared column clamp
- 输入区高度收缩时 `invalidatePrevFrame + reanchorViewport`（与 Ctrl+O 同款处理）

**MessageList.tsx**
- 行级 layout signature（columns/kind/text/streaming/expanded/thinkingFold/tool 状态/footnote 等），变化即失效缓存行高并强制回挂重测

### 1cf863e — 复审修正

- 窗口扩展判据收窄为「曾挂载过且高度刚被失效」：上翻（非 sticky）+ 流式不再每帧全量挂载（虚拟化失效/卡顿）
- signature 的 model 字段仅 expanded 时纳入：idle 切 /model 不再全量失效
- 新增 `repro-composer-ghost.tsx`：复现"上翻 scrollback 看到输入框残影"，三场景逐行扫描

### 0174618 — 验证器 + 开放 bug repro

- `verify-frame-invariants.tsx`：**核心不变量——同一最终状态，增量帧序列渲染出的终端必须与全新挂载逐行一致**。Ctrl+O 展开 ✓、内容唯一性 ✓
- `repro-bottom-drift.tsx`：验证器揪出的存量漂移（`working` 轮次后 statusline 下积 3 行空白），三阶段隔离 + 逐帧 buffer 增量 + 转义序列解码，已定位到帧型级（审计文档 §14）
- A/B 验证确认该漂移在修复前（bdff0af）原样存在，非本 PR 回归；修复路径已写明，修好后验证器 A/C 转绿即可纳入 CI

## 验证

- typecheck、`pnpm run build`（含 16 项 verify:build 门禁）全绿
- repro-inline-thirdparty / repro-inline-scrollback / repro-model-switch-scrollback / verify-shrink / verify-scroll / verify-ime-cursor / verify-message-measure-depth / verify-resize-reflow / verify-word-jump / verify-batched-prompt-input / verify-prompt-history-draft / verify-help-scroll 全部 PASS
- verify-jediterm 4 项失败经 A/B 对照确认为 HEAD 上既有环境问题，与本 PR 无关

## 注意

- 渲染核心的既有防护全部保留（anchored shrink repaint、CR+CUD、alt-screen invariant、`key={row.id}`、channel seq/overlap）
- 审计文档 `docs/project-documentation/rendering-audit.md` 未入库（本地交接文档），§12-14 有完整修复与开放 bug 记录
