### PR TITLE
ci: actions 升级到 Node 24 runtime 的当前主版本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,18 @@ jobs:
       # DSH_TUI_LANG=en themselves before their dynamic imports.
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Verify generated output is not checked in
         run: test -z "$(git ls-files -- lib)"
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -65,7 +65,7 @@ jobs:
       # 根 node_modules 的符号链接即完成解析，无需携带 vendor 的构建
       # 工具链；.tsx 脚本走的 src/ 由各组自己的 checkout 提供。
       - name: Upload compiled output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-build-${{ github.run_id }}
           retention-days: 3
@@ -88,15 +88,15 @@ jobs:
     env:
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -105,7 +105,7 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore compiled output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ci-build-${{ github.run_id }}
       # 带断言的回归：提问面板内联输入（issue #9）+ 工具卡排版
@@ -182,15 +182,15 @@ jobs:
     env:
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -199,7 +199,7 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore compiled output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ci-build-${{ github.run_id }}
       # 按键解析回归（issue #110）：Option+Enter（ESC CR）精确/合并/分块
@@ -258,15 +258,15 @@ jobs:
     env:
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -275,7 +275,7 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore compiled output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ci-build-${{ github.run_id }}
       # 审批服务配置回归（issue #49 尾巴）：裸组合 cordis.yml 必须挂载
@@ -374,15 +374,15 @@ jobs:
     env:
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -391,7 +391,7 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore compiled output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ci-build-${{ github.run_id }}
       # channel 层回归：发送链（submit/steer/撤回/打断重投）、compact 折叠、
@@ -544,15 +544,15 @@ jobs:
     env:
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm
@@ -561,7 +561,7 @@ jobs:
       - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Restore compiled output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ci-build-${{ github.run_id }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,18 +18,18 @@ jobs:
       # Gate scripts assert zh UI copy (same convention as CI).
       DSH_TUI_LANG: zh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # vendor/dsh-std 是 @dsh-std/* workspace 依赖的来源（#308）：
           # 不拉子模块时 prepare→compile 在空目录上构建出悬空链接，
           # tsc 全线 TS2307。
           submodules: recursive
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -25,7 +25,7 @@ jobs:
   star-history:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
       - name: 切换到图表专用分支（基于最新 main，同步远端）


### PR DESCRIPTION
## 动机

CI 日志持续警告 actions/checkout@v4、setup-node@v4、pnpm/action-setup@v4、upload/download-artifact@v4 仍以 Node 20 runtime 为目标、被 runner 强制切到 Node 24。逐个核对过各主版本的破坏性变更，确认本仓库用法全部兼容。

## 升级映射

| Action | 从 → 到 | 关键变更与本仓库兼容性 |
|---|---|---|
| checkout | v4 → v7 | v7 阻断 `pull_request_target` + fork PR 组合；本仓库无此触发器 |
| setup-node | v4 → v7 | v5 自动缓存/npm-only、v7 ESM 迁移；本仓库显式 `cache: pnpm` 不受影响 |
| pnpm/action-setup | v4 → v6 | v6 正式支持 pnpm 11（当前使用版本） |
| upload-artifact | v4 → v7 | Node 24 runtime；v7 新增单文件直传参数，不使用 |
| download-artifact | v4 → v8 | Node 24 + ESM 迁移，调用方透明 |
| setup-bun | v2（保持） | 已在当前主线 |

publish.yml / star-history.yml 同步升级 checkout / setup-node / pnpm。

## 验证

- 三个 workflow YAML 解析通过，job 结构不变。
- 纯版本号替换：56 行变更、无内容改动。
- CI 本跑即端到端验证。