### PR TITLE
ci: 增加 ci-gate 汇总 job 作为唯一 required check 候选

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,3 +490,36 @@ jobs:
       # 插件场景渲染崩溃边界：Thrower 场景必须被 PluginSceneBoundary 接住——
       # onError 精确一次、崩溃场景停止绘制、进程存活；健康场景不受影响。
       - run: node --import tsx/esm scripts/verify-plugin-scene-boundary.tsx
+
+  # CI 门禁：唯一的 required check 候选。汇总所有分组结果——任何一组失败
+  # 或被取消，gate 显式失败并逐组报告状态。if: always() 保证上游失败时
+  # gate 仍然运行（被跳过的 check 不会阻塞合并，失败才会）；后续 CI 内部
+  # 再拆组、改名、加 matrix，branch protection 只需盯住这一个稳定名字。
+  ci-gate:
+    needs: [build, render-scroll, input-terminal, session-workspace, channel-ui]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every group to have succeeded
+        env:
+          BUILD: ${{ needs.build.result }}
+          RENDER_SCROLL: ${{ needs.render-scroll.result }}
+          INPUT_TERMINAL: ${{ needs.input-terminal.result }}
+          SESSION_WORKSPACE: ${{ needs.session-workspace.result }}
+          CHANNEL_UI: ${{ needs.channel-ui.result }}
+        run: |
+          status=0
+          for pair in "build:${BUILD}" \
+                      "render-scroll:${RENDER_SCROLL}" \
+                      "input-terminal:${INPUT_TERMINAL}" \
+                      "session-workspace:${SESSION_WORKSPACE}" \
+                      "channel-ui:${CHANNEL_UI}"; do
+            name="${pair%%:*}"
+            result="${pair#*:}"
+            echo "${name}: ${result}"
+            if [ "${result}" != "success" ]; then
+              echo "::error title=CI gate::${name} 结束状态为 ${result}（要求 success）"
+              status=1
+            fi
+          done
+          exit "${status}"


### PR DESCRIPTION
## 动机

#467 把测试拆成 5 个并行 job 后，分支保护若直接 require 五个 job 名，以后改名/拆组/加 matrix 都要跟着改保护规则；而且 required check 在被 skip 时不会阻塞合并，存在漏网窗口。

## 改动

- 新增 `ci-gate` job：`needs` 全部五个分组（build / render-scroll / input-terminal / session-workspace / channel-ui）+ `if: always()`。
- gate 逐组打印结束状态，失败/取消的组打 `::error` 注解，一次性暴露所有坏组（不在 gate 层复刻 fail-fast 遮蔽），任一组非 success 则 exit 1。
- 纯新增 33 行，不改任何测试语义。

## 后续（单独 PR）

- 分支保护把 required check 配到 `ci-gate`。
- verify-resize-temporal 隔离到 non-blocking 的 flaky-observation。
- bootstrap 单次 compile + artifact 复用，消除每 job 重复编译。

## 验证

- YAML 结构解析通过（6 jobs，needs/if 正确）。
- gate shell 逻辑本地跑过：success/failure/cancelled 混合输入下逐组报告、exit 1、注解输出正确。