### PR TITLE
fix: 滚动节拍回调 + 输入边 React 合并 + rail 悬停滚动收起

### DIFF
--- a/scripts/probe-rail-ghost.tsx
+++ b/scripts/probe-rail-ghost.tsx
@@ -1,0 +1,156 @@
+/** 探针：滚动中 rail 列与悬停卡区域的残影。 */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+const rows: any[] = []
+for (let turn = 1; turn <= 8; turn++) {
+  rows.push({ id: turn * 2 - 1, kind: 'user', text: `问题 ${turn}` })
+  rows.push({ id: turn * 2, kind: 'assistant', text: Array.from({ length: 8 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+}
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 8',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(700)
+
+function railCol(y: number, offset = 0): string {
+  const buf = term.buffer.active
+  return (buf.getLine(buf.baseY + y)?.getCell(COLS - 2 + offset)?.getChars() ?? '')
+}
+function railColStr(): string {
+  return Array.from({ length: ROWS }, (_, y) => railCol(y) + railCol(y, 1)).join('')
+}
+/** rail 列里非空白 glyph 总数（残影 = 超过预期的 ─/━━/▴/▾ 数量）。 */
+function countGlyph(s: string, ch: string): number {
+  return s.split(ch).length - 1
+}
+
+console.log('== 阶段 1：无悬停，快速上滚 ==')
+const settledBefore = railColStr()
+const midSamples: string[] = []
+for (let burst = 0; burst < 3; burst++) {
+  for (let i = 0; i < 15; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(6)
+  }
+  midSamples.push(railColStr())
+  await sleep(60)
+}
+await sleep(600) // 充分排空
+console.log('== 排空后原子快照（rail 逐行 + 全屏摘要，同一次读取）==')
+{
+  const buf = term.buffer.active
+  const railCells: string[] = []
+  const heads: string[] = []
+  for (let y = 0; y < ROWS; y++) {
+    const a = buf.getLine(buf.baseY + y)?.getCell(COLS - 2)?.getChars() ?? ''
+    const b = buf.getLine(buf.baseY + y)?.getCell(COLS - 1)?.getChars() ?? ''
+    railCells.push(a + b)
+    heads.push((buf.getLine(buf.baseY + y)?.translateToString(true) ?? '').slice(0, 24))
+  }
+  for (let y = 0; y < ROWS; y++) {
+    if (railCells[y] !== '  ') console.log(`${String(y).padStart(2)}| rail=${JSON.stringify(railCells[y])}  head=${JSON.stringify(heads[y])}`)
+  }
+  console.log(`轻─=${railCells.join('').split('─').length - 1} 重━=${railCells.join('').split('━').length - 1}`)
+  const again: string[] = []
+  for (let y = 0; y < ROWS; y++) {
+    again.push((buf.getLine(buf.baseY + y)?.getCell(COLS - 2)?.getChars() ?? '') + (buf.getLine(buf.baseY + y)?.getCell(COLS - 1)?.getChars() ?? ''))
+  }
+  console.log(`立即复读相同: ${again.join('') === railCells.join('')}`)
+  await sleep(300)
+  const third: string[] = []
+  for (let y = 0; y < ROWS; y++) {
+    third.push((buf.getLine(buf.baseY + y)?.getCell(COLS - 2)?.getChars() ?? '') + (buf.getLine(buf.baseY + y)?.getCell(COLS - 1)?.getChars() ?? ''))
+  }
+  console.log(`300ms 后仍相同: ${third.join('') === railCells.join('')}  轻─=${third.join('').split('─').length - 1}`)
+}
+process.exit(0)
+
+console.log('== 阶段 2：悬停 tick 上滚动 ==')
+// 悬停第 4 个 tick
+stdin.write('\x1b[<35;100;18M')
+await sleep(300)
+const withCard = railColStr()
+console.log(`悬停后 rail 列轻─=${countGlyph(withCard, '─')} 重━=${countGlyph(withCard, '━')}`)
+// 卡在 rail 左侧：采样 84..98 列找圆角边框
+function cardRegion(): string[] {
+  const buf = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => {
+    let s = ''
+    for (let x = 80; x < 98; x++) s += buf.getLine(buf.baseY + y)?.getCell(x)?.getChars() ?? ''
+    return s
+  })
+}
+const cardRows = cardRegion().filter(l => /[╭╮╰╯│]/.test(l))
+console.log(`悬停卡行数=${cardRows.length}（期望 3）`)
+// 滚动（指针不动 → hover 保持，窗口滑动卡跟随）
+for (let i = 0; i < 10; i++) {
+  stdin.write('\x1b[<64;90;30M')
+  await sleep(8)
+}
+await sleep(200)
+const cardRowsDuring = cardRegion().filter(l => /[╭╮╰╯│]/.test(l))
+console.log(`滚动中卡行数=${cardRowsDuring.length}`)
+// 移开悬停
+stdin.write('\x1b[<35;30;20M')
+await sleep(300)
+const cardRowsAfter = cardRegion().filter(l => /[╭╮╰╯│]/.test(l))
+console.log(`移开后卡残留行数=${cardRowsAfter.length}（期望 0）`)
+if (cardRowsAfter.length > 0) console.log(`  残留内容: ${JSON.stringify(cardRowsAfter)}`)
+
+console.log('== 阶段 3：滚回底部 ==')
+for (let i = 0; i < 40; i++) {
+  stdin.write('\x1b[<65;90;30M')
+  await sleep(6)
+}
+await sleep(300)
+const final = railColStr()
+console.log(`最终 rail 列: 轻─=${countGlyph(final, '─')} 重━=${countGlyph(final, '━')} ▴=${countGlyph(final, '▴')} ▾=${countGlyph(final, '▾')}`)
+
+await inst.unmount()
+process.exit(0)

--- a/src/components/TimelineRail.tsx
+++ b/src/components/TimelineRail.tsx
@@ -78,11 +78,21 @@ export function TimelineRail({
   hoverEnabled: boolean
 }): React.ReactNode {
   const [, setTick] = React.useState(0)
+  const [hover, setHover] = React.useState<Hover>(null)
   React.useEffect(() => {
     if (!handle) return
-    return handle.subscribe(() => setTick(t => t + 1))
+    return handle.subscribe(() => {
+      setTick(t => t + 1)
+      // A scroll (wheel over the rail, tick/chevron jump, header click)
+      // slides the tick window under a STATIONARY pointer — without this,
+      // the hover card keeps re-narrating whatever turn now sits under the
+      // pointer cell, flapping previews across turns every frame (reads as
+      // ghosting). OpenCode's modality rule: only a real mouse move may
+      // re-enter hover; Grok likewise clears the hover popup on tick click.
+      // setHover(null) on an already-null hover is a React no-op.
+      setHover(null)
+    })
   }, [handle])
-  const [hover, setHover] = React.useState<Hover>(null)
 
   if (!handle) return null
   const viewport = handle.getViewportHeight()

--- a/src/ink/components/ScrollBox.tsx
+++ b/src/ink/components/ScrollBox.tsx
@@ -1,5 +1,6 @@
 import React, { type PropsWithChildren, type Ref, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import type { Except } from 'type-fest';
+import { FRAME_INTERVAL_MS } from '../constants.js';
 import { markScrollActivity } from '../../bootstrap/state.js';
 import type { DOMElement } from '../dom.js';
 import { markDirty, scheduleRenderFrom } from '../dom.js';
@@ -105,6 +106,32 @@ function ScrollBox({
   const notify = () => {
     for (const l of listenersRef.current) l();
   };
+  // Input-edge intent coalescing (Qwen Code's 16ms wheel merge, Crush's
+  // pre-queue filter): subscribers drive React state (MessageList's mount
+  // window, Chat's sticky flag, the timeline rail), so notifying per wheel
+  // EVENT runs a full React commit per event — a fast flick is 10-30
+  // events, each re-running the offsets/window/timeline loops on a big
+  // session. The scrollTop mutation and the ink render are already
+  // frame-throttled; this aligns the React commits to the same frame
+  // budget. Leading edge fires when the last notify is ≥ a frame old (a
+  // lone click feels instant); bursts collapse into one trailing notify.
+  const notifyQueuedRef = useRef(false);
+  const lastNotifyAtRef = useRef(-Infinity);
+  const notifyCoalesced = () => {
+    const since = performance.now() - lastNotifyAtRef.current;
+    if (!notifyQueuedRef.current && since >= FRAME_INTERVAL_MS) {
+      lastNotifyAtRef.current = performance.now();
+      notify();
+      return;
+    }
+    if (notifyQueuedRef.current) return;
+    notifyQueuedRef.current = true;
+    setTimeout(() => {
+      notifyQueuedRef.current = false;
+      lastNotifyAtRef.current = performance.now();
+      notify();
+    }, Math.max(0, FRAME_INTERVAL_MS - since));
+  };
   function scrollMutated(el: DOMElement): void {
     // Signal background intervals (IDE poll, LSP poll, GCS fetch, orphan
     // check) to skip their next tick — they compete for the event loop and
@@ -113,7 +140,7 @@ function ScrollBox({
     noteFrameCause('scroll');
     markDirty(el);
     markCommitStart();
-    notify();
+    notifyCoalesced();
     if (renderQueuedRef.current) return;
     renderQueuedRef.current = true;
     queueMicrotask(() => {

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -554,14 +554,14 @@ export default class Ink {
   }
 
   /**
-   * Schedule the next scroll-drain frame — Grok Build's Presenter, ported:
+   * Schedule the next scroll-drain frame — Grok Build's Presenter, ported.
+   * Grok keeps TWO cadence knobs (min_draw_ms for renders, scroll_ms for
+   * scroll); collapsing both to FRAME_INTERVAL_MS made big flicks steppy
+   * (the proportional step, 75%-of-remaining, × 4× the interval = chunky
+   * ramp and ~4× longer settle), so the drain keeps its own fast cadence:
    *
-   *  - CADENCE: one drain frame per FRAME_INTERVAL_MS (60fps). The old
-   *    quarter-interval timer (~250fps) multiplied pty writes 4× for zero
-   *    visible smoothness — a terminal paints at its display refresh, not
-   *    at our timer rate. Scroll throughput is unchanged: the drain step
-   *    is proportional (75% of remaining delta per frame), so fewer frames
-   *    just take proportionally bigger steps.
+   *  - CADENCE: quarter interval (~250fps). Drain frames are cheap
+   *    (DECSTBM + ~10 patches); scroll throughput is unchanged.
    *  - IN-FLIGHT GATE: while stdout still holds unflushed bytes above
    *    PTY_BACKLOG_BYTES (slow ConPTY round trip, ssh link), queue nothing
    *    further — re-probe at quarter interval instead. Grok's equivalent
@@ -588,7 +588,7 @@ export default class Ink {
       }, FRAME_INTERVAL_MS >> 2);
       return;
     }
-    this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS);
+    this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
   }
 
   onRender() {


### PR DESCRIPTION
## 概要

用户报「节点进度条有残影、滚动仍卡」。取证结论（probe-rail-ghost + perf-scroll-bench）：headless 排空态零残影，残影是滚动瞬态（悬停卡翻动 + 逐事件提交把中间布局画出去）；「还是卡」主因是昨晚把排空节拍误并为 16ms。三项修复：

1. **排空节拍回调 4ms** — Grok 本有 min_draw_ms / scroll_ms 两个旋钮，滚动用更快节拍；合并成 16ms 让比例步长（75% 剩余量）× 4 倍间隔 = 步进变粒、settling 慢 4 倍。背压门保留。
2. **输入边意图合并**（Qwen 16ms 滚轮合并 / Crush 队列前过滤）— notify() 逐滚轮事件的 React 提交改为前沿+16ms 尾沿合并。
3. **rail 悬停滚动收起**（OpenCode 输入模态 + Grok 点击 tick 清 hover 卡）— 指针静止时窗口滑过不再逐帧改述预览；流式 sticky follow 不打扰悬停。

基准：输出字节 92.2→82.0KB（对基线累计 -38%）。20 脚本回归全绿，build 门禁通过。

真机残影若再现：`DSH_TUI_RENDER_LOG=<路径> dsh-tui` 抓字节流取证。