### PR TITLE
ci: Windows/macOS 平台冒烟——install/compile/入口导入最小链路（观察档）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,49 @@ jobs:
       # scripts/run-ci-group.mjs 的 GROUPS 表（新增测试时同步登记）。
       - run: node scripts/run-ci-group.mjs flaky-observation
 
+  # 平台冒烟（non-blocking 观察档）：Windows（ConPTY/路径/行尾）与
+  # macOS（PTY/clang 工具链）上只有真实平台才能暴露的安装与编译差异。
+  # 最小链路：install → compile → 入口导入。结果只做观察（不接
+  # ci-gate、不阻塞合并），探明各平台差异后再逐步扩测并提升为
+  # required。fail-fast: false 让两个平台都跑完。
+  platform-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      DSH_TUI_LANG: zh
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # 与 build job 相同的显式编译语义；Windows 上 pnpm 脚本经 npm 转发，
+      # bash shell 保证 test/管道语法跨平台一致。
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - run: pnpm compile
+
+      - run: |
+          test -f lib/types/index.js
+          test -f lib/types/dsh-adapter/invariant.js
+
+      - name: Smoke-import compiled entry
+        run: node -e "import('./lib/types/index.js').then(() => console.log('entry import ok')).catch(e => { console.error(e); process.exit(1) })"
+
   # CI 门禁：唯一的 required check 候选。汇总所有分组结果——任何一组失败
   # 或被取消，gate 显式失败并逐组报告状态。if: always() 保证上游失败时
   # gate 仍然运行（被跳过的 check 不会阻塞合并，失败才会）；后续 CI 内部


### PR DESCRIPTION
## 动机

CI 至今只在 Ubuntu 上验证（Linux + Node 24），而本仓库包含大量平台敏感逻辑：Windows ConPTY、终端输入、路径处理、剪贴板、进程管理、macOS PTY。全量 86 条测试 ×3 平台不划算，先做最小链路冒烟。

## 改动

- `platform-smoke` job：matrix `windows-latest` + `macos-latest`，`fail-fast: false`，`shell: bash`（跨平台一致的 test/管道语法）。
- 链路与 build job 同语义：`pnpm install --ignore-scripts` → 单次 `pnpm compile` → 产物存在性断言 → `import('./lib/types/index.js')` 动态导入冒烟。
- **non-blocking 观察档**：不接 ci-gate、不阻塞合并。探明两平台的真实差异（工具链、native 可选依赖、路径）后再逐步扩测、提升为 required。

## 验证

- YAML 解析：8 jobs，gate needs 不变（未纳入 smoke）。
- CI 本跑即两平台端到端验证；失败即平台差异的实证信号。