### PR TITLE
feat(ui): 命令菜单卡片化 + 全面二级补全

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -224,7 +224,10 @@ export function completeCommands(
 ): CommandCompletion[] {
   if (!input.startsWith('/') || /[\r\n]/u.test(input)) return []
   const body = input.slice(1)
-  if (!/^[a-z0-9_-]*(?:[\t ]+[a-z0-9_-]*)*$/iu.test(body)) return []
+  // Token charset includes `. : /` so provider/model specs (e.g.
+  // `deepseek/deepseek-v4-flash`, `openai/gpt-4.1`) survive as ONE token —
+  // the /model completion matches its candidates against the whole spec.
+  if (!/^[a-z0-9_.:\/-]*(?:[\t ]+[a-z0-9_.:\/-]*)*$/iu.test(body)) return []
   const trailingSeparator = /[\t ]$/u.test(body)
   const tokens = body.split(/[\t ]+/u)
   const prefix = trailingSeparator ? '' : (tokens.pop() ?? '')

--- a/src/components/CommandSuggestions.tsx
+++ b/src/components/CommandSuggestions.tsx
@@ -1,30 +1,48 @@
 import React from 'react'
-import { Box, Text } from '../ui.js'
+import { Text } from '../ui.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { truncateToWidth } from '../ink/truncateToWidth.js'
 import type { LocalCommand } from '../commands.js'
 import { localizedDescription } from '../commands.js'
+import { t } from '../i18n.js'
+import { POINTER } from '../cc/figures.js'
+import { SuggestionCard, cardContentWidth, splitQueryMatch } from './SuggestionCard.js'
 
 /**
  * The slash-command suggestion overlay, mirroring Claude Code's
- * `PromptInputFooterSuggestions.tsx` (command layout only): a name column
- * padded to a fixed width, optional `[tag]`, then a truncated description.
- * The selected row renders in the theme's `suggestion` color, others dim.
+ * `PromptInputFooterSuggestions.tsx` (command layout only) wrapped in the
+ * shared rounded `SuggestionCard`:
+ *
+ *   ╭─ 命令 · 共 12 项 ──────────────────────╮
+ *   │ ❯ compact  Compact the conversation …  │   ← 选中：❯ + 加粗 + suggestion 色
+ *   │   compare  Compare selected messages … │   ← 名字里命中输入的段提亮
+ *   │ ↑2 · ↓3                                 │   ← 仅当列表被窗口裁剪
+ *   ╰─────────────────────────────────────────╯
+ *
+ * 未选中行整体 dim，唯独名字里匹配当前查询 token 的前缀以正常亮度提亮
+ * （bold 与 dim 在终端互斥，故提亮用非 dim 而非加粗）；选中行整行
+ * suggestion 色、名字加粗、前置 ❯ 指针。
  */
 export function CommandSuggestions({
   commands,
   selectedIndex,
   columns,
+  query = '',
+  accent,
 }: {
   commands: readonly (LocalCommand & { descriptionKey?: string })[]
   selectedIndex: number
   columns: number
+  /** 原始 `/…` 输入；其最后一段 token 用于名字前缀高亮。 */
+  query?: string
+  accent?: 'promptBorder' | 'planMode'
 }): React.ReactNode {
   if (commands.length === 0) return null
 
-  // Cap the command name column at 40% of terminal width to ensure the
-  // description has space (same as Claude Code).
-  const maxNameWidth = Math.floor(columns * 0.4)
+  // Cap the command name column at 40% of the card's content width to ensure
+  // the description has space (same ratio as Claude Code).
+  const usable = cardContentWidth(columns)
+  const maxNameWidth = Math.floor(usable * 0.4)
   const nameWidth = Math.min(
     Math.max(...commands.map(c => stringWidth(c.name))) + 5,
     maxNameWidth,
@@ -39,30 +57,57 @@ export function CommandSuggestions({
     ),
   )
   const visible = commands.slice(startIndex, startIndex + maxVisible)
+  const above = startIndex
+  const below = commands.length - (startIndex + visible.length)
+  // 前缀高亮取查询的最后一段 token（`/plan of` 高亮 `of` 命中的段）。
+  const queryToken = query.replace(/^\//, '').match(/[^ \t]*$/)?.[0] ?? ''
+
+  const title = `${t('sugg-commands-title')} · ${t('sugg-count', { n: commands.length })}`
+  const footer =
+    above > 0 || below > 0
+      ? [
+          above > 0 ? t('sugg-more-above', { n: above }) : null,
+          below > 0 ? t('sugg-more-below', { n: below }) : null,
+        ]
+          .filter((part): part is string => part !== null)
+          .join(' · ')
+      : null
 
   return (
-    <Box flexDirection="column">
-      {visible.map(command => {
+    <SuggestionCard
+      title={title}
+      columns={columns}
+      accent={accent}
+      footer={footer}
+      rows={visible.map(command => {
         const isSelected = command.name === commands[selectedIndex]?.name
-        const padded =
-          command.name +
-          ' '.repeat(Math.max(0, nameWidth - stringWidth(command.name)))
         const tagText = command.tag ? `[${command.tag}] ` : ''
         const tagWidth = stringWidth(tagText)
-        const descriptionWidth = Math.max(
-          0,
-          columns - nameWidth - tagWidth - 4,
-        )
+        // 行预算：内容宽 − 前导空格 1 − 指针列 2。
+        const descriptionWidth = Math.max(0, usable - 3 - nameWidth - tagWidth)
         const rawDescription = localizedDescription(command)
         const description =
           stringWidth(rawDescription) > descriptionWidth
             ? truncateToWidth(rawDescription, descriptionWidth - 1) + '…'
             : rawDescription
+        const parts = splitQueryMatch(command.name, queryToken)
+        const padAfter = Math.max(0, nameWidth - stringWidth(command.name))
         return (
           <Text key={command.name} wrap="truncate">
-            <Text color={isSelected ? 'suggestion' : undefined} dimColor={!isSelected}>
-              {padded}
-            </Text>
+            {' '}
+            {isSelected ? (
+              <Text color="suggestion" bold>{`${POINTER} ${command.name}`}</Text>
+            ) : parts ? (
+              // 嵌套 Text 会继承父级 dim（本 fork 的 dimColor 是颜色替换，
+              // dim={false} 盖不掉），故高亮段必须与 dim 段平铺为兄弟。
+              <>
+                <Text dimColor>{`  ${parts.before}`}</Text>
+                <Text>{parts.match}</Text>
+                <Text dimColor>{`${parts.after}${' '.repeat(padAfter)}`}</Text>
+              </>
+            ) : (
+              <Text dimColor>{`  ${command.name}${' '.repeat(padAfter)}`}</Text>
+            )}
             {tagText ? <Text dimColor>{tagText}</Text> : null}
             <Text color={isSelected ? 'suggestion' : undefined} dimColor={!isSelected}>
               {description}
@@ -70,6 +115,6 @@ export function CommandSuggestions({
           </Text>
         )
       })}
-    </Box>
+    />
   )
 }

--- a/src/components/CommandSuggestions.tsx
+++ b/src/components/CommandSuggestions.tsx
@@ -96,7 +96,7 @@ export function CommandSuggestions({
           <Text key={command.name} wrap="truncate">
             {' '}
             {isSelected ? (
-              <Text color="suggestion" bold>{`${POINTER} ${command.name}`}</Text>
+              <Text color="suggestion" bold>{`${POINTER} ${command.name}${' '.repeat(padAfter)}`}</Text>
             ) : parts ? (
               // 嵌套 Text 会继承父级 dim（本 fork 的 dimColor 是颜色替换，
               // dim={false} 盖不掉），故高亮段必须与 dim 段平铺为兄弟。

--- a/src/components/FileSuggestions.tsx
+++ b/src/components/FileSuggestions.tsx
@@ -1,28 +1,46 @@
 import React from 'react'
-import { Box, Text } from '../ui.js'
+import { Text } from '../ui.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { truncateToWidth } from '../ink/truncateToWidth.js'
 import type { FileCandidate } from '../utils/fileSuggestions.js'
+import { t } from '../i18n.js'
+import { POINTER } from '../cc/figures.js'
+import { SuggestionCard, cardContentWidth, splitQueryMatch } from './SuggestionCard.js'
 
 /**
- * The `@` file-completion overlay in CC's suggestion style: full relative
- * path (directory suffix stripped) + a `file`/`directory` description. The
- * selected row renders in the theme's `suggestion` color, others dim. The
- * name column is padded to a fixed display width so the description column
- * keeps its contract at narrow terminals (pinned by verify-cjk-truncate.tsx);
- * every pad/truncate uses display width, so CJK names never split a glyph.
+ * The `@` file-completion overlay in CC's suggestion style, wrapped in the
+ * shared rounded `SuggestionCard` (与 `/` 命令菜单同一视觉语言):
+ *
+ *   ╭─ 文件 · 共 12 项 ──────────────────────╮
+ *   │ ❯ ▸ src/components/     directory     │
+ *   │   + README.md           file          │
+ *   ╰─────────────────────────────────────────╯
+ *
+ * Full relative path (directory suffix stripped) + a `file`/`directory`
+ * description; the selected row renders `❯` + bold in the theme's
+ * `suggestion` color, others dim with the query-matched prefix of the name
+ * highlighted (non-dim). The name column is padded to a fixed display width
+ * so the description column keeps its contract at narrow terminals (pinned
+ * by verify-cjk-truncate.tsx); every pad/truncate uses display width, so CJK
+ * names never split a glyph.
  */
 export function FileSuggestions({
   files,
   selectedIndex,
   columns,
+  query = '',
+  accent,
 }: {
   files: readonly FileCandidate[]
   selectedIndex: number
   columns: number
+  /** `@` 触发 token 里已输入的查询（`mention.query`），用于名字前缀高亮。 */
+  query?: string
+  accent?: 'promptBorder' | 'planMode'
 }): React.ReactNode {
   if (files.length === 0) return null
 
+  const usable = cardContentWidth(columns)
   const maxVisible = 6
   const safeIndex = Math.min(Math.max(0, selectedIndex), files.length - 1)
   const startIndex = Math.max(
@@ -33,6 +51,8 @@ export function FileSuggestions({
     ),
   )
   const visible = files.slice(startIndex, startIndex + maxVisible)
+  const above = startIndex
+  const below = files.length - (startIndex + visible.length)
 
   const nameOf = (file: FileCandidate): string =>
     file.kind === 'directory' && file.path.endsWith('/')
@@ -40,11 +60,27 @@ export function FileSuggestions({
       : file.path
 
   const NAME_COLUMN = 20
-  const descriptionWidth = Math.max(0, columns - 24)
+  // 行预算：内容宽 − 前导空格 1 − 指针列 2 − 图标列 2。
+  const descriptionWidth = Math.max(0, usable - 25)
+
+  const title = `${t('sugg-files-title')} · ${t('sugg-count', { n: files.length })}`
+  const footer =
+    above > 0 || below > 0
+      ? [
+          above > 0 ? t('sugg-more-above', { n: above }) : null,
+          below > 0 ? t('sugg-more-below', { n: below }) : null,
+        ]
+          .filter((part): part is string => part !== null)
+          .join(' · ')
+      : null
 
   return (
-    <Box flexDirection="column">
-      {visible.map(file => {
+    <SuggestionCard
+      title={title}
+      columns={columns}
+      accent={accent}
+      footer={footer}
+      rows={visible.map(file => {
         const isSelected = file.id === files[safeIndex]?.id
         const name = nameOf(file)
         const icon = file.kind === 'directory' ? '▸ ' : '+ '
@@ -54,18 +90,29 @@ export function FileSuggestions({
           stringWidth(description) > descriptionWidth
             ? truncateToWidth(description, Math.max(0, descriptionWidth - 1)) + '…'
             : description
+        const parts = splitQueryMatch(name, query)
+        const pad = ' '.repeat(Math.max(1, NAME_COLUMN - stringWidth(name)))
         return (
           <Text key={file.id} wrap="truncate">
-            <Text color={isSelected ? 'suggestion' : undefined} dimColor={!isSelected}>
-              {icon}
-              {padded}
-            </Text>
+            {' '}
+            {isSelected ? (
+              <Text color="suggestion" bold>{`${POINTER} ${icon}${padded}`}</Text>
+            ) : parts ? (
+              // 平铺兄弟 span：嵌套 Text 继承父级 dim，高亮段会被 dim 吞掉。
+              <>
+                <Text dimColor>{`  ${icon}${parts.before}`}</Text>
+                <Text>{parts.match}</Text>
+                <Text dimColor>{`${parts.after}${pad}`}</Text>
+              </>
+            ) : (
+              <Text dimColor>{`  ${icon}${padded}`}</Text>
+            )}
             <Text color={isSelected ? 'suggestion' : undefined} dimColor={!isSelected}>
               {renderedDescription}
             </Text>
           </Text>
         )
       })}
-    </Box>
+    />
   )
 }

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -101,9 +101,10 @@ export interface PromptInputProps {
 /**
  * Claude Code style prompt input: rounded border box (top+bottom borders
  * only), `❯ ` prompt char (dimmed while a turn is working), the text with a
- * block cursor at the cursor position, and below it the slash-command
- * suggestion overlay (name column + description, selected row in the
- * `suggestion` color — mirroring Claude Code's PromptInputFooterSuggestions).
+ * block cursor at the cursor position, and above it the slash-command /
+ * file-completion suggestion card (SuggestionCard: rounded panel with the
+ * selected row behind a `❯` pointer in the theme's `suggestion` color,
+ * mirroring Claude Code's PromptInputFooterSuggestions layout).
  *
  * Empty input: a solid block caret on a blank cell and nothing else — no
  * placeholder text, so the terminal-painted IME preedit (pinyin) at the
@@ -1014,6 +1015,8 @@ export function PromptInput({
   // 的 style.position，常驻浮层 + 移除普通子节点不会触发 blit 解毒，被
   // 覆盖的转录行会留空（见 Chat.tsx dialogOverlayOpen 注释）。
   const floatersOpen = helpOpen || channel.pending.length > 0 || fileOverlayOpen || overlayOpen
+  // 补全卡片边框与输入框 idle 边框同色（plan 模式下整套面板一起变 sage 绿）。
+  const promptAccent = channel.mode.plan === true ? 'planMode' : 'promptBorder'
 
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -1062,22 +1065,22 @@ export function PromptInput({
           </Box>
         )}
         {fileOverlayOpen && (
-          <Box paddingLeft={2} paddingBottom={1}>
-            <FileSuggestions
-              files={fileMatches}
-              selectedIndex={fileSelected}
-              columns={columns}
-            />
-          </Box>
+          <FileSuggestions
+            files={fileMatches}
+            selectedIndex={fileSelected}
+            columns={columns}
+            query={mention?.query ?? ''}
+            accent={promptAccent}
+          />
         )}
         {overlayOpen && (
-          <Box paddingLeft={2} paddingBottom={1}>
-            <CommandSuggestions
-              commands={suggestions}
-              selectedIndex={selectedCommand}
-              columns={columns}
-            />
-          </Box>
+          <CommandSuggestions
+            commands={suggestions}
+            selectedIndex={selectedCommand}
+            columns={columns}
+            query={value}
+            accent={promptAccent}
+          />
         )}
       </OverlayAbove>
       )}
@@ -1116,7 +1119,7 @@ export function PromptInput({
         levels={channel.effortLevels}
         columns={columns}
         onLight={isLightThemeActive(themeName)}
-        idleColor={channel.mode.plan === true ? 'planMode' : 'promptBorder'}
+        idleColor={promptAccent}
       >
         <Box flexDirection="row" alignItems="flex-start" width="100%">
           <EffortChargeGlyph

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { Box, Text } from '../ui.js'
+import { stringWidth } from '../ink/stringWidth.js'
+
+/**
+ * `/` 命令菜单与 `@` 文件菜单共用的圆角卡片外壳（与输入框 EffortInputBorder
+ * 同款 ╭╮╰╯ 视觉语言）：
+ *
+ *   ╭─ 标题 ─────────────────────╮
+ *   │ ❯ 行内容 …                 │
+ *   │   行内容 …                 │
+ *   │ ↑2 · ↓3                    │  ← 仅当列表被裁剪
+ *   ╰────────────────────────────╯
+ *
+ * 底边 ╰╯ 直接坐在输入框顶边 ╭╮ 的上一行（PromptInput 的浮层包装去掉了
+ * 底部留白），卡片与输入框连成一体，读作"挂在输入框上的下拉"。边框色
+ * 跟随输入框 idle 色（plan 模式下整套面板一起变 sage 绿）。
+ *
+ * 每一行的左右 │ 由本组件包在行外——侧边框若是内容列旁的单行 Text，只
+ * 会画在自己那一行（行高的首行），多行列表的中段行会裸奔无边框。
+ * 卡片左右各占 2 列（│ + 1 空格），行内容的可用宽度由
+ * {@link cardContentWidth} 统一计算，CJK 截断契约（verify-cjk-truncate）
+ * 按该宽度钉住。
+ */
+export function SuggestionCard({
+  title,
+  columns,
+  accent,
+  footer,
+  rows,
+}: {
+  /** 嵌在顶边框里的标题（已本地化、含计数）。 */
+  title: string
+  columns: number
+  /** 边框色（主题 token）；缺省 promptBorder。 */
+  accent?: 'promptBorder' | 'planMode'
+  /** 底部 dim 提示行（滚动指示）；null/undefined 时不渲染。 */
+  footer?: string | null
+  /** 已渲染的行内容（每行一个节点），本组件为各行补上左右边框。 */
+  rows: readonly React.ReactNode[]
+}): React.ReactNode {
+  const inner = Math.max(0, columns - 2)
+  const lead = `─ ${title} `
+  // 标题放不下（极窄终端）时退化为素边框，不做半截标题。
+  const titleFits = stringWidth(lead) + 1 <= inner
+  const top = titleFits
+    ? `╭${lead}${'─'.repeat(inner - stringWidth(lead))}╮`
+    : `╭${'─'.repeat(inner)}╮`
+  const borderColor = accent ?? 'promptBorder'
+  return (
+    <Box flexDirection="column" width="100%" flexShrink={0}>
+      <Text color={borderColor} wrap="truncate-end">{top}</Text>
+      {rows.map((row, index) => (
+        <Box key={index} flexDirection="row" width="100%">
+          <Text color={borderColor}>│</Text>
+          {/* flexGrow 钉住右侧 │ 在最后一列；行内容自行按 cardContentWidth 截断。 */}
+          <Box flexDirection="column" flexGrow={1} minWidth={0}>
+            {row}
+          </Box>
+          <Text color={borderColor}>│</Text>
+        </Box>
+      ))}
+      {footer ? (
+        <Box flexDirection="row" width="100%">
+          <Text color={borderColor}>│</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <Text dimColor wrap="truncate-end"> {footer}</Text>
+          </Box>
+          <Text color={borderColor}>│</Text>
+        </Box>
+      ) : null}
+      <Text color={borderColor} wrap="truncate-end">{`╰${'─'.repeat(inner)}╯`}</Text>
+    </Box>
+  )
+}
+
+/**
+ * 卡片内一行内容的可用显示宽度：总宽减去两侧 │ + 各 1 空格的内边距。
+ * CommandSuggestions / FileSuggestions 的截断数学共用这一口径。
+ */
+export function cardContentWidth(columns: number): number {
+  return Math.max(0, columns - 4)
+}
+
+/**
+ * 把补全名按「命中的查询前缀」拆成三段（用于前缀高亮）。两级尝试，
+ * 均大小写不敏感，与 completeCommands / 文件候选的过滤语义对齐：
+ *   1. 整名前缀（文件查询是路径前缀，`src/re` 命中 `src/render`，
+ *      跨分隔符；命令 `/plan of` 命中完整路径 `plan off`）；
+ *   2. 最后一段 token 的前缀（命令按空格、文件按 `/` 分段）。
+ * 查询为空、或都不命中（别名命中、过期候选）返回 null——渲染方整体 dim。
+ */
+export function splitQueryMatch(
+  name: string,
+  query: string,
+): { before: string; match: string; after: string } | null {
+  if (query === '') return null
+  const lower = query.toLowerCase()
+  if (name.toLowerCase().startsWith(lower)) {
+    const matched = name.slice(0, Math.min(query.length, name.length))
+    return { before: '', match: matched, after: name.slice(matched.length) }
+  }
+  const tokenStart = Math.max(name.lastIndexOf(' '), name.lastIndexOf('/')) + 1
+  const segment = name.slice(tokenStart)
+  if (segment.toLowerCase().startsWith(lower)) {
+    const matched = segment.slice(0, Math.min(query.length, segment.length))
+    return {
+      before: name.slice(0, tokenStart),
+      match: matched,
+      after: segment.slice(matched.length),
+    }
+  }
+  return null
+}

--- a/src/components/SuggestionCard.tsx
+++ b/src/components/SuggestionCard.tsx
@@ -83,11 +83,13 @@ export function cardContentWidth(columns: number): number {
 }
 
 /**
- * 把补全名按「命中的查询前缀」拆成三段（用于前缀高亮）。两级尝试，
+ * 把补全名按「命中的查询前缀」拆成三段（用于前缀高亮）。三级尝试，
  * 均大小写不敏感，与 completeCommands / 文件候选的过滤语义对齐：
- *   1. 整名前缀（文件查询是路径前缀，`src/re` 命中 `src/render`，
- *      跨分隔符；命令 `/plan of` 命中完整路径 `plan off`）；
- *   2. 最后一段 token 的前缀（命令按空格、文件按 `/` 分段）。
+ *   1. 整名前缀（文件查询是路径前缀，`src/re` 命中 `src/render`）；
+ *   2. 最后一个空格 token 的前缀（嵌套命令 `model deepseek/…` 的
+ *      `deepseek/` 查询——补全名带 `model ` 路径前缀）；
+ *   3. 最后一个 `/` 段的前缀（`/model deepseek-v` 命中段
+ *      `deepseek-v4-flash` 的开头）。
  * 查询为空、或都不命中（别名命中、过期候选）返回 null——渲染方整体 dim。
  */
 export function splitQueryMatch(
@@ -96,19 +98,20 @@ export function splitQueryMatch(
 ): { before: string; match: string; after: string } | null {
   if (query === '') return null
   const lower = query.toLowerCase()
-  if (name.toLowerCase().startsWith(lower)) {
-    const matched = name.slice(0, Math.min(query.length, name.length))
-    return { before: '', match: matched, after: name.slice(matched.length) }
-  }
-  const tokenStart = Math.max(name.lastIndexOf(' '), name.lastIndexOf('/')) + 1
-  const segment = name.slice(tokenStart)
-  if (segment.toLowerCase().startsWith(lower)) {
+  const startsWith = (start: number): { before: string; match: string; after: string } | null => {
+    const segment = name.slice(start)
+    if (!segment.toLowerCase().startsWith(lower)) return null
     const matched = segment.slice(0, Math.min(query.length, segment.length))
     return {
-      before: name.slice(0, tokenStart),
+      before: name.slice(0, start),
       match: matched,
       after: segment.slice(matched.length),
     }
   }
-  return null
+  const lastSpace = name.lastIndexOf(' ')
+  return (
+    startsWith(0)
+    ?? (lastSpace >= 0 ? startsWith(lastSpace + 1) : null)
+    ?? startsWith(name.lastIndexOf('/') + 1)
+  )
 }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -42,12 +42,14 @@ import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateMode
 import type { ProviderSetupHost } from './providerWizard.js'
 import { readPresetPref, writePresetPref } from '../presetPrefs.js'
 import { composePreset, resolvePersistedPreset, rosterOf, runningPresetOf, serviceForAgent, type AgentPresetInfo } from './presets.js'
-import { isPresetName } from '../components/activityFrames.js'
+import { isPresetName, PRESET_NAMES } from '../components/activityFrames.js'
 import { existsSync, statSync, writeFileSync } from 'node:fs'
 import { logForDebugging } from '../utils/debug.js'
 import { homeDir, LEGACY_DATA_DIR } from '../utils/paths.js'
 import { extractMentions } from '../utils/mentions.js'
-import { t } from '../i18n.js'
+import { getLang, LANGS, t } from '../i18n.js'
+import { AUTO_THEME_NAME, THEME_NAMES } from '../theme.js'
+import { listCustomThemes } from '../customTheme.js'
 import { modeDisplayName, resolveSessionModes, type SessionModeSpec } from '../sessionModes.js'
 import { normalizeStatusBar, normalizeToolBackground, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import { SubagentActivityStore, type SubagentState } from './subagents.js'
@@ -2146,6 +2148,68 @@ export function createChannel(
   // another directory's listing.
   const fileCandidateCache = { cwd: '', load: undefined as Promise<readonly FileCandidate[]> | undefined }
 
+  // `/model <provider/id>` completion: the model catalog is async (one llm
+  // listModels per provider), so the first keystrokes that could be heading
+  // for /model warm a session-lifetime cache — the shared promise dedupes
+  // concurrent triggers, children() synchronously serves whatever has landed,
+  // and the arrival state.emit() reopens the menu mid-typing. switchModel's
+  // success path drops the cache so the [current] tag re-resolves against
+  // the new route.
+  const modelNodeCache = {
+    nodes: undefined as readonly CommandCompletionNode[] | undefined,
+    load: undefined as Promise<void> | undefined,
+  }
+  const warmModelNodes = (): void => {
+    if (modelNodeCache.load !== undefined) return
+    modelNodeCache.load = state.listModels().then((list) => {
+      modelNodeCache.nodes = list.map((model) => ({
+        name: `${model.provider}/${model.id}`,
+        description: model.name,
+        ...(state.provider === model.provider && state.model === model.id
+          ? { tag: 'current' }
+          : {}),
+      }))
+      state.emit()
+    }).catch(() => {
+      // listModels already swallows per-provider failures; this only fires
+      // when the llm service shape itself is missing — settle on an empty
+      // menu rather than retrying on every keystroke.
+      modelNodeCache.nodes = []
+    })
+  }
+
+  // `/preset <id>` completion: same warm-cache pattern as models. The
+  // current/default tags resolve at children() time (sync state reads), so
+  // no cache invalidation is needed on switch.
+  const presetOptionCache = {
+    list: undefined as readonly PresetOption[] | undefined,
+    load: undefined as Promise<void> | undefined,
+  }
+  const warmPresetOptions = (): void => {
+    if (presetOptionCache.load !== undefined) return
+    presetOptionCache.load = state.listPresets().then((list) => {
+      presetOptionCache.list = list
+      state.emit()
+    }).catch(() => {
+      presetOptionCache.list = []
+    })
+  }
+
+  // `/effort <id>` completion: state.effortLevels is the sync vocabulary
+  // (populated on route changes); when still unknown, one best-effort
+  // resolveEfforts warms it. `tried` caps the retry — resolveEfforts
+  // notifies on hard errors, so keystroke-time retries would spam.
+  const effortWarm = { tried: false }
+  const warmEffortLevels = (): void => {
+    if (state.effortLevels !== undefined || effortWarm.tried) return
+    effortWarm.tried = true
+    void resolveEfforts().then((resolved) => {
+      if (resolved === 'unavailable' || resolved === 'error') return
+      effortWarm.tried = false
+      state.emit()
+    }).catch(() => {})
+  }
+
   const state: ChannelState = {
     effortLevels: undefined,
     version: 0,
@@ -2191,7 +2255,91 @@ export function createChannel(
     pending: [],
     commandList: LOCAL_COMMANDS,
     commandCompletions(input: string) {
+      // Warm the async vocabularies as soon as the input could be heading
+      // for their commands (`/m`, `/pre`, …) — by the time a trailing space
+      // asks children() for nodes, the fetch has usually landed.
+      const head = input.slice(1).split(/[\t ]/)[0]?.toLowerCase() ?? ''
+      if (head !== '') {
+        if ('model'.startsWith(head)) warmModelNodes()
+        if ('preset'.startsWith(head)) warmPresetOptions()
+        if ('effort'.startsWith(head)) warmEffortLevels()
+      }
       return completeCommands(input, state.commandList, (path) => {
+        if (path.length === 1 && path[0] === 'model') {
+          // provider/id specs, current model tagged; see modelNodeCache.
+          warmModelNodes()
+          return modelNodeCache.nodes ?? []
+        }
+        if (path.length === 1 && path[0] === 'lang') {
+          return [
+            { name: 'status', description: 'Show the current UI language', descriptionKey: 'sugg-status-desc' },
+            ...LANGS.map((lang) => ({
+              name: lang,
+              description: `Switch the UI language to ${lang}`,
+              descriptionKey: lang === 'zh' ? 'sugg-lang-zh-desc' : 'sugg-lang-en-desc',
+              ...(getLang() === lang ? { tag: 'current' } : {}),
+            })),
+          ]
+        }
+        if (path.length === 1 && path[0] === 'theme') {
+          return [
+            { name: 'status', description: 'Show the current theme', descriptionKey: 'sugg-status-desc' },
+            { name: AUTO_THEME_NAME, description: 'Follow the terminal background', descriptionKey: 'sugg-theme-auto-desc' },
+            ...THEME_NAMES.map((name) => ({
+              name,
+              description: `Built-in theme ${name}`,
+              descriptionKey: 'sugg-theme-builtin-desc',
+            })),
+            ...listCustomThemes()
+              .filter((spec) => spec.name !== AUTO_THEME_NAME)
+              .map((spec) => ({
+                name: spec.name,
+                description: `User theme (${spec.base} base)`,
+                descriptionKey: 'sugg-theme-user-desc',
+              })),
+          ]
+        }
+        if (path.length === 1 && path[0] === 'effort') {
+          warmEffortLevels()
+          return [
+            { name: 'status', description: 'Show the current reasoning effort', descriptionKey: 'sugg-status-desc' },
+            ...(state.effortLevels ?? []).map((id) => ({
+              name: id,
+              description: 'Reasoning effort level',
+              descriptionKey: 'sugg-effort-level-desc',
+              ...(state.reasoningEffort === id ? { tag: 'current' } : {}),
+            })),
+          ]
+        }
+        if (path.length === 1 && path[0] === 'preset') {
+          warmPresetOptions()
+          return [
+            { name: 'status', description: 'Show the current agent preset', descriptionKey: 'sugg-status-desc' },
+            ...(presetOptionCache.list ?? []).map((preset) => ({
+              name: preset.id,
+              description: preset.description ?? preset.name ?? preset.id,
+              ...(preset.id === state.agentPreset
+                ? { tag: 'current' }
+                : preset.isDefault
+                  ? { tag: 'default' }
+                  : {}),
+            })),
+          ]
+        }
+        if (path.length === 1 && path[0] === 'activity') {
+          return [
+            { name: 'status', description: 'Show the current activity preset', descriptionKey: 'sugg-status-desc' },
+            { name: 'frames', description: 'List or switch frame presets', descriptionKey: 'sugg-activity-frames-desc' },
+          ]
+        }
+        if (path.length === 2 && path[0] === 'activity' && path[1] === 'frames') {
+          return PRESET_NAMES.map((name) => ({
+            name,
+            description: 'Animation frame preset',
+            descriptionKey: 'sugg-activity-frame-desc',
+            ...(state.activityFrames === name ? { tag: 'current' } : {}),
+          }))
+        }
         if (path.length === 1 && path[0] === 'workspace') {
           const builtins: CommandCompletionNode[] = [
             { name: 'resume', description: 'Switch to another workspace', descriptionKey: 'cmd-desc-workspace-resume' },

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -371,6 +371,16 @@ const dict = {
   'sugg-count': { zh: '共 {{n}} 项', en: '{{n}} items' },
   'sugg-more-above': { zh: '↑{{n}}', en: '↑{{n}}' },
   'sugg-more-below': { zh: '↓{{n}}', en: '↓{{n}}' },
+  // 二级补全子项描述（/lang /theme /effort /preset /activity 的 children）
+  'sugg-status-desc': { zh: '显示当前选择', en: 'Show the current choice' },
+  'sugg-lang-zh-desc': { zh: '切换界面语言到中文', en: 'Switch the UI language to Chinese' },
+  'sugg-lang-en-desc': { zh: '切换界面语言到英文', en: 'Switch the UI language to English' },
+  'sugg-theme-auto-desc': { zh: '跟随终端背景自动切换', en: 'Follow the terminal background' },
+  'sugg-theme-builtin-desc': { zh: '内置主题', en: 'Built-in theme' },
+  'sugg-theme-user-desc': { zh: '用户主题（{{base}} 基底）', en: 'User theme ({{base}} base)' },
+  'sugg-effort-level-desc': { zh: '思考强度档位', en: 'Reasoning effort level' },
+  'sugg-activity-frames-desc': { zh: '列出或切换动画帧预设', en: 'List or switch frame presets' },
+  'sugg-activity-frame-desc': { zh: '动画帧预设', en: 'Animation frame preset' },
 
   // ── components/HelpMenu.tsx ─────────────────────────────────────────
   'help-for-commands': { zh: '/ 查看命令', en: '/ for commands' },

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -365,6 +365,13 @@ const dict = {
   'frame-tail-2': { zh: '摆尾巴2', en: 'tail2' },
   'frame-tail-3': { zh: '摆尾巴3', en: 'tail3' },
 
+  // ── components/SuggestionCard.tsx（/ 命令菜单 · @ 文件菜单）─────────
+  'sugg-commands-title': { zh: '命令', en: 'commands' },
+  'sugg-files-title': { zh: '文件', en: 'files' },
+  'sugg-count': { zh: '共 {{n}} 项', en: '{{n}} items' },
+  'sugg-more-above': { zh: '↑{{n}}', en: '↑{{n}}' },
+  'sugg-more-below': { zh: '↓{{n}}', en: '↓{{n}}' },
+
   // ── components/HelpMenu.tsx ─────────────────────────────────────────
   'help-for-commands': { zh: '/ 查看命令', en: '/ for commands' },
   'help-this-help': { zh: '? 查看本帮助', en: '? for this help' },


### PR DESCRIPTION
## 内容

本 PR 把 \/\ 与 \@\ 补全菜单升级为圆角卡片，并将二级补全铺开到全部带词表的命令，交互统一为「输入前缀过滤 → Tab 补全 → 空格进二级 → Enter 直切」。

### 1. SuggestionCard 卡片化（\36ab062\）
- 新组件 \SuggestionCard\：与输入框同款 ╭╮╰╯ 圆角、标题嵌顶边框（命令/文件 · 共 N 项）、plan 模式随 idle 色变 sage 绿
- 选中行 ❯ 指针 + 名字加粗 + suggestion 色；未选中 dim + 查询前缀提亮（平铺 span，规避嵌套 Text 的 dim 继承）
- 列表被窗口裁剪时底部 ↑/↓ 滚动指示
- 行宽统一 \columns - 4\ 口径，CJK 截断契约不变

### 2. 选中行 padding 修复（\8ae979a\）
卡片化首版漏了选中分支的列填充（headless xterm 按列探针验证三行描述起始列一致）。

### 3. 全面二级补全（\24bb7ef\）
- \/model <provider/id>\：异步 warm 缓存（首击预热、共享 promise 去重、到达 emit 重开菜单），当前模型标 \[current]\；token 字符集放宽 \. : /\
- \/lang\ \/theme\ \/effort\ \/preset\ \/activity\（三级）补全词表
- \splitQueryMatch\ 三级匹配（整名 → 空格 token → 斜杠段）

## 验证
- verify-i18n-command-descriptions / verify-cjk-truncate 全绿
- tsc 干净、\pnpm run build\ 全门禁通过
- 24 项补全行为探针断言全过