### PR TITLE
refactor(chat): 用单一 reducer 管理弹出面板状态

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "prompt:debug": "node scripts/read-prompt-debug.mjs",
     "tui": "node --import tsx/esm scripts/run.ts",
     "smoke": "node --import tsx/esm scripts/smoke.tsx",
-    "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:herdr && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:web-coexistence && npm run verify:plugin-spec && npm run verify:plugin-grants && npm run verify:plugin-storage && npm run verify:plugin-messages && npm run verify:plugin-ledger && npm run verify:plugin-commands && npm run verify:plugin-negotiation && npm run verify:plugin-lifecycle && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap && npm run verify:wheel-selection && npm run verify:pointer-events",
+    "verify:build": "npm run verify:boundary && npm run verify:contract && npm run verify:herdr && npm run verify:manifest-deps && npm run verify:patch-surface && npm run verify:web-coexistence && npm run verify:plugin-spec && npm run verify:plugin-grants && npm run verify:plugin-storage && npm run verify:plugin-messages && npm run verify:plugin-ledger && npm run verify:plugin-commands && npm run verify:plugin-negotiation && npm run verify:plugin-lifecycle && npm run verify:packaged-presets && npm run verify:minimal-preset-tools && npm run verify:liangshen-bootstrap && npm run verify:wheel-selection && npm run verify:pointer-events && npm run verify:chat-overlay",
     "verify:boundary": "node --import tsx/esm scripts/verify-adapter-boundary.ts",
     "verify:contract": "node --import tsx/esm scripts/verify-upstream-contract.ts",
     "verify:herdr": "node --import tsx/esm scripts/verify-herdr-integration.ts",
@@ -120,6 +120,7 @@
     "verify:thinking-preview": "node --import tsx/esm scripts/verify-thinking-preview.tsx",
     "verify:wheel-selection": "node --import tsx/esm scripts/verify-wheel-selection.ts",
     "verify:pointer-events": "node --import tsx/esm scripts/verify-pointer-events.ts",
+    "verify:chat-overlay": "node --import tsx/esm scripts/verify-chat-overlay.ts",
     "sync:profile": "node scripts/sync-profile.mjs",
     "sync:profile:check": "node scripts/sync-profile.mjs --check"
   },

--- a/scripts/verify-chat-overlay.ts
+++ b/scripts/verify-chat-overlay.ts
@@ -98,6 +98,17 @@ check(
   reduce({ kind: 'theme', index: 1 }, { type: 'set-index', kind: 'model', index: 3 }),
   { kind: 'theme', index: 1 },
 )
