### PR TITLE
fix(goal): 折叠顶层 goal/change 事件——底栏 goal chip 从不显示的根因

### DIFF
--- a/scripts/verify-channel-goal-todo.mjs
+++ b/scripts/verify-channel-goal-todo.mjs
@@ -241,4 +241,119 @@ if (sessionHandler === undefined) {
   check('non-goal injected message ignored', channel.goal === undefined && channel.todos?.length === 2)
 }
 
+// ---- REAL-SHAPE scenario: the goal service writes durable snapshots as
+// top-level `goal/change` session events (not inlined in user/message
+// sources) and injects round prompts as goal-sourced messages WITHOUT a
+// change object. This is the shape found in production session logs — the
+// original inlined-source fold left the footer goal chip dark forever.
+{
+  const seed = [
+    {
+      type: 'goal/change',
+      seq: 1,
+      time: now - 5000,
+      data: {
+        kind: 'goal/change',
+        version: 1,
+        operation: 'create',
+        goal: {
+          id: 'goal-x1',
+          revision: 1,
+          objective: 'Demonstrate the goal chip',
+          phase: 'active',
+          maxGoalRounds: 1,
+        },
+        roundsStarted: 0,
+        createdAt: now - 5000,
+        updatedAt: now - 5000,
+      },
+    },
+    {
+      type: 'user/message',
+      seq: 2,
+      time: now - 4000,
+      data: {
+        source: { kind: 'goal', goalId: 'goal-x1', revision: 1, round: 1 },
+        content: [],
+      },
+    },
+    {
+      type: 'goal/change',
+      seq: 3,
+      time: now - 3000,
+      data: {
+        kind: 'goal/change',
+        version: 1,
+        operation: 'complete',
+        goal: {
+          id: 'goal-x1',
+          revision: 2,
+          objective: 'Demonstrate the goal chip',
+          phase: 'complete',
+          maxGoalRounds: 1,
+        },
+        roundsStarted: 1,
+        createdAt: now - 5000,
+        updatedAt: now - 3000,
+      },
+    },
+  ]
+  const goalAgent = {
+    id: 'a2',
+    status: 'idle',
+    session: { id: 's2', seq: 3, events: seed },
+    ctx: { on: () => () => {} },
+  }
+  const goalChannel = createChannel(ctx, goalAgent, {
+    model: 'deepseek-chat',
+    cwd: '/tmp',
+    provider: 'deepseek',
+    activity: false,
+  })
+  check('real-shape replay folds the goal', goalChannel.goal?.id === 'goal-x1', JSON.stringify(goalChannel.goal))
+  check('real-shape replay reaches complete phase', goalChannel.goal?.phase === 'complete')
+  check('real-shape round prompt advanced roundsStarted', goalChannel.goal?.roundsStarted === 1)
+
+  // Live top-level event: pause, then clear.
+  const handler = handlers.get('session/event')
+  if (handler === undefined) {
+    check('session/event handler captured (real-shape)', false)
+  } else {
+    handler(goalAgent.session, {
+      type: 'goal/change',
+      seq: 4,
+      time: now,
+      data: {
+        kind: 'goal/change',
+        version: 1,
+        operation: 'pause',
+        goal: {
+          id: 'goal-x1',
+          revision: 3,
+          objective: 'Demonstrate the goal chip',
+          phase: 'paused',
+          maxGoalRounds: 1,
+        },
+        roundsStarted: 1,
+        createdAt: now - 5000,
+        updatedAt: now,
+      },
+    })
+    check('live real-shape pause folds', goalChannel.goal?.phase === 'paused' && goalChannel.goal?.revision === 3)
+    handler(goalAgent.session, {
+      type: 'goal/change',
+      seq: 5,
+      time: now + 1,
+      data: {
+        kind: 'goal/change',
+        version: 1,
+        operation: 'clear',
+        cleared: { id: 'goal-x1', revision: 4 },
+        clearedAt: now + 1,
+      },
+    })
+    check('live real-shape clear folds', goalChannel.goal === undefined)
+  }
+}
+
 process.exit(failed)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -539,10 +539,11 @@ export interface Channel {
   readonly contextBarEnabled: boolean
   /**
    * Current same-session goal projection, when a goal exists. Derived live
-   * from the durable `goal/change` context events (round-zero goal-sourced
-   * user messages) in the session log — every goal mutation appends one, so
-   * this snapshot tracks create/edit/pause/resume/complete/block/clear in
-   * real time and replays correctly on resume/rewind.
+   * from the durable goal events in the session log — top-level
+   * `goal/change` snapshots (every goal mutation appends one) plus the
+   * goal-sourced continuation rounds that advance the counter — so this
+   * snapshot tracks create/edit/pause/resume/complete/block/clear in real
+   * time and replays correctly on resume/rewind.
    */
   readonly goal: ChannelGoal | undefined
   /**
@@ -4831,28 +4832,49 @@ ${output}
   }
 
   /**
+   * One durable goal mutation as the goal service records it (the `data` of
+   * a top-level `goal/change` session event, and of the snapshot a round-zero
+   * goal-sourced `user/message` may inline). Declared structurally: the
+   * pinned peer's `SessionEvent` union predates the event type, so the fold
+   * admits the payload by shape, not by union membership.
+   */
+  type GoalChangePayload = {
+    kind: 'goal/change'
+    version: number
+    operation:
+      | 'create'
+      | 'edit'
+      | 'pause'
+      | 'resume'
+      | 'complete'
+      | 'block'
+      | 'clear'
+    goal?: Omit<ChannelGoal, 'roundsStarted'>
+    roundsStarted?: number
+  }
+
+  /** Fold one goal mutation into the channel's goal projection. */
+  const applyGoalChange = (change: GoalChangePayload): void => {
+    if (change.operation === 'clear') {
+      state.goal = undefined
+    } else if (change.goal !== undefined) {
+      state.goal = {
+        ...change.goal,
+        roundsStarted: change.roundsStarted ?? state.goal?.roundsStarted ?? 0,
+      }
+    }
+  }
+
+  /**
    * Fold one goal-sourced message into the channel's goal projection.
-   * Round-zero goal messages carry the full durable snapshot (or a clear
+   * Round-zero goal messages may carry the full durable snapshot (or a clear
    * tombstone) in their source; positive-round messages are admitted
    * continuation prompts that only advance the rounds counter.
    */
   const applyGoalEvent = (event: SessionEvent<'user/message'>): void => {
     const source = event.data.source as unknown as {
       round: number
-      change?: {
-        kind: 'goal/change'
-        version: 1
-        operation:
-          | 'create'
-          | 'edit'
-          | 'pause'
-          | 'resume'
-          | 'complete'
-          | 'block'
-          | 'clear'
-        goal?: ChannelGoal
-        roundsStarted?: number
-      }
+      change?: GoalChangePayload
     }
     if (source.round > 0) {
       // Admitted continuation round — the snapshot itself is unchanged.
@@ -4867,14 +4889,7 @@ ${output}
     const change = source.change
     // oxlint-disable-next-line typescript/no-unnecessary-condition -- durable replay data may not match the static type
     if (change === undefined || change.kind !== 'goal/change') return
-    if (change.operation === 'clear') {
-      state.goal = undefined
-    } else if (change.goal !== undefined) {
-      state.goal = {
-        ...change.goal,
-        roundsStarted: change.roundsStarted ?? state.goal?.roundsStarted ?? 0,
-      }
-    }
+    applyGoalChange(change)
   }
 
   /** True while the durable transcript is being replayed (boot /resume /
@@ -4902,6 +4917,15 @@ ${output}
   }
 
   const renderEvent = (event: SessionEvent): void => {
+    // Top-level `goal/change` events are how the goal service actually
+    // records durable goal mutations (create/edit/pause/resume/complete/
+    // block/clear) — confirmed in production logs. The pinned peer's
+    // SessionEvent union predates the type, so admit it structurally: the
+    // goal chip and panel stay dark without this fold.
+    if ((event as { type: string }).type === 'goal/change') {
+      applyGoalChange((event as { data: GoalChangePayload }).data)
+      return
+    }
     switch (event.type) {
       case 'user/message': {
         // Compaction checkpoint: `source = { kind: 'plugin', plugin:
@@ -4947,10 +4971,13 @@ ${output}
           contextWarned = false
           break
         }
-        // Same-session goal domain: round-zero goal-sourced messages carry
-        // the durable goal snapshot (or clear tombstone) in their source.
-        // They are not transcript bubbles — they drive the goal panel's
-        // live projection (replayed on resume/rewind like every other event).
+        // Same-session goal domain: goal-sourced messages are the round
+        // driver's continuation prompts (positive rounds advance the
+        // counter); some hosts also inline the durable snapshot in a
+        // round-zero source. They are not transcript bubbles — they drive
+        // the goal panel's live projection (replayed on resume/rewind like
+        // every other event; the snapshot itself arrives as the top-level
+        // `goal/change` event admitted above).
         if ((event.data.source as { kind: string }).kind === 'goal') {
           applyGoalEvent(event)
           break


### PR DESCRIPTION
## 根因

底栏 goal chip（`statusBar.goal`，默认开）与 goal/todo 面板在**真实会话中从未显示过**。

PR #448 把 goal 投影挂在 goal-sourced `user/message` 的 `source.change`（内联快照）上，但对本机 `~/.dsh-cc/sessions` 全部 469 个会话日志解包取证证明，goal 服务的真实写入形状是：

| 真实事件 | 实际载荷 | 原逻辑 |
|---|---|---|
| 顶层 `goal/change` 事件 | 完整快照（create/edit/pause/resume/complete/block/clear） | switch 无此分支，静默丢弃 |
| goal-sourced `user/message` | 仅 `goalId/revision/round`（续轮提示，无快照） | 等内联 change，永远等不到 |

两条路都断 → `channel.goal` 恒为 `undefined`。原 `verify-channel-goal-todo` 种子恰好用了作者假设的内联形状，测试全绿、线上全黑。

## 修复

- `renderEvent` 结构化认入顶层 `goal/change`（pinned peer `dsh-session@0.1.1-rc.2` 的 `SessionEvent` 联合早于该事件类型，按形状收窄，不动 peer）
- 抽出 `applyGoalChange` 共享折叠核心；`user/message` 路径保留续轮计数 + 防御性内联快照兼容
- 更新 `Channel.goal` 文档注释反映真实事件来源

## 验证

- `verify-channel-goal-todo` 新增真实形状场景 6 断言（replay 折叠 / complete 相位 / 续轮推进 / live pause / live clear），19/19 通过
- `verify-goal-todo` 面板 e2e、`verify-display-settings` 21/21（含 goal chip 显隐开关）通过
- 隔离 worktree 全量 `pnpm run build`（tsc + verify:build 全套门禁）绿