### PR TITLE
fix(render): MessageList 补 stream-fold props 默认值，修复 main CI 在 verify-compact 的失败

### DIFF
--- a/scripts/verify-compact.mjs
+++ b/scripts/verify-compact.mjs
@@ -197,6 +197,9 @@ const listProps = (expanded) => ({
   )
   await sleep(200)
   const frame = toPlain(stdout.frames.at(-1) ?? '')
+  // 空帧守卫：渲染崩溃时两条 hides 断言会空洞通过（本文件曾因 MessageList
+  // 新增必需 prop 而空帧,只有 shows 报警）。先证明画面存在。
+  check('compact scenario renders at all', frame.includes('Conversation compacted'), '')
   check('folded summary shows the fold line', frame.includes('摘要已折叠'), '')
   check('folded summary hides the full text', !frame.includes(LONG_SUMMARY), '')
   instance.unmount()

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -46,6 +46,13 @@ const DEFAULT_ROW_HEIGHT = 2
 /** Cold-start estimate of the header block above the rows; corrected by the
  *  first layout measurement. */
 const DEFAULT_HEADER_LINES = 14
+/** Stable fallbacks for the stream-fold props: verify/repro harnesses and
+ *  embedders render MessageList with prop sets that predate them, and the
+ *  render must not throw (same rule as Chat's stubbed channel APIs). Module
+ *  scope keeps the identities stable so MemoRow's shallow compare and the
+ *  toggle callback's deps never churn. */
+const NO_STREAM_FOLDED: ReadonlySet<number> = new Set()
+const NOOP_TOGGLE_STREAM_FOLD = (_rowId: number): void => {}
 
 /**
  * Per-kind layout signature: the O(1) identity of every input that decides a
@@ -127,8 +134,8 @@ export function MessageList({
   expandedRows,
   selectedId,
   onToggleRow,
-  streamFoldedRows,
-  onToggleStreamFold,
+  streamFoldedRows = NO_STREAM_FOLDED,
+  onToggleStreamFold = NOOP_TOGGLE_STREAM_FOLD,
   model,
   diffLayout = 'auto',
   thinkingFold = 'preview',
@@ -154,8 +161,8 @@ export function MessageList({
   selectedId: number | null
   onToggleRow: (rowId: number) => void
   /** 流式 reasoning 行被用户折叠（点击展开/折叠对流式行同样有效）。 */
-  streamFoldedRows: ReadonlySet<number>
-  onToggleStreamFold: (rowId: number) => void
+  streamFoldedRows?: ReadonlySet<number>
+  onToggleStreamFold?: (rowId: number) => void
   model: string
   /** Edit/Write diff presentation preference (forwarded to tool cards). */
   diffLayout?: 'auto' | 'split' | 'unified'


### PR DESCRIPTION
main 的 CI 从 f7df160 起在 verify-compact 这一步失败。

原因：#460 给 MessageList 加了一个新的必需 prop `streamFoldedRows`，但几个直接渲染 MessageList 的测试脚本没有跟着更新。渲染时 `streamFoldedRows.has` 在 undefined 上抛错，输出空帧，两条检查“有没有显示”的断言因此失败；两条检查“有没有隐藏”的断言在空帧上照样通过，所以只报了一半。

同样的问题还有 verify-whale-toggle 和 verify-cjk-truncate——它们排在 verify-compact 之后，CI 停在第一个失败，没跑到它们。另外三个不在 CI 里的调试脚本（header-probe、repro-long-output、verify-sticky-anchor）也受影响。

修复：给 `streamFoldedRows` 和 `onToggleStreamFold` 加默认值（空集合和空函数，放在模块顶层保证引用稳定，不影响 MemoRow 的缓存）。仓库里已有约定：测试脚本和嵌入方会用不完整的 props 渲染组件，渲染不应该抛错。

顺便给 verify-compact 加了一条断言：先确认画面确实渲染出来，再检查折叠状态。避免下次再出现“组件崩了但一半断言还是绿的”。

验证：DSH_TUI_LANG=zh 下 verify-compact 通过（修复前 exit 2）；八个直接渲染 MessageList 的脚本按 CI 相同的命令全部通过；verify:build 全绿。