### PR TITLE
perf(render): 子代理渲染优化——动画时钟退出/流投影批处理/签名拆分（审计 P0+P1）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       # 对齐合并（token 率 100-300/s 下的全量深拷贝热路径），且生命周期
       # 事件（tool/call、subagent/end）保持同步立即可见。
       - run: node --import tsx/esm scripts/verify-subagent-stream-batching.tsx
+      # resize 时间稳定性（借鉴 Codex 的 resize 漂移维度）：落定后不得
+      # 继续漂、20 次宽度循环无累计漂移、流中 resize 终态 == 冷渲染。
+      - run: node --import tsx/esm scripts/verify-resize-temporal.tsx
 
       # 消息列表虚拟化回归：连续高度校正的嵌套更新上限（#129, React #185）、
       # 滚动窗口与 shrink 边界。measure-depth 需生产模式（minified #185）。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
       # 空转重渲染风暴回归（issue #433）：长历史 + 30ms 空转 commit 风暴下
       # renderScrollTop / 画面 / 输入框行数必须逐帧恒定，几何不震荡。
       - run: node --import tsx/esm scripts/repro-idle-oscillation.tsx
+      # settled 子代理卡片不得永久持有动画时钟（空闲帧归零回归）：
+      # 曾以 120ms/卡片持续驱动 React commit，N 张相位错开合成 ~30ms
+      # 均匀帧 cadence。
+      - run: node --import tsx/esm scripts/verify-subagent-settle.tsx
 
       # 消息列表虚拟化回归：连续高度校正的嵌套更新上限（#129, React #185）、
       # 滚动窗口与 shrink 边界。measure-depth 需生产模式（minified #185）。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,10 @@ jobs:
       # 曾以 120ms/卡片持续驱动 React commit，N 张相位错开合成 ~30ms
       # 均匀帧 cadence。
       - run: node --import tsx/esm scripts/verify-subagent-settle.tsx
+      # 子代理流投影批处理：chunk 风暴的 snapshot+行投影必须按 16ms 帧
+      # 对齐合并（token 率 100-300/s 下的全量深拷贝热路径），且生命周期
+      # 事件（tool/call、subagent/end）保持同步立即可见。
+      - run: node --import tsx/esm scripts/verify-subagent-stream-batching.tsx
 
       # 消息列表虚拟化回归：连续高度校正的嵌套更新上限（#129, React #185）、
       # 滚动窗口与 shrink 边界。measure-depth 需生产模式（minified #185）。

