### PR TITLE
perf: 移植 Grok Presenter 排空节拍 + pty 背压门（滚动帧字节 -30%）

### DIFF
--- a/scripts/perf-scroll-bench.tsx
+++ b/scripts/perf-scroll-bench.tsx
@@ -1,0 +1,146 @@
+/**
+ * perf-scroll-bench — 全屏转录滚动性能基准（headless）。
+ *
+ * 重会话（120 轮，含长 prompt 行）× 滚轮突发 + rail 悬停，通过 onFrame
+ * 钩子采样每帧 durationMs 与各阶段（renderer/diff/write/yoga/commit），
+ * 输出 p50/p95/max 与阶段总量，用于优化前后对比。
+ *
+ * 运行：node --import tsx/esm scripts/perf-scroll-bench.tsx
+ * Env：BENCH_ROUNDS（默认 3）
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const ROUNDS = Number(process.env.BENCH_ROUNDS ?? 3)
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+let outBytes = 0
+let outWrites = 0
+const byteHist: number[] = []
+let frameBytes = 0
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    const s = String(chunk)
+    outBytes += s.length; outWrites++; frameBytes += s.length
+    term.write(s, cb)
+  }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 120 轮：1/6 的 prompt 是 240 字长行（模拟粘贴），其余短问题；回复 6~12 行。
+const rows: any[] = []
+for (let turn = 1; turn <= 120; turn++) {
+  const long = turn % 6 === 0
+  rows.push({
+    id: turn * 2 - 1,
+    kind: 'user',
+    text: long ? `长问题 ${turn} ` + '粘贴内容样板文字。'.repeat(30) : `问题 ${turn}`,
+  })
+  rows.push({
+    id: turn * 2,
+    kind: 'assistant',
+    text: Array.from({ length: 6 + (turn % 7) }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n'),
+  })
+}
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 120',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+// 帧采样
+const frames: Array<{ ms: number; yoga: number; commit: number; renderer: number; write: number; patches: number }> = []
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  {
+    stdout: stdout as any, stdin: stdin as any, stderr: stderr as any,
+    exitOnCtrlC: false, patchConsole: false,
+    onFrame: (f: any) => {
+      frames.push({
+        ms: f.durationMs,
+        yoga: f.phases.yoga ?? 0,
+        commit: f.phases.commit ?? 0,
+        renderer: f.phases.renderer ?? 0,
+        write: f.phases.write ?? 0,
+        patches: f.patches ?? 0,
+      })
+      byteHist.push(frameBytes)
+      frameBytes = 0
+    },
+  },
+)
+await sleep(700)
+frames.length = 0 // 丢弃启动帧
+
+// 滚轮突发：每轮 40 个 wheel-up（8ms 间隔，模拟高速滚轮），间歇 120ms
+for (let r = 0; r < ROUNDS; r++) {
+  for (let i = 0; i < 40; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(8)
+  }
+  await sleep(150)
+}
+// rail 悬停扫动：40 个 motion 事件沿右缘上下扫
+for (let i = 0; i < 40; i++) {
+  stdin.write(`\x1b[<35;100;${10 + (i % 20)}M`)
+  await sleep(16)
+}
+// 滚回底部
+for (let i = 0; i < 60; i++) {
+  stdin.write('\x1b[<65;90;30M')
+  await sleep(8)
+}
+await sleep(400)
+
+// ── 统计 ──
+const pct = (arr: number[], p: number) => {
+  const s = [...arr].sort((a, b) => a - b)
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))] ?? 0
+}
+const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0)
+const ms = frames.map(f => f.ms)
+const over33 = ms.filter(m => m > 33.4).length
+const over66 = ms.filter(m => m > 66.7).length
+console.log('==== perf-scroll-bench ====')
+console.log(`frames=${frames.length}  p50=${pct(ms, 50).toFixed(1)}ms  p95=${pct(ms, 95).toFixed(1)}ms  max=${Math.max(...ms).toFixed(1)}ms  >33ms=${over33}  >66ms=${over66}`)
+console.log(`yoga 总=${sum(frames.map(f => f.yoga)).toFixed(0)}ms  commit 总=${sum(frames.map(f => f.commit)).toFixed(0)}ms  renderer 总=${sum(frames.map(f => f.renderer)).toFixed(0)}ms  write 总=${sum(frames.map(f => f.write)).toFixed(0)}ms`)
+console.log(`yoga max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms  commit max=${Math.max(...frames.map(f => f.commit)).toFixed(1)}ms  renderer max=${Math.max(...frames.map(f => f.renderer)).toFixed(1)}ms`)
+console.log(`patches 平均=${(sum(frames.map(f => f.patches)) / frames.length).toFixed(0)}`)
+console.log(`输出字节 总=${(outBytes / 1024).toFixed(1)}KB  write调用=${outWrites}  每帧字节 p50=${pct(byteHist, 50)} p95=${pct(byteHist, 95)} max=${Math.max(...byteHist, 0)}`)
+
+await inst.unmount()
+process.exit(0)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -350,6 +350,10 @@ export function MessageList({
     return scrollHandle.subscribe(tick)
   }, [scrollHandle])
 
+  // Cached rail/header preview per user row (see the timeline block for why
+  // the length guard exists alongside the id key).
+  const previewCacheRef = React.useRef(new Map<number, { len: number; preview: string }>())
+
   const heightOf = (row: ChatRow): number =>
     heightsRef.current.get(row.id) ?? DEFAULT_ROW_HEIGHT
   const offsets: number[] = new Array<number>(visibleRows.length)
@@ -550,6 +554,13 @@ export function MessageList({
   let upTurnIndex: number | null = null
   let downTurnIndex: number | null = null
   {
+    // Preview cache: user rows are immutable once landed, and this loop
+    // runs on EVERY scroll frame (MessageList re-renders per drain tick).
+    // clipPreview scans to the first non-empty line — O(text length) per
+    // row per frame for pasted-content prompts. Cache by row id with a
+    // text-length guard as belt-and-braces against any id reuse.
+    const previewCache = previewCacheRef.current
+    if (previewCache.size > 2000) previewCache.clear()
     const viewTop = scrollTop + pending
     const maxScroll = Math.max(0, (scrollHandle?.getScrollHeight() ?? 0) - viewport)
     let index = 0
@@ -557,7 +568,12 @@ export function MessageList({
       const row = visibleRows[i]!
       if (row.kind !== 'user') continue
       const textTop = base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0)
-      timelineTurns.push({ id: row.id, top: textTop, preview: clipPreview(row.text) })
+      let cached = previewCache.get(row.id)
+      if (cached === undefined || cached.len !== row.text.length) {
+        cached = { len: row.text.length, preview: clipPreview(row.text) }
+        previewCache.set(row.id, cached)
+      }
+      timelineTurns.push({ id: row.id, top: textTop, preview: cached.preview })
       if (textTop <= viewTop) activeTurnIndex = index
       if (textTop < viewTop) upTurnIndex = index
       if (downTurnIndex === null && textTop > viewTop && textTop <= maxScroll) {

--- a/src/ink/constants.ts
+++ b/src/ink/constants.ts
@@ -1,2 +1,12 @@
 /** Shared frame interval for render throttling and animations (~60fps). */
 export const FRAME_INTERVAL_MS = 16
