### PR TITLE
feat: fullscreen 改为出厂默认

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ npm install -g @deepseek-harness-tui/dsh-tui
 `⌘` 需终端支持扩展键盘协议（iTerm2 / kitty / WezTerm / ghostty / tmux）；
 macOS 自带 Terminal.app 会自行消费 `⌘` 快捷键，请继续使用 `Ctrl`。
 
-**鼠标（`fullscreen: true` 全屏模式；默认关，profile 补丁层覆盖开启）**
+**鼠标（全屏模式默认开启；`fullscreen: false` 可退回 inline 主屏模式）**
 
 | 操作 | 功能 |
 |---|---|
 | 拖拽选择 | 应用内文本选区，**松开即复制**（OSC 52 + `wl-copy`/`xclip`/`xsel` 原生兜底；tmux 内走 `load-buffer -w`），复制后自动取消选区并弹出「已复制 N 个字符」提示 |
 | 双击 / 三击 | 选词 / 选行，同样即选即复制 |
-| 滚轮 | 仅在 fullscreen 且鼠标跟踪启用时：Help 打开时滚动帮助，否则滚动消息列表（±3 行/格）；默认 inline 模式不会把滚轮事件交给 TUI |
+| 滚轮 | 仅在 fullscreen 且鼠标跟踪启用时：Help 打开时滚动帮助，否则滚动消息列表（±3 行/格）；inline 模式不会把滚轮事件交给 TUI |
 | `Esc` | 拖拽进行中取消选区（不复制） |
 | 单击消息行 | 展开/收起该行 |
 | 单击「加载更早消息」/「ctrl+e 显示前 N 条」 | 加载更早消息 / 展开全部 |

--- a/scripts/repro-inline-scrollback.tsx
+++ b/scripts/repro-inline-scrollback.tsx
@@ -1,7 +1,7 @@
 /**
  * inline 模式 scrollback 污染复现（issue #38/#19/#39 统一验证）：
- * npm 安装默认 fullscreen: false —— 不进 alt screen，终端 scrollback 由
- * 终端原生接管。若增量重绘的 erase 行数与上一帧实际占行不一致（或帧高
+ * 本脚本以 inline（主屏）直挂——不传 fullscreen prop（组件默认 false），
+ * 不进 alt screen，终端 scrollback 由终端原生接管。若增量重绘的 erase 行数与上一帧实际占行不一致（或帧高
  * 超过视口无法全部擦除），旧帧内容会永久落入 scrollback：用户上滚看到
  * "UI 重复渲染 / 启动页随机插入 / 输出结束后上方内容乱掉"。
  *

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -64,7 +64,11 @@ export interface Config {
    *  `ctx used/window` readout) in the status footer; off hides that row
    *  while the status/mode lines stay (issue #29). */
   contextBar?: boolean
-  /** Run in the terminal's alternate screen (Claude Code fullscreen layout). */
+  /** Run in the terminal's alternate screen (Claude Code fullscreen layout).
+   *  Defaults to true — the fullscreen surface is the more complete one
+   *  (mouse, timeline rail, scrollbar gutter, selection copy), so fresh
+   *  installs start there; cordis.yml `fullscreen: false` or a /settings
+   *  toggle opts back into the inline main-screen layout. */
   fullscreen?: boolean
   /** UI language: `en` / `zh`. When absent, the `DSH_TUI_LANG` env var wins,
    *  then the `/lang` choice persisted in `~/.dsh-tui/lang.json`, then `zh`. */
@@ -107,7 +111,7 @@ export const Config: Schema<Config> = Schema.object({
   activity: Schema.boolean().default(true),
   activityFrames: Schema.string().required(false),
   contextBar: Schema.boolean().default(true),
-  fullscreen: Schema.boolean().default(false),
+  fullscreen: Schema.boolean().default(true),
   lang: Schema.string().required(false),
   preset: Schema.string().required(false),
   diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),


### PR DESCRIPTION
## 动机

fullscreen 形态的完善度已全面领先 inline 主屏：

- **鼠标交互**（点击/悬停/滚轮/拖拽选区即选即复制）全屏独占；
- **时间线轨 / 滚动条 gutter** 仅全屏转录渲染；
- 长会话打开性能达标（尾部窗口挂载 + 分帧补画落地后，全屏打开已不是慢路径）。

新装用户没有理由先落在功能残缺的 inline 再自己找开关——出厂默认改为全屏。

## 改动

- `src/dsh-adapter/index.ts`：`fullscreen` schema 默认 `false` → `true`（含 JSDoc 说明）。
- 消费点仅 boot 一处（`plugin.ts` 的 `bootedFullscreen`）；**显式选择优先于默认**的既有语义不变——`cordis.yml` 写 `fullscreen: false` 或 `/settings` 关掉仍退回 inline。
- Chat 组件 prop 默认保持 `false`：直挂组件的测试/基准不受影响（它们自带显式 prop）。
- README 鼠标章节措辞更新（「默认关」已过时）；`repro-inline-scrollback` 的前提注释同步（该脚本本来就是组件直挂 inline，行为不变）。

## 验证

- `pnpm run build`（含 verify:build 门禁）通过；
- `repro-inline-scrollback`（inline 直挂）ALL PASS——组件路径零影响；
- `verify-launcher` / `verify-update` 通过（启动器/更新链路不涉及该字段）。

## 兼容性

- 存量用户：settings 文档或 cordis.yml 里有显式值的，行为完全不变（显式值继续生效）；
- 只有「从未配置过」的安装会从下次启动起进入全屏。