+check(
+  'T4c mouse pick sets an absolute index on panels that stay open (effort, rewind list)',
+  [
+    reduce({ kind: 'effort', index: 0 }, { type: 'set-index', kind: 'effort', index: 2 }),
+    reduce(
+      { kind: 'rewind', index: 0, confirm: null, modes: null, modeIndex: 0, busy: false },
+      { type: 'set-index', kind: 'rewind', index: 2 },
+    ).index,
+  ],
+  [{ kind: 'effort', index: 2 }, 2],
+)
 
 // --- T5: history draft edits ---------------------------------------------
 check(

--- a/scripts/verify-chat-overlay.ts
+++ b/scripts/verify-chat-overlay.ts
@@ -1,0 +1,182 @@
+/**
+ * verify-chat-overlay — transition tests for the chat transient-dialog
+ * state machine (src/screens/chatOverlay.ts).
+ *
+ * Chat 底部瞬态浮层(picker/对话框/tips)收敛为一个判别联合后,互斥、环绕
+ * 移动、异步回调的 kind 守卫、以及 OverlayAbove 的挂载谓词全部变成可以
+ * 离线断言的纯函数——本脚本把布尔时代的行为表逐项钉死:
+ *   - open 是替换语义(异步 open 迟到时顶掉当前浮层,不再叠开)
+ *   - close-if 只关自己(加载失败的回调不能误关用户后来打开的浮层)
+ *   - move 的环绕公式与旧逐 picker 手写公式逐点一致,空表 no-op
+ *   - rewind 的 busy/confirm/modes 三段流转与键盘分支的语义相同
+ *   - dialogOverlayVisible 与旧 dialogOverlayOpen 聚合(含数据门与 tips
+ *     空浮层怪癖)逐 kind 等值
+ */
+import {
+  NO_OVERLAY,
+  chatOverlayReducer,
+  dialogOverlayVisible,
+  wrapIndex,
+  type ChatOverlay,
+  type ChatOverlayAction,
+} from '../src/screens/chatOverlay.js'
+import type { ChatRow } from '../src/dsh-adapter/channel.js'
+
+let failures = 0
+
+function check(name: string, actual: unknown, expected: unknown): void {
+  const a = JSON.stringify(actual)
+  const e = JSON.stringify(expected)
+  if (a !== e) {
+    failures++
+    console.error(`FAIL ${name}`)
+    console.error(`      expected: ${e}`)
+    console.error(`      actual:   ${a}`)
+  } else {
+    console.log(`ok   ${name}`)
+  }
+}
+
+function reduce(state: ChatOverlay, ...actions: ChatOverlayAction[]): ChatOverlay {
+  return actions.reduce(chatOverlayReducer, state)
+}
+
+const fakeRow = { id: 7, kind: 'user', text: 'prompt' } as unknown as ChatRow
+
+// --- T1: open replaces, close resets -------------------------------------
+check('T1a open from none', reduce(NO_OVERLAY, { type: 'open', overlay: { kind: 'model', index: 2 } }), { kind: 'model', index: 2 })
+check(
+  'T1b async open replaces the current overlay (effort landing over model)',
+  reduce(
+    { kind: 'model', index: 2 },
+    { type: 'open', overlay: { kind: 'effort', index: 1 } },
+  ),
+  { kind: 'effort', index: 1 },
+)
+check('T1c close', reduce({ kind: 'tips' }, { type: 'close' }), { kind: 'none' })
+check(
+  'T1d open-if drops a stale async open when the user opened something else',
+  reduce({ kind: 'model', index: 0 }, { type: 'open-if', overlay: { kind: 'effort', index: 1 }, when: ['none'] }),
+  { kind: 'model', index: 0 },
+)
+check(
+  'T1e open-if opens over an allowed kind (idle, and flow stage transitions)',
+  [
+    reduce(NO_OVERLAY, { type: 'open-if', overlay: { kind: 'effort', index: 1 }, when: ['none'] }),
+    reduce(
+      { kind: 'workspace-flow', flow: { kind: 'choices', title: 'a', choices: [] } as never, index: 2, busy: true, input: null },
+      { type: 'open-if', overlay: { kind: 'workspace-flow', flow: { kind: 'choices', title: 'b', choices: [] } as never, index: 0, busy: false, input: null }, when: ['none', 'workspace-flow'] },
+    ).kind,
+  ],
+  [{ kind: 'effort', index: 1 }, 'workspace-flow'],
+)
+
+// --- T2: close-if only closes its own kind -------------------------------
+check('T2a close-if matching', reduce({ kind: 'preset', index: 0 }, { type: 'close-if', kind: 'preset' }), { kind: 'none' })
+check(
+  'T2b close-if mismatched is a no-op (stale loader must not close the picker the user opened later)',
+  reduce({ kind: 'model', index: 1 }, { type: 'close-if', kind: 'preset' }),
+  { kind: 'model', index: 1 },
+)
+
+// --- T3: move wrap parity with the boolean-era per-picker formulas --------
+check('T3a up from 0 wraps to count-1', reduce({ kind: 'theme', index: 0 }, { type: 'move', delta: -1, count: 5 }), { kind: 'theme', index: 4 })
+check('T3b down from count-1 wraps to 0', reduce({ kind: 'theme', index: 4 }, { type: 'move', delta: 1, count: 5 }), { kind: 'theme', index: 0 })
+check('T3c empty list is a no-op (skills while the snapshot loads)', reduce({ kind: 'skills', index: 0 }, { type: 'move', delta: 1, count: 0 }), { kind: 'skills', index: 0 })
+// The /plan and /lang branches hand-wrote two-entry toggles; the shared
+// wrap must reproduce them exactly.
+check('T3d two-entry up parity', [wrapIndex(0, -1, 2), wrapIndex(1, -1, 2)], [1, 0])
+check('T3e two-entry down parity', [wrapIndex(0, 1, 2), wrapIndex(1, 1, 2)], [1, 0])
+check('T3f thinking focus toggles on either arrow', reduce({ kind: 'thinking', focus: 0 }, { type: 'move', delta: 1, count: 2 }, { type: 'move', delta: 1, count: 2 }), { kind: 'thinking', focus: 0 })
+// The /effort slider used a modulo formula; same fixed points.
+check('T3g effort modulo parity', [wrapIndex(1, -1, 3), wrapIndex(2, 1, 3)], [0, 0])
+
+// --- T4: set-index is kind-guarded ---------------------------------------
+check('T4a set-index applies on its picker', reduce({ kind: 'model', index: 0 }, { type: 'set-index', kind: 'model', index: 3 }), { kind: 'model', index: 3 })
+check(
+  'T4b stale loader set-index ignored after the picker changed',
+  reduce({ kind: 'theme', index: 1 }, { type: 'set-index', kind: 'model', index: 3 }),
+  { kind: 'theme', index: 1 },
+)
+
+// --- T5: history draft edits ---------------------------------------------
+check(
+  'T5a partial patch keeps unnamed fields',
+  reduce({ kind: 'history', query: 'ab', cursor: 2, focus: 3 }, { type: 'history-edit', cursor: 1 }),
+  { kind: 'history', query: 'ab', cursor: 1, focus: 3 },
+)
+check(
+  'T5b edit ignored outside history',
+  reduce({ kind: 'search' }, { type: 'history-edit', query: 'x' }),
+  { kind: 'search' },
+)
+
+// --- T6: workspace-flow sub-state ----------------------------------------
+const flow = { kind: 'choices', title: 't', choices: [] } as never
+const flowState: ChatOverlay = { kind: 'workspace-flow', flow, index: 0, busy: false, input: null }
+check('T6a flow-busy applies', reduce(flowState, { type: 'flow-busy', busy: true }), { ...flowState, busy: true })
+check('T6b flow-busy ignored elsewhere', reduce({ kind: 'tips' }, { type: 'flow-busy', busy: true }), { kind: 'tips' })
+const flowInput = { choiceId: 'c', value: 'ab', cursor: 2 }
+check('T6c flow-input enters editing', reduce(flowState, { type: 'flow-input', input: flowInput }), { ...flowState, input: flowInput })
+check(
+  'T6d flow-input-edit rewrites value+cursor',
+  reduce({ ...flowState, input: flowInput }, { type: 'flow-input-edit', value: 'a', cursor: 1 }),
+  { ...flowState, input: { choiceId: 'c', value: 'a', cursor: 1 } },
+)
+check('T6e flow-input-edit without an input is a no-op', reduce(flowState, { type: 'flow-input-edit', value: 'a', cursor: 1 }), flowState)
+
+// --- T7: rewind three-stage flow -----------------------------------------
+const rewindList: ChatOverlay = { kind: 'rewind', index: 1, confirm: null, modes: null, modeIndex: 0, busy: false }
+check('T7a list move targets the candidate cursor', reduce(rewindList, { type: 'move', delta: 1, count: 3 }), { ...rewindList, index: 2 })
+check('T7b busy set', reduce(rewindList, { type: 'rewind-busy', busy: true }), { ...rewindList, busy: true })
+const modes = [{ id: 'files', label: 'files' }] as never
+check(
+  'T7c decision lands: busy clears, confirm+modes set, modeIndex reset',
+  reduce({ ...rewindList, busy: true }, { type: 'rewind-decision', confirm: fakeRow, modes }),
+  { ...rewindList, busy: false, confirm: fakeRow, modes, modeIndex: 0 },
+)
+check(
+  'T7d move in the modes pane targets modeIndex, not the list index',
+  reduce({ ...rewindList, confirm: fakeRow, modes }, { type: 'move', delta: 1, count: 2 }),
+  { ...rewindList, confirm: fakeRow, modes, modeIndex: 1 },
+)
+check(
+  'T7e move on the plain confirm pane is a no-op (Enter/Esc only)',
+  reduce({ ...rewindList, confirm: fakeRow }, { type: 'move', delta: 1, count: 3 }),
+  { ...rewindList, confirm: fakeRow },
+)
+check(
+  // Boolean-era parity: Esc from the modes pane cleared confirm+modes but
+  // left modeIndex as-is — the next rewind-decision resets it to 0.
+  'T7f rewind-back returns to the list; modeIndex stays until the next decision',
+  reduce({ ...rewindList, confirm: fakeRow, modes, modeIndex: 1 }, { type: 'rewind-back' }),
+  { ...rewindList, modeIndex: 1 },
+)
+check('T7g decision ignored outside rewind', reduce({ kind: 'tips' }, { type: 'rewind-decision', confirm: fakeRow, modes: null }), { kind: 'tips' })
+
+// --- T8: dialogOverlayVisible parity with the boolean-era aggregate ------
+const gates = { workspaceTargetCount: 0, effortOptionCount: 0, presetOptionCount: 0 }
+const loaded = { workspaceTargetCount: 2, effortOptionCount: 3, presetOptionCount: 2 }
+check('T8a none never mounts', dialogOverlayVisible(NO_OVERLAY, loaded), false)
+check('T8b plain picker mounts', dialogOverlayVisible({ kind: 'model', index: 0 }, gates), true)
+check('T8c workspace picker gated on targets', [
+  dialogOverlayVisible({ kind: 'workspace-picker', index: 0 }, gates),
+  dialogOverlayVisible({ kind: 'workspace-picker', index: 0 }, loaded),
+], [false, true])
+check('T8d effort gated on >1 options', [
+  dialogOverlayVisible({ kind: 'effort', index: 0 }, { ...loaded, effortOptionCount: 1 }),
+  dialogOverlayVisible({ kind: 'effort', index: 0 }, loaded),
+], [false, true])
+check('T8e preset gated on >0 options', [
+  dialogOverlayVisible({ kind: 'preset', index: 0 }, gates),
+  dialogOverlayVisible({ kind: 'preset', index: 0 }, loaded),
+], [false, true])
+// Boolean-era quirk preserved verbatim: /tips mounts the (empty) wrapper.
+check('T8f tips still counts as overlay-open', dialogOverlayVisible({ kind: 'tips' }, gates), true)
+check('T8g search mounts the bar', dialogOverlayVisible({ kind: 'search' }, gates), true)
+
+if (failures > 0) {
+  console.error(`\n${failures} failure(s)`)
+  process.exit(1)
+}
+console.log('\nverify-chat-overlay: all checks passed')

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -73,6 +73,13 @@ import { LoadingState } from '../components/design-system/LoadingState.js'
 import { Pane } from '../components/design-system/Pane.js'
 import { loadHistory, type HistoryEntry } from '../history.js'
 import { formatLoadedContextReport } from '../utils/loaded-context.js'
+import {
+  NO_OVERLAY,
+  chatOverlayReducer,
+  dialogOverlayVisible,
+  wrapIndex,
+  type WorkspaceFlowInput,
+} from './chatOverlay.js'
 
 /** Shared empty snapshot for hosts whose channel has no event log. */
 const NO_EVENTS: readonly SessionEvent[] = []
@@ -301,13 +308,20 @@ export function Chat({
   const [streamFoldedRows, setStreamFoldedRows] = React.useState<ReadonlySet<number>>(
     () => new Set(),
   )
-  const [modelPickerOpen, setModelPickerOpen] = React.useState(false)
+  /**
+   * The transient-dialog layer (every picker/dialog `<OverlayAbove>` hosts,
+   * plus /tips) as ONE value: mutual exclusion between the panels is
+   * structural instead of emerging from "an open picker makes the prompt
+   * inert". Transitions live in the pure reducer (chatOverlay.ts), which
+   * scripts/verify-chat-overlay.ts pins without a renderer. Async data the
+   * pickers show (model list, preset roster, …) stays in the caches below —
+   * it persists across open/close so a reopened picker paints the previous
+   * list while the fresh one loads, exactly as the boolean era did.
+   */
+  const [overlay, dispatchOverlay] = React.useReducer(chatOverlayReducer, NO_OVERLAY)
   const [models, setModels] = React.useState<readonly LlmModelInfo[]>([])
-  const [modelIndex, setModelIndex] = React.useState(0)
   /** `/skills` 技能目录（issue #204）：null = 注册表快照在途。 */
-  const [skillsPickerOpen, setSkillsPickerOpen] = React.useState(false)
   const [skillsList, setSkillsList] = React.useState<readonly SkillInfo[] | null>(null)
-  const [skillsIndex, setSkillsIndex] = React.useState(0)
   /** `/resume` opens the session browser, a screen rather than a panel. It
    *  owns its own selection, filters and keyboard — Chat only opens it. */
   const [browserOpen, setBrowserOpen] = React.useState(false)
@@ -315,74 +329,22 @@ export function Chat({
    *  browser, a screen rather than a panel: it owns its own focus, staged
    *  drafts and keyboard; Chat only opens it. */
   const [settingsOpen, setSettingsOpen] = React.useState(false)
-  const [workspacePickerOpen, setWorkspacePickerOpen] = React.useState(false)
   const [workspaceTargets, setWorkspaceTargets] = React.useState<readonly TuiWorkspaceTarget[]>([])
-  const [workspaceIndex, setWorkspaceIndex] = React.useState(0)
-  /** Bare `/workspace` action menu (resume / rename / open + extensions). */
-  const [workspaceMenuOpen, setWorkspaceMenuOpen] = React.useState(false)
-  const [workspaceMenuIndex, setWorkspaceMenuIndex] = React.useState(0)
-  const [workspaceFlow, setWorkspaceFlow] = React.useState<Extract<TuiWorkspaceCommandResult, { kind: 'choices' }> | null>(null)
-  const [workspaceFlowIndex, setWorkspaceFlowIndex] = React.useState(0)
-  const [workspaceFlowBusy, setWorkspaceFlowBusy] = React.useState(false)
-  const [workspaceFlowInput, setWorkspaceFlowInput] = React.useState<{
-    choiceId: string
-    value: string
-    cursor: number
-    placeholder?: string
-  } | null>(null)
   const workspaceFlowRequestRef = React.useRef(0)
   const workspaceFlowAbortRef = React.useRef<AbortController | null>(null)
-  /** `/activity` indicator picker (pi extension's interactive select). */
-  const [activityPickerOpen, setActivityPickerOpen] = React.useState(false)
-  const [activityIndex, setActivityIndex] = React.useState(0)
-  /** `/preset` agent-preset picker (issue #8): roster list loads async. */
-  const [presetPickerOpen, setPresetPickerOpen] = React.useState(false)
+  /** `/preset` agent-preset roster (issue #8): loads async, persists. */
   const [presetOptions, setPresetOptions] = React.useState<readonly PresetOption[]>([])
-  const [presetIndex, setPresetIndex] = React.useState(0)
-  /** `/effort` rheostat slider: adapter levels load async, focus moves ←/→. */
-  const [effortSliderOpen, setEffortSliderOpen] = React.useState(false)
+  /** `/effort` adapter levels: load async before the slider opens. */
   const [effortOptions, setEffortOptions] = React.useState<readonly EffortOption[]>([])
-  const [effortIndex, setEffortIndex] = React.useState(0)
-  /** `/theme` color-theme picker (built-ins + ~/.dsh-tui/themes user themes). */
-  const [themePickerOpen, setThemePickerOpen] = React.useState(false)
-  const [themeIndex, setThemeIndex] = React.useState(0)
-  /** `/permission` sandbox-preset picker (the command itself is registered
-   *  by dsh-sandbox-policy; bare `/permission` opens this picker). */
-  const [permissionPickerOpen, setPermissionPickerOpen] = React.useState(false)
-  const [permissionIndex, setPermissionIndex] = React.useState(0)
-  /** `/plan` on/off picker (registered by dsh-plan-mode; bare `/plan` opens
-   *  this picker instead of toggling blindly). */
-  const [planPickerOpen, setPlanPickerOpen] = React.useState(false)
-  const [planIndex, setPlanIndex] = React.useState(0)
-  /** `/lang` en/zh picker (bare `/lang` opens this picker). */
-  const [langPickerOpen, setLangPickerOpen] = React.useState(false)
-  const [langIndex, setLangIndex] = React.useState(0)
   const [themeName, setTheme] = useTheme()
   const { rows: terminalRows } = useTerminalSize()
   const [showAllMessages, setShowAllMessages] = React.useState(false)
   /** Fold state for the GoalTodoPanel todo section (ctrl/cmd+q or click). */
   const [todoCollapsed, setTodoCollapsed] = React.useState(false)
   const [thinkingVisible, setThinkingVisible] = React.useState(true)
-  const [thinkingOpen, setThinkingOpen] = React.useState(false)
-  const [thinkingFocus, setThinkingFocus] = React.useState(0)
-  /** ctrl+r history search dialog (ported from CC's HistorySearchDialog). */
-  const [historyOpen, setHistoryOpen] = React.useState(false)
-  const [historyQuery, setHistoryQuery] = React.useState('')
-  const [historyCursor, setHistoryCursor] = React.useState(0)
-  const [historyFocus, setHistoryFocus] = React.useState(0)
+  /** ctrl+r history-search entries (loaded on open, persists). */
   const [historyEntries, setHistoryEntries] = React.useState<readonly HistoryEntry[]>([])
   const [historyFill, setHistoryFill] = React.useState<string | null>(null)
-  /** Double-Esc rewind picker (CC rewind): open state + focused row + confirm. */
-  const [rewindOpen, setRewindOpen] = React.useState(false)
-  const [rewindIndex, setRewindIndex] = React.useState(0)
-  const [rewindConfirm, setRewindConfirm] = React.useState<ChatRow | null>(null)
-  /** Plugin rewind modes (tui/rewind-prompt seam): extra choices offered in
-   *  the confirm pane; null = the plain conversation-only confirm. */
-  const [rewindModes, setRewindModes] = React.useState<readonly TuiRewindMode[] | null>(null)
-  const [rewindModeIndex, setRewindModeIndex] = React.useState(0)
-  /** True while the tui/rewind-prompt decision is in flight (a plugin may be
-   *  showing its own dialog); keys except Esc are swallowed meanwhile. */
-  const [rewindBusy, setRewindBusy] = React.useState(false)
   /** Monotonic token: only the latest rewind decision may land (a slow
    *  plugin answering after the user moved on must not open a confirm for
    *  a row they are no longer looking at). */
@@ -396,8 +358,6 @@ export function Chat({
     btwAbortRef.current = null
     setBtw(null)
   }
-  /** /tips usage-tips overlay: pure UI state, no session side effects. */
-  const [tipsOpen, setTipsOpen] = React.useState(false)
   /** Subagent dashboard (Ctrl+A): displays active/completed subagents. */
   const [subagentDashboardOpen, setSubagentDashboardOpen] = React.useState(false)
   /** Detail view for a specific subagent (opened from dashboard). */
@@ -452,8 +412,10 @@ export function Chat({
     ink?.invalidatePrevFrame()
     ink?.reanchorViewport()
   }, [])
-  /** `/` transcript search (less-style incsearch, ported from CC's REPL). */
-  const [searchOpen, setSearchOpen] = React.useState(false)
+  /** `/` transcript search (less-style incsearch, ported from CC's REPL).
+   *  Only the bar's open/closed mode lives in `overlay`; the query and match
+   *  counters persist past the bar closing so n/N keep walking the matches. */
+  const searchActive = overlay.kind === 'search'
   const [searchQuery, setSearchQuery] = React.useState('')
   const [searchCursor, setSearchCursor] = React.useState(0)
   const [searchCount, setSearchCount] = React.useState(0)
@@ -564,20 +526,20 @@ export function Chat({
 
   const handleWorkspaceResult = (result: TuiWorkspaceCommandResult): void => {
     workspaceFlowAbortRef.current = null
-    setWorkspaceFlowBusy(false)
-    setWorkspaceFlowInput(null)
     if (result.kind === 'target') {
-      setWorkspaceFlow(null)
+      dispatchOverlay({ type: 'close-if', kind: 'workspace-flow' })
       void channel.switchWorkspace(result.target)
       return
     }
     if (result.choices.length === 0) {
-      setWorkspaceFlow(null)
+      dispatchOverlay({ type: 'close-if', kind: 'workspace-flow' })
       channel.notify(t('workspace-command-empty'))
       return
     }
-    setWorkspaceFlow(result)
-    setWorkspaceFlowIndex(0)
+    dispatchOverlay({
+      type: 'open',
+      overlay: { kind: 'workspace-flow', flow: result, index: 0, busy: false, input: null },
+    })
   }
 
   const runWorkspaceFlowAction = (
@@ -586,7 +548,7 @@ export function Chat({
     const request = ++workspaceFlowRequestRef.current
     const controller = new AbortController()
     workspaceFlowAbortRef.current = controller
-    setWorkspaceFlowBusy(true)
+    dispatchOverlay({ type: 'flow-busy', busy: true })
     void Promise.resolve()
       .then(() => action(controller.signal))
       .then((result) => {
@@ -595,7 +557,7 @@ export function Chat({
       .catch((error: unknown) => {
         if (request !== workspaceFlowRequestRef.current) return
         workspaceFlowAbortRef.current = null
-        setWorkspaceFlowBusy(false)
+        dispatchOverlay({ type: 'flow-busy', busy: false })
         channel.notify(
           t('workspace-command-failed', { err: error instanceof Error ? error.message : String(error) }),
           { color: 'error', timeoutMs: 8000 },
@@ -641,8 +603,13 @@ export function Chat({
         return
       }
       setWorkspaceTargets(targets)
-      setWorkspaceIndex(Math.max(0, targets.findIndex(target => target.cwd === channel.cwd)))
-      setWorkspacePickerOpen(true)
+      dispatchOverlay({
+        type: 'open',
+        overlay: {
+          kind: 'workspace-picker',
+          index: Math.max(0, targets.findIndex(target => target.cwd === channel.cwd)),
+        },
+      })
     }).catch((error: unknown) => {
       channel.notify(
         t('workspace-list-failed', { err: error instanceof Error ? error.message : String(error) }),
@@ -656,7 +623,7 @@ export function Chat({
    * built-ins dispatch locally, extension commands go through the channel.
    */
   const runWorkspaceMenuOption = (option: { id: string } | undefined): void => {
-    setWorkspaceMenuOpen(false)
+    dispatchOverlay({ type: 'close-if', kind: 'workspace-menu' })
     if (option === undefined) return
     if (option.id === 'resume') {
       openWorkspaceResume()
@@ -751,8 +718,13 @@ export function Chat({
           return true
         }
         setHelpOpen(false)
-        setActivityIndex(Math.max(0, PRESET_NAMES.indexOf(channel.activityFrames ?? 'random')))
-        setActivityPickerOpen(true)
+        dispatchOverlay({
+          type: 'open',
+          overlay: {
+            kind: 'activity',
+            index: Math.max(0, PRESET_NAMES.indexOf(channel.activityFrames ?? 'random')),
+          },
+        })
         return true
       }
       case 'preset': {
@@ -779,16 +751,26 @@ export function Chat({
           return true
         }
         setHelpOpen(false)
-        setPresetPickerOpen(true)
+        // The picker opens immediately over the cached roster (no loading
+        // pane — deliberate contrast with /model); the fresh list lands with
+        // the authoritative focus. Both loader writes are kind-guarded, so a
+        // picker the user already left is not resurrected or re-focused.
+        dispatchOverlay({
+          type: 'open',
+          overlay: {
+            kind: 'preset',
+            index: Math.max(0, presetOptions.findIndex(preset => preset.id === channel.agentPreset)),
+          },
+        })
         void channel.listPresets().then((list) => {
           if (list.length === 0) {
-            setPresetPickerOpen(false)
+            dispatchOverlay({ type: 'close-if', kind: 'preset' })
             channel.notify(t('preset-roster-unmounted'), { color: 'warning' })
             return
           }
           setPresetOptions(list)
           const index = list.findIndex(preset => preset.id === channel.agentPreset)
-          setPresetIndex(index >= 0 ? index : 0)
+          dispatchOverlay({ type: 'set-index', kind: 'preset', index: index >= 0 ? index : 0 })
         })
         return true
       }
@@ -818,8 +800,10 @@ export function Chat({
           setEffortOptions(efforts)
           const current = channel.reasoningEffort ?? defaultEffort
           const index = efforts.findIndex(effort => effort.id === current)
-          setEffortIndex(index >= 0 ? index : 0)
-          setEffortSliderOpen(true)
+          dispatchOverlay({
+            type: 'open',
+            overlay: { kind: 'effort', index: index >= 0 ? index : 0 },
+          })
         })
         return true
       }
@@ -849,8 +833,10 @@ export function Chat({
           return true
         }
         setHelpOpen(false)
-        setLangIndex(getLang() === 'zh' ? 0 : 1)
-        setLangPickerOpen(true)
+        dispatchOverlay({
+          type: 'open',
+          overlay: { kind: 'lang', index: getLang() === 'zh' ? 0 : 1 },
+        })
         return true
       }
       case 'theme': {
@@ -886,8 +872,13 @@ export function Chat({
           return true
         }
         setHelpOpen(false)
-        setThemeIndex(Math.max(0, getThemeOptions().findIndex(option => option.value === themeName)))
-        setThemePickerOpen(true)
+        dispatchOverlay({
+          type: 'open',
+          overlay: {
+            kind: 'theme',
+            index: Math.max(0, getThemeOptions().findIndex(option => option.value === themeName)),
+          },
+        })
         return true
       }
       case 'new': {
@@ -976,13 +967,24 @@ export function Chat({
           return true
         }
         setHelpOpen(false)
-        setModelPickerOpen(true)
+        // Opens over the cached catalog (empty cache shows the loading
+        // pane); the fresh list lands with the authoritative focus, and the
+        // kind-guarded set-index cannot re-focus a picker the user left.
+        dispatchOverlay({
+          type: 'open',
+          overlay: {
+            kind: 'model',
+            index: Math.max(0, models.findIndex(
+              model => model.provider === channel.provider && model.id === channel.model,
+            )),
+          },
+        })
         void channel.listModels().then((list) => {
           setModels(list)
           const index = list.findIndex(
             model => model.provider === channel.provider && model.id === channel.model,
           )
-          setModelIndex(index >= 0 ? index : 0)
+          dispatchOverlay({ type: 'set-index', kind: 'model', index: index >= 0 ? index : 0 })
         })
         return true
       }
@@ -1011,11 +1013,10 @@ export function Chat({
         }
         setHelpOpen(false)
         setSkillsList(null)
-        setSkillsIndex(0)
-        setSkillsPickerOpen(true)
+        dispatchOverlay({ type: 'open', overlay: { kind: 'skills', index: 0 } })
         void channel.listSkills().then((list) => {
           if (list === undefined) {
-            setSkillsPickerOpen(false)
+            dispatchOverlay({ type: 'close-if', kind: 'skills' })
             channel.notify(t('skills-load-failed'), { color: 'error' })
             return
           }
@@ -1048,8 +1049,10 @@ export function Chat({
       }
       case 'thinking':
         setHelpOpen(false)
-        setThinkingOpen(true)
-        setThinkingFocus(thinkingVisible ? 0 : 1)
+        dispatchOverlay({
+          type: 'open',
+          overlay: { kind: 'thinking', focus: thinkingVisible ? 0 : 1 },
+        })
         return true
       case 'tokens': {
         const usage = t('tokens-usage', { in: formatTokens(channel.tokens.input), out: formatTokens(channel.tokens.output) })
@@ -1081,8 +1084,7 @@ export function Chat({
         if (subcommand === '') {
           // Bare `/workspace` opens the action menu (resume / rename / open
           // plus any registered extensions) instead of a text usage line.
-          setWorkspaceMenuIndex(0)
-          setWorkspaceMenuOpen(true)
+          dispatchOverlay({ type: 'open', overlay: { kind: 'workspace-menu', index: 0 } })
         } else if (subcommand === 'resume') {
           openWorkspaceResume()
         } else if (subcommand === 'rename') {
@@ -1279,8 +1281,10 @@ export function Chat({
         if (mounted && parts.length === 0) {
           setHelpOpen(false)
           const index = (PERMISSION_PRESET_IDS as readonly string[]).indexOf(channel.mode.sandbox ?? '')
-          setPermissionIndex(index >= 0 ? index : 1)
-          setPermissionPickerOpen(true)
+          dispatchOverlay({
+            type: 'open',
+            overlay: { kind: 'permission', index: index >= 0 ? index : 1 },
+          })
           return true
         }
         if (mounted) {
@@ -1306,8 +1310,10 @@ export function Chat({
         const parts = rawInput.trim().split(/\s+/).filter(Boolean)
         if (mounted && parts.length === 0) {
           setHelpOpen(false)
-          setPlanIndex(channel.mode.plan === true ? 0 : 1)
-          setPlanPickerOpen(true)
+          dispatchOverlay({
+            type: 'open',
+            overlay: { kind: 'plan', index: channel.mode.plan === true ? 0 : 1 },
+          })
           return true
         }
         if (mounted) {
@@ -1398,7 +1404,7 @@ export function Chat({
       }
       case 'tips':
         setHelpOpen(false)
-        setTipsOpen(true)
+        dispatchOverlay({ type: 'open', overlay: { kind: 'tips' } })
         return true
       case 'connect':
         setHelpOpen(false)
@@ -1454,6 +1460,9 @@ export function Chat({
     : NO_ROWS
 
   // ctrl+r history search: substring match on the query, newest first.
+  // The draft lives in the overlay variant; the derived '' while closed
+  // keeps the memo inputs stable (nothing renders the matches then).
+  const historyQuery = overlay.kind === 'history' ? overlay.query : ''
   const historyMatches = React.useMemo(() => {
     const q = historyQuery.trim().toLowerCase()
     return q ? historyEntries.filter(e => e.text.toLowerCase().includes(q)) : historyEntries
@@ -1463,15 +1472,15 @@ export function Chat({
   // selectable user turns; steering side-questions are excluded). Computed
   // per render while the picker is open — `channel.rows` is a live in-place
   // array (see selectableRows).
-  const rewindRows = rewindOpen
+  const rewindRows = overlay.kind === 'rewind'
     ? channel.rows
       .filter(row => row.kind === 'user' && row.label === undefined)
       .reverse()
     : NO_ROWS
   /** Open the rewind picker (from PromptInput's double-Esc on an empty input). */
   const openRewind = () => {
-    // rewindOpen is still false this render, so rewindRows is empty — scan
-    // directly instead of reading the gated list.
+    // The overlay is not 'rewind' yet this render, so rewindRows is empty —
+    // scan directly instead of reading the gated list.
     const candidates = channel.rows
       .filter(row => row.kind === 'user' && row.label === undefined)
       .reverse()
@@ -1479,12 +1488,11 @@ export function Chat({
       channel.notify(t('rewind-none'))
       return
     }
-    setRewindIndex(0)
-    setRewindConfirm(null)
-    setRewindModes(null)
-    setRewindBusy(false)
     rewindRequestRef.current += 1
-    setRewindOpen(true)
+    dispatchOverlay({
+      type: 'open',
+      overlay: { kind: 'rewind', index: 0, confirm: null, modes: null, modeIndex: 0, busy: false },
+    })
   }
   /**
    * Enter on a rewind candidate: ask the plugins first (tui/rewind-prompt).
@@ -1493,14 +1501,14 @@ export function Chat({
    */
   const requestRewindConfirm = async (row: ChatRow) => {
     const token = ++rewindRequestRef.current
-    setRewindBusy(true)
+    dispatchOverlay({ type: 'rewind-busy', busy: true })
     const decision = await channel.promptRewind(row)
     if (token !== rewindRequestRef.current) return
-    setRewindBusy(false)
-    if (decision === 'cancel') return
-    setRewindConfirm(row)
-    setRewindModes(decision?.modes ?? null)
-    setRewindModeIndex(0)
+    if (decision === 'cancel') {
+      dispatchOverlay({ type: 'rewind-busy', busy: false })
+      return
+    }
+    dispatchOverlay({ type: 'rewind-decision', confirm: row, modes: decision?.modes ?? null })
   }
   /** Execute the confirmed rewind; the message comes back into the input. */
   const performRewind = async (row: ChatRow, mode: string | null = null) => {
@@ -1623,7 +1631,7 @@ export function Chat({
   // Incsearch: highlight all matches (screen-space overlay) and keep the
   // current match row in view as the query changes (CC semantics).
   React.useEffect(() => {
-    if (!searchOpen) return
+    if (!searchActive) return
     setHighlight(searchQuery)
     const count = searchMatches.length
     setSearchCount(count)
@@ -1634,11 +1642,11 @@ export function Chat({
     if (target) {
       seekRow(target.row.id)
     }
-  }, [searchQuery, searchOpen])
+  }, [searchQuery, searchActive])
 
   // n/N navigation: move the current match into view.
   React.useEffect(() => {
-    if (!searchOpen) return
+    if (!searchActive) return
     const target = searchMatches[searchCurrent]
     // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: out-of-range index on an empty/filtered list
     if (target) {
@@ -1724,14 +1732,13 @@ export function Chat({
     // them, so this is a no-op there.
     if (key.wheelUp || key.wheelDown) {
       if (helpOpen) return
-      const overlayOpen =
-        thinkingOpen || searchOpen || historyOpen || rewindOpen || tipsOpen ||
-        modelPickerOpen || skillsPickerOpen || themePickerOpen ||
-        langPickerOpen || planPickerOpen || permissionPickerOpen ||
-        activityPickerOpen || presetPickerOpen || effortSliderOpen ||
-        workspaceMenuOpen || workspaceFlow !== null ||
-        (workspacePickerOpen && workspaceTargets.length > 0)
-      if (overlayOpen) return
+      // Any open transient dialog is modal to the wheel; the one exception
+      // mirrors the render gate — a workspace picker whose target list has
+      // not landed paints nothing, so wheel-through keeps scrolling.
+      const overlayModal =
+        overlay.kind !== 'none' &&
+        (overlay.kind !== 'workspace-picker' || workspaceTargets.length > 0)
+      if (overlayModal) return
       handle?.scrollBy(key.wheelUp ? -3 : 3)
       event.stopImmediatePropagation()
       return
@@ -1758,17 +1765,17 @@ export function Chat({
       event.stopImmediatePropagation()
       return
     }
-    if (searchOpen) {
+    if (overlay.kind === 'search') {
       // Transcript search bar (less-style): edit the query, Enter commits
       // (query persists for n/N), Esc/ctrl+c cancels back to the anchor.
       if (key.escape || (key.ctrl && input === 'c')) {
-        setSearchOpen(false)
+        dispatchOverlay({ type: 'close' })
         setHighlight('')
         handle?.scrollTo(searchAnchorRef.current)
       } else if (plainReturn) {
         // Enter commits; 0-match junk queries don't persist (CC behavior).
         if (searchCount === 0) setSearchQuery('')
-        setSearchOpen(false)
+        dispatchOverlay({ type: 'close' })
       } else if (key.backspace) {
         if (searchCursor > 0) {
           setSearchQuery(searchQuery.slice(0, searchCursor - 1) + searchQuery.slice(searchCursor))
@@ -1807,265 +1814,250 @@ export function Chat({
       event.stopImmediatePropagation()
       return
     }
-    if (thinkingOpen) {
+    if (overlay.kind === 'thinking') {
       if (key.upArrow || key.downArrow) {
-        setThinkingFocus(index => (index === 0 ? 1 : 0))
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: 2 })
       } else if (plainReturn) {
-        const visible = thinkingFocus === 0
+        const visible = overlay.focus === 0
         setThinkingVisible(visible)
-        setThinkingOpen(false)
+        dispatchOverlay({ type: 'close' })
         channel.notify(t('thinking-toggled', { state: visible ? t('thinking-on') : t('thinking-off') }))
       } else if (key.escape) {
-        setThinkingOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (workspaceFlow !== null) {
+    if (overlay.kind === 'workspace-flow') {
+      const { flow, busy, input: flowInput } = overlay
       if (key.escape) {
-        if (workspaceFlowInput !== null && !workspaceFlowBusy) {
-          setWorkspaceFlowInput(null)
+        if (flowInput !== null && !busy) {
+          dispatchOverlay({ type: 'flow-input', input: null })
           return
         }
         workspaceFlowAbortRef.current?.abort()
         workspaceFlowAbortRef.current = null
         workspaceFlowRequestRef.current += 1
-        setWorkspaceFlowBusy(false)
-        setWorkspaceFlow(null)
+        dispatchOverlay({ type: 'close' })
         return
       }
-      if (workspaceFlowBusy) return
-      if (workspaceFlowInput !== null) {
-        const choice = workspaceFlow.choices.find(candidate => candidate.id === workspaceFlowInput.choiceId)
+      if (busy) return
+      if (flowInput !== null) {
+        const choice = flow.choices.find(candidate => candidate.id === flowInput.choiceId)
         const editor = choice?.input
         if (plainReturn) {
-          const value = workspaceFlowInput.value.trim()
+          const value = flowInput.value.trim()
           if (value.length === 0) {
             channel.notify(t('workspace-flow-input-empty'), { color: 'warning' })
           } else if (editor !== undefined) {
             runWorkspaceFlowAction(signal => editor.submit(value, signal))
           }
-        } else if (key.backspace && workspaceFlowInput.cursor > 0) {
-          setWorkspaceFlowInput(current => current === null ? null : {
-            ...current,
-            value: current.value.slice(0, current.cursor - 1) + current.value.slice(current.cursor),
-            cursor: current.cursor - 1,
+        } else if (key.backspace && flowInput.cursor > 0) {
+          dispatchOverlay({
+            type: 'flow-input-edit',
+            value: flowInput.value.slice(0, flowInput.cursor - 1) + flowInput.value.slice(flowInput.cursor),
+            cursor: flowInput.cursor - 1,
           })
-        } else if (key.delete && workspaceFlowInput.cursor < workspaceFlowInput.value.length) {
-          setWorkspaceFlowInput(current => current === null ? null : {
-            ...current,
-            value: current.value.slice(0, current.cursor) + current.value.slice(current.cursor + 1),
+        } else if (key.delete && flowInput.cursor < flowInput.value.length) {
+          dispatchOverlay({
+            type: 'flow-input-edit',
+            value: flowInput.value.slice(0, flowInput.cursor) + flowInput.value.slice(flowInput.cursor + 1),
+            cursor: flowInput.cursor,
           })
         } else if (key.leftArrow) {
-          setWorkspaceFlowInput(current => current === null ? null : {
-            ...current,
-            cursor: Math.max(0, current.cursor - 1),
+          dispatchOverlay({
+            type: 'flow-input-edit',
+            value: flowInput.value,
+            cursor: Math.max(0, flowInput.cursor - 1),
           })
         } else if (key.rightArrow) {
-          setWorkspaceFlowInput(current => current === null ? null : {
-            ...current,
-            cursor: Math.min(current.value.length, current.cursor + 1),
+          dispatchOverlay({
+            type: 'flow-input-edit',
+            value: flowInput.value,
+            cursor: Math.min(flowInput.value.length, flowInput.cursor + 1),
           })
         } else if (input.length > 0 && !key.ctrl && !key.meta && !key.super && !key.tab) {
-          setWorkspaceFlowInput(current => current === null ? null : {
-            ...current,
-            value: current.value.slice(0, current.cursor) + input + current.value.slice(current.cursor),
-            cursor: current.cursor + input.length,
+          dispatchOverlay({
+            type: 'flow-input-edit',
+            value: flowInput.value.slice(0, flowInput.cursor) + input + flowInput.value.slice(flowInput.cursor),
+            cursor: flowInput.cursor + input.length,
           })
         }
         return
       }
-      if (key.upArrow) {
-        setWorkspaceFlowIndex(index => (index <= 0 ? workspaceFlow.choices.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setWorkspaceFlowIndex(index => (index >= workspaceFlow.choices.length - 1 ? 0 : index + 1))
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: flow.choices.length })
       } else if (key.tab && !key.shift) {
-        const choice = workspaceFlow.choices[workspaceFlowIndex]
+        const choice = flow.choices[overlay.index]
         if (choice?.input !== undefined) {
           const value = choice.input.initialValue ?? ''
-          setWorkspaceFlowInput({
+          const flowInputNext: WorkspaceFlowInput = {
             choiceId: choice.id,
             value,
             cursor: value.length,
             ...(choice.input.placeholder === undefined ? {} : { placeholder: choice.input.placeholder }),
-          })
+          }
+          dispatchOverlay({ type: 'flow-input', input: flowInputNext })
         }
       } else if (plainReturn) {
-        const choice = workspaceFlow.choices[workspaceFlowIndex]
+        const choice = flow.choices[overlay.index]
         if (choice !== undefined) {
           runWorkspaceFlowAction(signal => choice.choose(signal))
         }
       }
       return
     }
-    if (workspacePickerOpen) {
-      if (key.upArrow) {
-        setWorkspaceIndex(index => (index <= 0 ? workspaceTargets.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setWorkspaceIndex(index => (index >= workspaceTargets.length - 1 ? 0 : index + 1))
+    if (overlay.kind === 'workspace-picker') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: workspaceTargets.length })
       } else if (plainReturn) {
-        const target = workspaceTargets[workspaceIndex]
-        setWorkspacePickerOpen(false)
+        const target = workspaceTargets[overlay.index]
+        dispatchOverlay({ type: 'close' })
         if (target !== undefined) void channel.switchWorkspace(target)
       } else if (key.escape) {
-        setWorkspacePickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (workspaceMenuOpen) {
+    if (overlay.kind === 'workspace-menu') {
       const menu = workspaceMenuOptions
-      if (key.upArrow) {
-        setWorkspaceMenuIndex(index => (index <= 0 ? menu.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setWorkspaceMenuIndex(index => (index >= menu.length - 1 ? 0 : index + 1))
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: menu.length })
       } else if (plainReturn) {
-        const option = menu[workspaceMenuIndex]
+        const option = menu[overlay.index]
         runWorkspaceMenuOption(option)
       } else if (key.escape) {
-        setWorkspaceMenuOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (modelPickerOpen) {
-      if (key.upArrow) {
-        setModelIndex(index => (index <= 0 ? models.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setModelIndex(index => (index >= models.length - 1 ? 0 : index + 1))
+    if (overlay.kind === 'model') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: models.length })
       } else if (plainReturn) {
-        const model = models[modelIndex]
+        const model = models[overlay.index]
         // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: out-of-range index on an empty list
         if (model) {
           // Enter switches the live model right away: the conversation is
           // forked at its end and continued with an agent routed to the new
           // model (history replays unchanged).
-          setModelPickerOpen(false)
+          dispatchOverlay({ type: 'close' })
           channel.notify(t('model-switching', { name: model.name }))
           void channel.switchModel(model.provider, model.id).then((ok) => {
             if (ok) channel.notify(t('model-switched', { name: model.name }))
           })
         } else {
-          setModelPickerOpen(false)
+          dispatchOverlay({ type: 'close' })
         }
       } else if (key.escape) {
-        setModelPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (skillsPickerOpen) {
+    if (overlay.kind === 'skills') {
       const list = skillsList ?? []
-      if (key.upArrow) {
-        if (list.length > 0) setSkillsIndex(index => (index <= 0 ? list.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        if (list.length > 0) setSkillsIndex(index => (index >= list.length - 1 ? 0 : index + 1))
+      if (key.upArrow || key.downArrow) {
+        // count 0 (snapshot still loading) is a no-op inside the reducer.
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: list.length })
       } else if (plainReturn) {
-        const skill = list[skillsIndex]
-        setSkillsPickerOpen(false)
+        const skill = list[overlay.index]
+        dispatchOverlay({ type: 'close' })
         // 可直调技能 Enter 填入 `/name `——与 / 菜单选中技能同一条
         // completion-only 分发路径；模型专用技能（userInvocable=false）只关闭。
         // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: out-of-range index on an empty list
         if (skill?.userInvocable) setHistoryFill(`/${skill.name} `)
       } else if (key.escape) {
-        setSkillsPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (activityPickerOpen) {
-      if (key.upArrow) {
-        setActivityIndex(index => (index <= 0 ? PRESET_NAMES.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setActivityIndex(index => (index >= PRESET_NAMES.length - 1 ? 0 : index + 1))
+    if (overlay.kind === 'activity') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: PRESET_NAMES.length })
       } else if (plainReturn) {
-        const name = PRESET_NAMES[activityIndex]
-        setActivityPickerOpen(false)
+        const name = PRESET_NAMES[overlay.index]
+        dispatchOverlay({ type: 'close' })
         if (name) channel.setActivityFrames(name)
       } else if (key.escape) {
-        setActivityPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (effortSliderOpen) {
+    if (overlay.kind === 'effort') {
       if (key.leftArrow || key.rightArrow) {
         const delta = key.leftArrow ? -1 : 1
-        const next = (effortIndex + delta + effortOptions.length) % effortOptions.length
-        setEffortIndex(next)
+        // The same wrap rule the reducer applies — computed here too so the
+        // newly focused level is applied in this very keystroke.
+        const next = wrapIndex(overlay.index, delta, effortOptions.length)
+        dispatchOverlay({ type: 'move', delta, count: effortOptions.length })
         const option = effortOptions[next]
         // Live-apply: the slider IS the control; Esc does not revert.
         if (option) void channel.setEffort(option.id)
       } else if (plainReturn || key.escape) {
-        setEffortSliderOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (presetPickerOpen) {
-      if (key.upArrow) {
-        setPresetIndex(index => (index <= 0 ? presetOptions.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setPresetIndex(index => (index >= presetOptions.length - 1 ? 0 : index + 1))
+    if (overlay.kind === 'preset') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: presetOptions.length })
       } else if (plainReturn) {
-        const option = presetOptions[presetIndex]
-        setPresetPickerOpen(false)
+        const option = presetOptions[overlay.index]
+        dispatchOverlay({ type: 'close' })
         if (option) void channel.switchPreset(option.id)
       } else if (key.escape) {
-        setPresetPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (permissionPickerOpen) {
-      if (key.upArrow) {
-        setPermissionIndex(index => (index <= 0 ? PERMISSION_PRESET_IDS.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setPermissionIndex(index => (index >= PERMISSION_PRESET_IDS.length - 1 ? 0 : index + 1))
+    if (overlay.kind === 'permission') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: PERMISSION_PRESET_IDS.length })
       } else if (plainReturn) {
-        const id = PERMISSION_PRESET_IDS[permissionIndex]
-        setPermissionPickerOpen(false)
+        const id = PERMISSION_PRESET_IDS[overlay.index]
+        dispatchOverlay({ type: 'close' })
         if (id !== undefined) {
           void channel.runExternalCommand('permission', ` ${id}`).then((text) => {
             if (text !== undefined && text !== '') channel.notify(text)
           })
         }
       } else if (key.escape) {
-        setPermissionPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (planPickerOpen) {
-      if (key.upArrow) {
-        setPlanIndex(index => (index <= 0 ? 1 : 0))
-      } else if (key.downArrow) {
-        setPlanIndex(index => (index >= 1 ? 0 : index + 1))
+    if (overlay.kind === 'plan') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: 2 })
       } else if (plainReturn) {
-        const on = planIndex === 0
-        setPlanPickerOpen(false)
+        const on = overlay.index === 0
+        dispatchOverlay({ type: 'close' })
         void channel.runExternalCommand('plan', on ? '' : ' off').then((text) => {
           if (text !== undefined && text !== '') channel.notify(text)
         })
       } else if (key.escape) {
-        setPlanPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (langPickerOpen) {
-      if (key.upArrow) {
-        setLangIndex(index => (index <= 0 ? 1 : 0))
-      } else if (key.downArrow) {
-        setLangIndex(index => (index >= 1 ? 0 : index + 1))
+    if (overlay.kind === 'lang') {
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: 2 })
       } else if (plainReturn) {
-        const lang = LANGS[langIndex]
-        setLangPickerOpen(false)
+        const lang = LANGS[overlay.index]
+        dispatchOverlay({ type: 'close' })
         if (lang !== undefined) applyLang(lang)
       } else if (key.escape) {
-        setLangPickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (themePickerOpen) {
+    if (overlay.kind === 'theme') {
       const options = getThemeOptions()
-      if (key.upArrow) {
-        setThemeIndex(index => (index <= 0 ? options.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setThemeIndex(index => (index >= options.length - 1 ? 0 : index + 1))
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: options.length })
       } else if (plainReturn) {
-        setThemePickerOpen(false)
-        const name = options[themeIndex]?.value
+        dispatchOverlay({ type: 'close' })
+        const name = options[overlay.index]?.value
         if (name !== undefined) {
           const ok = setTheme(name)
           channel.notify(
@@ -2074,123 +2066,118 @@ export function Chat({
           )
         }
       } else if (key.escape) {
-        setThemePickerOpen(false)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
-    if (historyOpen) {
+    if (overlay.kind === 'history') {
+      const { query, cursor, focus } = overlay
       if (key.escape) {
-        setHistoryOpen(false)
+        dispatchOverlay({ type: 'close' })
       } else if (key.ctrl && (input === 'c' || input === 'd')) {
         // CC's history search cancels on ctrl+c/ctrl+d too.
-        setHistoryOpen(false)
+        dispatchOverlay({ type: 'close' })
       } else if (plainReturn) {
-        const entry = historyMatches[historyFocus]
+        const entry = historyMatches[focus]
         // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: out-of-range index on an empty match list
         if (entry) {
           setHistoryFill(entry.text)
-          setHistoryOpen(false)
+          dispatchOverlay({ type: 'close' })
         }
       } else if (key.upArrow) {
-        setHistoryFocus(index =>
-          historyMatches.length === 0 ? 0 : (index <= 0 ? historyMatches.length - 1 : index - 1),
-        )
+        if (historyMatches.length > 0) {
+          dispatchOverlay({ type: 'move', delta: -1, count: historyMatches.length })
+        }
       } else if (key.downArrow || (isMod(key) && input === 'r')) {
         // CC's historySearch:next — ↓ and repeat ctrl+r walk to the next match.
-        setHistoryFocus(index =>
-          historyMatches.length === 0 ? 0 : (index >= historyMatches.length - 1 ? 0 : index + 1),
-        )
+        if (historyMatches.length > 0) {
+          dispatchOverlay({ type: 'move', delta: 1, count: historyMatches.length })
+        }
       } else if (key.backspace) {
-        if (historyCursor > 0) {
-          const next = historyQuery.slice(0, historyCursor - 1) + historyQuery.slice(historyCursor)
-          setHistoryQuery(next)
-          setHistoryCursor(historyCursor - 1)
-          setHistoryFocus(0)
+        if (cursor > 0) {
+          dispatchOverlay({
+            type: 'history-edit',
+            query: query.slice(0, cursor - 1) + query.slice(cursor),
+            cursor: cursor - 1,
+            focus: 0,
+          })
         }
       } else if (key.delete) {
-        if (historyCursor < historyQuery.length) {
-          setHistoryQuery(historyQuery.slice(0, historyCursor) + historyQuery.slice(historyCursor + 1))
-          setHistoryFocus(0)
+        if (cursor < query.length) {
+          dispatchOverlay({
+            type: 'history-edit',
+            query: query.slice(0, cursor) + query.slice(cursor + 1),
+            focus: 0,
+          })
         }
       } else if (key.leftArrow) {
         // Step by code point, not UTF-16 unit: an emoji is two units, and
         // a mid-pair caret offset would split it in the SearchBox render.
-        setHistoryCursor(cursor => {
-          if (cursor <= 0) return 0
-          const ch = [...historyQuery.slice(0, cursor)].pop()!
-          return cursor - ch.length
-        })
+        if (cursor > 0) {
+          const ch = [...query.slice(0, cursor)].pop()!
+          dispatchOverlay({ type: 'history-edit', cursor: cursor - ch.length })
+        }
       } else if (key.rightArrow) {
-        setHistoryCursor(cursor => {
-          if (cursor >= historyQuery.length) return historyQuery.length
-          const ch = [...historyQuery.slice(cursor)][0]!
-          return cursor + ch.length
-        })
+        if (cursor < query.length) {
+          const ch = [...query.slice(cursor)][0]!
+          dispatchOverlay({ type: 'history-edit', cursor: cursor + ch.length })
+        }
       } else if (key.home) {
-        setHistoryCursor(0)
+        dispatchOverlay({ type: 'history-edit', cursor: 0 })
       } else if (key.end) {
-        setHistoryCursor(historyQuery.length)
+        dispatchOverlay({ type: 'history-edit', cursor: query.length })
       } else if (!key.ctrl && !key.meta && !key.super && input) {
-        const next = historyQuery.slice(0, historyCursor) + input + historyQuery.slice(historyCursor)
-        setHistoryQuery(next)
-        setHistoryCursor(historyCursor + input.length)
-        setHistoryFocus(0)
+        dispatchOverlay({
+          type: 'history-edit',
+          query: query.slice(0, cursor) + input + query.slice(cursor),
+          cursor: cursor + input.length,
+          focus: 0,
+        })
       }
       return
     }
-    if (rewindOpen) {
+    if (overlay.kind === 'rewind') {
       // While the plugin decision is in flight the picker is read-only;
       // Esc abandons the wait (the stale answer is dropped by the token).
-      if (rewindBusy) {
+      if (overlay.busy) {
         if (key.escape) {
           rewindRequestRef.current += 1
-          setRewindBusy(false)
+          dispatchOverlay({ type: 'rewind-busy', busy: false })
         }
         return
       }
-      if (rewindConfirm !== null) {
-        if (rewindModes !== null) {
+      if (overlay.confirm !== null) {
+        const row = overlay.confirm
+        if (overlay.modes !== null) {
           // Plugin offered modes: the confirm pane is a choice list —
           // option 0 is always the built-in conversation-only rewind.
-          const optionCount = rewindModes.length + 1
-          if (key.upArrow) {
-            setRewindModeIndex(index => (index <= 0 ? optionCount - 1 : index - 1))
-          } else if (key.downArrow) {
-            setRewindModeIndex(index => (index >= optionCount - 1 ? 0 : index + 1))
+          const optionCount = overlay.modes.length + 1
+          if (key.upArrow || key.downArrow) {
+            dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: optionCount })
           } else if (plainReturn) {
-            const row = rewindConfirm
-            const mode = rewindModeIndex === 0 ? null : (rewindModes[rewindModeIndex - 1]?.id ?? null)
-            setRewindOpen(false)
-            setRewindConfirm(null)
-            setRewindModes(null)
+            const mode = overlay.modeIndex === 0 ? null : (overlay.modes[overlay.modeIndex - 1]?.id ?? null)
+            dispatchOverlay({ type: 'close' })
             void performRewind(row, mode)
           } else if (key.escape) {
-            setRewindConfirm(null)
-            setRewindModes(null)
+            dispatchOverlay({ type: 'rewind-back' })
           }
           return
         }
         // Confirmation state: Enter rewinds, Esc backs out to the list.
         if (plainReturn) {
-          const row = rewindConfirm
-          setRewindOpen(false)
-          setRewindConfirm(null)
+          dispatchOverlay({ type: 'close' })
           void performRewind(row)
         } else if (key.escape) {
-          setRewindConfirm(null)
+          dispatchOverlay({ type: 'rewind-back' })
         }
-      } else if (key.upArrow) {
-        setRewindIndex(index => (index <= 0 ? rewindRows.length - 1 : index - 1))
-      } else if (key.downArrow) {
-        setRewindIndex(index => (index >= rewindRows.length - 1 ? 0 : index + 1))
+      } else if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: rewindRows.length })
       } else if (plainReturn) {
-        const row = rewindRows[rewindIndex]
+        const row = rewindRows[overlay.index]
         // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: out-of-range index on an empty list
         if (row) void requestRewindConfirm(row)
       } else if (key.escape) {
-        setRewindOpen(false)
-        setRewindConfirm(null)
-        setRewindModes(null)
+        dispatchOverlay({ type: 'close' })
       }
       return
     }
@@ -2212,11 +2199,11 @@ export function Chat({
       return
     }
     if (isMod(key) && input === 'r' && !helpOpen) {
-      setHistoryQuery('')
-      setHistoryCursor(0)
-      setHistoryFocus(0)
       setHistoryEntries(loadHistory())
-      setHistoryOpen(true)
+      dispatchOverlay({
+        type: 'open',
+        overlay: { kind: 'history', query: '', cursor: 0, focus: 0 },
+      })
       return
     }
     if (key.shift && key.upArrow && !selectionActive && !helpOpen) {
@@ -2271,7 +2258,7 @@ export function Chat({
         setSearchCursor(0)
         setSearchCurrent(0)
         setSearchCount(0)
-        setSearchOpen(true)
+        dispatchOverlay({ type: 'open', overlay: { kind: 'search' } })
         event.stopImmediatePropagation()
       }
     } else if (key.ctrl && (input === 'c' || input === 'd')) {
@@ -2415,12 +2402,11 @@ export function Chat({
     return fullscreen ? dashboard : <AlternateScreen>{dashboard}</AlternateScreen>
   }
 
-  /** Prompt input is inert while a modal dialog owns the keyboard. */
+  /** Prompt input is inert while a modal dialog owns the keyboard. The
+   *  overlay union covers every picker/dialog and /tips in one check;
+   *  message-selection mode and the /btw panel live outside it. */
   const promptSelectionActive =
-    selectionActive || modelPickerOpen || skillsPickerOpen || workspacePickerOpen || workspaceMenuOpen || workspaceFlow !== null || activityPickerOpen ||
-    effortSliderOpen || presetPickerOpen || themePickerOpen || permissionPickerOpen || planPickerOpen || langPickerOpen ||
-    thinkingOpen || historyOpen || rewindOpen || searchOpen ||
-    btw !== null || tipsOpen
+    selectionActive || overlay.kind !== 'none' || btw !== null
 
   // The trajectory scene replaces the conversation for as long as it is open.
   // Rendering it INSTEAD of (not above) the transcript is what makes it a
@@ -2435,18 +2421,17 @@ export function Chat({
     return fullscreen ? scene : <AlternateScreen>{scene}</AlternateScreen>
   }
 
-  // 浮层整体挂载条件：必须与内部各面板的可见条件精确同值。关闭时把
-  // 整个 absolute 浮层从树里移除——渲染器的"移除 absolute 节点"检测只看
-  // 被移除子树自身的 style.position（dom.ts collectRemovedRects），若浮层
-  // 常驻、只移除其普通子节点，blit 解毒不触发，被覆盖的转录行会在
-  // blit-skip 后留空（Esc 关 picker 一片空白的根因）。
-  const dialogOverlayOpen =
-    thinkingOpen || (workspacePickerOpen && workspaceTargets.length > 0) || workspaceMenuOpen || workspaceFlow !== null ||
-    modelPickerOpen || skillsPickerOpen ||
-    activityPickerOpen || (effortSliderOpen && effortOptions.length > 1) ||
-    (presetPickerOpen && presetOptions.length > 0) || themePickerOpen ||
-    permissionPickerOpen || planPickerOpen || langPickerOpen || historyOpen ||
-    rewindOpen || searchOpen || tipsOpen
+  // 浮层整体挂载条件：与内部各面板的可见条件同值（数据门在
+  // dialogOverlayVisible 里逐面板镜像）。关闭时把整个 absolute 浮层从树里
+  // 移除——渲染器的"移除 absolute 节点"检测只看被移除子树自身的
+  // style.position（dom.ts collectRemovedRects），若浮层常驻、只移除其
+  // 普通子节点，blit 解毒不触发，被覆盖的转录行会在 blit-skip 后留空
+  // （Esc 关 picker 一片空白的根因）。
+  const dialogOverlayOpen = dialogOverlayVisible(overlay, {
+    workspaceTargetCount: workspaceTargets.length,
+    effortOptionCount: effortOptions.length,
+    presetOptionCount: presetOptions.length,
+  })
 
   // The sticky header pins the turn owning the viewport top row
   // (timeline.activeId, reported by MessageList) — scrolled up to an old
@@ -2612,9 +2597,9 @@ export function Chat({
             onDecide={value => dialogs.decide(dialogSnapshot.key, value)}
             onCancel={() => dialogs.cancel(dialogSnapshot.key)}
           />
-        ) : tipsOpen ? (
+        ) : overlay.kind === 'tips' ? (
           <Box flexDirection="column" marginTop={1}>
-            <TipsPanel onClose={() => setTipsOpen(false)} />
+            <TipsPanel onClose={() => dispatchOverlay({ type: 'close-if', kind: 'tips' })} />
           </Box>
         ) : btw !== null ? (
           <Box flexDirection="column" marginTop={1}>
@@ -2674,83 +2659,79 @@ export function Chat({
             高列表探出帧顶。整体条件挂载：见 dialogOverlayOpen 注释。 */}
         {dialogOverlayOpen && (
         <OverlayAbove maxHeight={Math.max(terminalRows - 8, 1)}>
-          {thinkingOpen && (
+          {overlay.kind === 'thinking' && (
             <ThinkingToggle
               currentValue={thinkingVisible}
-              focusIndex={thinkingFocus}
+              focusIndex={overlay.focus}
               onPick={(index) => {
                 // 点击行 = 设焦点 + 应用（与 Enter 同一条路径）
                 const visible = index === 0
-                setThinkingFocus(index)
                 setThinkingVisible(visible)
-                setThinkingOpen(false)
+                dispatchOverlay({ type: 'close' })
                 channel.notify(t('thinking-toggled', { state: visible ? t('thinking-on') : t('thinking-off') }))
               }}
             />
           )}
-          {workspacePickerOpen && workspaceTargets.length > 0 && (
+          {overlay.kind === 'workspace-picker' && workspaceTargets.length > 0 && (
             <Box flexDirection="column" marginTop={1}>
               <WorkspacePicker
                 targets={workspaceTargets}
-                focusIndex={workspaceIndex}
+                focusIndex={overlay.index}
                 currentCwd={channel.cwd}
                 onPick={(index) => {
-                  // 点击行 = 设焦点 + 切换（与 Enter 同一条路径）
+                  // 点击行 = 切换该行目标（与 Enter 同一条路径）
                   const target = workspaceTargets[index]
-                  setWorkspaceIndex(index)
-                  setWorkspacePickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   if (target !== undefined) void channel.switchWorkspace(target)
                 }}
               />
             </Box>
           )}
-          {workspaceMenuOpen && (
+          {overlay.kind === 'workspace-menu' && (
             <Box flexDirection="column" marginTop={1}>
               <WorkspaceMenuPicker
                 options={workspaceMenuOptions}
-                focusIndex={workspaceMenuIndex}
+                focusIndex={overlay.index}
                 onPick={(index) => {
-                  // 点击行 = 设焦点 + 执行（与 Enter 同一条路径）
-                  setWorkspaceMenuIndex(index)
+                  // 点击行 = 执行该行（与 Enter 同一条路径）
                   runWorkspaceMenuOption(workspaceMenuOptions[index])
                 }}
               />
             </Box>
           )}
-          {workspaceFlow !== null && (
+          {overlay.kind === 'workspace-flow' && (
             <Box flexDirection="column" marginTop={1}>
               <WorkspaceFlowPicker
-                title={workspaceFlow.title}
-                choices={workspaceFlow.choices}
-                focusIndex={workspaceFlowIndex}
-                busy={workspaceFlowBusy}
-                input={workspaceFlowInput}
+                title={overlay.flow.title}
+                choices={overlay.flow.choices}
+                focusIndex={overlay.index}
+                busy={overlay.busy}
+                input={overlay.input}
                 onPick={(index) => {
                   // 点击行 = 设焦点 + 执行分支（与 Enter 同一条路径）；
                   // busy/输入态在组件侧禁点
-                  const choice = workspaceFlow.choices[index]
+                  const choice = overlay.flow.choices[index]
                   if (choice === undefined) return
-                  setWorkspaceFlowIndex(index)
+                  dispatchOverlay({ type: 'set-index', kind: 'workspace-flow', index })
                   runWorkspaceFlowAction(signal => choice.choose(signal))
                 }}
               />
             </Box>
           )}
-          {modelPickerOpen && (
+          {overlay.kind === 'model' && (
             <Box flexDirection="column" marginTop={1}>
               {models.length === 0 ? (
                 <ModelPickerLoading />
               ) : (
                 <ModelPicker
                   models={models}
-                  focusIndex={modelIndex}
+                  focusIndex={overlay.index}
                   currentModel={`${channel.provider}/${channel.model}`}
                   onPick={(index) => {
-                    // 点击行 = 设焦点 + 应用（与 Enter 同一条路径）
+                    // 点击行 = 应用该行模型（与 Enter 同一条路径）
                     const model = models[index]
                     if (!model) return
-                    setModelIndex(index)
-                    setModelPickerOpen(false)
+                    dispatchOverlay({ type: 'close' })
                     channel.notify(t('model-switching', { name: model.name }))
                     void channel.switchModel(model.provider, model.id).then((ok) => {
                       if (ok) channel.notify(t('model-switched', { name: model.name }))
@@ -2760,78 +2741,74 @@ export function Chat({
               )}
             </Box>
           )}
-          {skillsPickerOpen && (
+          {overlay.kind === 'skills' && (
             <Box flexDirection="column" marginTop={1}>
               {skillsList === null ? (
                 <SkillsPickerLoading />
               ) : (
                 <SkillsPicker
                   skills={skillsList}
-                  focusIndex={skillsIndex}
+                  focusIndex={overlay.index}
                   onPick={(index) => {
                     const skill = skillsList[index]
                     if (!skill) return
-                    setSkillsIndex(index)
-                    setSkillsPickerOpen(false)
+                    dispatchOverlay({ type: 'close' })
                     if (skill.userInvocable) setHistoryFill(`/${skill.name} `)
                   }}
                 />
               )}
             </Box>
           )}
-          {activityPickerOpen && (
+          {overlay.kind === 'activity' && (
             <Box flexDirection="column" marginTop={1}>
               <ActivityPicker
-                focusIndex={activityIndex}
+                focusIndex={overlay.index}
                 currentPreset={channel.activityFrames}
                 onPick={(index) => {
-                  setActivityIndex(index)
-                  setActivityPickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   const name = PRESET_NAMES[index]
                   if (name) channel.setActivityFrames(name)
                 }}
               />
             </Box>
           )}
-          {effortSliderOpen && effortOptions.length > 1 && (
+          {overlay.kind === 'effort' && effortOptions.length > 1 && (
             <Box flexDirection="column" marginTop={1}>
               <EffortSlider
                 options={effortOptions}
-                focusIndex={effortIndex}
+                focusIndex={overlay.index}
                 currentId={channel.reasoningEffort}
                 // 点击档位 = 移到该档并即时应用（与 ←/→ 同语义）
                 onPick={(index) => {
-                  setEffortIndex(index)
+                  dispatchOverlay({ type: 'set-index', kind: 'effort', index })
                   const option = effortOptions[index]
                   if (option) void channel.setEffort(option.id)
                 }}
               />
             </Box>
           )}
-          {presetPickerOpen && presetOptions.length > 0 && (
+          {overlay.kind === 'preset' && presetOptions.length > 0 && (
             <Box flexDirection="column" marginTop={1}>
               <PresetPicker
                 presets={presetOptions}
-                focusIndex={presetIndex}
+                focusIndex={overlay.index}
                 currentPreset={channel.agentPreset}
                 onPick={(index) => {
-                  setPresetIndex(index)
-                  setPresetPickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   const option = presetOptions[index]
                   if (option) void channel.switchPreset(option.id)
                 }}
               />
             </Box>
           )}
-          {permissionPickerOpen && (
+          {overlay.kind === 'permission' && (
             <Box flexDirection="column" marginTop={1}>
               <PermissionsPicker
-                focusIndex={permissionIndex}
+                focusIndex={overlay.index}
                 currentMode={channel.mode.sandbox}
                 cwd={channel.cwd}
                 onPick={(index) => {
-                  setPermissionIndex(index)
-                  setPermissionPickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   const id = PERMISSION_PRESET_IDS[index]
                   if (id !== undefined) {
                     void channel.runExternalCommand('permission', ` ${id}`).then((text) => {
@@ -2842,14 +2819,13 @@ export function Chat({
               />
             </Box>
           )}
-          {planPickerOpen && (
+          {overlay.kind === 'plan' && (
             <Box flexDirection="column" marginTop={1}>
               <PlanPicker
-                focusIndex={planIndex}
+                focusIndex={overlay.index}
                 currentOn={channel.mode.plan === true}
                 onPick={(index) => {
-                  setPlanIndex(index)
-                  setPlanPickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   const on = index === 0
                   void channel.runExternalCommand('plan', on ? '' : ' off').then((text) => {
                     if (text !== undefined && text !== '') channel.notify(text)
@@ -2858,29 +2834,27 @@ export function Chat({
               />
             </Box>
           )}
-          {langPickerOpen && (
+          {overlay.kind === 'lang' && (
             <Box flexDirection="column" marginTop={1}>
               <LangPicker
-                focusIndex={langIndex}
+                focusIndex={overlay.index}
                 currentLang={getLang()}
                 onPick={(index) => {
                   const lang = LANGS[index]
                   if (lang === undefined) return
-                  setLangIndex(index)
-                  setLangPickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   applyLang(lang)
                 }}
               />
             </Box>
           )}
-          {themePickerOpen && (
+          {overlay.kind === 'theme' && (
             <Box flexDirection="column" marginTop={1}>
               <ThemePicker
-                focusIndex={themeIndex}
+                focusIndex={overlay.index}
                 currentTheme={themeName}
                 onPick={(index) => {
-                  setThemeIndex(index)
-                  setThemePickerOpen(false)
+                  dispatchOverlay({ type: 'close' })
                   const name = getThemeOptions()[index]?.value
                   if (name !== undefined) {
                     const ok = setTheme(name)
@@ -2893,61 +2867,57 @@ export function Chat({
               />
             </Box>
           )}
-          {historyOpen && (
+          {overlay.kind === 'history' && (
             <Box flexDirection="column" marginTop={1}>
               <HistorySearchDialog
-                query={historyQuery}
-                cursorOffset={historyCursor}
+                query={overlay.query}
+                cursorOffset={overlay.cursor}
                 matches={historyMatches}
-                focusIndex={historyFocus}
+                focusIndex={overlay.focus}
                 onPick={(index) => {
                   // 点击行 = 填入该历史命令（与 Enter 同路径）
                   const entry = historyMatches[index]
                   if (entry) {
                     setHistoryFill(entry.text)
-                    setHistoryOpen(false)
+                    dispatchOverlay({ type: 'close' })
                   }
                 }}
               />
             </Box>
           )}
-          {rewindOpen && (
+          {overlay.kind === 'rewind' && (
             <Box flexDirection="column" marginTop={1}>
               <RewindPicker
                 rows={rewindRows}
-                focusIndex={rewindIndex}
-                confirmRow={rewindConfirm}
-                modes={rewindModes}
-                modeIndex={rewindModeIndex}
-                busy={rewindBusy}
+                focusIndex={overlay.index}
+                confirmRow={overlay.confirm}
+                modes={overlay.modes}
+                modeIndex={overlay.modeIndex}
+                busy={overlay.busy}
                 onPickRow={(index) => {
                   // 列表页点击只选中：进入确认态保留键盘 Enter 显式触发
-                  setRewindIndex(index)
+                  dispatchOverlay({ type: 'set-index', kind: 'rewind', index })
                 }}
                 onConfirm={() => {
                   // 确认页即显式确认层，点击直接执行（与 Enter 同路径）
-                  const row = rewindConfirm
+                  const row = overlay.confirm
                   if (row === null) return
-                  setRewindOpen(false)
-                  setRewindConfirm(null)
+                  dispatchOverlay({ type: 'close' })
                   void performRewind(row)
                 }}
                 onPickMode={(index) => {
                   // 模式列表点击直接执行该模式（与 Enter 同路径）
-                  const row = rewindConfirm
+                  const row = overlay.confirm
                   if (row === null) return
-                  // 模式页仅当 rewindModes 非空才渲染，这里空安全取值
-                  const mode = index === 0 ? null : (rewindModes?.[index - 1]?.id ?? null)
-                  setRewindModeIndex(index)
-                  setRewindOpen(false)
-                  setRewindConfirm(null)
-                  setRewindModes(null)
+                  // 模式页仅当 modes 非空才渲染，这里空安全取值
+                  const mode = index === 0 ? null : (overlay.modes?.[index - 1]?.id ?? null)
+                  dispatchOverlay({ type: 'close' })
                   void performRewind(row, mode)
                 }}
               />
             </Box>
           )}
-          {searchOpen && <TranscriptSearchBar query={searchQuery} cursorOffset={searchCursor} count={searchCount} current={searchCurrent} />}
+          {overlay.kind === 'search' && <TranscriptSearchBar query={searchQuery} cursorOffset={searchCursor} count={searchCount} current={searchCurrent} />}
         </OverlayAbove>
         )}
       </Box>

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -536,9 +536,13 @@ export function Chat({
       channel.notify(t('workspace-command-empty'))
       return
     }
+    // open-if: 'workspace-flow' stays allowed so an in-flow action can
+    // transition to its next stage; a picker the user opened after leaving
+    // the menu wins over a late command result.
     dispatchOverlay({
-      type: 'open',
+      type: 'open-if',
       overlay: { kind: 'workspace-flow', flow: result, index: 0, busy: false, input: null },
+      when: ['none', 'workspace-flow'],
     })
   }
 
@@ -603,12 +607,14 @@ export function Chat({
         return
       }
       setWorkspaceTargets(targets)
+      // open-if: the listing is async — whatever the user opened meanwhile wins.
       dispatchOverlay({
-        type: 'open',
+        type: 'open-if',
         overlay: {
           kind: 'workspace-picker',
           index: Math.max(0, targets.findIndex(target => target.cwd === channel.cwd)),
         },
+        when: ['none'],
       })
     }).catch((error: unknown) => {
       channel.notify(
@@ -800,9 +806,12 @@ export function Chat({
           setEffortOptions(efforts)
           const current = channel.reasoningEffort ?? defaultEffort
           const index = efforts.findIndex(effort => effort.id === current)
+          // open-if: a picker the user opened during the round trip wins
+          // over this late-arriving slider.
           dispatchOverlay({
-            type: 'open',
+            type: 'open-if',
             overlay: { kind: 'effort', index: index >= 0 ? index : 0 },
+            when: ['none'],
           })
         })
         return true

--- a/src/screens/chatOverlay.ts
+++ b/src/screens/chatOverlay.ts
@@ -104,9 +104,11 @@ export type ChatOverlayAction =
    * `count <= 0` move is a no-op (an empty list has no focus to move).
    */
   | { type: 'move'; delta: 1 | -1; count: number }
-  /** An async loader landed with the authoritative focus index (model list /
-   *  preset roster). Ignored unless that picker is still up. */
-  | { type: 'set-index'; kind: 'model' | 'preset'; index: number }
+  /** Set the focused row to an absolute index — an async loader landing
+   *  with the authoritative focus (model list / preset roster), or a mouse
+   *  click on a row of a panel that stays open (effort slider, workspace
+   *  flow). Ignored unless that panel is still up. */
+  | { type: 'set-index'; kind: 'model' | 'preset' | 'effort' | 'workspace-flow' | 'rewind'; index: number }
   /** Edit the history-search draft (query text, caret, focused match). */
   | { type: 'history-edit'; query?: string; cursor?: number; focus?: number }
   /** Workspace flow: an action is running (keys except Esc are swallowed). */

--- a/src/screens/chatOverlay.ts
+++ b/src/screens/chatOverlay.ts
@@ -1,0 +1,249 @@
+/**
+ * The chat screen's transient-dialog layer (the pickers, dialogs and panels
+ * that float above the prompt in `<OverlayAbove>`, plus /tips) as one
+ * explicit state machine.
+ *
+ * Previously this layer lived in ~28 sibling `useState` booleans+indices in
+ * Chat.tsx, with mutual exclusion emerging from "an open picker makes the
+ * prompt inert, so no second open command can be typed", and with two
+ * hand-maintained OR-aggregates (`promptSelectionActive`,
+ * `dialogOverlayOpen`) whose comments warned they must stay exactly in sync
+ * with the per-panel render conditions. A single discriminated union makes
+ * the exclusion structural — one variable can only hold one variant — and
+ * turns both aggregates into derivations that cannot drift.
+ *
+ * Design constraints, in order:
+ *   1. Behavior-preserving: every keyboard path, open/close side effect and
+ *      async-callback landing keeps its observable behavior. The one
+ *      deliberate change: an async OPEN landing while another overlay is up
+ *      (e.g. `/effort`'s listEfforts resolving after the user opened
+ *      `/model`) now REPLACES it instead of stacking two panels — the
+ *      stacked rendering was an unreachable-by-keyboard race, not a feature.
+ *   2. Pure and total: the reducer is a plain function, unit-tested by
+ *      scripts/verify-chat-overlay.ts without a renderer. Actions that no
+ *      longer apply (an async result landing after the overlay changed) are
+ *      ignored rather than writing orphan state.
+ *   3. Async data caches (model list, preset roster, …) stay OUTSIDE the
+ *      union in Chat.tsx: they persist across open/close so a reopened
+ *      picker can paint the previous list while the fresh one loads,
+ *      exactly as before.
+ */
+import type { ChatRow } from '../dsh-adapter/channel.js'
+import type { TuiRewindMode } from '../dsh-adapter/extension-events.js'
+import type { TuiWorkspaceCommandResult } from '../workspaces.js'
+
+/** The `kind: 'choices'` result a workspace command can return. */
+export type WorkspaceFlowChoices = Extract<TuiWorkspaceCommandResult, { kind: 'choices' }>
+
+/** Text-entry sub-state of the workspace flow (Tab into a choice's input). */
+export type WorkspaceFlowInput = {
+  choiceId: string
+  value: string
+  cursor: number
+  placeholder?: string
+}
+
+export type ChatOverlay =
+  | { kind: 'none' }
+  | { kind: 'thinking'; focus: number }
+  | { kind: 'workspace-picker'; index: number }
+  | { kind: 'workspace-menu'; index: number }
+  | {
+      kind: 'workspace-flow'
+      flow: WorkspaceFlowChoices
+      index: number
+      busy: boolean
+      input: WorkspaceFlowInput | null
+    }
+  | { kind: 'model'; index: number }
+  | { kind: 'skills'; index: number }
+  | { kind: 'activity'; index: number }
+  | { kind: 'effort'; index: number }
+  | { kind: 'preset'; index: number }
+  | { kind: 'theme'; index: number }
+  | { kind: 'permission'; index: number }
+  | { kind: 'plan'; index: number }
+  | { kind: 'lang'; index: number }
+  | { kind: 'history'; query: string; cursor: number; focus: number }
+  | {
+      kind: 'rewind'
+      index: number
+      confirm: ChatRow | null
+      modes: readonly TuiRewindMode[] | null
+      modeIndex: number
+      busy: boolean
+    }
+  // `/` transcript search: only the open/closed mode lives here. The query,
+  // cursor and match counters stay in Chat.tsx — they survive the bar
+  // closing so n/N keep walking the matches (CC semantics).
+  | { kind: 'search' }
+  | { kind: 'tips' }
+
+export const NO_OVERLAY: ChatOverlay = { kind: 'none' }
+
+export type ChatOverlayAction =
+  /** Open a variant, replacing whatever is up (including `none`). */
+  | { type: 'open'; overlay: ChatOverlay }
+  /** Close unconditionally (only dispatched from the open overlay's own keys). */
+  | { type: 'close' }
+  /** Close only if the given kind is still up — the safe form for async
+   *  callbacks (a loader failing after the user already moved on). */
+  | { type: 'close-if'; kind: ChatOverlay['kind'] }
+  /**
+   * Open only while the current kind is one of `when` — the safe form for an
+   * OPEN that arrives from an async callback (`/effort`'s level list, the
+   * workspace target list, a workspace command's choices). A user who opened
+   * something else during the round trip keeps what they opened; the stale
+   * open is dropped. Synchronous opens keep using plain `open`.
+   */
+  | { type: 'open-if'; overlay: ChatOverlay; when: readonly ChatOverlay['kind'][] }
+  /**
+   * Move the focused row by one with wrap-around, over a list of `count`
+   * entries. On `rewind` this targets whichever cursor the sub-state focuses
+   * (mode list when a plugin offered modes, else the candidate list). A
+   * `count <= 0` move is a no-op (an empty list has no focus to move).
+   */
+  | { type: 'move'; delta: 1 | -1; count: number }
+  /** An async loader landed with the authoritative focus index (model list /
+   *  preset roster). Ignored unless that picker is still up. */
+  | { type: 'set-index'; kind: 'model' | 'preset'; index: number }
+  /** Edit the history-search draft (query text, caret, focused match). */
+  | { type: 'history-edit'; query?: string; cursor?: number; focus?: number }
+  /** Workspace flow: an action is running (keys except Esc are swallowed). */
+  | { type: 'flow-busy'; busy: boolean }
+  /** Workspace flow: enter (object) or leave (null) the text-input state. */
+  | { type: 'flow-input'; input: WorkspaceFlowInput | null }
+  /** Workspace flow: edit the text-input draft in place. */
+  | { type: 'flow-input-edit'; value: string; cursor: number }
+  /** Rewind: the plugin decision round-trip started / was abandoned. */
+  | { type: 'rewind-busy'; busy: boolean }
+  /** Rewind: the plugin decision landed — show the confirm pane (modes turn
+   *  it into a choice list). Stale decisions are dropped by the caller's
+   *  request token before dispatch; a changed overlay drops them here. */
+  | { type: 'rewind-decision'; confirm: ChatRow; modes: readonly TuiRewindMode[] | null }
+  /** Rewind: Esc from the confirm/modes pane back to the candidate list. */
+  | { type: 'rewind-back' }
+
+/**
+ * One-step wrap-around cursor move — the single source of the wrapping rule
+ * every list overlay uses (Chat.tsx's effort slider reads it too, to apply
+ * the newly focused level in the same keystroke that dispatches the move).
+ */
+export function wrapIndex(index: number, delta: 1 | -1, count: number): number {
+  return delta === -1
+    ? (index <= 0 ? count - 1 : index - 1)
+    : (index >= count - 1 ? 0 : index + 1)
+}
+
+export function chatOverlayReducer(state: ChatOverlay, action: ChatOverlayAction): ChatOverlay {
+  switch (action.type) {
+    case 'open':
+      return action.overlay
+    case 'close':
+      return NO_OVERLAY
+    case 'close-if':
+      return state.kind === action.kind ? NO_OVERLAY : state
+    case 'open-if':
+      return action.when.includes(state.kind) ? action.overlay : state
+    case 'move': {
+      if (action.count <= 0) return state
+      if (state.kind === 'rewind') {
+        // The confirm pane with plugin modes has its own cursor; the plain
+        // confirm pane has none (Enter/Esc only — a move must not disturb
+        // the list index behind it).
+        if (state.confirm !== null) {
+          return state.modes !== null
+            ? { ...state, modeIndex: wrapIndex(state.modeIndex, action.delta, action.count) }
+            : state
+        }
+        return { ...state, index: wrapIndex(state.index, action.delta, action.count) }
+      }
+      if (state.kind === 'thinking') {
+        return { ...state, focus: wrapIndex(state.focus, action.delta, action.count) }
+      }
+      if (
+        state.kind === 'workspace-picker'
+        || state.kind === 'workspace-menu'
+        || state.kind === 'workspace-flow'
+        || state.kind === 'model'
+        || state.kind === 'skills'
+        || state.kind === 'activity'
+        || state.kind === 'effort'
+        || state.kind === 'preset'
+        || state.kind === 'theme'
+        || state.kind === 'permission'
+        || state.kind === 'plan'
+        || state.kind === 'lang'
+      ) {
+        return { ...state, index: wrapIndex(state.index, action.delta, action.count) }
+      }
+      if (state.kind === 'history') {
+        return { ...state, focus: wrapIndex(state.focus, action.delta, action.count) }
+      }
+      return state
+    }
+    case 'set-index':
+      return state.kind === action.kind ? { ...state, index: action.index } : state
+    case 'history-edit':
+      return state.kind === 'history'
+        ? {
+            ...state,
+            ...(action.query === undefined ? {} : { query: action.query }),
+            ...(action.cursor === undefined ? {} : { cursor: action.cursor }),
+            ...(action.focus === undefined ? {} : { focus: action.focus }),
+          }
+        : state
+    case 'flow-busy':
+      return state.kind === 'workspace-flow' ? { ...state, busy: action.busy } : state
+    case 'flow-input':
+      return state.kind === 'workspace-flow' ? { ...state, input: action.input } : state
+    case 'flow-input-edit':
+      return state.kind === 'workspace-flow' && state.input !== null
+        ? { ...state, input: { ...state.input, value: action.value, cursor: action.cursor } }
+        : state
+    case 'rewind-busy':
+      return state.kind === 'rewind' ? { ...state, busy: action.busy } : state
+    case 'rewind-decision':
+      return state.kind === 'rewind'
+        ? { ...state, busy: false, confirm: action.confirm, modes: action.modes, modeIndex: 0 }
+        : state
+    case 'rewind-back':
+      return state.kind === 'rewind' ? { ...state, confirm: null, modes: null } : state
+  }
+}
+
+/**
+ * Whether the `<OverlayAbove>` wrapper mounts. Mounting is all-or-nothing:
+ * the renderer's removed-absolute-node blit detection only fires when the
+ * removed subtree itself is `position: absolute` (dom.ts
+ * collectRemovedRects), so the whole overlay must leave the tree when its
+ * last panel closes — see the mount-site comment in Chat.tsx.
+ *
+ * The per-kind data gates mirror the per-panel render conditions verbatim:
+ * a picker whose async list has not landed (or came back trivially small)
+ * paints nothing, so the wrapper must not mount for it either. `tips`
+ * returns true even though the panel renders in the prompt slot rather than
+ * inside the overlay — preserved verbatim from the boolean-era aggregate
+ * (the empty absolute wrapper is zero-size and paints nothing).
+ */
+export function dialogOverlayVisible(
+  overlay: ChatOverlay,
+  gates: {
+    workspaceTargetCount: number
+    effortOptionCount: number
+    presetOptionCount: number
+  },
+): boolean {
+  switch (overlay.kind) {
+    case 'none':
+      return false
+    case 'workspace-picker':
+      return gates.workspaceTargetCount > 0
+    case 'effort':
+      return gates.effortOptionCount > 1
+    case 'preset':
+      return gates.presetOptionCount > 0
+    default:
+      return true
+  }
+}


### PR DESCRIPTION
Chat.tsx 里 19 个弹出面板（/model、/theme、Ctrl+R 历史搜索、rewind 等）各自用独立的 useState 布尔加索引管理，一共 28 个。面板之间没有直接的互斥保证：一个面板打开时输入框变为只读，用户打不出第二条命令，靠这个间接避免同时打开。promptSelectionActive 和 dialogOverlayOpen 两个汇总条件要手工和各面板的渲染条件保持一致，注释里也写了改动时必须同步。

这个 PR 把这些状态合并成 src/screens/chatOverlay.ts 里的一个 reducer。同一时刻只有一个面板打开，由类型保证；两个汇总条件直接从 reducer 状态算出来；异步回调（比如模型列表加载完成）只在对应面板还开着时生效，不会写进已关闭面板的状态。

键盘行为逐分支保持不变。OverlayAbove 仍然整体按条件挂载（渲染器检测 absolute 节点移除依赖这一点）。模型列表等数据照旧缓存在组件里，重新打开面板时先显示上次的列表。

行为变化只有一处：/effort 和 /workspace 的列表是异步加载的，加载完成时如果用户已经打开了别的面板，以前会两个面板叠在一起，现在丢弃迟到的那个。

新增 scripts/verify-chat-overlay.ts 覆盖所有状态转移，挂进 verify:build。picker、thinking、btw、help、trace、model-switch 等现有渲染回归全部通过，inline 和 fullscreen 两种模式都手动测过。

全屏页面（/settings、/resume、轨迹）和审批、问卷面板这次没动。