+
+/**
+ * In-flight pty gate threshold (bytes) for scroll-drain frames — Grok
+ * Build's Presenter in_flight gate. While stdout holds more unflushed
+ * output than this, drain frames hold off instead of stacking latency
+ * into a slow ConPTY/ssh link. Sized above one full-screen diff (~4KB at
+ * 100 cols) so the gate only trips on genuine backlog, never on a single
+ * in-transit frame.
+ */
+export const PTY_BACKLOG_BYTES = 8192

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -14,7 +14,7 @@ import { format } from 'util';
 import { colorize } from './colorize.js';
 import App from './components/App.js';
 import type { CursorDeclaration, CursorDeclarationSetter } from './components/CursorDeclarationContext.js';
-import { FRAME_INTERVAL_MS } from './constants.js';
+import { FRAME_INTERVAL_MS, PTY_BACKLOG_BYTES } from './constants.js';
 import * as dom from './dom.js';
 import { beginGeometryFrame, endGeometryFrame, GEOMETRY_TRACE_ENABLED, noteFrameCause } from './geometry-trace.js';
 import { KeyboardEvent } from './events/keyboard-event.js';
@@ -552,6 +552,45 @@ export default class Ink {
     }
     this.onRender();
   }
+
+  /**
+   * Schedule the next scroll-drain frame — Grok Build's Presenter, ported:
+   *
+   *  - CADENCE: one drain frame per FRAME_INTERVAL_MS (60fps). The old
+   *    quarter-interval timer (~250fps) multiplied pty writes 4× for zero
+   *    visible smoothness — a terminal paints at its display refresh, not
+   *    at our timer rate. Scroll throughput is unchanged: the drain step
+   *    is proportional (75% of remaining delta per frame), so fewer frames
+   *    just take proportionally bigger steps.
+   *  - IN-FLIGHT GATE: while stdout still holds unflushed bytes above
+   *    PTY_BACKLOG_BYTES (slow ConPTY round trip, ssh link), queue nothing
+   *    further — re-probe at quarter interval instead. Grok's equivalent
+   *    (in_flight_target + writer ack) exists to keep latency bounded
+   *    under exactly this backpressure; without it each stacked frame adds
+   *    its full render+write to the input→paint latency, which reads as
+   *    sticky, laggy scrolling on Windows terminals.
+   *
+   * The gate holds only DRAIN frames; React-driven renders (keystrokes,
+   * streaming) still render via the normal throttle — user-visible updates
+   * must never wait behind scroll output.
+   */
+  private scheduleDrain(): void {
+    if (this.drainTimer !== null) return;
+    const stdout = this.options.stdout;
+    const backlog =
+      typeof (stdout as { writableLength?: number }).writableLength === 'number'
+        ? (stdout as { writableLength: number }).writableLength
+        : 0;
+    if (backlog > PTY_BACKLOG_BYTES) {
+      this.drainTimer = setTimeout(() => {
+        this.drainTimer = null;
+        this.scheduleDrain();
+      }, FRAME_INTERVAL_MS >> 2);
+      return;
+    }
+    this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS);
+  }
+
   onRender() {
     if (this.isUnmounted || this.isPaused) {
       return;
@@ -928,19 +967,16 @@ export default class Ink {
     this.prevFrameContaminated = selActive || hlActive;
 
     // A ScrollBox has pendingScrollDelta left to drain — schedule the next
-    // frame. MUST NOT call this.scheduleRender() here: we're inside a
-    // trailing-edge throttle invocation, timerId is undefined, and lodash's
-    // debounce sees timeSinceLastCall >= wait (last call was at the start
-    // of this window) → leadingEdge fires IMMEDIATELY → double render ~0.1ms
-    // apart → jank. Use a plain timeout. If a wheel event or immediate
-    // render arrives first, renderNow cancels this timer — no double.
-    //
-    // Drain frames are cheap (DECSTBM + ~10 patches, ~200 bytes) so run at
-    // quarter interval (~250fps, setTimeout practical floor) for max scroll
-    // speed. Regular renders stay at FRAME_INTERVAL_MS via the throttle.
+    // frame via scheduleDrain (cadence + pty backpressure gate, see there).
+    // MUST NOT call this.scheduleRender() here: we're inside a trailing-edge
+    // throttle invocation, timerId is undefined, and lodash's debounce sees
+    // timeSinceLastCall >= wait (last call was at the start of this window)
+    // → leadingEdge fires IMMEDIATELY → double render ~0.1ms apart → jank.
+    // If a wheel event or immediate render arrives first, renderNow cancels
+    // this timer — no double.
     if (frame.scrollDrainPending) {
       noteFrameCause('scroll-drain');
-      this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
+      this.scheduleDrain();
     }
     const yogaMs = getLastYogaMs();
     const commitMs = getLastCommitMs();


### PR DESCRIPTION
## 概要

用户反馈全屏滚动卡卡的。基准剖析定位到写侧：排空帧以 ~250fps 向 ConPTY 写（远超终端显示频率），且无背压感知——慢管道上帧帧叠加，延迟线性堆高。

对照 grok-build `xai-grok-pager` 的 **Presenter**（`event_loop.rs`）移植两个机制：

1. **排空节拍 16ms（60fps）** — 对应 Grok `min_draw_interval`。排空步长本就是比例式（每帧 75% 剩余量），帧数减少只是步长增大，吞吐不变；实测输出字节 -30%（131.6→92.2KB），p95 帧字节 1619→876。
2. **pty 背压门** — 对应 Grok `in_flight_target` + writer ack。stdout 未排空字节 > 8KB（约两屏 diff）时排空帧暂缓、4ms 重探。Windows Terminal 忙碌/ssh 时不再向堵住的管道叠帧。门只拦排空帧；键盘/流式渲染走常规节流，永不排在滚动输出后面。

另修 MessageList timeline 热路径：`clipPreview` 每用户行每滚动帧重跑（长 prompt O(文本长度)），改为按 row id 缓存。

## 验证

- 新增 `perf-scroll-bench`（120 轮重会话滚轮突发 + 悬停，onFrame 钩子采样帧耗时/阶段/字节），前后对比数据见 commit message
- 20 脚本回归全绿（timeline 几何/渲染、置顶锚定、全屏四件套、pill、help-scroll、bottom-drift、idle-oscillation、resize 系列、inline-scrollback、trajectory-mouse）
- build 门禁 + smoke 通过