--- a/scripts/verify-resize-temporal.tsx
+++ b/scripts/verify-resize-temporal.tsx
@@ -1,0 +1,183 @@
+/**
+ * Resize temporal-stability regression（审计 P1-C，借鉴 Codex 的 resize
+ * 时间漂移测试维度）。
+ *
+ * 现有 verify-resize-reflow 只验证「最终画面对不对」；本脚本补测：
+ *   1. 时间不变量：resize 落定后 250ms 与 1000ms 的画面必须完全一致
+ *      （不许继续慢慢漂）；
+ *   2. 往返不变量：90↔150 宽度循环 20 次后回到基线宽度，composer/
+ *      sentinel 行必须精确回到基线位置（无累计漂移）；
+ *   3. 流中 resize：streaming 期间反复 resize，消息 finalize 后的画面
+ *      必须与同内容冷渲染完全一致（resize + live mutation 竞争不留下
+ *      任何与冷路径不同的几何）。
+ *
+ * 运行：node --import tsx/esm scripts/verify-resize-temporal.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'kitty'
+process.env.DSH_TUI_THEME = 'dark'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/ink/instances.js'),
+])
+
+const BASE_COLS = 108
+const ROWS = 34
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
+  if (!ok) failed += 1
+}
+
+function makeTerminal() {
+  const term = new XTerm({ cols: BASE_COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  let lastFlushed: Promise<void> = Promise.resolve()
+  class FakeStdout extends Writable {
+    columns = BASE_COLS
+    rows = ROWS
+    isTTY = true
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+      lastFlushed = new Promise<void>(res => term.write(String(chunk), () => { cb(); res() }))
+    }
+  }
+  const stdout = new FakeStdout() as any
+  const stderr = (new (class extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } })()) as any
+  const stdin = (new (class extends PassThrough { isTTY = true; setRawMode() { return this }; ref() { return this }; unref() { return this } })()) as any
+  return { term, stdout, stderr, stdin, flush: () => lastFlushed }
+}
+
+function screenLines(term: typeof XTerm.prototype): string[] {
+  const buf = term.buffer.active
+  const out: string[] = []
+  for (let y = 0; y < ROWS; y++) out.push((buf.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+  return out
+}
+
+// ---- 稳定历史（无时间敏感组件：无 subagent 卡片、无 running tool）----
+function makeRows(): any[] {
+  const rows: any[] = []
+  let id = 0
+  for (let t = 0; t < 40; t++) {
+    rows.push({ id: id++, kind: 'user', text: '问题 ' + t + '：分析模块 ' + t + ' 的边界条件与失败模式' })
+    rows.push({ id: id++, kind: 'assistant', text: '回答 ' + t + '：\n\n- 条件成立\n- 边界已覆盖\n- 结论稳定', streaming: false })
+  }
+  rows.push({ id: id++, kind: 'assistant', text: 'SENTINEL-TAIL 最终结论：全部检查通过。', streaming: false })
+  return rows
+}
+
+async function mountChat(rows: any[]) {
+  const listeners = new Set<() => void>()
+  const channel: any = {
+    version: 0, rows, status: 'idle', sessionTitle: 'resize-temporal', agentId: 'x',
+    model: 'deepseek-v4-flash', reasoningEffort: 'max',
+    tokens: { input: 100, output: 40 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo',
+    gitBranch: 'main', working: false, spinnerMode: 'requesting', responseChars: 0,
+    activeToolCount: 0, turnStart: 0, lastUserText: rows[0].text,
+    pending: [], commandList: [], notifications: [],
+    mode: { plan: false }, effortLevels: undefined,
+    subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+    submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+    listModels: () => Promise.resolve([]), listSessions: () => [],
+    setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [],
+  }
+  const t = makeTerminal()
+  await render(
+    <AlternateScreen>
+      <Chat channel={channel} questionStore={new QuestionStore()} />
+    </AlternateScreen>,
+    { stdout: t.stdout, stdin: t.stdin, stderr: t.stderr, exitOnCtrlC: false, patchConsole: false },
+  )
+  const ink: any = instances.get(t.stdout)
+  if (!ink) throw new Error('Ink instance not found')
+  ink.setAltScreenActive(true, true)
+  return {
+    ...t,
+    bump: () => { channel.version++; for (const cb of listeners) (cb as () => void)() },
+    unmount: () => ink.unmount(),
+  }
+}
+
+function doResize(app: { stdout: any; term: typeof XTerm.prototype }, w: number, h: number) {
+  app.stdout.columns = w
+  app.stdout.rows = h
+  app.term.resize(w, h)
+  app.stdout.emit('resize')
+}
+
+// ================= 1+2. 时间稳定性 & 往返循环 =================
+const app = await mountChat(makeRows())
+await sleep(1500)
+await app.flush()
+
+const baseline = screenLines(app.term)
+const composerY = (lines: string[]) => lines.findIndex(l => l.includes('╭'))
+const sentinelY = (lines: string[]) => lines.findIndex(l => l.includes('SENTINEL-TAIL'))
+check('基线含 composer 与 sentinel', composerY(baseline) >= 0 && sentinelY(baseline) >= 0, `composer=${composerY(baseline)} sentinel=${sentinelY(baseline)}`)
+
+// ---- 1. resize 落定后不得继续漂 ----
+doResize(app, 90, ROWS)
+await sleep(250); await app.flush()
+const at250 = screenLines(app.term)
+await sleep(750); await app.flush()
+const at1000 = screenLines(app.term)
+check('resize 落定后 250ms 与 1000ms 画面一致（时间不变量）', at250.join('\n') === at1000.join('\n'))
+
+// ---- 2. 90↔150 循环 20 次后回基线 ----
+for (let i = 0; i < 20; i++) {
+  doResize(app, i % 2 === 0 ? 150 : 90, ROWS)
+  await sleep(12)
+  await app.flush()
+}
+doResize(app, BASE_COLS, ROWS)
+await sleep(400); await app.flush()
+const roundTrip = screenLines(app.term)
+check('20 次宽度循环后画面回到基线（无累计漂移）', roundTrip.join('\n') === baseline.join('\n'), `composer ${composerY(baseline)}→${composerY(roundTrip)}, sentinel ${sentinelY(baseline)}→${sentinelY(roundTrip)}`)
+app.unmount()
+await sleep(150)
+
+// ================= 3. 流中 resize：终态 == 冷渲染 =================
+const liveRows = makeRows()
+const streamRow: any = { id: 9999, kind: 'assistant', text: '', streaming: true }
+liveRows.push(streamRow)
+const app2 = await mountChat(liveRows)
+await sleep(1500); await app2.flush()
+
+const STREAM_TEXT = '流式内容：第一段论述比较长，用来触发宽度变化下的重排。'.repeat(8) + '\n\n- 要点甲\n- 要点乙\n- 结论 TAILMARK-终'
+// 逐段流入，期间反复 resize（resize + live mutation 竞争）
+for (let i = 0; i < 10; i++) {
+  streamRow.text = STREAM_TEXT.slice(0, Math.floor((STREAM_TEXT.length * (i + 1)) / 10))
+  app2.bump()
+  await sleep(40)
+  if (i % 3 === 0) { doResize(app2, i % 2 === 0 ? 88 : 132, ROWS) }
+  await app2.flush()
+}
+streamRow.text = STREAM_TEXT
+streamRow.streaming = false
+doResize(app2, BASE_COLS, ROWS)
+app2.bump()
+await sleep(600); await app2.flush()
+const warm = screenLines(app2.term)
+// 计数用全文唯一的尾标记（正文字符串内部有 repeat，不能当标记）
+const streamedOnce = warm.join('\n').split('TAILMARK-终').length - 1
+check('finalize 后流式文本恰好出现一次（无重复）', streamedOnce === 1, 'occurrences=' + streamedOnce)
+app2.unmount()
+await sleep(150)
+
+// 冷渲染：同最终内容、同尺寸、从零渲染
+const coldRows = makeRows()
+coldRows.push({ id: 9999, kind: 'assistant', text: STREAM_TEXT, streaming: false })
+const app3 = await mountChat(coldRows)
+await sleep(1500); await app3.flush()
+const cold = screenLines(app3.term)
+check('流中 resize 终态 == 冷渲染（live mutation 竞争无残留几何）', warm.join('\n') === cold.join('\n'))
+app3.unmount()
+
+console.log(failed === 0 ? '\nALL PASS' : '\n' + failed + ' 项失败')
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-subagent-settle.tsx
+++ b/scripts/verify-subagent-settle.tsx
@@ -1,0 +1,137 @@
+/**
+ * Settled-subagent idle render regression（外部审计报告 P0-A/P0-4）。
+ *
+ * SubagentMessage 曾无条件 `useAnimationFrame(120)` 且丢弃 viewportRef：
+ * settled 卡片永远保持 animation clock 订阅（keepAlive），空闲会话以
+ * ~120ms/卡片 持续产生 React commit + 帧；waterfall key 还含 time，
+ * running 时每 tick 强制 remount。N 张相位错开的卡片 → ~30ms 均匀帧
+ * cadence（#433 的形态）。
+ *
+ * 断言：
+ *   1) 控制组：存在 running 卡片时空闲窗口内确实有帧（动画没被误杀）；
+ *   2) 全部 settled 后空闲 1s 帧数 = 0（clock 完全退出）。
+ * 运行：node --import tsx/esm scripts/verify-subagent-settle.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'kitty'
+process.env.DSH_TUI_THEME = 'dark'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+])
+
+const COLS = 100
+const ROWS = 32
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough { isTTY = true; setRawMode() { return this }; ref() { return this }; unref() { return this } }
+const stdout = new FakeStdout() as any
+const stderr = new FakeStderr() as any
+const stdin = new FakeStdin() as any
+
+/** 帧计数器：onFrame 每 paint 一次 +1，窗口内增量即空闲渲染压力。 */
+let frameCount = 0
+
+function subagentCard(id: number, agentId: string, status: 'running' | 'completed'): any {
+  const startedAt = Date.now() - 120_000
+  return {
+    id,
+    kind: 'subagent',
+    text: '子任务 ' + agentId + '：检索并归纳结论',
+    subagent: {
+      agentId,
+      runId: agentId,
+      description: '子任务 ' + agentId + '：检索并归纳结论',
+      provider: 'dsh', model: 'deepseek-v4-flash', effort: 'medium',
+      status,
+      startedAt,
+      completedAt: status === 'completed' ? startedAt + 60_000 : undefined,
+      durationMs: status === 'completed' ? 60_000 : undefined,
+      outputLines: status === 'running' ? ['正在读取 src/index.ts', '正在匹配 pattern', '第三行占位输出'] : [],
+      toolCalls: [{ id: agentId + '-c1', name: 'Grep', status: 'ok', startedAt }],
+      tokens: { total: 2048 },
+      stopReason: status === 'completed' ? 'completed' : undefined,
+    },
+  }
+}
+
+const listeners = new Set<() => void>()
+const makeRows = (statuses: Array<'running' | 'completed'>) => {
+  const rows: any[] = [{ id: 0, kind: 'user', text: '开始并行子任务分析' }]
+  statuses.forEach((s, i) => rows.push(subagentCard(i + 1, 'sa-' + i, s)))
+  rows.push({ id: 90, kind: 'assistant', text: '汇总完成。', streaming: false })
+  return rows
+}
+let channelRows = makeRows(['running', 'running'])
+const channel: any = {
+  version: 0, rows: channelRows, status: 'idle', sessionTitle: 'subagent-idle', agentId: 'x',
+  model: 'deepseek-v4-flash', reasoningEffort: 'max',
+  tokens: { input: 100, output: 40 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo',
+  gitBranch: 'main', working: false, spinnerMode: 'requesting', responseChars: 0,
+  activeToolCount: 0, turnStart: 0, lastUserText: '开始并行子任务分析',
+  pending: [], commandList: [], notifications: [],
+  mode: { plan: false }, effortLevels: undefined,
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => [],
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) (cb as () => void)() }
+
+async function countIdleFrames(windowMs: number): Promise<number> {
+  await sleep(300)
+  const before = frameCount
+  await sleep(windowMs)
+  return frameCount - before
+}
+
+await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} />
+  </AlternateScreen>,
+  { stdout, stdin, stderr, exitOnCtrlC: false, patchConsole: false, onFrame: () => { frameCount++ } },
+)
+
+// 开机动画（LogoV2 splash）落定后再测
+await sleep(1800)
+
+// ---- 控制组：2 张 running 卡片 → 空闲窗口内必须有帧 ----
+const runningFrames = await countIdleFrames(1000)
+check('running 卡片驱动空闲帧（动画存在）', runningFrames >= 4, 'frames=' + runningFrames)
+
+// ---- 全部 settle：running → completed（走真实高度变化路径）----
+channelRows.forEach(row => {
+  if (row.kind !== 'subagent' || !row.subagent) return
+  const sub = row.subagent
+  sub.status = 'completed'
+  sub.completedAt = sub.startedAt + 60_000
+  sub.durationMs = 60_000
+  sub.outputLines = []
+  sub.stopReason = 'completed'
+})
+bump()
+await sleep(300)
+
+const settledFrames = await countIdleFrames(1000)
+check('settled 后空闲帧归零（clock 完全退出）', settledFrames === 0, 'frames=' + settledFrames)
+
+console.log(failed === 0 ? '\nALL PASS' : '\n' + failed + ' 项失败')
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-subagent-stream-batching.tsx
+++ b/scripts/verify-subagent-stream-batching.tsx
@@ -1,0 +1,132 @@
+/**
+ * Subagent stream projection batching regression（外部审计 P0-C）。
+ *
+ * 真实 cordis Context + 真实 createChannel + 假 agents 服务。向一个
+ * 已链接的 subagent session 连发 N 个 assistant/chunk（text-delta），
+ * 统计 SubagentActivityStore.snapshot 的调用次数（投影次数的精确代理：
+ * 每次 snapshot 都伴随一次全量深拷贝 + SubagentRow 重建路径）。
+ *
+ * 契约：
+ *   1. chunk 风暴期间投影数远小于 chunk 数（按 16ms 帧对齐合并）；
+ *   2. 风暴结束后最终 output 内容与逐 chunk 拼接完全一致（不丢字）；
+ *   3. 非 chunk 事件（tool/call、subagent/end）立即投影：end 后状态
+ *      同步可见（completed），不等下一个 16ms 帧；
+ *   4. chunk 之后紧接 end（16ms 内）：end 的立即投影包含 chunk 数据
+ *      （被取代的延迟 flush 不产生多余重复投影）。
+ *
+ * 运行：node --import tsx/esm scripts/verify-subagent-stream-batching.tsx
+ */
+process.env.FORCE_COLOR = '3'
+// 断言文案与 locale 无关
+process.env.DSH_TUI_LANG = 'zh'
+
+// 家目录隔离：channel 构造路径会 touch 用户目录，先切临时目录再 import。
+const { mkdtempSync, mkdirSync } = await import('node:fs')
+const { tmpdir } = await import('node:os')
+const { join: joinPath } = await import('node:path')
+const isolatedHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-subagent-batch-'))
+process.env.HOME = isolatedHome
+process.env.USERPROFILE = isolatedHome
+mkdirSync(joinPath(isolatedHome, '.dsh-tui'), { recursive: true })
+
+const [{ Context }, { createChannel }, { SubagentActivityStore }] = await Promise.all([
+  import('@deepseek-ai/cordis'),
+  import('../src/dsh-adapter/channel.js'),
+  import('../src/dsh-adapter/subagents.js'),
+])
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+// ── snapshot 计数插桩：包一层原方法 ──
+let snapshotCalls = 0
+const originalSnapshot = SubagentActivityStore.prototype.snapshot
+SubagentActivityStore.prototype.snapshot = function (...args: []) {
+  snapshotCalls += 1
+  return (originalSnapshot as (...a: []) => unknown).apply(this, args)
+} as typeof SubagentActivityStore.prototype.snapshot
+
+// ── harness：真实 cordis root + 假 agents 服务（含 get） ──
+const childSession = { id: 'child-session', seq: 0, events: [], header: {} }
+const ctx = new Context()
+;(ctx as unknown as { provide(name: string, value: unknown): () => void }).provide('agents', {
+  get(id: string) {
+    return id === 'child-agent'
+      ? { session: childSession, options: { provider: 'fake-provider', model: 'model-00' } }
+      : undefined
+  },
+})
+
+const parent = {
+  id: 'parent-agent',
+  status: 'idle',
+  options: {},
+  ctx,
+  session: { id: 'parent-session', seq: 0, events: [], header: {} },
+  followup() {},
+  steer() {},
+  inbox: { remove() {} },
+} as never
+
+const channel = createChannel(ctx as never, parent, {
+  model: 'model-00', cwd: '/tmp/demo', provider: 'fake-provider', activity: false,
+})
+const emitSessionEvent = (event: unknown) =>
+  (ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit('session/event', childSession, event)
+
+const chunk = (text: string) => ({ type: 'assistant/chunk', data: { chunk: { type: 'text-delta', text } } })
+
+// ── subagent/start：真实事件路径建立 agentId↔session 链接 ──
+;(ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit('subagent/start', {
+  id: 'child-agent', runId: 'run-1', provider: 'fake-provider',
+})
+await sleep(50)
+const linked = channel.subagents.length === 1 && channel.subagents[0]!.agentId === 'child-agent'
+check('subagent/start 建立 tracked subagent', linked, JSON.stringify(channel.subagents.map(s => s.agentId)))
+
+// ── 1. chunk 风暴：200 个 delta 同步连发（事件循环同一 tick 内）──
+const BURST = 200
+let expected = ''
+snapshotCalls = 0
+for (let i = 0; i < BURST; i++) {
+  const piece = `段${i}…`
+  expected += piece
+  emitSessionEvent(chunk(piece))
+}
+// 同 tick 发完：此时投影应远少于 chunk 数（仅 start 路径与 store 内部，
+// channel 层的投影最多 0 次——全部延迟到 16ms flush）
+const syncProjections = snapshotCalls
+await sleep(120) // 等 16ms flush 落定
+const subRow = channel.rows.find(r => r.kind === 'subagent')
+const projected = (subRow?.subagent?.outputLines ?? []).join('')
+check('chunk 风暴同步投影被延迟（远少于 chunk 数）', syncProjections <= 2, `syncProjections=${syncProjections}/${BURST}`)
+check('chunk 内容完整投影（不丢字）', projected === expected, `len=${projected.length}/${expected.length}`)
+check('flush 后投影次数受帧数约束', snapshotCalls - syncProjections <= 3, `flushProjections=${snapshotCalls - syncProjections}`)
+
+// ── 2. 非 chunk 事件立即投影 ──
+snapshotCalls = 0
+emitSessionEvent({ type: 'tool/call', data: { callId: 'c1', name: 'Grep', arguments: '{}' } })
+const toolVisible = channel.rows.find(r => r.kind === 'subagent')?.subagent?.toolCalls.some(t => t.name === 'Grep')
+check('tool/call 立即投影（不等帧）', toolVisible === true, 'toolCalls=' + JSON.stringify(channel.rows.find(r => r.kind === 'subagent')?.subagent?.toolCalls.map(t => t.name)))
+
+// ── 3. chunk 后 16ms 内 end：最终状态同步可见且包含 chunk 数据 ──
+emitSessionEvent(chunk('尾巴'))
+expected += '尾巴'
+;(ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit('subagent/end', {
+  id: 'child-agent', stopReason: 'completed', lastAssistantMessage: [{ type: 'text', text: '最终结论' }],
+})
+const endedRow = channel.rows.find(r => r.kind === 'subagent')
+check('subagent/end 状态同步可见（completed）', endedRow?.subagent?.status === 'completed', 'status=' + String(endedRow?.subagent?.status))
+check('end 前最后一帧 chunk 已含在投影中', (endedRow?.subagent?.outputLines ?? []).join('') === expected, 'len=' + (endedRow?.subagent?.outputLines ?? []).length)
+check('final summary 不被延迟覆盖', endedRow?.subagent?.summary === '最终结论', 'summary=' + String(endedRow?.subagent?.summary))
+// 被取代的延迟 flush 不再重复投影
+const afterEnd = snapshotCalls
+await sleep(80)
+check('被取代的延迟 flush 无多余投影', snapshotCalls - afterEnd <= 1, `extra=${snapshotCalls - afterEnd}`)
+
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/Chat/SubagentMessage.tsx
+++ b/src/components/Chat/SubagentMessage.tsx
@@ -63,10 +63,14 @@ export function SubagentMessage({ subagent, addMargin, activityFrames, onClick }
   isExpanded: boolean
   onClick: () => void
 }): React.ReactNode {
-  const [, time] = useAnimationFrame(120)
+  const settled = subagent.status === 'completed' || subagent.status === 'failed' || subagent.status === 'cancelled'
+  // 动画订阅仅限运行中的卡片：settled 后传 null 退出共享 clock（keepAlive
+  // 归零 → interval 清除），否则历史里的每张完成卡片都以 120ms 永久驱动
+  // React commit。viewportRef 必须挂到根节点——useTerminalViewport 初始
+  // isVisible:true，ref 不挂就永远不修正（虚拟化滚出视口的卡片继续动画）。
+  const [viewportRef, time] = useAnimationFrame(settled ? null : 120)
   const { columns } = useTerminalSize()
   const info = status(subagent)
-  const settled = subagent.status === 'completed' || subagent.status === 'failed' || subagent.status === 'cancelled'
   const elapsed = subagent.completedAt ? subagent.durationMs : Date.now() - subagent.startedAt
   const lastRunning = [...subagent.toolCalls].reverse().find(tool => tool.status === 'running')
   const previousDone = lastRunning
@@ -77,7 +81,7 @@ export function SubagentMessage({ subagent, addMargin, activityFrames, onClick }
   const runningGlyph = preset.frames[Math.floor(time / preset.intervalMs) % preset.frames.length] ?? '·'
   const rowWidth = Math.max(20, (columns ?? 80) - WATERFALL_GUTTER)
 
-  return <Box flexDirection="column" marginTop={addMargin ? 1 : 0} paddingLeft={2} onClick={onClick}>
+  return <Box flexDirection="column" marginTop={addMargin ? 1 : 0} paddingLeft={2} onClick={onClick} ref={viewportRef}>
     <Box flexDirection="row" gap={1}>
       <Text color={info.color}>{settled ? info.glyph : ` ${runningGlyph}`}</Text>
       <Text bold>{`${t('subagent-card-prefix')}${subagent.description}`}</Text>
@@ -125,7 +129,10 @@ export function SubagentMessage({ subagent, addMargin, activityFrames, onClick }
       </Text>
     )}
     {!settled && Array.from({ length: WATERFALL_ROWS }, (_, index) => (
-      <Text key={`${subagent.agentId}-wf-${index}-${time}`} dimColor wrap="truncate">{`  │ ${clipLine(activity[index] ?? '', rowWidth)}`}</Text>
+      // key 不含 time：含 time 的 key 让每个 animation tick 都变成
+      // unmount+mount，DOMElement/Yoga node churn 且 nodeCache 失配扩大
+      // terminal damage。内容更新走 in-place diff。
+      <Text key={`${subagent.agentId}-wf-${index}`} dimColor wrap="truncate">{`  │ ${clipLine(activity[index] ?? '', rowWidth)}`}</Text>
     ))}
     {settled && subagent.status === 'failed' && subagent.error && (
       <Text color="error" wrap="truncate">{`  └ ${clipLine(subagent.error, rowWidth)}`}</Text>

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -45,6 +45,78 @@ const DEFAULT_ROW_HEIGHT = 2
  *  first layout measurement. */
 const DEFAULT_HEADER_LINES = 14
 
+/**
+ * Per-kind layout signature: the O(1) identity of every input that decides a
+ * row's rendered HEIGHT (see sigRef in MessageList). Fields are scoped to the
+ * row's own renderer — a global flat signature over-invalidates (a diffLayout
+ * switch must not drop user-message heights). Text uses length as the proxy:
+ * full-text hashing per row per frame would defeat virtualization's budget,
+ * and a same-length miss only degrades to the previous behavior.
+ */
+function layoutSignature(
+  row: ChatRow,
+  columns: number,
+  expanded: boolean,
+  expandedRows: ReadonlySet<number>,
+  thinkingVisible: boolean,
+  thinkingFold: string,
+  diffLayout: string,
+  model: string,
+  failureHintRowId: number | null | undefined,
+  failureHint: string | undefined,
+): string {
+  // Universal height inputs: width reflows every row; kind switches height
+  // semantics wholesale; text length drives wrapping.
+  const parts: Array<string | number | boolean> = [columns, row.kind, row.text?.length ?? 0]
+  switch (row.kind) {
+    case 'assistant':
+      // Streaming vs settled swaps renderers; Ctrl+O/per-row expand adds the
+      // metadata row (model only renders expanded — keeps an idle /model
+      // switch from touching settled rows).
+      parts.push(row.streaming === true, expanded, expandedRows.has(row.id), expanded ? model : '')
+      break
+    case 'reasoning':
+      // thinkingFold (preview vs full) and the visibility filter change the
+      // folded card's height; streaming shows verbose live.
+      parts.push(row.streaming === true, expanded, expandedRows.has(row.id), thinkingVisible, thinkingFold)
+      break
+    case 'tool': {
+      const tool = row.tool
+      parts.push(
+        expanded,
+        expandedRows.has(row.id),
+        diffLayout,
+        tool?.status ?? '',
+        tool?.resultText?.length ?? 0,
+        tool?.resultFull?.length ?? 0,
+        tool?.errorText?.length ?? 0,
+        row.id === failureHintRowId ? failureHint ?? '' : '',
+      )
+      break
+    }
+    case 'subagent':
+      // 卡片高度输入：running→settled 折叠 waterfall+tool 行（5→1 行），
+      // failed 增加 error 行。缺这些字段的话 offscreen 结算后 cached
+      // height 永不过期 → 滚回 blank band / 滚不到底。
+      parts.push(
+        row.subagent?.status ?? '',
+        row.subagent?.toolCalls.length ?? 0,
+        row.subagent?.outputLines.length ?? 0,
+        row.subagent?.error?.length ?? 0,
+      )
+      break
+    case 'compact':
+      // Folded one-liner vs full summary text.
+      parts.push(expanded, expandedRows.has(row.id))
+      break
+    default:
+      // user / notice / interrupt / local / local-output: height follows
+      // text + columns alone (selection/background never change height).
+      break
+  }
+  return parts.join('|')
+}
+
 export function MessageList({
   rows,
   expanded,
@@ -204,35 +276,24 @@ export function MessageList({
     const sigs = sigRef.current
     for (let i = 0; i < visibleRows.length; i++) {
       const row = visibleRows[i]!
-      const tool = row.tool
-      const sig = [
+      // Per-kind signature: only the inputs that row's OWN renderer consumes.
+      // A global flat array (every field × every row) over-invalidates — a
+      // /settings diffLayout switch used to drop every user/assistant/
+      // reasoning height at once, remounting the widened window over rows
+      // whose rendering never changed (Yoga spike + measure churn for
+      // nothing). Base parts cover the universal height inputs.
+      const sig = layoutSignature(
+        row,
         columns,
-        row.kind,
-        row.text?.length ?? 0,
-        row.streaming === true,
         expanded,
-        expandedRows.has(row.id),
+        expandedRows,
         thinkingVisible,
         thinkingFold,
         diffLayout,
-        // Model only renders on expanded rows (MessageMetadata) — folding
-        // it out of the signature keeps an idle /model switch from
-        // invalidating every cached height at once.
-        expanded ? model : '',
-        tool?.status ?? '',
-        tool?.resultText?.length ?? 0,
-        tool?.resultFull?.length ?? 0,
-        tool?.errorText?.length ?? 0,
-        // Subagent 卡片的高度输入：running→settled 折叠 waterfall+tool 行
-        // （高度 5→1），failed 增加 error 行。这些字段不进签名的话，
-        // offscreen 卡片结算后 cached height 永不过期 → offsets/bottomPad
-        // 用不存在的几何 → 滚回时 blank band / 滚不到底。
-        row.subagent?.status ?? '',
-        row.subagent?.toolCalls.length ?? 0,
-        row.subagent?.outputLines.length ?? 0,
-        row.subagent?.error?.length ?? 0,
-        row.id === failureHintRowId ? failureHint ?? '' : '',
-      ].join('|')
+        model,
+        failureHintRowId,
+        failureHint,
+      )
       if (sigs.get(row.id) !== sig) {
         if (sigs.size >= HEIGHTS_CACHE_MAX) {
           const oldest = sigs.keys().next().value

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -223,6 +223,14 @@ export function MessageList({
         tool?.resultText?.length ?? 0,
         tool?.resultFull?.length ?? 0,
         tool?.errorText?.length ?? 0,
+        // Subagent 卡片的高度输入：running→settled 折叠 waterfall+tool 行
+        // （高度 5→1），failed 增加 error 行。这些字段不进签名的话，
+        // offscreen 卡片结算后 cached height 永不过期 → offsets/bottomPad
+        // 用不存在的几何 → 滚回时 blank band / 滚不到底。
+        row.subagent?.status ?? '',
+        row.subagent?.toolCalls.length ?? 0,
+        row.subagent?.outputLines.length ?? 0,
+        row.subagent?.error?.length ?? 0,
         row.id === failureHintRowId ? failureHint ?? '' : '',
       ].join('|')
       if (sigs.get(row.id) !== sig) {
@@ -489,11 +497,6 @@ export function MessageList({
     registerRowRef?.(rowId, el)
   }, [registerRowRef])
 
-  // Second-resolution clock for the running tool card's live elapsed time.
-  // Computed per render (cheap) but only forwarded to running rows, so
-  // settled rows never see a changing prop.
-  const nowSec = Math.floor(Date.now() / 1000)
-
   return (
     <>
       {rows.some(row => row.folded) && (
@@ -548,7 +551,6 @@ export function MessageList({
               toolResultView={tool?.resultView}
               toolStartedAt={tool?.startedAt}
               toolDurationMs={tool?.durationMs}
-              nowSec={tool?.status === 'running' ? nowSec : undefined}
               subagent={subagent}
               onToggleRow={onToggleRow}
               setRowRef={setRowRef}
@@ -607,9 +609,6 @@ type MemoRowProps = {
   toolResultView: ToolResultView | undefined
   toolStartedAt: number | undefined
   toolDurationMs: number | undefined
-  /** Second-resolution clock, forwarded only while the tool runs so the
-   *  live elapsed label ticks; settled rows never receive a changing prop. */
-  nowSec: number | undefined
   // SubagentRow, stable ref (subagent lifecycle events update the store, not
   // the row ref itself, so a plain ref compare stays correct).
   subagent: SubagentRow | undefined

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1427,7 +1427,7 @@ export function createChannel(
         runtime.interrupt(target, { kind: 'ancestor', agent })
         subagentStore.onCancelled(agentId, 'interrupted')
         state.subagents = subagentStore.snapshot()
-        syncSubagentRows()
+        syncSubagentRows(state.subagents)
         state.emit()
         return true
       } catch {
@@ -1461,9 +1461,12 @@ export function createChannel(
   /**
    * Sync subagentStore state into ChatRows (insert/update in state.rows).
    * Called whenever subagent state changes (spawned/completed/failed/output).
+   * Accepts a caller-taken snapshot to avoid the double copy on the hot path
+   * (session/event fires per subagent token: snapshot here + snapshot in the
+   * caller = two full state copies before emitStream's 16ms throttle).
    */
-  const syncSubagentRows = (): void => {
-    const snapshot = subagentStore.snapshot()
+  const syncSubagentRows = (preSnapshot?: readonly SubagentState[]): void => {
+    const snapshot = preSnapshot ?? subagentStore.snapshot()
     for (const sub of snapshot) {
       let row = subagentRowsByAgentId.get(sub.agentId)
       if (!row) {
@@ -5565,7 +5568,7 @@ ${output}
         if (subagentId) {
           subagentStore.onSessionEvent(subagentId, event)
           state.subagents = subagentStore.snapshot()
-          syncSubagentRows()
+          syncSubagentRows(state.subagents)
           if (event.type === 'assistant/chunk') state.emitStream()
           else state.emit()
           return
@@ -5627,7 +5630,7 @@ ${output}
             // Session discovery is best-effort and must not break the parent turn.
           }
           state.subagents = subagentStore.snapshot()
-          syncSubagentRows()
+          syncSubagentRows(state.subagents)
           state.emit()
         })
         const disposeEnd = ctx.on('subagent/end' as any, (info: { id: string; stopReason: string; lastAssistantMessage?: unknown[] }) => {
@@ -5646,7 +5649,7 @@ ${output}
           else if (info.stopReason === 'cancelled' || info.stopReason === 'aborted') subagentStore.onCancelled(info.id, info.stopReason, output)
           else subagentStore.onFailed(info.id, info.stopReason || 'Unknown error')
           state.subagents = subagentStore.snapshot()
-          syncSubagentRows()
+          syncSubagentRows(state.subagents)
           state.emit()
         })
         return () => {

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1426,8 +1426,7 @@ export function createChannel(
       try {
         runtime.interrupt(target, { kind: 'ancestor', agent })
         subagentStore.onCancelled(agentId, 'interrupted')
-        state.subagents = subagentStore.snapshot()
-        syncSubagentRows(state.subagents)
+        syncSubagentsNow()
         state.emit()
         return true
       } catch {
@@ -1549,6 +1548,31 @@ export function createChannel(
   const listeners = new Set<() => void>()
   /** True while a frame-aligned stream notification is pending (emitStream). */
   let streamNotifyScheduled = false
+  /** True while subagent assistant/chunk deltas have deferred their
+   *  snapshot+projection to the frame-aligned flush (emitStream's timer).
+   *  Chunks arrive at token rate (100-300 events/s) and the projection is a
+   *  full deep state copy (SubagentActivityStore.snapshot) plus a SubagentRow
+   *  rebuild per tracked agent — running that per token sits BEFORE
+   *  emitStream's 16ms coalescing and defeats it. Non-chunk events
+   *  (tool/call, subagent/end, interrupt) project immediately and clear
+   *  this flag, so lifecycle transitions stay synchronous. */
+  let subagentStreamDirty = false
+  /** Deferred projection for the frame-aligned flush: runs INSIDE the
+   *  emitStream timer, before listeners wake, so React always reads fully
+   *  projected rows. No-op unless a chunk marked the projection dirty. */
+  const flushSubagentStream = (): void => {
+    if (!subagentStreamDirty) return
+    subagentStreamDirty = false
+    state.subagents = subagentStore.snapshot()
+    syncSubagentRows(state.subagents)
+  }
+  /** Immediate projection; supersedes any pending deferred flush (the fresh
+   *  snapshot already contains everything the deferred pass would project). */
+  const syncSubagentsNow = (): void => {
+    subagentStreamDirty = false
+    state.subagents = subagentStore.snapshot()
+    syncSubagentRows(state.subagents)
+  }
   // foldRows incremental cursor (see foldRows): rows only append past the
   // fold line, so each pass touches only newly-eligible rows.
   const foldCursor: { rows: unknown; index: number } = { rows: null, index: 0 }
@@ -2481,6 +2505,9 @@ export function createChannel(
       streamNotifyScheduled = true
       const timer = setTimeout(() => {
         streamNotifyScheduled = false
+        // Deferred subagent projection rides this same frame: flush BEFORE
+        // the listeners wake so React reads fully projected rows.
+        flushSubagentStream()
         foldRows(state.rows, MAX_ROWS, foldCursor)
         for (const listener of listeners) listener()
       }, 16)
@@ -5567,10 +5594,17 @@ ${output}
         const subagentId = subagentStore.getSubagentIdBySession(session)
         if (subagentId) {
           subagentStore.onSessionEvent(subagentId, event)
-          state.subagents = subagentStore.snapshot()
-          syncSubagentRows(state.subagents)
-          if (event.type === 'assistant/chunk') state.emitStream()
-          else state.emit()
+          if (event.type === 'assistant/chunk') {
+            // Token-rate path (100-300 events/s): the store append stays
+            // synchronous (cheap); the expensive snapshot + row projection
+            // defers to the frame-aligned flush inside emitStream's 16ms
+            // timer, so it coalesces exactly like the main-agent stream.
+            subagentStreamDirty = true
+            state.emitStream()
+          } else {
+            syncSubagentsNow()
+            state.emit()
+          }
           return
         }
         // Otherwise handle main agent session
@@ -5629,8 +5663,7 @@ ${output}
           } catch {
             // Session discovery is best-effort and must not break the parent turn.
           }
-          state.subagents = subagentStore.snapshot()
-          syncSubagentRows(state.subagents)
+          syncSubagentsNow()
           state.emit()
         })
         const disposeEnd = ctx.on('subagent/end' as any, (info: { id: string; stopReason: string; lastAssistantMessage?: unknown[] }) => {
@@ -5648,8 +5681,7 @@ ${output}
           if (info.stopReason === 'completed') subagentStore.onCompleted(info.id, output, info.stopReason)
           else if (info.stopReason === 'cancelled' || info.stopReason === 'aborted') subagentStore.onCancelled(info.id, info.stopReason, output)
           else subagentStore.onFailed(info.id, info.stopReason || 'Unknown error')
-          state.subagents = subagentStore.snapshot()
-          syncSubagentRows(state.subagents)
+          syncSubagentsNow()
           state.emit()
         })
         return () => {


### PR DESCRIPTION
## 背景

外部审计报告（基于 Codex TUI 源码对比）逐条核验为真后按其优先级落地第一轮全部范围（P0-A/B/C + P1-A/C），共 7 提交，每项先写 repro 再修（先红后绿）。

## 修复清单

| 提交 | 内容 | 实测收益 |
|---|---|---|
| b574b54 | settled 卡片退出动画时钟 + waterfall 稳定 key | 空闲帧 **8/s → 0**；消除每 tick 的 DOMElement/Yoga remount churn |
| ea261a0 | 高度签名纳入 subagent 状态 + 删死 prop nowSec | 修 offscreen 结算后滚回 blank band / 滚不到底的根因 |
| 5c2eb99 | syncSubagentRows 复用调用方 snapshot | 每 token 少一次全量深拷贝 |
| e65a691 | **流投影移进 16ms 帧对齐 flush**（审计 P0-C 核心） | 200 chunk 同 tick 投影 **200 次 → 0 次**（合并为 1 次 flush），890 字符零丢失 |
| 7a1cab5 | layout signature 按 kind 拆分 | /settings 切 diffLayout 不再全表失效重测（消 Yoga 尖峰） |
| 578ec0d/16c24d8 | 三项新回归挂 CI | — |

## 关键设计

**P0-C 批处理**：assistant/chunk（token 率 100-300/s）只做廉价 store 追加并标 `subagentStreamDirty`，昂贵的 snapshot + SubagentRow 重建延迟到 emitStream 定时器内、React 唤醒之前执行——与主流路径同帧合并。非 chunk 事件（tool/call、subagent/end、interrupt）经 `syncSubagentsNow()` 立即投影并清脏：生命周期转换保持同步可见，被取代的延迟 flush 变为 no-op。

**签名拆分**：`layoutSignature()` 纯函数按 kind 编入各自渲染器消费的高度输入（assistant: streaming/expanded/model；tool: diffLayout/status/result；subagent: status/toolCalls/outputLines/error；…），不再全字段×全行。

## 验证
- verify-subagent-settle：控制组 running 卡片仍有动画帧（防误杀），全部 settled 后空闲 1s 帧 = 0；
- verify-subagent-stream-batching：真实 cordis + createChannel，9/9 断言（投影计数/内容完整/生命周期同步/无重复投影）；
- verify-resize-temporal（借鉴 Codex 时间漂移维度）：落定不慢漂、20 次宽度循环无累计漂移、流中 resize 终态 == 冷渲染；
- 既有门禁 15 项全绿（measure-depth / extension-events / trace-projection / scroll / shrink / ghost 系列 / resize-reflow / inline-scrollback 等）。

## 与 #433 的关系
settled 卡片的 120ms 时钟是 ~30ms 均匀帧 cadence 的候选源之一（4 张相位错开即合成 30ms）。若 #433 会话含 subagent 卡片，本 PR 直接命中。

## 未做（P2，需先 benchmark）
Codex 式 Smooth↔CatchUp 自适应流压——审计标注置信度中等，待 profile 数据后再启动。