### PR TITLE
feat: 滚动导航（rail 全轮次/一键回底/gutter 三态）+ 长会话性能优化线

### DIFF
--- a/scripts/analyze-cpuprof.cjs
+++ b/scripts/analyze-cpuprof.cjs
@@ -1,0 +1,19 @@
+/** 聚合 cpuprofile：自耗时 top 函数。用法：node scripts/analyze-cpuprof.cjs <file.cpuprofile> */
+const fs = require('fs')
+const prof = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+const byId = new Map(prof.nodes.map(n => [n.id, n]))
+const self = new Map()
+const totalWeight = prof.samples.length
+for (let i = 0; i < prof.samples.length; i++) {
+  const id = prof.samples[i]
+  const n = byId.get(id)
+  if (!n) continue
+  const f = n.callFrame
+  const key = `${f.functionName || '(anon)'} ${f.url ? f.url.split('/').slice(-2).join('/') : ''}:${f.lineNumber + 1}`
+  self.set(key, (self.get(key) ?? 0) + 1)
+}
+const sorted = [...self.entries()].sort((a, b) => b[1] - a[1]).slice(0, 25)
+console.log(`总样本=${totalWeight} (~${(totalWeight / 100).toFixed(1)}s @100Hz)`)
+for (const [k, v] of sorted) {
+  console.log(`${(v / totalWeight * 100).toFixed(1).padStart(5)}%  ${(v / 100).toFixed(2)}s  ${k}`)
+}

--- a/scripts/analyze-cpuprofile-callers.mjs
+++ b/scripts/analyze-cpuprofile-callers.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/** Aggregate .cpuprofile by (function, caller) pairs — attributes self time
+ *  to the immediate parent, exposing WHO drives a hot leaf like stringWidth. */
+import { readFileSync } from 'node:fs'
+
+const file = process.argv[2]
+const filter = process.argv[3] ?? '' // substring filter on leaf function name
+const profile = JSON.parse(readFileSync(file, 'utf8'))
+const { nodes, samples, timeDeltas } = profile
+const byId = new Map(nodes.map(n => [n.id, n]))
+const parent = new Map()
+for (const n of nodes) for (const c of n.children ?? []) parent.set(c, n)
+const self = new Map()
+let t = 0
+for (let i = 0; i < samples.length; i++) {
+  t += timeDeltas[i] ?? 0
+  const id = samples[i]
+  self.set(id, (self.get(id) ?? 0) + (timeDeltas[i] ?? 0))
+}
+const agg = new Map() // parentKey -> µs
+for (const [id, us] of self) {
+  const n = byId.get(id)
+  if (!n) continue
+  const fname = n.callFrame.functionName || '(anon)'
+  if (filter && !fname.includes(filter)) continue
+  const p = parent.get(id)
+  const pc = p?.callFrame
+  const pkey = p ? `${pc.functionName || '(anon)'} @ ${(pc.url || '').replace(/^.*(node_modules|dsh-tui)\//, '')}:${pc.lineNumber + 1}` : '(root)'
+  agg.set(pkey, (agg.get(pkey) ?? 0) + us)
+}
+const rows = [...agg.entries()].sort((a, b) => b[1] - a[1])
+console.log(`filter='${filter}' — self time grouped by caller`)
+for (const [k, us] of rows.slice(0, 20)) console.log(`${(us / 1000).toFixed(0).padStart(7)}ms  ${k}`)

--- a/scripts/analyze-cpuprofile.mjs
+++ b/scripts/analyze-cpuprofile.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/** Parse a V8 .cpuprofile: top self-time functions within a time window. */
+import { readFileSync } from 'node:fs'
+
+const file = process.argv[2]
+const sinceMs = Number(process.argv[3] ?? 0) // only samples with delta >= since (µs)
+const profile = JSON.parse(readFileSync(file, 'utf8'))
+const { nodes, samples, timeDeltas } = profile
+const byId = new Map(nodes.map(n => [n.id, n]))
+const self = new Map() // nodeId -> µs
+const total = new Map()
+let t = 0
+for (let i = 0; i < samples.length; i++) {
+  const d = timeDeltas[i] ?? 0
+  t += d
+  if (t < sinceMs * 1000) continue
+  const id = samples[i]
+  self.set(id, (self.get(id) ?? 0) + d)
+}
+// attribute to function key
+const rows = []
+for (const [id, us] of self) {
+  const n = byId.get(id)
+  if (!n) continue
+  const cf = n.callFrame
+  const key = `${cf.functionName || '(anon)'} @ ${(cf.url || '').replace(/^.*node_modules\//, 'nm/').replace(/^.*dsh-tui./, '')}:${cf.lineNumber + 1}`
+  rows.push([key, us])
+}
+rows.sort((a, b) => b[1] - a[1])
+console.log(`samples=${samples.length} window>=${sinceMs}ms`)
+for (const [k, us] of rows.slice(0, 30)) {
+  console.log(`${(us / 1000).toFixed(0).padStart(7)}ms  ${k}`)
+}

--- a/scripts/analyze-geometry-trace.mjs
+++ b/scripts/analyze-geometry-trace.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/** Summarize a DSH_TUI_GEOMETRY_TRACE jsonl: per-frame cause + list window + scroll geometry. */
+import { readFileSync } from 'node:fs'
+const lines = readFileSync(process.argv[2] ?? 'trace.jsonl', 'utf8').trim().split('\n').map(l => JSON.parse(l))
+const limit = Number(process.argv[3] ?? Infinity)
+let i = 0
+for (const e of lines) {
+  if (i++ >= limit) break
+  const l = e.list
+  const listStr = l ? `s${l.start}-e${l.end}/${l.rowCount} vp${l.viewport} top${l.topPad} bot${l.bottomPad} tot${l.total} sticky${l.sticky ? 1 : 0}` : '-'
+  const scrollStr = (e.scroll ?? []).map(s => `st${s.scrollTop}/${s.renderScrollTop} h${s.scrollHeight}/max${s.maxScroll} stky${s.sticky ? 1 : 0} grew${s.grew ? 1 : 0}`).join(' ')
+  console.log(`f${e.frame} ${String(e.cause).padEnd(12)} ${String(e.ms).padStart(5)}ms | ${listStr} | ${scrollStr}`)
+}
+console.log(`total frames=${lines.length}`)

--- a/scripts/perf-long-session.tsx
+++ b/scripts/perf-long-session.tsx
@@ -1,0 +1,128 @@
+/**
+ * perf-long-session — 长会话滚动基准（用户报告：打开长会话哪怕滑动都卡）。
+ *
+ * 场景：800 轮混合会话（user + 工具行 + assistant ≈ 2400 行），滚轮突发。
+ * 对比 120 轮（perf-scroll-bench）找出随行数超线性增长的成本。
+ *
+ * 输出：帧耗时分位、阶段总量（重点 commit——React 提交 = 组件树遍历）、
+ * 输出字节。若 commit/yoga 随行数暴涨 → 挂载窗口或全量循环泄漏。
+ *
+ * 运行：node --import tsx/esm scripts/perf-long-session.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+let outBytes = 0
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    const s = String(chunk)
+    outBytes += s.length
+    term.write(s, cb)
+  }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 800 轮：每轮 user + 2 工具行 + assistant(4 行) ≈ 3 行/轮 → 2400 行。
+// 全部在 300 行折叠窗口之上 → timeline 走全量 rows 循环。
+const rows: any[] = []
+let id = 0
+for (let turn = 1; turn <= 800; turn++) {
+  rows.push({ id: ++id, kind: 'user', text: `问题 ${turn}` })
+  for (let t = 0; t < 2; t++) {
+    rows.push({
+      id: ++id, kind: 'tool', text: '',
+      tool: {
+        callId: `t${turn}-${t}`, name: 'Read',
+        argsText: `{"file_path": "/tmp/f${t}.ts"}`, argsFull: '{}',
+        status: 'ok', startedAt: 0, durationMs: 30,
+        resultText: `内容行 1\n内容行 2`,
+      },
+    })
+  }
+  rows.push({ id: ++id, kind: 'assistant', text: Array.from({ length: 4 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+}
+console.log(`fixture: ${rows.length} 行, 800 轮 user`)
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 800',
+  scrollGutter: 'timeline',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+const frames: Array<{ ms: number; yoga: number; commit: number; renderer: number }> = []
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  {
+    stdout: stdout as any, stdin: stdin as any, stderr: stderr as any,
+    exitOnCtrlC: false, patchConsole: false,
+    onFrame: (f: any) => {
+      frames.push({ ms: f.durationMs, yoga: f.phases.yoga ?? 0, commit: f.phases.commit ?? 0, renderer: f.phases.renderer ?? 0 })
+    },
+  },
+)
+await sleep(1500)
+frames.length = 0
+outBytes = 0
+
+// 滚轮突发：3 轮 × 30 事件
+for (let r = 0; r < 3; r++) {
+  for (let i = 0; i < 30; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(8)
+  }
+  await sleep(200)
+}
+await sleep(400)
+
+const pct = (arr: number[], p: number) => {
+  const s = [...arr].sort((a, b) => a - b)
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))] ?? 0
+}
+const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0)
+const ms = frames.map(f => f.ms)
+console.log('==== perf-long-session (800 轮 / 2400 行) ====')
+console.log(`frames=${frames.length}  p50=${pct(ms, 50).toFixed(1)}ms  p95=${pct(ms, 95).toFixed(1)}ms  max=${Math.max(...ms).toFixed(1)}ms`)
+console.log(`yoga 总=${sum(frames.map(f => f.yoga)).toFixed(0)}ms max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms`)
+console.log(`commit 总=${sum(frames.map(f => f.commit)).toFixed(0)}ms max=${Math.max(...frames.map(f => f.commit)).toFixed(1)}ms`)
+console.log(`renderer 总=${sum(frames.map(f => f.renderer)).toFixed(0)}ms max=${Math.max(...frames.map(f => f.renderer)).toFixed(1)}ms`)
+console.log(`输出 ${(outBytes / 1024).toFixed(1)}KB`)
+const heap = process.memoryUsage()
+console.log(`heap used=${(heap.heapUsed / 1048576).toFixed(0)}MB rss=${(heap.rss / 1048576).toFixed(0)}MB`)
+
+await inst.unmount()
+process.exit(0)

--- a/scripts/perf-open-heavy.tsx
+++ b/scripts/perf-open-heavy.tsx
@@ -1,0 +1,145 @@
+/**
+ * perf-open-heavy — 长会话「打开 + 滚动」真实形态基准。
+ *
+ * 与 perf-long-session 的差别：行内容是 markdown 代码块（走 lexer +
+ * 语法高亮路径，绕开 looksLikePlainText 快路），并单独计量「打开」
+ * 阶段（render() 到静息）的帧数/耗时——用户报「打开长会话就卡」。
+ *
+ * 运行：node --import tsx/esm scripts/perf-open-heavy.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+let outBytes = 0
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    const s = String(chunk)
+    outBytes += s.length
+    term.write(s, cb)
+  }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 240 轮 × (user + 2 工具 + assistant 代码块回复) ≈ 3 行/轮 → 720 行，
+// 代码块每个 ~18 行 → 打开时折叠窗口 300 行全挂载 + 高亮。
+const codeReply = (turn: number) => `实现说明 ${turn}：\n\n\`\`\`ts\n// 模块 ${turn}：解析器 + 高亮路径压力\nexport function parse${turn}(input: string): Ast {\n  const tokens = lexer.scan(input, { mode: 'full', trace: false })\n  if (tokens.length === 0) return { kind: 'empty', span: [0, 0] }\n  const nodes: Node[] = []\n  for (const tok of tokens) {\n    if (tok.type === 'kw') nodes.push(transformKeyword(tok))\n    else if (tok.type === 'str') nodes.push(literal(tok.value, tok.span))\n    else nodes.push(identifier(tok))\n  }\n  return { kind: 'program', body: nodes, span: [0, input.length] }\n}\n\`\`\`\n\n后续按上述结构执行。`
+const rows: any[] = []
+let id = 0
+for (let turn = 1; turn <= 240; turn++) {
+  rows.push({ id: ++id, kind: 'user', text: `问题 ${turn}：帮我实现第 ${turn} 号模块的解析器` })
+  for (let t = 0; t < 2; t++) {
+    rows.push({
+      id: ++id, kind: 'tool', text: '',
+      tool: {
+        callId: `t${turn}-${t}`, name: t ? 'Bash' : 'Read',
+        argsText: t ? '{"command": "node --check mod.js"}' : `{"file_path": "/src/mod${turn}.ts"}`,
+        argsFull: '{}',
+        status: 'ok', startedAt: 0, durationMs: 30,
+        resultText: `checking mod${turn}.ts\nno syntax errors\ndone`,
+      },
+    })
+  }
+  rows.push({ id: ++id, kind: 'assistant', text: codeReply(turn) })
+}
+console.log(`fixture: ${rows.length} 行（含 markdown 代码块 + 高亮）`)
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 240',
+  scrollGutter: 'timeline',
+  whale: process.env.BENCH_WHALE !== '0',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+// ── 阶段 A：打开（render → 静息 500ms 无新帧）──
+const frames: Array<{ ms: number; commit: number; yoga: number; at: number }> = []
+let openBytes = 0
+const t0 = performance.now()
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  {
+    stdout: stdout as any, stdin: stdin as any, stderr: stderr as any,
+    exitOnCtrlC: false, patchConsole: false,
+    onFrame: (f: any) => {
+      frames.push({ ms: f.durationMs, commit: f.phases.commit ?? 0, yoga: f.phases.yoga ?? 0, at: performance.now() - t0 })
+    },
+  },
+)
+// 静息探测：每 100ms 查帧数，连续 5 次不增 = 打开完成
+let lastCount = -1, settledRounds = 0, openMs = 0
+while (settledRounds < 5) {
+  await sleep(100)
+  if (frames.length === lastCount) settledRounds++
+  else { settledRounds = 0; lastCount = frames.length }
+  openMs = performance.now() - t0
+  if (openMs > 30000) break
+}
+const openFrames = frames.length
+const openTotal = frames.reduce((a, f) => a + f.ms, 0)
+const openMax = Math.max(...frames.map(f => f.ms))
+console.log(`==== 打开阶段 ====`)
+console.log(`render→静息: ${openMs.toFixed(0)}ms  帧数=${openFrames}  帧耗时总和=${openTotal.toFixed(0)}ms  最长单帧=${openMax.toFixed(1)}ms`)
+console.log(`帧时刻与间隔: ${frames.map(f => `${f.at.toFixed(0)}ms(+${(f.at - (frames[frames.indexOf(f) - 1]?.at ?? 0)).toFixed(0)})`).join(' ')}`)
+console.log(`打开期 commit 总=${frames.reduce((a, f) => a + f.commit, 0).toFixed(0)}ms  yoga 总=${frames.reduce((a, f) => a + f.yoga, 0).toFixed(0)}ms`)
+
+// ── 阶段 B：滚动（代码块行，滚入新行 = lexer + 高亮 + yoga）──
+frames.length = 0
+outBytes = 0
+for (let r = 0; r < 3; r++) {
+  for (let i = 0; i < 30; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(8)
+  }
+  await sleep(200)
+}
+await sleep(400)
+const pct = (arr: number[], p: number) => {
+  const s = [...arr].sort((a, b) => a - b)
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))] ?? 0
+}
+const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0)
+const ms = frames.map(f => f.ms)
+console.log(`==== 滚动阶段（markdown/高亮行）====`)
+console.log(`frames=${frames.length}  p50=${pct(ms, 50).toFixed(1)}ms  p95=${pct(ms, 95).toFixed(1)}ms  max=${Math.max(...ms).toFixed(1)}ms`)
+console.log(`commit 总=${sum(frames.map(f => f.commit)).toFixed(0)}ms max=${Math.max(...frames.map(f => f.commit)).toFixed(1)}ms`)
+console.log(`yoga 总=${sum(frames.map(f => f.yoga)).toFixed(0)}ms max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms`)
+console.log(`输出 ${(outBytes / 1024).toFixed(1)}KB`)
+const heap = process.memoryUsage()
+console.log(`heap used=${(heap.heapUsed / 1048576).toFixed(0)}MB rss=${(heap.rss / 1048576).toFixed(0)}MB`)
+
+await inst.unmount()
+process.exit(0)

--- a/scripts/perf-real-open.tsx
+++ b/scripts/perf-real-open.tsx
@@ -154,6 +154,35 @@ if (!INLINE) {
   console.log(`==== 二次滚动（重挂载行 = LRU 命中验证）====`)
   console.log(`frames=${frames.length}  p50=${pct(ms2, 50).toFixed(1)}ms  p95=${pct(ms2, 95).toFixed(1)}ms  max=${Math.max(...ms2).toFixed(1)}ms`)
   console.log(`  yoga 总=${sum(frames, f => f.yoga).toFixed(0)}ms max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms`)
+  // ── 阶段 D：上滚阅读 + 流式输出并发（经典卡顿组合）──
+  // 先上滚打破 sticky（视口停在中部历史），再让尾部行以 streaming=true
+  // （走 StreamingMarkdown 前缀稳定路径）持续 text += chunk + version++。
+  frames.length = 0; byteHist.length = 0
+  for (let i = 0; i < 40; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(8)
+  }
+  await sleep(300)
+  frames.length = 0; byteHist.length = 0
+  const streamRow = rows[rows.length - 1]!
+  streamRow.streaming = true
+  const origText = streamRow.text
+  const chunk = '流式增量段落：继续分析模块边界与常量折叠的正确性，覆盖深层嵌套与循环引用的边界情况。\n\n'
+  let streamed = 0
+  const streamStart = performance.now()
+  while (performance.now() - streamStart < 3000) {
+    streamRow.text = origText + chunk.repeat(++streamed)
+    channel.version++ // useSyncExternalStore 的快照就是 version
+    listeners.forEach(l => l())
+    await sleep(33)
+  }
+  streamRow.streaming = undefined
+  await sleep(400)
+  const msD = frames.map(f => f.ms)
+  console.log(`==== 上滚阅读 + 流式并发 ====`)
+  console.log(`frames=${frames.length}  p50=${pct(msD, 50).toFixed(1)}ms  p95=${pct(msD, 95).toFixed(1)}ms  max=${Math.max(...msD).toFixed(1)}ms`)
+  console.log(`  commit 总=${sum(frames, f => f.commit).toFixed(0)}ms max=${Math.max(...frames.map(f => f.commit)).toFixed(1)}ms`)
+  console.log(`  yoga 总=${sum(frames, f => f.yoga).toFixed(0)}ms max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms`)
   const heap = process.memoryUsage()
   console.log(`heap used=${(heap.heapUsed / 1048576).toFixed(0)}MB rss=${(heap.rss / 1048576).toFixed(0)}MB`)
 }

--- a/scripts/perf-real-open.tsx
+++ b/scripts/perf-real-open.tsx
@@ -1,0 +1,162 @@
+/**
+ * perf-real-open — 贴近用户报告的形态：「打开长会话，还没流式输出，
+ * 连滚动都卡」。
+ *
+ * 与 perf-open-heavy 的差别：
+ *  1. 行内容是真实尺寸 —— thinking ~2KB、tool result ~4KB、assistant
+ *     ~1.5KB markdown（现有 bench 全是十几行小内容，滚入成本被低估）；
+ *  2. INLINE（主屏）模式 —— fullscreen 默认 false，historyPaintEnabled
+ *     生效，打开时折叠窗口 300 行全挂载；现有 bench 全传 fullscreen。
+ *
+ * 输出：打开阶段（render→静息）总时长 / 帧数 / 帧耗时 / 输出字节，
+ * 以及打开后第一批滚轮事件的帧滞后（交互延迟体感来源）。
+ *
+ * 运行：node --import tsx/esm scripts/perf-real-open.tsx
+ * Env：INLINE=0 强制 fullscreen 对照组
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const INLINE = process.env.INLINE !== '0'
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+let outBytes = 0
+let frameBytes = 0
+const byteHist: number[] = []
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    const s = String(chunk)
+    outBytes += s.length; frameBytes += s.length
+    term.write(s, cb)
+  }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 真实尺寸行：每轮 = user + thinking(2KB) + 2×tool(result 4KB) + assistant(1.5KB md)
+const mdPara = (n: number) => `#### 第 ${n} 段\n\n这是正文段落，包含 **加粗**、\`code\` 与列表：\n\n- 要点一：解析输入并构建 AST\n- 要点二：遍历节点做常量折叠\n- 要点三：回写 source map\n\n\`\`\`ts\nexport function fold${n}(node: Node): Node {\n  if (node.kind === 'num') return node\n  const lhs = fold${n}(node.lhs)\n  const rhs = fold${n}(node.rhs)\n  if (lhs.kind === 'num' && rhs.kind === 'num') return { kind: 'num', value: lhs.value + rhs.value, span: node.span }\n  return { ...node, lhs, rhs }\n}\n\`\`\`\n\n结论：该模块可以安全内联。`
+const rows: any[] = []
+let id = 0
+for (let turn = 1; turn <= 160; turn++) {
+  rows.push({ id: ++id, kind: 'user', text: `帮我实现第 ${turn} 号模块的解析器，要求覆盖边界情况并给出测试。` })
+  rows.push({ id: ++id, kind: 'reasoning', text: `思考过程 ${turn}：`.padEnd(2048, '先分析输入的结构，再决定遍历顺序；对每个节点检查类型约束；边界包括空输入、深层嵌套与循环引用。') })
+  for (let t = 0; t < 2; t++) {
+    rows.push({
+      id: ++id, kind: 'tool', text: '',
+      tool: {
+        callId: `t${turn}-${t}`, name: t ? 'Bash' : 'Read',
+        argsText: t ? '{"command": "node --check mod.js && node --test"}' : `{"file_path": "/src/mod${turn}.ts"}`,
+        argsFull: '{}', status: 'ok', startedAt: 0, durationMs: 30,
+        resultText: Array.from({ length: 48 }, (_, i) => `  line ${i}: checking module ${turn}-${t} … ok  depth=${i} tokens=${i * 37}`).join('\n'),
+      },
+    })
+  }
+  rows.push({ id: ++id, kind: 'assistant', text: mdPara(turn) + '\n\n' + mdPara(turn + 1000) })
+}
+console.log(`fixture: ${rows.length} 行（thinking 2KB / tool result 4KB / assistant md 3KB）  mode=${INLINE ? 'INLINE(主屏)' : 'FULLSCREEN'}`)
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 160',
+  scrollGutter: 'timeline', whale: true,
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+// ── 阶段 A：打开（render → 静息）──
+const frames: Array<{ ms: number; at: number; commit: number; yoga: number }> = []
+const t0 = performance.now()
+const tree = <Chat channel={channel} questionStore={new QuestionStore()} fullscreen={!INLINE} />
+const inst = await render(INLINE ? tree : <AlternateScreen>{tree}</AlternateScreen>, {
+  stdout: stdout as any, stdin: stdin as any, stderr: stderr as any,
+  exitOnCtrlC: false, patchConsole: false,
+  onFrame: (f: any) => {
+    frames.push({ ms: f.durationMs, at: performance.now() - t0, commit: f.phases.commit ?? 0, yoga: f.phases.yoga ?? 0 })
+    byteHist.push(frameBytes); frameBytes = 0
+  },
+})
+let lastCount = -1, settledRounds = 0, openMs = 0
+while (settledRounds < 5) {
+  await sleep(100)
+  if (frames.length === lastCount) settledRounds++
+  else { settledRounds = 0; lastCount = frames.length }
+  openMs = performance.now() - t0
+  if (openMs > 60000) break
+}
+const sum = (a: number[], f: (x: any) => number) => a.reduce((s, x) => s + f(x), 0)
+const pct = (arr: number[], p: number) => { const s = [...arr].sort((a, b) => a - b); return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))] ?? 0 }
+console.log(`==== 打开阶段 ====`)
+console.log(`render→静息: ${openMs.toFixed(0)}ms  帧数=${frames.length}  帧耗时总和=${sum(frames, f => f.ms).toFixed(0)}ms  最长单帧=${Math.max(...frames.map(f => f.ms)).toFixed(1)}ms`)
+console.log(`  commit 总=${sum(frames, f => f.commit).toFixed(0)}ms  yoga 总=${sum(frames, f => f.yoga).toFixed(0)}ms  输出=${(outBytes / 1024).toFixed(0)}KB`)
+console.log(`  打开后 1s/2s/3s 内帧数: ${frames.filter(f => f.at < 1000).length} / ${frames.filter(f => f.at < 2000).length} / ${frames.filter(f => f.at < 3000).length}`)
+
+// ── 阶段 B：滚轮（fullscreen 才有应用侧滚动；主屏滚动是终端原生的）──
+if (!INLINE) {
+  frames.length = 0; byteHist.length = 0
+  const wheelTimes: number[] = []
+  for (let r = 0; r < 3; r++) {
+    for (let i = 0; i < 30; i++) {
+      stdin.write('\x1b[<64;90;30M')
+      wheelTimes.push(performance.now())
+      await sleep(8)
+    }
+    await sleep(200)
+  }
+  await sleep(400)
+  const ms = frames.map(f => f.ms)
+  console.log(`==== 滚动阶段（大内容行滚入 = markdown+highlight）====`)
+  console.log(`frames=${frames.length}  p50=${pct(ms, 50).toFixed(1)}ms  p95=${pct(ms, 95).toFixed(1)}ms  max=${Math.max(...ms).toFixed(1)}ms`)
+  console.log(`  commit 总=${sum(frames, f => f.commit).toFixed(0)}ms max=${Math.max(...frames.map(f => f.commit)).toFixed(1)}ms`)
+  console.log(`  yoga 总=${sum(frames, f => f.yoga).toFixed(0)}ms max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms`)
+  console.log(`  输出=${(outBytes / 1024).toFixed(1)}KB  每帧字节 p50=${pct(byteHist, 50)} p95=${pct(byteHist, 95)} max=${Math.max(...byteHist, 0)}`)
+
+  // ── 阶段 C：滚回底部再滚上 —— 行二次挂载，验证 wrap 跨挂载缓存命中 ──
+  frames.length = 0; byteHist.length = 0
+  for (let i = 0; i < 80; i++) {
+    stdin.write('\x1b[<65;90;30M')
+    await sleep(8)
+  }
+  await sleep(300)
+  for (let i = 0; i < 80; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(8)
+  }
+  await sleep(400)
+  const ms2 = frames.map(f => f.ms)
+  console.log(`==== 二次滚动（重挂载行 = LRU 命中验证）====`)
+  console.log(`frames=${frames.length}  p50=${pct(ms2, 50).toFixed(1)}ms  p95=${pct(ms2, 95).toFixed(1)}ms  max=${Math.max(...ms2).toFixed(1)}ms`)
+  console.log(`  yoga 总=${sum(frames, f => f.yoga).toFixed(0)}ms max=${Math.max(...frames.map(f => f.yoga)).toFixed(1)}ms`)
+  const heap = process.memoryUsage()
+  console.log(`heap used=${(heap.heapUsed / 1048576).toFixed(0)}MB rss=${(heap.rss / 1048576).toFixed(0)}MB`)
+}
+
+await inst.unmount()
+process.exit(0)

--- a/scripts/perf-real-open.tsx
+++ b/scripts/perf-real-open.tsx
@@ -5,8 +5,10 @@
  * 与 perf-open-heavy 的差别：
  *  1. 行内容是真实尺寸 —— thinking ~2KB、tool result ~4KB、assistant
  *     ~1.5KB markdown（现有 bench 全是十几行小内容，滚入成本被低估）；
- *  2. INLINE（主屏）模式 —— fullscreen 默认 false，historyPaintEnabled
- *     生效，打开时折叠窗口 300 行全挂载；现有 bench 全传 fullscreen。
+ *  2. INLINE（主屏）模式 —— 本基准显式以 inline 挂载（组件默认 false），
+ *     historyPaintEnabled 生效，打开时折叠窗口 300 行全挂载；现有 bench
+ *     全传 fullscreen。（注：应用出厂配置已默认 fullscreen；这里测的是
+ *     inline 形态本身的成本。）
  *
  * 输出：打开阶段（render→静息）总时长 / 帧数 / 帧耗时 / 输出字节，
  * 以及打开后第一批滚轮事件的帧滞后（交互延迟体感来源）。

--- a/scripts/perf-tool-stream.tsx
+++ b/scripts/perf-tool-stream.tsx
@@ -1,0 +1,113 @@
+/**
+ * perf-tool-stream — 工具调用流式基准：出工具时每 chunk 的渲染成本。
+ *
+ * 场景：已有 200 行历史（含代码块），随后流式落 6 个工具调用
+ * （running → ok，带 resultText）。模拟真实"出工具"的节奏。
+ *
+ * 输出：每 chunk 的帧耗时 + 帧数 + 阶段分类（是否每 chunk 全窗口重渲）。
+ *
+ * 运行：node --import tsx/esm scripts/perf-tool-stream.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 历史：100 轮 × 2 行 = 200 行（user + assistant 短回复）
+const rows: any[] = []
+let id = 0
+for (let turn = 1; turn <= 100; turn++) {
+  rows.push({ id: ++id, kind: 'user', text: `问题 ${turn}` })
+  rows.push({ id: ++id, kind: 'assistant', text: `回复 ${turn}：完成。` })
+}
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 100',
+  scrollGutter: 'timeline',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+const emit = () => { channel.version++; for (const l of listeners) l() }
+
+const frames: Array<{ ms: number; commit: number; yoga: number }> = []
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  {
+    stdout: stdout as any, stdin: stdin as any, stderr: stderr as any,
+    exitOnCtrlC: false, patchConsole: false,
+    onFrame: (f: any) => frames.push({ ms: f.durationMs, commit: f.phases.commit ?? 0, yoga: f.phases.yoga ?? 0 }),
+  },
+)
+await sleep(1000)
+frames.length = 0
+
+// ── 出工具：6 个工具依次 running → ok ──
+for (let t = 1; t <= 6; t++) {
+  const before = frames.length
+  const sumBefore = frames.reduce((a, f) => a + f.ms, 0)
+  // running 落地
+  rows.push({
+    id: ++id, kind: 'tool', text: '',
+    tool: {
+      callId: `c${t}`, name: t % 2 ? 'Read' : 'Bash',
+      argsText: `{"file_path": "/src/file${t}.ts"}`, argsFull: '{}',
+      status: 'running', startedAt: Date.now(), durationMs: undefined,
+      resultText: undefined,
+    },
+  })
+  emit()
+  await sleep(300)
+  // 结果落地（同一行 in-place 突变）
+  const row = rows[rows.length - 1]
+  row.tool.status = 'ok'
+  row.tool.durationMs = 120 + t * 30
+  row.tool.resultText = `file ${t} line 1\nfile ${t} line 2\nfile ${t} line 3`
+  emit()
+  await sleep(300)
+  const chunkFrames = frames.slice(before)
+  const chunkMs = frames.reduce((a, f) => a + f.ms, 0) - sumBefore
+  console.log(`工具 ${t}: 帧数=${chunkFrames.length} 帧耗时和=${chunkMs.toFixed(1)}ms max=${chunkFrames.length ? Math.max(...chunkFrames.map(f => f.ms)).toFixed(1) : '-'}ms`)
+}
+
+const ms = frames.map(f => f.ms)
+console.log(`== 出工具期间: frames=${frames.length} p50=${ms.length ? [...ms].sort((a,b)=>a-b)[Math.floor(ms.length/2)].toFixed(1) : '-'}ms max=${ms.length ? Math.max(...ms).toFixed(1) : '-'}ms`)
+console.log(`commit 总=${frames.reduce((a, f) => a + f.commit, 0).toFixed(0)}ms  yoga 总=${frames.reduce((a, f) => a + f.yoga, 0).toFixed(0)}ms`)
+
+await inst.unmount()
+process.exit(0)

--- a/scripts/probe-fold-ticks.tsx
+++ b/scripts/probe-fold-ticks.tsx
@@ -1,0 +1,87 @@
+/** 探针：工具重会话（300 行折叠窗口内只有少量 user 轮）的 rail 节点数。 */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 模拟真实工具重会话：每轮 = user + 50 个工具行 + assistant（~52 行/轮）。
+// 12 轮 = 624 行 > 300 → 折叠窗口只留最后 300 行 ≈ 5-6 轮。
+const rows: any[] = []
+let id = 0
+for (let turn = 1; turn <= 12; turn++) {
+  rows.push({ id: ++id, kind: 'user', text: `问题 ${turn}` })
+  for (let t = 0; t < 50; t++) {
+    rows.push({
+      id: ++id, kind: 'tool', text: '',
+      tool: {
+        callId: `t${turn}-${t}`, name: 'Read',
+        argsText: `{"file_path": "/tmp/f${t}.ts"}`, argsFull: '{}',
+        status: 'ok', startedAt: 0, durationMs: 30,
+        resultText: `文件 ${t} 内容行 1\n文件 ${t} 内容行 2`,
+      },
+    })
+  }
+  rows.push({ id: ++id, kind: 'assistant', text: `回复 ${turn} 完毕。` })
+}
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 12',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(900)
+
+const buf = term.buffer.active
+const rail: string[] = []
+for (let y = 0; y < ROWS; y++) {
+  rail.push((buf.getLine(buf.baseY + y)?.getCell(COLS - 2)?.getChars() ?? '') + (buf.getLine(buf.baseY + y)?.getCell(COLS - 1)?.getChars() ?? ''))
+}
+const all = rail.join('')
+console.log(`rail 列 40 行：`)
+rail.forEach((r, y) => { if (r !== '  ') console.log(`${String(y).padStart(2)}|[${r}]`) })
+console.log(`tick 数（─+━）= ${all.split('─').length - 1 + all.split('━').length - 1}（会话共 12 轮）`)
+console.log(`可见的「问题 N」编号：`, Array.from(new Set(Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '').join('\n').matchAll(/问题 (\d+)/g).map(m => Number(m[1])))).sort((a, b) => a - b).join(','))
+
+await inst.unmount()
+process.exit(0)

--- a/scripts/probe-jump-blank.tsx
+++ b/scripts/probe-jump-blank.tsx
@@ -1,0 +1,91 @@
+/** 探针：快速回底时的空白帧。上滚 30 格 → End 回底，50ms 采样 600ms。 */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// 更重的会话：20 轮 × 9 行 = 180 行内容（视口 ~24 行），从顶部跳底距离大
+const rows: any[] = []
+for (let turn = 1; turn <= 20; turn++) {
+  rows.push({ id: turn * 2 - 1, kind: 'user', text: `问题 ${turn}` })
+  rows.push({ id: turn * 2, kind: 'assistant', text: Array.from({ length: 8 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+}
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 20',
+  scrollGutter: 'timeline',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(700)
+
+function blankCount(): { blank: number; tailVisible: boolean; head: string } {
+  const buf = term.buffer.active
+  const lines = Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
+  // 转录区 = 第 0/1 行（可能有置顶头）到 prompt 框上缘
+  let promptRow = -1
+  for (let y = ROWS - 1; y >= 0; y--) { if (lines[y]!.trimStart().startsWith('❯')) { promptRow = y; break } }
+  const end = promptRow >= 0 ? promptRow - 2 : ROWS - 4
+  let blank = 0
+  for (let y = 1; y < end; y++) if (lines[y]!.trim() === '') blank++
+  return { blank, tailVisible: lines.some(l => l.includes('问题 20')), head: lines[1]!.trimEnd().slice(0, 26) }
+}
+
+// 上滚到顶部区域
+for (let i = 0; i < 30; i++) {
+  stdin.write('\x1b[<64;90;30M')
+  await sleep(60)
+}
+await sleep(300)
+console.log(`回底前: ${JSON.stringify(blankCount())}`)
+
+// End 回底，立即开始 50ms 采样
+stdin.write('\x1b[F')
+for (let s = 0; s < 12; s++) {
+  await sleep(50)
+  console.log(`t=${(s + 1) * 50}ms: ${JSON.stringify(blankCount())}`)
+}
+
+await inst.unmount()
+process.exit(0)

--- a/scripts/repro-resume-position.tsx
+++ b/scripts/repro-resume-position.tsx
@@ -1,0 +1,218 @@
+/**
+ * repro-resume-position — 用户报告：进入 resume 的历史会话时视图不在最底
+ * 下（落在中部历史），既卡又看不到最新消息。
+ *
+ * 三条真实进入路径逐一验证落点：
+ *  S1 启动器 boot --resume：Chat 冷挂载时 rows 已完整回放（工厂 setup
+ *     hook 先于首帧）——预置长历史直接 render。
+ *  S2 /resume 浏览器恢复（之前钉在底部）：短会话 A → /resume → Enter →
+ *     resumeTo 原地清空重填 rows（真实语义：同数组、id 从 0 重放）→ 浏览
+ *     器关闭 → 转录重挂载。
+ *  S3 /resume 浏览器恢复（之前上滚阅读）：同 S2 但恢复前先滚轮上滚打破
+ *     sticky——检验挂载时的滚动状态是否干净。
+ *
+ * 行形状对齐真实长会话：user + thinking(600B) + 工具卡(24 行结果) +
+ * assistant(9-12 行 markdown)，90 轮 ≈ 300 行（超过 120 行折叠窗口）。
+ *
+ * 断言（每场景）：
+ *  - 视口包含最后一条消息的结尾标记（最新消息可见）；
+ *  - 无 "N 条新消息"/回到底部 pill（!isSticky 的唯一可见信号）；
+ *  - 视口不包含中部历史的独有标记（没停在半路）。
+ * 另测打开→静息时长（卡顿体感代理）。
+ *
+ * 运行：node --import tsx/esm scripts/repro-resume-position.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+function screenLines(): string[] {
+  const buf = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
+}
+
+// ── 会话行工厂：真实形状（thinking / 工具卡 / assistant 长文）──
+const T0 = Date.now() - 600_000
+function buildHistory(turns: number, tailMark: string, midMark: string): any[] {
+  const rows: any[] = []
+  let id = 0
+  for (let i = 1; i <= turns; i++) {
+    rows.push({ id: id++, kind: 'user', text: `问题 ${i}：帮我看看这个模块的解析逻辑`, time: T0 + i * 8000 })
+    const mid = i === Math.floor(turns / 2) ? `【${midMark}】` : ''
+    if (i % 3 === 0) {
+      rows.push({
+        id: id++, kind: 'reasoning',
+        text: `思考 ${i}：`.padEnd(600, '先分析结构再遍历节点，检查类型约束与边界。'),
+      })
+      rows.push({
+        id: id++, kind: 'tool', text: '',
+        tool: {
+          callId: `t${i}`, name: 'Bash', argsText: '{"command": "node --check mod.js"}',
+          argsFull: '{}', status: 'ok', startedAt: 0, durationMs: 30,
+          resultText: Array.from({ length: 24 }, (_, k) => `  line ${k}: ok depth=${k}`).join('\n'),
+        },
+      })
+    }
+    rows.push({
+      id: id++, kind: 'assistant',
+      text: `回复 ${i}：${mid}${'这一段是正文内容，分析输入结构、遍历节点、检查类型约束与边界情况，覆盖空输入、深层嵌套和循环引用。'.repeat(3)}${i === turns ? ` ${tailMark}` : ''}`,
+      time: T0 + i * 8000 + 3000,
+    })
+  }
+  return rows
+}
+
+const sessions: any[] = Array.from({ length: 4 }, (_, i) => ({
+  id: `s${i}`,
+  kind: { kind: 'root' },
+  title: { text: `历史会话 ${i}`, source: 'auto' },
+  cwd: '/tmp/demo',
+  createdAt: T0 - i * 60_000,
+  updatedAt: T0 + i * 60_000,
+  bytes: 12_000 + i * 1000,
+  branch: 'main',
+  model: 'deepseek-v4-flash',
+  childCount: 0,
+  hasPrompt: true,
+  label: undefined,
+  agentPreset: undefined,
+}))
+
+function makeChannel(initialRows: any[]) {
+  const listeners = new Set<() => void>()
+  const rows = initialRows
+  const channel: any = {
+    version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+    model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+    tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+    working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+    pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+    activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '',
+    scrollGutter: 'timeline', whale: true,
+    subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+    emit() { channel.version++; for (const cb of listeners) cb() },
+    submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+    listModels: () => Promise.resolve([]),
+    listSessions: () => Promise.resolve(sessions),
+    deleteSession: () => Promise.resolve(true),
+    renameSessionTo: () => Promise.resolve(true),
+    setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+    commandCompletions: (input: string) => completeCommands(input),
+    // 真实 resumeTo 语义（channel.ts ~2955）：同数组原地清空重填、id 从 0
+    // 重放、同步完成、末尾一次 emit。
+    async resumeTo(sessionId: string) {
+      rows.length = 0
+      for (const row of buildHistory(90, 'TAILMARK_Q7X', 'MIDMARK_Z9')) rows.push(row)
+      channel.lastUserText = '问题 90'
+      channel.agentId = sessionId
+      channel.emit()
+      return { ok: true }
+    },
+  }
+  return channel
+}
+
+function assertLanded(tag: string, ms: number): void {
+  const lines = screenLines()
+  const screen = lines.join('\n')
+  const tailVisible = screen.includes('TAILMARK_Q7X')
+  const midVisible = screen.includes('MIDMARK_Z9')
+  const pill = screen.includes('条新消息') || screen.includes('回到底部')
+  check(`${tag}: 最新消息结尾标记可见（在最底下）`, tailVisible,
+    tailVisible ? '' : `视口末行="${lines[ROWS - 3]!.trimEnd().slice(0, 40)}"`)
+  check(`${tag}: 无新消息 pill（sticky 已钉底）`, !pill)
+  check(`${tag}: 视口不在中部历史`, !midVisible)
+  console.log(`  [${tag}] 打开→检查点 ${ms.toFixed(0)}ms`)
+  if (!tailVisible || process.env.DUMP) {
+    console.log('  ──── 视口全量 ────')
+    lines.forEach((l, y) => console.log(`  ${String(y).padStart(2)}|${l.replace(/\s+$/, '')}`))
+  }
+}
+
+// ── S1：boot --resume（冷挂载 + 预置完整长历史）──
+{
+  const channel = makeChannel(buildHistory(90, 'TAILMARK_Q7X', 'MIDMARK_Z9'))
+  const inst = await render(
+    <AlternateScreen><Chat channel={channel} questionStore={new QuestionStore()} fullscreen /></AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  const t0 = performance.now()
+  await sleep(700)
+  assertLanded('S1 boot--resume', performance.now() - t0)
+  await inst.unmount()
+}
+
+// ── S2/S3：/resume 浏览器（S3 恢复前先上滚打破 sticky）──
+for (const [tag, scrollFirst] of [['S2 resume(at-bottom)', false], ['S3 resume(scrolled-up)', true]] as const) {
+  const channel = makeChannel(buildHistory(15, '', ''))
+  const inst = await render(
+    <AlternateScreen><Chat channel={channel} questionStore={new QuestionStore()} fullscreen /></AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(700)
+  if (scrollFirst) {
+    for (let i = 0; i < 12; i++) { stdin.write('\x1b[<64;50;20M'); await sleep(16) }
+    await sleep(250)
+    check(`${tag}: 前置——上滚后视口离开底部`, !screenLines().join('\n').includes('问题 15'))
+  }
+  // /resume → 浏览器 → Enter 恢复聚焦会话
+  stdin.write('/resume')
+  await sleep(300)
+  stdin.write('\r')
+  await sleep(500)
+  check(`${tag}: 浏览器打开`, screenLines().some(l => l.includes('历史会话')), '')
+  stdin.write('\r') // Enter → resumeTo → onClose
+  const t0 = performance.now()
+  await sleep(700)
+  assertLanded(tag, performance.now() - t0)
+  // 回到底部探针：滚 1 上再 2 下（pill 出现会使视口矮 2 行，等量滚回
+  // 必然差 2 行——这是既有 pill 语义；多滚一下代表用户“回到底部”）。
+  stdin.write('\x1b[<64;50;20M')
+  await sleep(200)
+  stdin.write('\x1b[<65;50;20M')
+  await sleep(120)
+  stdin.write('\x1b[<65;50;20M')
+  await sleep(400)
+  const healed = screenLines().join('\n').includes('TAILMARK_Q7X')
+  check(`${tag}: 滚离后滚回底部，最新消息可见`, healed)
+  if (!healed) {
+    console.log('  ──── 自愈探针后视口 ────')
+    screenLines().forEach((l, y) => console.log(`  ${String(y).padStart(2)}|${l.replace(/\s+$/, '')}`))
+  }
+  await inst.unmount()
+}
+
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -78,6 +78,18 @@ const GROUPS = {
 // 预算、行恒 1 不换行——断言零 wrapped 行、Pane 内无幽灵空行、翻页
 // 后标题/页脚/焦点仍在屏。
     ["verify-picker-edge", ['node', '--import', 'tsx/esm', 'scripts/verify-picker-edge.tsx']],
+// 滚动条 gutter 三态回归：rail 悬停/滚动/常驻三模式下 gutter 占位
+// 与内容宽度协商，切换不闪烁、不塌行。
+    ["verify-scrollbar-gutter", ['node', '--import', 'tsx/esm', 'scripts/verify-scrollbar-gutter.tsx']],
+// 一键回底回归：pill 常驻显示、End/Enter 回底、远距回底不触发空白
+// 死锁（大偏移一步到位后首帧即有内容）。
+    ["verify-back-to-bottom", ['node', '--import', 'tsx/esm', 'scripts/verify-back-to-bottom.tsx']],
+// 时间线 rail 回归：rail 覆盖全部轮次（含折叠轮），高亮锚定视口顶、
+// ▲/▼ 目标不越过 maxScroll。
+    ["verify-timeline-rail", ['node', '--import', 'tsx/esm', 'scripts/verify-timeline-rail.tsx']],
+// 恢复历史会话落点回归：/resume 后最新消息末行必须可见且可达
+// （scrollToBottom 补画完成后的锚定终态），不再落屏外。
+    ["repro-resume-position", ['node', '--import', 'tsx/esm', 'scripts/repro-resume-position.tsx']],
   ],
   'input-terminal': [
 // 按键解析回归（issue #110）：Option+Enter（ESC CR）精确/合并/分块

--- a/scripts/verify-back-to-bottom.tsx
+++ b/scripts/verify-back-to-bottom.tsx
@@ -170,5 +170,54 @@ await pressKey('end')
 }
 
 await inst.unmount()
+
+// ── 7. 远距跳底：20 轮重会话从中部 End 回底，不空白、末轮可见 ──
+// 修复前：viewport 落在从未挂载的行上（spacer 高度全是估算），topPad
+// 吞掉视口 = 永久空白，直到下一次 wheel 才救活。
+{
+  const heavy: any[] = []
+  for (let turn = 1; turn <= 20; turn++) {
+    heavy.push({ id: turn * 2 - 1, kind: 'user', text: `问题 ${turn}` })
+    heavy.push({ id: turn * 2, kind: 'assistant', text: Array.from({ length: 8 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+  }
+  const heavyChannel: any = { ...channel, rows: heavy, lastUserText: '问题 20' }
+  const inst2 = await render(
+    <AlternateScreen>
+      <Chat channel={heavyChannel} questionStore={new QuestionStore()} fullscreen />
+    </AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(700)
+  // 上滚 30 格 → 中部（跳底距离 ≈ 150 行 ≫ 视口）
+  for (let i = 0; i < 30; i++) {
+    stdin.write('\x1b[<64;90;30M')
+    await sleep(60)
+  }
+  await sleep(300)
+  // End 回底 + 采样
+  stdin.write('\x1b[F')
+  let settledAt = -1
+  for (let s = 0; s < 12; s++) {
+    await sleep(50)
+    if (screenLines().some(l => l.includes('问题 20'))) { settledAt = (s + 1) * 50; break }
+  }
+  check('远距 End 回底：末轮可见（≤600ms）', settledAt > 0, `settledAt=${settledAt}ms`)
+  await sleep(300)
+  const lines = screenLines()
+  // 空白行统计：转译区（跳过置顶头）连续全空行数 ≤ 6（轮间分隔正常 2-3 行）
+  let promptRow = -1
+  for (let y = ROWS - 1; y >= 0; y--) { if (lines[y]!.trimStart().startsWith('❯')) { promptRow = y; break } }
+  const endRow = promptRow >= 0 ? promptRow - 2 : ROWS - 4
+  let maxRun = 0, run = 0
+  for (let y = 1; y < endRow; y++) {
+    if (lines[y]!.trim() === '') run++
+    else run = 0
+    maxRun = Math.max(maxRun, run)
+  }
+  check('远距回底后无空白带（连续空行 ≤6）', maxRun <= 6, `maxRun=${maxRun}`)
+  check('远距回底后 pill 消失', pillText() === null, `pill=${JSON.stringify(pillText())}`)
+  await inst2.unmount()
+}
+
 console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-back-to-bottom.tsx
+++ b/scripts/verify-back-to-bottom.tsx
@@ -1,0 +1,174 @@
+/**
+ * verify-back-to-bottom — 一键回底：pill 常驻化 + End/Enter 键。
+ *
+ * 断言（headless xterm 100×40，全屏 Chat，8 轮对话）：
+ *   1. 钉底：无 pill；
+ *   2. 上滚：pill 出现「↓ 回到底部」；再流入新消息（追加 1 轮）→
+ *      pill 切「↓ N 条新消息」；
+ *   3. 按 End：回底（末轮可见、pill 消失）；
+ *   4. 再上滚：pill 出现；按 Enter：回底（pill 消失）；
+ *   5. 再上滚：点击 pill：回底；
+ *   6. 钉底按 End：无操作（末轮仍可见，不崩）。
+ *
+ * 运行：node --import tsx/esm scripts/verify-back-to-bottom.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+const rows: any[] = []
+for (let turn = 1; turn <= 8; turn++) {
+  rows.push({ id: turn * 2 - 1, kind: 'user', text: `问题 ${turn}` })
+  rows.push({ id: turn * 2, kind: 'assistant', text: Array.from({ length: 8 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+}
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 8',
+  scrollGutter: 'timeline',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+const emitChannel = () => { channel.version++; for (const l of listeners) l() }
+
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(700)
+
+function screenLines(): string[] {
+  const buf = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
+}
+/** pill 行文本（含 ↓ 的左缘行），无则 null。 */
+function pillText(): string | null {
+  for (const l of screenLines()) {
+    if (/↓/.test(l)) return l.trim()
+  }
+  return null
+}
+const lastTurnVisible = () => screenLines().some(l => l.includes('问题 8'))
+const wheel = async (up: boolean, times: number) => {
+  for (let i = 0; i < times; i++) {
+    stdin.write(`\x1b[<${up ? 64 : 65};90;30M`)
+    await sleep(150)
+  }
+}
+const pressKey = async (name: string) => {
+  const seqs: Record<string, string> = {
+    end: '\x1b[F',
+    enter: '\r',
+  }
+  stdin.write(seqs[name]!)
+  await sleep(400)
+}
+
+// ── 1. 钉底：无 pill ──
+check('钉底无 pill', pillText() === null, `pill=${JSON.stringify(pillText())}`)
+
+// ── 2. 上滚：常驻 pill；流入新消息后切计数 ──
+await wheel(true, 6)
+{
+  const p = pillText()
+  check('上滚后 pill 出现（回到底部）', p !== null && p.includes('回到底部'), `pill=${JSON.stringify(p)}`)
+}
+// 追加一轮新消息（模拟流式落定）
+rows.push({ id: 17, kind: 'user', text: '问题 9' })
+rows.push({ id: 18, kind: 'assistant', text: '回复 9 第 1 行\n回复 9 第 2 行' })
+emitChannel()
+await sleep(500)
+{
+  const p = pillText()
+  check('新消息后 pill 切计数', p !== null && /2 条新消息/.test(p), `pill=${JSON.stringify(p)}`)
+}
+
+// ── 3. End 键回底 ──
+await pressKey('end')
+{
+  check('End 后回到底部（末轮可见）', lastTurnVisible())
+  check('End 后 pill 消失', pillText() === null, `pill=${JSON.stringify(pillText())}`)
+}
+
+// ── 4. 上滚后 Enter 回底 ──
+await wheel(true, 8)
+{
+  check('再次上滚 pill 重现', pillText() !== null, `pill=${JSON.stringify(pillText())}`)
+}
+await pressKey('enter')
+{
+  check('Enter 后回到底部', lastTurnVisible() && pillText() === null,
+    `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
+}
+
+// ── 5. 点击 pill 回底 ──
+await wheel(true, 8)
+{
+  const lines = screenLines()
+  let pillRow = -1, pillCol = -1
+  for (let y = 0; y < ROWS && pillRow === -1; y++) {
+    const l = lines[y]!
+    const x = l.indexOf('↓')
+    if (x >= 0) { pillRow = y; pillCol = x }
+  }
+  check('点击前 pill 可见', pillRow !== -1, `row=${pillRow}`)
+  if (pillRow !== -1) {
+    stdin.write(`\x1b[<0;${pillCol + 2};${pillRow + 1}M`)
+    stdin.write(`\x1b[<0;${pillCol + 2};${pillRow + 1}m`)
+    await sleep(500)
+    check('点击 pill 后回到底部', lastTurnVisible() && pillText() === null,
+      `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
+  }
+}
+
+// ── 6. 钉底按 End：无操作不崩 ──
+await pressKey('end')
+{
+  check('钉底按 End 无操作', lastTurnVisible() && pillText() === null)
+}
+
+await inst.unmount()
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-scrollbar-gutter.tsx
+++ b/scripts/verify-scrollbar-gutter.tsx
@@ -1,0 +1,211 @@
+/**
+ * verify-scrollbar-gutter — `dsh-tui.scrollGutter` 设置三态：timeline（默认）
+ * / scrollbar（比例滚动条）/ hidden（无边栏），以及 scrollbar 形态的滑块
+ * 几何与轨道点击。
+ *
+ * 断言（headless xterm 100×40，全屏 Chat，8 轮对话）：
+ *   1. 默认 timeline：rail 出现（▴/tick/▾）；
+ *   2. setScrollGutter('scrollbar')：██ 滑块出现，钉底时贴底；无 ▴▾ tick；
+ *   3. 上滚：滑块上移且仍在轨道内；
+ *   4. 点击轨道顶部：滚到顶（问题 1 可见），滑块贴顶；
+ *   5. setScrollGutter('hidden')：右缘无任何 gutter glyph，转译区占满宽；
+ *   6. 切回 timeline：rail 恢复。
+ *
+ * 运行：node --import tsx/esm scripts/verify-scrollbar-gutter.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+const rows: any[] = []
+for (let turn = 1; turn <= 8; turn++) {
+  rows.push({ id: turn * 2 - 1, kind: 'user', text: `问题 ${turn}` })
+  rows.push({ id: turn * 2, kind: 'assistant', text: Array.from({ length: 8 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+}
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 8',
+  scrollGutter: 'timeline',
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+const emitChannel = () => { channel.version++; for (const l of listeners) l() }
+const setGutter = async (mode: string) => {
+  channel.scrollGutter = mode
+  emitChannel()
+  await sleep(400)
+}
+
+const inst = await render(
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>,
+  { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(700)
+
+function screenLines(): string[] {
+  const buf = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
+}
+function cellAt(y: number, col: number): string {
+  const buf = term.buffer.active
+  return buf.getLine(buf.baseY + y)?.getCell(col)?.getChars() ?? ''
+}
+function gutterRange(): [number, number] {
+  const lines = screenLines()
+  const top = /^❯/.test(lines[0]!.trimEnd()) ? 1 : 0
+  let promptRow = -1
+  for (let y = ROWS - 1; y >= 0; y--) {
+    if (lines[y]!.trimStart().startsWith('❯')) { promptRow = y; break }
+  }
+  return [top, promptRow >= 0 ? promptRow - 2 : ROWS - 4]
+}
+/** gutter 快照：{ thumbs: ██ 行, ticks: ─/━ 行, chevrons: ▴/▾ 行 }。
+ *  whale 图案的 █ 会落在 gutter 列——只把「两列均 █ 且同行左侧 20 列
+ *  内无 whale 图形字符」的行认作滑块。 */
+function gutterSnapshot(): { thumbs: number[]; ticks: number[]; chevrons: number[] } {
+  const [top, bottom] = gutterRange()
+  const thumbs: number[] = [], ticks: number[] = [], chevrons: number[] = []
+  for (let y = top; y < bottom; y++) {
+    const two = cellAt(y, COLS - 2) + cellAt(y, COLS - 1)
+    if (two.includes('██')) {
+      let whale = false
+      for (let x = COLS - 24; x < COLS - 4; x++) {
+        const c = cellAt(y, x)
+        if (c === '█' || c === '▀' || c === '▄' || c === '▀▀') { whale = true; break }
+      }
+      if (!whale) thumbs.push(y)
+    }
+    else if (two.includes('▴') || two.includes('▾')) chevrons.push(y)
+    else if (two === '━━' || two === '──' || two === ' ─') ticks.push(y)
+  }
+  return { thumbs, ticks, chevrons }
+}
+const wheel = async (up: boolean, times: number) => {
+  for (let i = 0; i < times; i++) {
+    stdin.write(`\x1b[<${up ? 64 : 65};90;30M`)
+    await sleep(150)
+  }
+}
+const clickAt = async (col: number, row: number) => {
+  stdin.write(`\x1b[<0;${col};${row}M`)
+  stdin.write(`\x1b[<0;${col};${row}m`)
+  await sleep(400)
+}
+
+// ── 1. 默认 timeline ──
+{
+  const snap = gutterSnapshot()
+  check('默认 timeline：rail tick + chevron 存在', snap.ticks.length > 0 && snap.chevrons.length === 2,
+    `ticks=${snap.ticks.length} chevrons=${snap.chevrons.length}`)
+  check('默认 timeline：无 ██ 滑块', snap.thumbs.length === 0, `thumbs=${snap.thumbs.length}`)
+}
+
+// ── 2. 切 scrollbar：██ 贴底，无 chevron/tick ──
+await setGutter('scrollbar')
+{
+  const snap = gutterSnapshot()
+  check('scrollbar：██ 滑块出现', snap.thumbs.length >= 2, `thumbs=${snap.thumbs.length}`)
+  check('scrollbar：无 timeline glyph', snap.chevrons.length === 0 && snap.ticks.length === 0,
+    `chevrons=${snap.chevrons.length} ticks=${snap.ticks.length}`)
+  const [top, bottom] = gutterRange()
+  check('scrollbar：钉底滑块贴底', snap.thumbs[snap.thumbs.length - 1] === bottom - 1,
+    `last=${snap.thumbs[snap.thumbs.length - 1]} bottom=${bottom}`)
+}
+
+// ── 3. 上滚（whale 滚出视口）：滑块在轨道内且离开底端 ──
+await wheel(true, 16)
+{
+  const snap = gutterSnapshot()
+  const [top, bottom] = gutterRange()
+  check('上滚后滑块存在（非 whale）', snap.thumbs.length >= 2, `thumbs=${JSON.stringify(snap.thumbs)}`)
+  if (snap.thumbs.length > 0) {
+    const first = snap.thumbs[0]!, last = snap.thumbs[snap.thumbs.length - 1]!
+    check('上滚后滑块仍在轨道内', first >= top && last < bottom, `first=${first} last=${last} range=[${top},${bottom})`)
+    check('上滚后滑块离开底端', last < bottom - 1, `last=${last} bottom=${bottom}`)
+  }
+}
+
+// ── 4. 点击轨道顶部：滚到顶（whale 回到视口，跳过滑块位置断言）──
+{
+  const [top] = gutterRange()
+  await clickAt(COLS, top + 1)
+  const lines = screenLines()
+  check('点击轨道顶后滚到顶（问题 1 可见）', lines.slice(0, 24).some(l => l.includes('问题 1')),
+    `top4=${JSON.stringify(lines.slice(0, 4).map(l => l.trimEnd().slice(0, 24)))}`)
+}
+
+// ── 5. 切 hidden：无 gutter（whale 的 █ 不算——只查 timeline/scrollbar glyph）──
+await setGutter('hidden')
+{
+  const [top, bottom] = gutterRange()
+  let anyGlyph = false
+  for (let y = top; y < bottom; y++) {
+    const two = cellAt(y, COLS - 2) + cellAt(y, COLS - 1)
+    if (two.includes('▴') || two.includes('▾') || two === '━━' || two === '──' || two === ' ─') anyGlyph = true
+    if (two.includes('██')) {
+      let whale = false
+      for (let x = COLS - 24; x < COLS - 4; x++) {
+        const c = cellAt(y, x)
+        if (c === '█' || c === '▀' || c === '▄') { whale = true; break }
+      }
+      if (!whale) anyGlyph = true
+    }
+  }
+  check('hidden：右缘无任何 gutter glyph', !anyGlyph)
+}
+
+// ── 6. 切回 timeline：rail 恢复 ──
+await wheel(false, 30)
+await setGutter('timeline')
+{
+  const snap = gutterSnapshot()
+  check('切回 timeline：rail 恢复', snap.ticks.length === 8 && snap.chevrons.length === 2,
+    `ticks=${snap.ticks.length} chevrons=${snap.chevrons.length}`)
+}
+
+await inst.unmount()
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-timeline-rail.tsx
+++ b/scripts/verify-timeline-rail.tsx
@@ -307,5 +307,57 @@ await wheel(false, 20)
 }
 
 await inst.unmount()
+
+// ── 8. 工具重会话：折叠窗口吃掉大半轮次，rail 仍覆盖全部轮 ──
+// 每轮 = user + 50 工具行 + assistant（52 行/轮）×12 = 624 行 > 300 →
+// 折叠窗口只剩 ~5 轮。修复前 rail 只画窗口内轮次（5 tick）；修复后
+// 上报全部 12 轮，折叠轮带 folded 标记，点击走 reveal 路径。
+{
+  const heavy: any[] = []
+  let hid = 0
+  for (let turn = 1; turn <= 12; turn++) {
+    heavy.push({ id: ++hid, kind: 'user', text: `问题 ${turn}` })
+    for (let t = 0; t < 50; t++) {
+      heavy.push({
+        id: ++hid, kind: 'tool', text: '',
+        tool: {
+          callId: `t${turn}-${t}`, name: 'Read',
+          argsText: `{"file_path": "/tmp/f${t}.ts"}`, argsFull: '{}',
+          status: 'ok', startedAt: 0, durationMs: 30,
+          resultText: `文件 ${t} 内容行 1\n文件 ${t} 内容行 2`,
+        },
+      })
+    }
+    heavy.push({ id: ++hid, kind: 'assistant', text: `回复 ${turn} 完毕。` })
+  }
+  const heavyChannel: any = { ...channel, rows: heavy, lastUserText: '问题 12' }
+  const inst2 = await render(
+    <AlternateScreen>
+      <Chat channel={heavyChannel} questionStore={new QuestionStore()} fullscreen />
+    </AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(900)
+  const snap = railSnapshot()
+  check('工具重会话：rail 覆盖全部 12 轮', snap.ticks.length === 12,
+    `ticks=${snap.ticks.length}（折叠窗口内仅 ~5 轮）`)
+  check('工具重会话：恰一个 ━━', snap.activeRow !== null, `active=${snap.activeRow}`)
+  // 点击第一个 tick（问题 1，被折叠）→ reveal + 跳转
+  const firstTick = snap.ticks[0]
+  if (firstTick !== undefined) {
+    await clickAt(COLS, firstTick + 1)
+    await sleep(600)
+    const lines = screenLines()
+    check('点击折叠 tick：问题 1 揭示并到顶', lines.slice(0, 6).some(l => l.includes('问题 1')),
+      `top6=${JSON.stringify(lines.slice(0, 4).map(l => l.trimEnd().slice(0, 30)))}`)
+    const snap2 = railSnapshot()
+    // 揭示后 sticky header 占 1 行 → 视口缩 1 → 整个 tick 块平移；按
+    // 轮次索引断言（━�� 在第 0 个 tick 上），不按屏幕行号。
+    check('揭示后 ━━ 移到首 tick（问题 1）', snap2.activeRow !== null && snap2.ticks.indexOf(snap2.activeRow) === 0,
+      `active=${snap2.activeRow} ticks=${JSON.stringify(snap2.ticks)}`)
+  }
+  await inst2.unmount()
+}
+
 console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-timeline-rail.tsx
+++ b/scripts/verify-timeline-rail.tsx
@@ -286,6 +286,29 @@ await wheel(false, 20)
   }
 }
 
+// ── 6b. 快速划过 tick：dwell 门下全程无卡（残影修复的回归）──
+{
+  const snap = railSnapshot()
+  let anyCard = false
+  // 8ms 间隔连续扫过全部 tick 行（模拟快速划过）
+  for (const row of snap.ticks) {
+    stdin.write(`\x1b[<35;${COLS};${row + 1}M`)
+    await sleep(8)
+    if (screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮'))) anyCard = true
+  }
+  await sleep(60)
+  if (screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮'))) anyCard = true
+  check('快速划过 tick 全程无预览卡（dwell 门）', !anyCard)
+  // 停留后卡照常出现
+  const row = snap.ticks[2]
+  if (row !== undefined) {
+    stdin.write(`\x1b[<35;${COLS};${row + 1}M`)
+    await sleep(350)
+    check('停留 350ms 后预览卡出现', screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')))
+    await hoverAt(30, 20)
+  }
+}
+
 // ── 7. resize 59 列：rail 隐藏；恢复 100 列：rail 回来 ──
 {
   ;(stdout as any).columns = 59

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -76,12 +76,20 @@ function lexWithCache(content: string, allowCache: boolean): Token[] {
   const tokens = marked.lexer(content)
   if (content.length > TOKEN_CACHE_MAX_SOURCE_LENGTH) return tokens
 
-  if (
+  // Evict oldest entries (Map preserves insertion order) until both the
+  // count and char budgets fit. The previous full clear() nuked the whole
+  // cache every time a long session crossed 200 blocks — every subsequent
+  // row remount then re-ran the lexer (scroll-through-a-long-session
+  // stutter); evicting only what the newcomer displaces keeps the working
+  // set warm.
+  while (
     tokenCache.size >= TOKEN_CACHE_CAPACITY ||
     tokenCacheChars + content.length > TOKEN_CACHE_CHAR_BUDGET
   ) {
-    tokenCache.clear()
-    tokenCacheChars = 0
+    const oldest = tokenCache.keys().next().value
+    if (oldest === undefined) break
+    tokenCache.delete(oldest)
+    tokenCacheChars -= oldest.length
   }
   tokenCache.set(content, tokens)
   tokenCacheChars += content.length

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -31,8 +31,14 @@ import type { ToolBackground } from '../tuiDisplayPrefs.js'
  * rows; `selectedId` highlights the selected row.
  */
 /** Render cap for very long sessions (CC's MAX_MESSAGES_WITHOUT_VIRTUALIZATION
- *  equivalent): older rows fold behind a Divider until Ctrl+E expands them. */
-const MAX_RENDERED_ROWS = 300
+ *  equivalent): older rows fold behind a Divider until Ctrl+E expands them.
+ *  120 (was 300): opening a long session paints the whole cap into the
+ *  main-screen scrollback (historyPaint), and each row's first markdown
+ *  lex + wrap costs ~2-5ms — 300 rows saturated the main thread for ~6s
+ *  on open (measured, 800-row inline session). 120 rows ≈ 4-5 screens of
+ *  paint (<1s) with the rest behind the show-previous divider (CC parity:
+ *  the transcript is a viewport, not a printout; load-earlier restores). */
+const MAX_RENDERED_ROWS = 120
 
 // --- layout virtualization constants -------------------------------------
 // Offscreen rows render as fixed-height spacers whose heights come from the
@@ -303,9 +309,20 @@ export function MessageList({
    *  free: those rows sit in scrollback and the diff skips them. */
   const lastStartRef = React.useRef<number>(-1)
   const holdUntilRef = React.useRef<number>(0)
+  /** True when frame-budgeted history painting still has batches left
+   *  (main-screen open): the layout effect schedules the next slice. */
+  const paintPendingRef = React.useRef(false)
+  const paintQueuedRef = React.useRef(false)
+  /** Persistent history-paint edge: how far batched painting has advanced
+   *  (index into visibleRows). -1 = not painting / reset (list head change:
+   *  rewind, new session, loadOlder — must repaint from scratch). */
+  const paintEdgeRef = React.useRef(-1)
   const listHeadId = visibleRows[0]?.id
   if (listHeadId !== undefined && paintedBaseRef.current !== undefined && listHeadId !== paintedBaseRef.current) {
     paintedOnceRef.current = new Set()
+    // History repaints from scratch after a head change too (rewind /
+    // loadOlder prepends rows that must paint again).
+    paintEdgeRef.current = -1
   }
   if (listHeadId !== undefined) paintedBaseRef.current = listHeadId
   /** Content-space offset of visibleRows[0] (header + dividers), measured. */
@@ -458,15 +475,53 @@ export function MessageList({
     // hundreds of markdown rows the user never sees (measured: 4.3s of
     // saturated main thread before first paint on a 960-row session; the
     // virtualization window re-mounts rows on demand as they scroll in).
+    // FRAME-BUDGETED: mounting the whole window in ONE commit saturated the
+    // main thread for seconds (measured 6s wall with ZERO frames in the
+    // first second on an 800-row inline open — every input queued behind
+    // the React render). Extend in batches of ~2 viewports of measured
+    // height per commit instead; the pending-batch effect schedules the
+    // next slice, so the app paints, drains input, and stays interactive
+    // while history streams in above the fold (opencode-style progressive
+    // transcript hydration; the terminal accepts rows whenever they land).
     const paintedOnce = paintedOnceRef.current
+    let paintPending = false
     if (historyPaintEnabled) {
-      for (let i = 0; i < start; i++) {
+      // Persistent batch edge: the sticky floor-walk RESETS start to the
+      // tail every frame, so a per-frame budget walk from `start` re-spends
+      // its whole budget on already-painted rows and never reaches deeper
+      // unpainted ones (measured: an infinite 0.3ms/frame batch loop).
+      // Remember how far painting has advanced; each batch extends THAT
+      // edge upward by the budget.
+      if (paintEdgeRef.current < 0) paintEdgeRef.current = start
+      let firstUnpainted = -1
+      for (let i = 0; i < paintEdgeRef.current; i++) {
         if (!paintedOnce.has(visibleRows[i]!.id)) {
-          start = i
+          firstUnpainted = i
           break
         }
       }
+      if (firstUnpainted !== -1) {
+        // Budget: extend the paint edge upward by ~half a viewport of
+        // measured content per commit (height estimates; unknown rows fall
+        // back to DEFAULT_ROW_HEIGHT and over-mount slightly — harmless).
+        // Measured: larger batches (2 viewports) put 50ms+ of first-wrap
+        // yoga into one frame; half a viewport keeps batches near the
+        // 16ms frame budget while still finishing an 800-row open in
+        // well under two seconds of background batches.
+        let budget = Math.min(viewport, termRows) / 2 + OVERSCAN_LINES
+        let j = paintEdgeRef.current
+        while (j > firstUnpainted && budget > 0) {
+          j--
+          budget -= heightOf(visibleRows[j]!)
+        }
+        paintEdgeRef.current = j
+        start = Math.min(start, j)
+        paintPending = j > 0
+      }
+    } else {
+      paintEdgeRef.current = -1
     }
+    paintPendingRef.current = paintPending
     // Unknown-height extension (layout signature, see sigRef): a row whose
     // cached height was just INVALIDATED must remount to re-measure even
     // when it sits outside the window — its spacer otherwise falls back to
@@ -720,6 +775,22 @@ export function MessageList({
         noteFrameCause('measure')
         setMeasureTick(t => t + 1)
       })
+    }
+    // History-paint continuation (main-screen open): more never-painted
+    // batches remain — schedule the next slice on the macrotask queue so
+    // pending input events (wheel, keys) drain between batches and the app
+    // stays interactive while preset history streams in. A timeout of 0 is
+    // enough: each batch's mount+measure work is bounded (~2 viewports),
+    // unlike the previous single-commit full mount that saturated the main
+    // thread for seconds.
+    if (paintPendingRef.current && !paintQueuedRef.current) {
+      paintQueuedRef.current = true
+      setTimeout(() => {
+        paintQueuedRef.current = false
+        if (!paintPendingRef.current) return
+        noteFrameCause('measure')
+        setMeasureTick(t => t + 1)
+      }, 0)
     }
   })
 
@@ -1144,18 +1215,22 @@ export function LogoHeader({
   effort,
   cwd,
   whale = true,
+  skipIntro = false,
 }: {
   model: string
   effort?: string | undefined
   cwd: string
   whale?: boolean
+  /** Jump straight to the settled header (long-session resume: the ~3.4s
+   *  opening animation competes with transcript mount batches). */
+  skipIntro?: boolean
 }): React.ReactNode {
   // Minimal mode drops the whole splash (whale art AND wordmark) — only the
   // transcript and a bare status bar remain.
   if (isMinimalMode()) return null
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <LogoV2 model={model} effort={effort} cwd={cwd} whale={whale} />
+      <LogoV2 model={model} effort={effort} cwd={cwd} whale={whale} skipIntro={skipIntro} />
     </Box>
   )
 }

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -145,6 +145,7 @@ export function MessageList({
   onToggleAll,
   onLoadOlder,
   thinkingVisible = true,
+  historyPaintEnabled = true,
   registerRowRef,
   scrollHandle,
   forceMountRowId,
@@ -179,6 +180,15 @@ export function MessageList({
    *  earlier messages" affordance; shown only when rows were folded). */
   onLoadOlder?: () => void
   thinkingVisible?: boolean
+  /**
+   * Whether rows outside the virtualization window must still be painted
+   * once (main-screen mode: unpainted rows leave NO copy in the terminal
+   * scrollback, so preset history would vanish). The alt-screen has no
+   * scrollback — passing false skips the mount-everything-on-open
+   * expansion there (a 300-row fold window of markdown otherwise costs
+   * seconds of lex/highlight/layout before first paint).
+   */
+  historyPaintEnabled?: boolean
   /** Transcript search: register each row's DOM element for scroll-to-match. */
   registerRowRef?: (rowId: number, el: DOMElement | null) => void
   /** Scroll viewport the list virtualizes against. */
@@ -442,11 +452,19 @@ export function MessageList({
     // vanish from the user's scrollback. Extending mounts everything above
     // on the first frame (topPad 0, full paint), then the set fills and the
     // window tightens to the tail.
+    // MAIN-SCREEN ONLY (historyPaintEnabled): the alt-screen has no
+    // scrollback — a row outside the window has no "copy" to preserve, and
+    // mounting the whole fold window on open lexed/highlighted/laid out
+    // hundreds of markdown rows the user never sees (measured: 4.3s of
+    // saturated main thread before first paint on a 960-row session; the
+    // virtualization window re-mounts rows on demand as they scroll in).
     const paintedOnce = paintedOnceRef.current
-    for (let i = 0; i < start; i++) {
-      if (!paintedOnce.has(visibleRows[i]!.id)) {
-        start = i
-        break
+    if (historyPaintEnabled) {
+      for (let i = 0; i < start; i++) {
+        if (!paintedOnce.has(visibleRows[i]!.id)) {
+          start = i
+          break
+        }
       }
     }
     // Unknown-height extension (layout signature, see sigRef): a row whose

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -583,21 +583,42 @@ export function MessageList({
     if (previewCache.size > 2000) previewCache.clear()
     const viewTop = scrollTop + pending
     const maxScroll = Math.max(0, (scrollHandle?.getScrollHeight() ?? 0) - viewport)
-    let index = 0
+    // Measured tops for turns INSIDE the fold window (user rows are never
+    // filtered by the thinking toggle, so a user row absent from
+    // visibleRows is exactly a folded one).
+    const measuredTops = new Map<number, number>()
     for (let i = 0; i < visibleRows.length; i++) {
       const row = visibleRows[i]!
       if (row.kind !== 'user') continue
-      const textTop = base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0)
+      measuredTops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
+    }
+    // Walk ALL rows (not the fold window): the rail must cover the whole
+    // conversation — a tool-heavy session packs 300 rows into a handful
+    // of turns, and window-only turns made the rail show "2-3 nodes".
+    // Folded turns carry folded:true + top:-1; their tops are unknown
+    // until revealed (they are all ABOVE the viewport, so active/down
+    // over measured turns is unaffected; ▲ may name a folded turn — its
+    // click goes through the reveal path, not scrollTo).
+    let index = 0
+    for (const row of rows) {
+      if (row.kind !== 'user') continue
       let cached = previewCache.get(row.id)
       if (cached === undefined || cached.len !== row.text.length) {
         cached = { len: row.text.length, preview: clipPreview(row.text) }
         previewCache.set(row.id, cached)
       }
-      timelineTurns.push({ id: row.id, top: textTop, preview: cached.preview })
-      if (textTop <= viewTop) activeTurnIndex = index
-      if (textTop < viewTop) upTurnIndex = index
-      if (downTurnIndex === null && textTop > viewTop && textTop <= maxScroll) {
-        downTurnIndex = index
+      const textTop = measuredTops.get(row.id)
+      if (textTop !== undefined) {
+        timelineTurns.push({ id: row.id, top: textTop, preview: cached.preview })
+        if (textTop <= viewTop) activeTurnIndex = index
+        if (textTop < viewTop) upTurnIndex = index
+        if (downTurnIndex === null && textTop > viewTop && textTop <= maxScroll) {
+          downTurnIndex = index
+        }
+      } else {
+        timelineTurns.push({ id: row.id, top: -1, preview: cached.preview, folded: true })
+        // Above the fold ⇒ strictly above the viewport: a legal ▲ target.
+        upTurnIndex = index
       }
       index++
     }
@@ -611,8 +632,11 @@ export function MessageList({
   }
   const lastTimelineReportRef = React.useRef('')
   React.useEffect(() => {
+    // Preview text never mutates for a given row id, so ids+tops+fold
+    // flags fully determine the snapshot — skipping previews keeps the
+    // per-frame signature O(turns) small integers, not O(preview chars).
     const sig =
-      timelineTurns.map(t => `${t.id}:${t.top}:${t.preview}`).join('|') +
+      timelineTurns.map(t => `${t.id}:${t.top}:${t.folded ? 1 : 0}`).join('|') +
       `#a${timeline.activeId}#u${timeline.upId}#d${timeline.downId}`
     if (sig !== lastTimelineReportRef.current) {
       lastTimelineReportRef.current = sig

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -61,14 +61,27 @@ const NO_STREAM_FOLDED: ReadonlySet<number> = new Set()
 const NOOP_TOGGLE_STREAM_FOLD = (_rowId: number): void => {}
 
 /**
- * Per-kind layout signature: the O(1) identity of every input that decides a
- * row's rendered HEIGHT (see sigRef in MessageList). Fields are scoped to the
- * row's own renderer — a global flat signature over-invalidates (a diffLayout
- * switch must not drop user-message heights). Text uses length as the proxy:
- * full-text hashing per row per frame would defeat virtualization's budget,
- * and a same-length miss only degrades to the previous behavior.
+ * Per-kind layout signature PARTS: the O(1) identity of every input that
+ * decides a row's rendered HEIGHT (see sigRef in MessageList). Fields are
+ * scoped to the row's own renderer — a global flat signature
+ * over-invalidates (a diffLayout switch must not drop user-message
+ * heights). Text uses length as the proxy: full-text hashing per row per
+ * frame would defeat virtualization's budget, and a same-length miss only
+ * degrades to the previous behavior.
+ *
+ * Returns a PARTS VECTOR instead of a joined string: the caller compares
+ * slot-by-slot against the cached vector (all primitives), allocating only
+ * when a row's inputs actually changed. Building a joined string per row
+ * per render was O(rows) allocation churn on every scroll tick — the GC
+ * share of the long-session scroll profile.
+ *
+ * The vector is a MODULE-LEVEL SCRATCH BUFFER: single-threaded synchronous
+ * render makes reuse safe, and the unchanged case (the overwhelming
+ * majority) allocates nothing. Callers that retain the vector must copy
+ * (parts.slice()).
  */
-function layoutSignature(
+const signatureScratch: Array<string | number | boolean> = []
+function signatureParts(
   row: ChatRow,
   columns: number,
   expanded: boolean,
@@ -80,26 +93,27 @@ function layoutSignature(
   model: string,
   failureHintRowId: number | null | undefined,
   failureHint: string | undefined,
-): string {
+): Array<string | number | boolean> {
+  signatureScratch.length = 0
   // Universal height inputs: width reflows every row; kind switches height
   // semantics wholesale; text length drives wrapping.
-  const parts: Array<string | number | boolean> = [columns, row.kind, row.text?.length ?? 0]
+  signatureScratch.push(columns, row.kind, row.text?.length ?? 0)
   switch (row.kind) {
     case 'assistant':
       // Streaming vs settled swaps renderers; Ctrl+O/per-row expand adds the
       // metadata row (model only renders expanded — keeps an idle /model
       // switch from touching settled rows).
-      parts.push(row.streaming === true, expanded, expandedRows.has(row.id), expanded ? model : '')
+      signatureScratch.push(row.streaming === true, expanded, expandedRows.has(row.id), expanded ? model : '')
       break
     case 'reasoning':
       // thinkingFold (preview vs full) and the visibility filter change the
       // folded card's height; streaming shows verbose live unless the user
       // clicked it folded (streamFolded collapses to the ticker/header).
-      parts.push(row.streaming === true, expanded, expandedRows.has(row.id), streamFolded.has(row.id), thinkingVisible, thinkingFold)
+      signatureScratch.push(row.streaming === true, expanded, expandedRows.has(row.id), streamFolded.has(row.id), thinkingVisible, thinkingFold)
       break
     case 'tool': {
       const tool = row.tool
-      parts.push(
+      signatureScratch.push(
         expanded,
         expandedRows.has(row.id),
         diffLayout,
@@ -115,7 +129,7 @@ function layoutSignature(
       // 卡片高度输入：running→settled 折叠 waterfall+tool 行（5→1 行），
       // failed 增加 error 行。缺这些字段的话 offscreen 结算后 cached
       // height 永不过期 → 滚回 blank band / 滚不到底。
-      parts.push(
+      signatureScratch.push(
         row.subagent?.status ?? '',
         row.subagent?.toolCalls.length ?? 0,
         row.subagent?.outputLines.length ?? 0,
@@ -124,14 +138,14 @@ function layoutSignature(
       break
     case 'compact':
       // Folded one-liner vs full summary text.
-      parts.push(expanded, expandedRows.has(row.id))
+      signatureScratch.push(expanded, expandedRows.has(row.id))
       break
     default:
       // user / notice / interrupt / local / local-output: height follows
       // text + columns alone (selection/background never change height).
       break
   }
-  return parts.join('|')
+  return signatureScratch
 }
 
 export function MessageList({
@@ -243,34 +257,102 @@ export function MessageList({
   const hiddenCount = rows.length - MAX_RENDERED_ROWS
   // The thinking filter runs BEFORE virtualization so window indices line up.
   //
-  // Empty settled assistant rows (PR #383's duplicate-dot bug): when the
-  // model calls a tool without producing text, the assistant/message event
-  // carries empty text — rendered as a lone `●` bullet dangling above the
-  // tool card. Filter them BEFORE virtualization (not by rendering null in
-  // TranscriptRow): a null row never mounts, never enters paintedOnce, and
-  // would stall the main-screen history-paint batch loop forever. A row
-  // that is STILL STREAMING keeps its place even with empty text — the
-  // live dot is the "model is answering" affordance and content may yet
-  // arrive.
-  const visibleRows = (showAll || hiddenCount <= 0
-    ? rows
-    : rows.slice(hiddenCount)
-  ).filter(row =>
-    !(row.kind === 'assistant' && row.streaming !== true && (row.text ?? '').trim() === '') &&
-    (thinkingVisible || row.kind !== 'reasoning'),
-  )
-
-  // CC addMargin: every rendered block gets a 1-row top margin except the
-  // first. Pre-pass over the FULL list so a windowed row keeps the exact
-  // spacing it would have in a fully-mounted list.
-  const margins = new Map<number, boolean>()
-  {
-    let prev: ChatRow['kind'] | undefined
-    for (const row of visibleRows) {
-      margins.set(row.id, prev !== undefined)
-      prev = row.kind
+  // Fingerprint memo: every scroll tick re-rendered this pipeline even when
+  // nothing changed — slice + filter allocate a fresh rows-length array and
+  // the margins pre-pass allocates a Map with one entry per row (3200-row
+  // session ⇒ ~200KB churn per 16ms tick, the GC share of the scroll
+  // profile). The inputs are all identity-stable across ticks: channel.rows
+  // is a live in-place array (identity changes only on rewind/new session),
+  // showAll/thinkingVisible are React state. Rows APPENDED in place keep the
+  // identity — the cache must key on rows.length too (streaming appends).
+  const visibleRowsCacheRef = React.useRef<{
+    rows: readonly ChatRow[]
+    rowsLength: number
+    showAll: boolean
+    thinkingVisible: boolean
+    out: readonly ChatRow[]
+    margins: ReadonlyMap<number, boolean>
+    /** Per-row `streaming === true` bits. The settle flip (streaming cleared
+     * in place, rows identity/length unchanged) changes empty-assistant
+     * filtering below, so the cache must rebuild on any bit change. */
+    streamBits: Uint8Array
+  } | null>(null)
+  /** Generation counter for the visibleRows cache (timeline memo key). */
+  const visGenRef = React.useRef(0)
+  const visibleCache = visibleRowsCacheRef.current
+  // Streaming-bit fingerprint: in-place `streaming = false` writes (turn
+  // settle) are invisible to the rows-identity/length key above, but an
+  // assistant row that settles with EMPTY text crosses the empty-assistant
+  // filter boundary (visible-while-streaming → filtered-when-settled).
+  // Allocation-free scan; rebuild only when a bit actually flipped.
+  let streamBitsSame = visibleCache !== null && visibleCache.streamBits.length === rows.length
+  if (streamBitsSame) {
+    const bits = visibleCache!.streamBits
+    for (let i = 0; i < rows.length; i++) {
+      if (bits[i] !== (rows[i]!.streaming === true ? 1 : 0)) { streamBitsSame = false; break }
     }
   }
+  if (
+    visibleCache === null ||
+    visibleCache.rows !== rows ||
+    visibleCache.rowsLength !== rows.length ||
+    visibleCache.showAll !== (showAll || hiddenCount <= 0) ||
+    visibleCache.thinkingVisible !== thinkingVisible ||
+    !streamBitsSame
+  ) {
+    const sliced = showAll || hiddenCount <= 0
+      ? rows
+      : rows.slice(hiddenCount)
+    // Empty settled assistant rows (PR #383's duplicate-dot bug): when the
+    // model calls a tool without producing text, the assistant/message event
+    // carries empty text — rendered as a lone `●` bullet dangling above the
+    // tool card. Filter them BEFORE virtualization (not by rendering null in
+    // TranscriptRow): a null row never mounts, never enters paintedOnce, and
+    // would stall the main-screen history-paint batch loop forever. A row
+    // that is STILL STREAMING keeps its place even with empty text — the
+    // live dot is the "model is answering" affordance and content may yet
+    // arrive.
+    let hasEmptyAssistant = false
+    for (const row of sliced) {
+      if (row.kind === 'assistant' && row.streaming !== true && (row.text ?? '').trim() === '') {
+        hasEmptyAssistant = true
+        break
+      }
+    }
+    const out = hasEmptyAssistant
+      ? sliced.filter(row =>
+          !(row.kind === 'assistant' && row.streaming !== true && (row.text ?? '').trim() === '') &&
+          (thinkingVisible || row.kind !== 'reasoning'),
+        )
+      : thinkingVisible
+        ? sliced
+        : sliced.filter(row => row.kind !== 'reasoning')
+    // CC addMargin: every rendered block gets a 1-row top margin except the
+    // first. Pre-pass over the FULL list so a windowed row keeps the exact
+    // spacing it would have in a fully-mounted list.
+    const margins = new Map<number, boolean>()
+    {
+      let prev: ChatRow['kind'] | undefined
+      for (const row of out) {
+        margins.set(row.id, prev !== undefined)
+        prev = row.kind
+      }
+    }
+    const streamBits = new Uint8Array(rows.length)
+    for (let i = 0; i < rows.length; i++) streamBits[i] = rows[i]!.streaming === true ? 1 : 0
+    visibleRowsCacheRef.current = {
+      rows,
+      rowsLength: rows.length,
+      showAll: showAll || hiddenCount <= 0,
+      thinkingVisible,
+      out,
+      margins,
+      streamBits,
+    }
+    visGenRef.current++
+  }
+  const visibleRows = visibleRowsCacheRef.current!.out
+  const margins = visibleRowsCacheRef.current!.margins
   // Selection keeps its highlight; expanded rows render with no fill (the
   // diff line tints inside cards are the only backgrounds in the transcript).
   const rowBackground = (rowId: number) => {
@@ -289,6 +371,9 @@ export function MessageList({
   // DEFAULT_ROW_HEIGHT, which only perturbs deep scrollback estimates.
   const HEIGHTS_CACHE_MAX = 5000
   const heightsRef = React.useRef(new Map<number, number>())
+  /** Geometry version: bumped at EVERY heightsRef mutation so downstream
+   *  memos (timeline tops) can key on it instead of re-deriving offsets. */
+  const heightsVersionRef = React.useRef(0)
   const localRefs = React.useRef(new Map<number, DOMElement>())
   /** Row ids that have been mounted (and therefore painted into the
    *  terminal) at least once. The sticky window may skip a row ONLY after
@@ -336,6 +421,7 @@ export function MessageList({
   if (lastColumns.current !== columns) {
     lastColumns.current = columns
     heightsRef.current.clear()
+    heightsVersionRef.current++
     baseRef.current = null
   }
 
@@ -354,7 +440,13 @@ export function MessageList({
   // Text identity uses length as an O(1) proxy — per-frame full-text
   // hashing over every row would defeat virtualization's budget, and a
   // same-length miss only degrades to the previous behavior.
-  const sigRef = React.useRef(new Map<number, string>())
+  //
+  // VECTORS, not strings: the cache stores the parts VECTOR and the
+  // comparison is slot-by-slot — the unchanged case (every settled row on
+  // every scroll tick) allocates nothing. A joined string per row per
+  // render was O(rows) garbage per tick (3200-row session ⇒ several MB/s
+  // into minor GC; the GC share of the scroll profile).
+  const sigRef = React.useRef(new Map<number, Array<string | number | boolean>>())
   {
     const sigs = sigRef.current
     for (let i = 0; i < visibleRows.length; i++) {
@@ -365,7 +457,7 @@ export function MessageList({
       // reasoning height at once, remounting the widened window over rows
       // whose rendering never changed (Yoga spike + measure churn for
       // nothing). Base parts cover the universal height inputs.
-      const sig = layoutSignature(
+      const parts = signatureParts(
         row,
         columns,
         expanded,
@@ -378,14 +470,23 @@ export function MessageList({
         failureHintRowId,
         failureHint,
       )
-      if (sigs.get(row.id) !== sig) {
-        if (sigs.size >= HEIGHTS_CACHE_MAX) {
-          const oldest = sigs.keys().next().value
-          if (oldest !== undefined) sigs.delete(oldest)
+      const cachedParts = sigs.get(row.id)
+      let same = false
+      if (cachedParts !== undefined && cachedParts.length === parts.length) {
+        same = true
+        for (let s = 0; s < parts.length; s++) {
+          if (parts[s] !== cachedParts[s]) { same = false; break }
         }
-        sigs.set(row.id, sig)
-        heightsRef.current.delete(row.id)
       }
+      if (same) continue
+      if (sigs.size >= HEIGHTS_CACHE_MAX) {
+        const oldest = sigs.keys().next().value
+        if (oldest !== undefined) sigs.delete(oldest)
+      }
+      // Copy out of the module-level scratch buffer — the next row reuses it.
+      sigs.set(row.id, parts.slice())
+      heightsRef.current.delete(row.id)
+      heightsVersionRef.current++
     }
   }
 
@@ -403,7 +504,13 @@ export function MessageList({
 
   const heightOf = (row: ChatRow): number =>
     heightsRef.current.get(row.id) ?? DEFAULT_ROW_HEIGHT
-  const offsets: number[] = new Array<number>(visibleRows.length)
+  // Reused offsets buffer: the prefix-scan itself must run every render
+  // (heightsRef mutates in the measure effect), but the ARRAY need not be
+  // fresh — offsets never escapes this render scope. A new 3200-slot array
+  // per scroll tick was pure GC fodder.
+  const offsetsBufRef = React.useRef<number[]>([])
+  const offsets: number[] = offsetsBufRef.current
+  offsets.length = visibleRows.length
   let total = 0
   for (let i = 0; i < visibleRows.length; i++) {
     offsets[i] = total
@@ -541,9 +648,8 @@ export function MessageList({
     // streaming row below/above the window remounted per chunk — full
     // markdown re-lex + wrap of the whole growing text, invisible to the
     // user reading history (measured: 3s of streaming while scrolled up
-    // burned 2.7s of yoga, max 126ms single-chunk spikes). Its height is
-    // in flux anyway; the final settle invalidates once more and remounts
-    // exactly once.
+    // burned 2.5s of yoga and +84MB heap). Its height is in flux anyway;
+    // the final settle invalidates once more and remounts exactly once.
     for (let i = 0; i < start; i++) {
       if (visibleRows[i]!.streaming === true) continue
       const rowId = visibleRows[i]!.id
@@ -572,8 +678,7 @@ export function MessageList({
   // Runs for non-sticky views; sticky mounts the tail anyway. Streaming
   // rows are skipped — THIS loop is the measured hot path of the
   // read-while-streaming stall (the streaming tail row sits below the
-  // window and its height invalidated per chunk; A/B without the guard:
-  // yoga 总 2674ms / max 126ms over a 3s stream, with it: 13ms / 3.6ms).
+  // window and invalidated per chunk).
   for (let i = end; i < visibleRows.length; i++) {
     if (visibleRows[i]!.streaming === true) continue
     const rowId = visibleRows[i]!.id
@@ -656,60 +761,85 @@ export function MessageList({
   // there, so a turn past it could never own the top row, and naming it
   // would make ▼ repeat itself forever (the stuck-▼ bug). Reported
   // post-commit, only when the signature changes.
-  const timelineTurns: TimelineTurn[] = []
+  let timelineTurns: TimelineTurn[] = []
   let activeTurnIndex: number | null = null
   let upTurnIndex: number | null = null
   let downTurnIndex: number | null = null
+  const timelineMemoRef = React.useRef<{ key: string; turns: TimelineTurn[] } | null>(null)
   {
-    // Preview cache: user rows are immutable once landed, and this loop
-    // runs on EVERY scroll frame (MessageList re-renders per drain tick).
-    // clipPreview scans to the first non-empty line — O(text length) per
-    // row per frame for pasted-content prompts. Cache by row id with a
-    // text-length guard as belt-and-braces against any id reuse.
-    const previewCache = previewCacheRef.current
-    if (previewCache.size > 2000) previewCache.clear()
+    // Split into (a) a GEOMETRY-memoized turns list and (b) a per-frame
+    // allocation-free target scan. Before the split this block rebuilt on
+    // EVERY scroll tick: an 800-object turns array, an 800-entry
+    // measuredTops Map, and the report effect's turns.map().join('|')
+    // signature — several hundred KB of churn per second of scrolling on a
+    // tool-heavy session.
+    //
+    // (a) turns/tops/folded change ONLY when geometry changes: row heights
+    // (heightsVersion — bumped at every heightsRef mutation), the visible
+    // window's content (visGen — bumped when the visibleRows cache
+    // rebuilds), the measured header base, or the rows array growing. Key
+    // on those; previews stay in their own id-keyed cache.
+    const memo = timelineMemoRef.current
+    const memoKey = `${visGenRef.current}:${heightsVersionRef.current}:${base}:${rows.length}:${columns}`
+    if (memo === null || memo.key !== memoKey) {
+      const previewCache = previewCacheRef.current
+      if (previewCache.size > 2000) previewCache.clear()
+      // Measured tops for turns INSIDE the fold window (user rows are never
+      // filtered by the thinking toggle, so a user row absent from
+      // visibleRows is exactly a folded one).
+      const measuredTops = new Map<number, number>()
+      for (let i = 0; i < visibleRows.length; i++) {
+        const row = visibleRows[i]!
+        if (row.kind !== 'user') continue
+        measuredTops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
+      }
+      // Walk ALL rows (not the fold window): the rail must cover the whole
+      // conversation — a tool-heavy session packs 300 rows into a handful
+      // of turns, and window-only turns made the rail show "2-3 nodes".
+      // Folded turns carry folded:true + top:-1; their tops are unknown
+      // until revealed (they are all ABOVE the viewport, so active/down
+      // over measured turns is unaffected; ▲ may name a folded turn — its
+      // click goes through the reveal path, not scrollTo).
+      const turns: TimelineTurn[] = []
+      for (const row of rows) {
+        if (row.kind !== 'user') continue
+        let cached = previewCache.get(row.id)
+        if (cached === undefined || cached.len !== row.text.length) {
+          cached = { len: row.text.length, preview: clipPreview(row.text) }
+          previewCache.set(row.id, cached)
+        }
+        const textTop = measuredTops.get(row.id)
+        if (textTop !== undefined) {
+          turns.push({ id: row.id, top: textTop, preview: cached.preview })
+        } else {
+          turns.push({ id: row.id, top: -1, preview: cached.preview, folded: true })
+        }
+      }
+      timelineMemoRef.current = { key: memoKey, turns }
+    }
+    timelineTurns = timelineMemoRef.current!.turns
+    // (b) per-frame target scan — pure integer comparisons over the
+    // memoized list; viewTop is projected (scrollTop + pending) so
+    // boundary crossings register during wheel bursts, not one drain
+    // frame late. downId additionally requires top ≤ maxScroll: the
+    // renderer clamps scrollTop there, so a turn past it could never own
+    // the top row, and naming it would make ▼ repeat itself forever.
     const viewTop = scrollTop + pending
     const maxScroll = Math.max(0, (scrollHandle?.getScrollHeight() ?? 0) - viewport)
-    // Measured tops for turns INSIDE the fold window (user rows are never
-    // filtered by the thinking toggle, so a user row absent from
-    // visibleRows is exactly a folded one).
-    const measuredTops = new Map<number, number>()
-    for (let i = 0; i < visibleRows.length; i++) {
-      const row = visibleRows[i]!
-      if (row.kind !== 'user') continue
-      measuredTops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
-    }
-    // Walk ALL rows (not the fold window): the rail must cover the whole
-    // conversation — a tool-heavy session packs 300 rows into a handful
-    // of turns, and window-only turns made the rail show "2-3 nodes".
-    // Folded turns carry folded:true + top:-1; their tops are unknown
-    // until revealed (they are all ABOVE the viewport, so active/down
-    // over measured turns is unaffected; ▲ may name a folded turn — its
-    // click goes through the reveal path, not scrollTo).
-    let index = 0
-    for (const row of rows) {
-      if (row.kind !== 'user') continue
-      let cached = previewCache.get(row.id)
-      if (cached === undefined || cached.len !== row.text.length) {
-        cached = { len: row.text.length, preview: clipPreview(row.text) }
-        previewCache.set(row.id, cached)
-      }
-      const textTop = measuredTops.get(row.id)
-      if (textTop !== undefined) {
-        timelineTurns.push({ id: row.id, top: textTop, preview: cached.preview })
-        if (textTop <= viewTop) activeTurnIndex = index
-        if (textTop < viewTop) upTurnIndex = index
-        if (downTurnIndex === null && textTop > viewTop && textTop <= maxScroll) {
-          downTurnIndex = index
-        }
-      } else {
-        timelineTurns.push({ id: row.id, top: -1, preview: cached.preview, folded: true })
+    for (let i = 0; i < timelineTurns.length; i++) {
+      const t = timelineTurns[i]!
+      if (t.folded === true) {
         // Above the fold ⇒ strictly above the viewport: a legal ▲ target.
-        upTurnIndex = index
+        upTurnIndex = i
+        continue
       }
-      index++
+      if (t.top <= viewTop) activeTurnIndex = i
+      if (t.top < viewTop) upTurnIndex = i
+      if (downTurnIndex === null && t.top > viewTop && t.top <= maxScroll) {
+        downTurnIndex = i
+      }
     }
-    if (index > 0 && activeTurnIndex === null) activeTurnIndex = 0
+    if (timelineTurns.length > 0 && activeTurnIndex === null) activeTurnIndex = 0
   }
   const timeline: TimelineSnapshot = {
     turns: timelineTurns,
@@ -719,12 +849,12 @@ export function MessageList({
   }
   const lastTimelineReportRef = React.useRef('')
   React.useEffect(() => {
-    // Preview text never mutates for a given row id, so ids+tops+fold
-    // flags fully determine the snapshot — skipping previews keeps the
-    // per-frame signature O(turns) small integers, not O(preview chars).
-    const sig =
-      timelineTurns.map(t => `${t.id}:${t.top}:${t.folded ? 1 : 0}`).join('|') +
-      `#a${timeline.activeId}#u${timeline.upId}#d${timeline.downId}`
+    // O(1) signature: the memo key pins the turns' geometry identity
+    // (heights/window/base/rows-length) and the three ids pin the
+    // viewport-derived targets. Any top change bumps the geometry key, so
+    // the report still fires exactly when the snapshot content changes —
+    // without rebuilding an O(turns) joined string per commit.
+    const sig = `${timelineMemoRef.current?.key ?? ''}#a${timeline.activeId}#u${timeline.upId}#d${timeline.downId}`
     if (sig !== lastTimelineReportRef.current) {
       lastTimelineReportRef.current = sig
       onTimeline?.(timeline)
@@ -749,6 +879,7 @@ export function MessageList({
           if (oldest !== undefined) heightsRef.current.delete(oldest)
         }
         heightsRef.current.set(id, h)
+        heightsVersionRef.current++
         changed = true
       }
     }

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -908,7 +908,20 @@ export function MessageList({
         scrollHandle.setClampBounds(min, undefined)
       } else {
         const min = Math.max(0, base + topPad - viewport)
-        scrollHandle.setClampBounds(min, Math.max(min, base + mountedBottom - viewport))
+        // Upper clamp only while unmounted content remains below the window
+        // (bottomPad spacer): it exists to pin the paint to the mounted edge
+        // during burst scrolls that outrun React's window re-render. Once the
+        // tail is fully mounted (bottomPad 0) there IS no unmounted gap — the
+        // estimated `mountedBottom` can sit a line short of the real Yoga
+        // extent (engine flex-basis cache vs final child layout drift, see
+        // render-node-to-output's scrollHeight floor), and an estimated clamp
+        // would then cull the last line at every non-sticky paint — the
+        // scrolled-away-and-back tail loss. Leave the max open; the renderer
+        // still caps at the frame's real maxScroll.
+        scrollHandle.setClampBounds(
+          min,
+          bottomPad <= 0 ? undefined : Math.max(min, base + mountedBottom - viewport),
+        )
       }
     }
     if (changed && !measureQueuedRef.current) {

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -529,14 +529,23 @@ export function MessageList({
     // content geometry wrong for exactly that long (blank band after
     // Ctrl+O, unreachable scroll bottom after a tool result lands). One
     // remount per change; the measure tick + hold then tighten again.
-    // Guard: only rows that have actually MOUNTED here once qualify
+    // Guard 1: only rows that have actually MOUNTED here once qualify
     // (paintedOnce fills from localRefs post-commit) — a brand-new
     // streaming row has never been measured, and extending over it would
     // mount everything below the window every frame while the user reads
     // scrolled-up (virtualization defeated, per-frame full mount = the
     // long-session stall). New rows keep the original path: their height
     // lands once the window reaches them.
+    // Guard 2: rows actively STREAMING are skipped too. A streaming row's
+    // signature invalidates EVERY chunk (text length grows), so a painted
+    // streaming row below/above the window remounted per chunk — full
+    // markdown re-lex + wrap of the whole growing text, invisible to the
+    // user reading history (measured: 3s of streaming while scrolled up
+    // burned 2.7s of yoga, max 126ms single-chunk spikes). Its height is
+    // in flux anyway; the final settle invalidates once more and remounts
+    // exactly once.
     for (let i = 0; i < start; i++) {
+      if (visibleRows[i]!.streaming === true) continue
       const rowId = visibleRows[i]!.id
       if (!heightsRef.current.has(rowId) && paintedOnceRef.current.has(rowId)) {
         start = i
@@ -557,11 +566,16 @@ export function MessageList({
     lastStartRef.current = start
   }
   // Tail-side invalidated-height extension (see the start-side loop above
-  // for the rationale and the mounted-once guard): rows BELOW the window
-  // whose height was just invalidated remount to re-measure, so bottomPad
-  // keeps real geometry while the user reads scrolled-up content and the
-  // tail streams. Runs for non-sticky views; sticky mounts the tail anyway.
+  // for the rationale and both guards): rows BELOW the window whose height
+  // was just invalidated remount to re-measure, so bottomPad keeps real
+  // geometry while the user reads scrolled-up content and the tail streams.
+  // Runs for non-sticky views; sticky mounts the tail anyway. Streaming
+  // rows are skipped — THIS loop is the measured hot path of the
+  // read-while-streaming stall (the streaming tail row sits below the
+  // window and its height invalidated per chunk; A/B without the guard:
+  // yoga 总 2674ms / max 126ms over a 3s stream, with it: 13ms / 3.6ms).
   for (let i = end; i < visibleRows.length; i++) {
+    if (visibleRows[i]!.streaming === true) continue
     const rowId = visibleRows[i]!.id
     if (!heightsRef.current.has(rowId) && paintedOnceRef.current.has(rowId)) end = i + 1
   }

--- a/src/components/ScrollbarGutter.tsx
+++ b/src/components/ScrollbarGutter.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { Box, Text, NoSelect, type ScrollBoxHandle } from '../ui.js'
+import { RAIL_MIN_TERMINAL_WIDTH, RAIL_WIDTH } from '../ink/timeline-rail.js'
+
+/** Thumb glyph across the 2-col gutter: solid, clearly positional —
+ *  deliberately distinct from the timeline's ━━ active tick. */
+const THUMB = '██'
+
+/**
+ * Proportional scrollbar for the fullscreen transcript's gutter — the
+ * `scrollbar` option of the `dsh-tui.scrollGutter` setting (the timeline
+ * rail's sibling; same 2-column slot, same chrome rules):
+ *
+ *  - the thumb (██) shows the visible window's position AND size over the
+ *    whole content (viewport²/content tall, positioned by scrollTop);
+ *  - clicking the track scrolls the clicked position to the viewport top
+ *    (classic scrollbar semantics — the thumb centers under the click
+ *    through the follow-up renders);
+ *  - the gutter is permanent while scrollable (Qwen's rule: an
+ *    auto-hiding gutter that changes content width rewraps everything);
+ *    hidden below 60 terminal columns or when the content fits (inline
+ *    mode keeps the terminal's native scrollback);
+ *  - NoSelect fences the glyphs out of click-drag text selection; the
+ *    wheel over the gutter scrolls the transcript.
+ *
+ * Thumb dragging is intentionally NOT implemented (Grok's MVP rule): a
+ * proportional thumb encodes position, and the tick rail remains the
+ * semantic navigator. Click-to-position covers the same need.
+ */
+export function ScrollbarGutter({
+  handle,
+  terminalWidth,
+}: {
+  handle: ScrollBoxHandle | null
+  terminalWidth: number
+}): React.ReactNode {
+  const [, setTick] = React.useState(0)
+  React.useEffect(() => {
+    if (!handle) return
+    return handle.subscribe(() => setTick(t => t + 1))
+  }, [handle])
+
+  if (!handle) return null
+  const viewport = handle.getViewportHeight()
+  const content = handle.getScrollHeight()
+  const maxScroll = Math.max(0, content - viewport)
+  if (viewport < 2 || content <= viewport || terminalWidth < RAIL_MIN_TERMINAL_WIDTH) return null
+
+  // Thumb: the visible window mapped onto the gutter. Height proportional
+  // to the visible fraction (≥2 rows so it is always grabbable-looking);
+  // top follows scrollTop over the scroll range.
+  const thumbH = Math.max(2, Math.round((viewport * viewport) / content))
+  const trackH = Math.max(1, viewport - thumbH)
+  const thumbTop = Math.round((handle.getScrollTop() / Math.max(1, maxScroll)) * trackH)
+  const thumbBottom = Math.min(viewport, thumbTop + thumbH)
+
+  // Clicking the track maps the clicked row's position on the track back
+  // to a scrollTop and scrolls that content position to the viewport top.
+  const trackScrollTop = (y: number): number => {
+    if (y <= 0) return 0
+    if (y >= trackH) return maxScroll
+    return Math.round((y / trackH) * maxScroll)
+  }
+
+  const rows: React.ReactNode[] = []
+  for (let y = 0; y < viewport; y++) {
+    const inThumb = y >= thumbTop && y < thumbBottom
+    rows.push(
+      <Box
+        key={y}
+        height={1}
+        flexShrink={0}
+        onClick={() => handle.scrollTo(trackScrollTop(y))}
+      >
+        <Text color={inThumb ? 'inactive' : undefined}>{inThumb ? THUMB : '  '}</Text>
+      </Box>,
+    )
+  }
+
+  return (
+    <NoSelect fromLeftEdge>
+      {/* Raw ink-box (not the themed Box): onWheel is a host-level prop
+          (same as ScrollBox's viewport) — wheel over the gutter scrolls
+          the transcript, the gutter has no scroll of its own. */}
+      <ink-box
+        onWheel={e => {
+          if (e.deltaY !== 0) handle.scrollBy(e.deltaY)
+        }}
+        style={{ flexDirection: 'column', flexShrink: 0, width: RAIL_WIDTH }}
+      >
+        {rows}
+      </ink-box>
+    </NoSelect>
+  )
+}

--- a/src/components/TimelineRail.tsx
+++ b/src/components/TimelineRail.tsx
@@ -61,6 +61,7 @@ export function TimelineRail({
   downId,
   terminalWidth,
   hoverEnabled,
+  onRevealTurn,
 }: {
   handle: ScrollBoxHandle | null
   /** Turns in conversation order (MessageList's measured snapshot). */
@@ -76,6 +77,13 @@ export function TimelineRail({
   /** False while a modal overlay owns the screen — suppress the hover
    *  card (the rail itself stays, but stops narrating). */
   hoverEnabled: boolean
+  /**
+   * Reveal-and-seek for FOLDED turns (older than the recent-rows window):
+   * Chat expands the fold (showAll) and seeks through the force-mount
+   * path — the row's top is unknown until it mounts, so the coordinate
+   * jump below does not apply to it.
+   */
+  onRevealTurn: (rowId: number) => void
 }): React.ReactNode {
   const [, setTick] = React.useState(0)
   const [hover, setHover] = React.useState<Hover>(null)
@@ -125,9 +133,14 @@ export function TimelineRail({
   // prompt exactly at the viewport top; the renderer clamps unreachable
   // tail tops to maxScroll (their turns stay on screen, just short of
   // owning the top row — and ▼ never names them, see timeline-rail.ts).
+  // FOLDDED turns have no measured top (-1): their click (and ▲ naming
+  // one) routes through onRevealTurn instead — expand the fold, then the
+  // existing force-mount seek lands the row once it measures.
   const jumpToIndex = (index: number) => {
     const turn = turns[index]
-    if (turn) handle.scrollTo(turn.top)
+    if (!turn) return
+    if (turn.folded) onRevealTurn(turn.id)
+    else handle.scrollTo(turn.top)
   }
   const jumpToId = (id: number | null) => {
     if (id === null) return

--- a/src/components/TimelineRail.tsx
+++ b/src/components/TimelineRail.tsx
@@ -19,6 +19,10 @@ const TICK_ACTIVE = '━━'
 const TICK_HOVER = '──'
 const TICK_IDLE = ' ─'
 
+/** Pointer rest time before the hover preview card pops (ms). Sweeps
+ *  never mount a card; only a deliberate pause does. */
+const HOVER_DWELL_MS = 120
+
 /** What the pointer is over. One state so tick/chevron hovers can never
  *  overlap (the rail is 2 cols wide — a row is one target or the other). */
 type Hover =
@@ -87,6 +91,31 @@ export function TimelineRail({
 }): React.ReactNode {
   const [, setTick] = React.useState(0)
   const [hover, setHover] = React.useState<Hover>(null)
+  // Dwell-gated preview card: the card pops only after the pointer RESTS
+  // on a tick for HOVER_DWELL_MS. Sweeping the rail fires enter/leave per
+  // cell — without the gate each crossing mounts an absolute-positioned
+  // card at a new spot (flapping previews, absolute-rect churn, and the
+  // fast-sweep residue users reported). The glyph highlight stays instant
+  // (cheap, no overlay); only the card waits for intent.
+  const [cardIndex, setCardIndex] = React.useState<number | null>(null)
+  const dwellTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const clearDwell = React.useCallback(() => {
+    if (dwellTimerRef.current !== null) {
+      clearTimeout(dwellTimerRef.current)
+      dwellTimerRef.current = null
+    }
+    setCardIndex(null)
+  }, [])
+  const armDwell = React.useCallback((index: number) => {
+    if (dwellTimerRef.current !== null) clearTimeout(dwellTimerRef.current)
+    dwellTimerRef.current = setTimeout(() => {
+      dwellTimerRef.current = null
+      setCardIndex(index)
+    }, HOVER_DWELL_MS)
+  }, [])
+  React.useEffect(() => () => {
+    if (dwellTimerRef.current !== null) clearTimeout(dwellTimerRef.current)
+  }, [])
   React.useEffect(() => {
     if (!handle) return
     return handle.subscribe(() => {
@@ -99,8 +128,9 @@ export function TimelineRail({
       // re-enter hover; Grok likewise clears the hover popup on tick click.
       // setHover(null) on an already-null hover is a React no-op.
       setHover(null)
+      clearDwell()
     })
-  }, [handle])
+  }, [handle, clearDwell])
 
   if (!handle) return null
   const viewport = handle.getViewportHeight()
@@ -182,8 +212,14 @@ export function TimelineRail({
         height={1}
         flexShrink={0}
         onClick={() => jumpToIndex(index)}
-        onMouseEnter={() => setHover({ kind: 'tick', index })}
-        onMouseLeave={() => setHover(null)}
+        onMouseEnter={() => {
+          setHover({ kind: 'tick', index })
+          armDwell(index)
+        }}
+        onMouseLeave={() => {
+          setHover(null)
+          clearDwell()
+        }}
       >
         <Text color={color}>{glyph}</Text>
       </Box>,
@@ -191,13 +227,16 @@ export function TimelineRail({
   }
 
   // Hover preview card, anchored left of the rail and vertically centered
-  // on the hovered tick (shrink-to-fit, rounded chrome). Suppressed while
-  // an overlay owns the screen — the rail stops narrating over dialogs.
+  // on the hovered tick (shrink-to-fit, rounded chrome). Dwell-gated: only
+  // cardIndex (armed after HOVER_DWELL_MS of rest) draws — a sweep keeps
+  // hover flashing on glyphs but never mounts the overlay. Suppressed
+  // while an overlay owns the screen — the rail stops narrating over
+  // dialogs.
   let card: React.ReactNode = null
-  if (hoverEnabled && hover?.kind === 'tick') {
-    const turn = turns[hover.index]
+  if (hoverEnabled && cardIndex !== null) {
+    const turn = turns[cardIndex]
     if (turn && turn.preview.length > 0) {
-      const tickRow = geo.tickTop + hover.index - geo.windowStart
+      const tickRow = geo.tickTop + cardIndex - geo.windowStart
       if (tickRow >= geo.tickTop && tickRow < geo.downRow) {
         const budget = Math.min(32, Math.max(16, Math.floor((terminalWidth - RAIL_WIDTH) / 2)))
         const lines = wrapPreviewLines(turn.preview, budget)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -51,7 +51,7 @@ import { getLang, LANGS, t } from '../i18n.js'
 import { AUTO_THEME_NAME, THEME_NAMES } from '../theme.js'
 import { listCustomThemes } from '../customTheme.js'
 import { modeDisplayName, resolveSessionModes, type SessionModeSpec } from '../sessionModes.js'
-import { normalizeStatusBar, normalizeToolBackground, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
+import { normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import { SubagentActivityStore, type SubagentState } from './subagents.js'
 export type { SubagentState } from './subagents.js'
 import type { SpinnerMode } from '../components/Spinner/spinnerMode.js'
@@ -525,6 +525,10 @@ export interface Channel {
   readonly thinkingFold: 'preview' | 'full'
   /** Live tool-card background treatment. */
   readonly toolBackground: ToolBackground
+  /** What the fullscreen transcript's right gutter shows (settings
+   *  `dsh-tui.scrollGutter`: turn timeline / proportional scrollbar /
+   *  nothing). */
+  readonly scrollGutter: ScrollGutterMode
   /** Live status-footer visibility and compactness preferences. */
   readonly statusBar: Readonly<StatusBarConfig>
   /** Whether the header's pixel whale art shows (settings `dsh-tui.whale`). */
@@ -874,6 +878,8 @@ export interface ChannelState {
   thinkingFold: 'preview' | 'full'
   /** Tool-card background treatment (see the public Channel type). */
   toolBackground: ToolBackground
+  /** Transcript gutter mode (see the public Channel type). */
+  scrollGutter: ScrollGutterMode
   /** Status-footer preferences (see the public Channel type). */
   statusBar: StatusBarConfig
   /** Apply a diff-layout change (see the public Channel type). */
@@ -882,6 +888,8 @@ export interface ChannelState {
   setThinkingFold(mode: 'preview' | 'full'): void
   /** Apply a tool-card background change. */
   setToolBackground(background: ToolBackground): void
+  /** Apply a transcript gutter mode change. */
+  setScrollGutter(mode: ScrollGutterMode): void
   /** Apply status-footer preference changes. */
   setStatusBar(config: Partial<StatusBarConfig>): void
   /** Whale header art switch (see the public Channel type). */
@@ -1388,6 +1396,8 @@ export function createChannel(
     thinkingFold?: 'preview' | 'full'
     /** Tool-card background treatment; default `none`. */
     toolBackground?: ToolBackground
+    /** Transcript gutter mode; default `timeline` (settings `dsh-tui.scrollGutter`). */
+    scrollGutter?: ScrollGutterMode
     /** Status-footer field visibility and compactness. */
     statusBar?: Partial<StatusBarConfig>
     /** Show the header's pixel whale art; default on. */
@@ -2337,6 +2347,7 @@ export function createChannel(
     diffLayout: options.diffLayout ?? 'auto',
     thinkingFold: options.thinkingFold ?? 'preview',
     toolBackground: normalizeToolBackground(options.toolBackground),
+    scrollGutter: normalizeScrollGutter(options.scrollGutter),
     statusBar: normalizeStatusBar(options.statusBar),
     whale: options.whale !== false,
     minimal: options.minimal === true,
@@ -3438,6 +3449,12 @@ export function createChannel(
       const normalized = normalizeToolBackground(background)
       if (normalized === state.toolBackground) return
       state.toolBackground = normalized
+      state.emit()
+    },
+    setScrollGutter(mode) {
+      const normalized = normalizeScrollGutter(mode)
+      if (normalized === state.scrollGutter) return
+      state.scrollGutter = normalized
       state.emit()
     },
     setStatusBar(config) {

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -9,7 +9,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
 import type { SessionModeSpec } from '../sessionModes.js'
-import { DEFAULT_STATUS_BAR, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
+import { DEFAULT_STATUS_BAR, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 
 export const name = 'dsh-tui'
 // `tuiWorkspaces` must stay OUT of this code-level inject (issue #183): the
@@ -88,6 +88,10 @@ export interface Config {
   thinkingFold?: 'preview' | 'full'
   /** Tool-card background strength; defaults to no added background. */
   toolBackground?: ToolBackground
+  /** What the fullscreen transcript's right gutter shows (settings
+   *  `dsh-tui.scrollGutter`): `timeline` turn rail (default), `scrollbar`
+   *  proportional thumb, or `hidden`. */
+  scrollGutter?: ScrollGutterMode
   /** Status-footer field visibility and compact presentation preferences. */
   statusBar?: Partial<StatusBarConfig>
   /** Shift+Tab session-mode cycle (array order IS the cycle order; index 0
@@ -117,6 +121,7 @@ export const Config: Schema<Config> = Schema.object({
   diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
   thinkingFold: Schema.union(['preview', 'full']).default('preview'),
   toolBackground: Schema.union(['none', 'subtle', 'strong']).default('none'),
+  scrollGutter: Schema.union(['timeline', 'scrollbar', 'hidden']).default('timeline'),
   statusBar: Schema.object({
     compact: Schema.boolean().default(DEFAULT_STATUS_BAR.compact),
     model: Schema.boolean().default(DEFAULT_STATUS_BAR.model),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -27,7 +27,7 @@ import { clearResumeTarget, writeResumeTarget } from '../sessionHistory.js'
 import { resolveSessionCwd } from '../utils/workspaceRoot.js'
 import { checkForTuiUpdate, installedTuiVersion, isBootDeadlockTarget, isVersionNewer, resolveDshProfileName, resolveTuiUpdateTarget, updateTuiAndRestart } from '../update.js'
 import { getLang, isLang, resolveStartupLang, setLang, t, writeLangPref } from '../i18n.js'
-import { DEFAULT_STATUS_BAR, normalizeStatusBar, normalizeToolBackground, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
+import { DEFAULT_STATUS_BAR, normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import { detectLegacyEnv, migrateLegacyDataDir, RENAMED_ENV } from '../utils/paths.js'
 import { attachHerdrIntegration } from '../herdr.js'
 import { logMouseDebug } from '../utils/debug.js'
@@ -379,6 +379,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     diffLayout: config.diffLayout,
     thinkingFold: config.thinkingFold,
     toolBackground: config.toolBackground,
+    scrollGutter: config.scrollGutter,
     statusBar: config.statusBar,
     handle,
   })
@@ -414,6 +415,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
         diffLayout: Schema.union(['auto', 'split', 'unified']).default('auto'),
         thinkingFold: Schema.union(['preview', 'full']).default('preview'),
         toolBackground: Schema.union(['none', 'subtle', 'strong']).default('none'),
+        scrollGutter: Schema.union(['timeline', 'scrollbar', 'hidden']).default('timeline'),
         statusBar: Schema.object({
           compact: Schema.boolean().default(DEFAULT_STATUS_BAR.compact),
           model: Schema.boolean().default(DEFAULT_STATUS_BAR.model),
@@ -455,6 +457,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       fullscreen?: boolean
       thinkingFold?: 'preview' | 'full'
       toolBackground?: ToolBackground
+      scrollGutter?: ScrollGutterMode
       statusBar?: Partial<StatusBarConfig>
     }
     const applyLayout = (value: SettingsValue): void => {
@@ -491,6 +494,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     const applyDisplay = (value: SettingsValue): void => {
       channel.setThinkingFold(value.thinkingFold ?? config.thinkingFold ?? 'preview')
       channel.setToolBackground(normalizeToolBackground(value.toolBackground ?? config.toolBackground))
+      channel.setScrollGutter(normalizeScrollGutter(value.scrollGutter ?? config.scrollGutter))
       channel.setStatusBar(normalizeStatusBar(value.statusBar ?? config.statusBar))
     }
     const apply = (next: SettingsValue): void => {
@@ -593,6 +597,19 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
             { value: 'none', label: 'None', descriptions: { zh: '无' } },
             { value: 'subtle', label: 'Subtle', descriptions: { zh: '轻微' } },
             { value: 'strong', label: 'Strong', descriptions: { zh: '明显' } },
+          ],
+        },
+        {
+          path: ['scrollGutter'],
+          label: 'Transcript gutter',
+          descriptions: { zh: '转录边栏' },
+          hint: 'Right gutter of the fullscreen transcript: per-turn timeline ticks, a proportional scrollbar, or nothing.',
+          hintDescriptions: { zh: '全屏转录区右侧边栏：按轮次的时间线节点、比例滚动条，或留空。' },
+          kind: 'select',
+          options: [
+            { value: 'timeline', label: 'Turn timeline', descriptions: { zh: '轮次时间线' } },
+            { value: 'scrollbar', label: 'Scrollbar', descriptions: { zh: '滚动条' } },
+            { value: 'hidden', label: 'Hidden', descriptions: { zh: '隐藏' } },
           ],
         },
         {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -625,8 +625,9 @@ const dict = {
   'rename-current': { zh: '当前名称  {{title}}', en: 'Current title  {{title}}' },
   'rename-done': { zh: '已重命名为「{{title}}」', en: 'Renamed to "{{title}}"' },
   'compact-summary-folded': { zh: '摘要已折叠', en: 'Summary folded' },
-  'new-message': { zh: '{{n}} 条新消息', en: '1 new message' },
-  'new-messages': { zh: '{{n}} 条新消息', en: '{{n}} new messages' },
+  'new-message': { zh: '↓ {{n}} 条新消息', en: '↓ 1 new message' },
+  'new-messages': { zh: '↓ {{n}} 条新消息', en: '↓ {{n}} new messages' },
+  'back-to-bottom': { zh: '↓ 回到底部（Enter/End）', en: '↓ back to bottom (Enter/End)' },
 
   // ── components/ThemePicker.tsx ──────────────────────────────────────
   'theme-builtin-base': { zh: '内置 · {{name}} 基底', en: 'Built-in · {{name}} base' },

--- a/src/ink/components/ScrollBox.tsx
+++ b/src/ink/components/ScrollBox.tsx
@@ -113,15 +113,21 @@ function ScrollBox({
   // events, each re-running the offsets/window/timeline loops on a big
   // session. The scrollTop mutation and the ink render are already
   // frame-throttled; this aligns the React commits to the same frame
-  // budget. Leading edge fires when the last notify is ≥ a frame old (a
-  // lone click feels instant); bursts collapse into one trailing notify.
+  // budget. Both edges defer to a microtask: the remaining input events of
+  // the same stdin batch then land BEFORE any commit, and one commit
+  // covers the whole batch (the sync leading edge used to run a full
+  // commit inside the wheel dispatch itself — pure input latency).
   const notifyQueuedRef = useRef(false);
   const lastNotifyAtRef = useRef(-Infinity);
   const notifyCoalesced = () => {
     const since = performance.now() - lastNotifyAtRef.current;
     if (!notifyQueuedRef.current && since >= FRAME_INTERVAL_MS) {
+      notifyQueuedRef.current = true;
       lastNotifyAtRef.current = performance.now();
-      notify();
+      queueMicrotask(() => {
+        notifyQueuedRef.current = false;
+        notify();
+      });
       return;
     }
     if (notifyQueuedRef.current) return;
@@ -187,10 +193,37 @@ function ScrollBox({
     scrollToBottom() {
       const el = domRef.current;
       if (!el) return;
+      el.scrollAnchor = undefined;
+      const viewportH = el.scrollViewportHeight ?? 0;
+      const maxScroll = Math.max(0, (el.scrollHeight ?? 0) - viewportH);
+      const distance = maxScroll - (el.scrollTop ?? 0);
+      if (distance > viewportH && viewportH > 0) {
+        // FAR jump: drain instead of teleport. The viewport would land on
+        // rows that were never mounted — their spacer heights are
+        // DEFAULT_ROW_HEIGHT estimates, so the topPad swallows the view
+        // (blank transcript) AND it is a fixed point: unmounted rows never
+        // measure, nothing retried until the next wheel event. The drain
+        // walks the exact wheel path instead: proportional steps, the
+        // virtualization window follows per commit (it mounts the union of
+        // committed + pending), the visual clamp pins to the mounted edge
+        // while rows measure as they enter — no blank at any distance. The
+        // renderer's at-bottom re-pin restores sticky when it lands
+        // (stickyScroll=false + pending undefined + scrollTop >= maxScroll).
+        el.stickyScroll = false;
+        el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + distance;
+        scrollMutated(el);
+        return;
+      }
       el.pendingScrollDelta = undefined;
       el.stickyScroll = true;
-      markDirty(el);
-      notify();
+      // DOM-direct pre-write of the target (near jumps only): the notify
+      // below triggers MessageList's window recompute, and its React commit
+      // must read the NEW scrollTop — the old order (notify first, renderer
+      // moves scrollTop later) left the window one commit behind. The
+      // renderer's sticky branch re-pins scrollTop to the exact fresh
+      // maxScroll next frame, so a stale cached height costs one frame.
+      el.scrollTop = maxScroll;
+      scrollMutated(el);
       forceRender(n => n + 1);
     },
     getScrollTop() {

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -804,7 +804,27 @@ function renderNodeToOutput(
         // within the viewport (equal to the scroll container's
         // paddingTop), and innerHeight already subtracts padding, so
         // including it double-counts padding and inflates maxScroll.
-        const scrollHeight = contentYoga?.getComputedHeight() ?? 0
+        let scrollHeight = contentYoga?.getComputedHeight() ?? 0
+        // Defensive extent floor: the wrapper's Yoga height can land ONE LINE
+        // short of its children's laid-out extent (the engine's flex-basis
+        // measure cache and the child's final subtree layout can disagree by
+        // a row — measured on resume of a long session: wrapper 286 while the
+        // last row's bottom sat at 287, stable across forced re-layouts). A
+        // short scrollHeight clamps maxScroll below the real bottom, so the
+        // sticky pin parks the viewport a line up and the tail line culls
+        // against the viewport edge — permanently invisible AND unreachable
+        // (no scroll position ever shows it; the user loses the newest
+        // message). The children's real extent is the authoritative floor.
+        // O(direct children) — the windowed list keeps this tiny, and the
+        // painter walks the same nodes right below.
+        if (content !== undefined) {
+          for (const child of content.childNodes) {
+            const childYoga = (child as DOMElement).yogaNode
+            if (childYoga === undefined) continue
+            const bottom = childYoga.getComputedTop() + childYoga.getComputedHeight()
+            if (bottom > scrollHeight) scrollHeight = bottom
+          }
+        }
         // Capture previous scroll bounds BEFORE overwriting — the at-bottom
         // follow check compares against last frame's max.
         const prevScrollHeight = node.scrollHeight ?? scrollHeight

--- a/src/ink/timeline-rail.ts
+++ b/src/ink/timeline-rail.ts
@@ -54,6 +54,17 @@ export interface TimelineTurn {
   top: number
   /** First non-empty prompt line, char-capped (see clipPreview). */
   preview: string
+  /**
+   * True while the row sits BEFORE the fold window (older than the most
+   * recent MAX_RENDERED_ROWS rows): its top is unknown (unmounted since
+   * before the fold; `top` carries −1) and clicking the tick must first
+   * reveal the folded history (Chat: showAll + force-mount + seek) rather
+   * than scrollTo(−1). Rendering a tick for it is still correct — the
+   * turn EXISTS and is navigable, it is just folded away right now
+   * (drawing only window turns read as "the rail covers just 2-3 nodes"
+   * on tool-heavy sessions where 300 rows ≈ a handful of turns).
+   */
+  folded?: boolean
 }
 
 /** The per-commit snapshot MessageList reports and the rail + sticky

--- a/src/ink/wrap-text.ts
+++ b/src/ink/wrap-text.ts
@@ -5,6 +5,53 @@ import { wrapAnsi } from './wrapAnsi.js'
 
 const ELLIPSIS = '…'
 
+// --- cross-mount wrap cache ------------------------------------------------
+// wrapText is pure: (text, maxWidth, wrapType) deterministically maps to one
+// output string. Yet before this cache every consumer re-wrapped from
+// scratch:
+//
+//  - dom.ts measureTextNode seeds its per-NODE incremental cache on first
+//    measure; virtualization unmounts scrolled-away rows, so scrolling back
+//    re-mounts the row's Text nodes and re-runs the FULL wrap (wrap-ansi
+//    tokenizes + string-width-measures every word — 100-300ms single-frame
+//    yoga spikes when a row of large settled text scrolls in, the dominant
+//    long-session scroll stall);
+//  - render-node-to-output.ts wraps every VISIBLE text node on every full
+//    paint pass (no per-node cache at all there).
+//
+// A content-addressed LRU here makes both paths O(1) for immutable settled
+// text (Markdown memo keeps content identity stable for the whole session).
+// The key embeds the raw text, so V8's content-hash Map lookup matches even
+// a rebuilt string. Budget mirrors line-width-cache: whole-cache clear on
+// overflow (repopulates within a frame or two).
+const WRAP_CACHE_MAX_ENTRIES = 2048
+const WRAP_CACHE_MAX_CHARS = 2_000_000
+const wrapCache = new Map<string, string>()
+let wrapCacheChars = 0
+/** Values below this are not worth a cache entry (key building costs about
+ *  as much as the wrap itself for trivial single-word strings). */
+const WRAP_CACHE_MIN_LENGTH = 24
+
+function cachedWrap(
+  text: string,
+  maxWidth: number,
+  wrapType: Styles['textWrap'],
+  compute: () => string,
+): string {
+  if (text.length < WRAP_CACHE_MIN_LENGTH) return compute()
+  const key = `${maxWidth}\u0000${wrapType}\u0000${text}`
+  const hit = wrapCache.get(key)
+  if (hit !== undefined) return hit
+  const result = compute()
+  if (wrapCache.size >= WRAP_CACHE_MAX_ENTRIES || wrapCacheChars + text.length > WRAP_CACHE_MAX_CHARS) {
+    wrapCache.clear()
+    wrapCacheChars = 0
+  }
+  wrapCache.set(key, result)
+  wrapCacheChars += text.length
+  return result
+}
+
 // sliceAnsi may include a boundary-spanning wide char (e.g. CJK at position
 // end-1 with width 2 overshoots by 1). Retry with a tighter bound once.
 function sliceFit(text: string, start: number, end: number): string {
@@ -50,17 +97,21 @@ export default function wrapText(
   wrapType: Styles['textWrap'],
 ): string {
   if (wrapType === 'wrap') {
-    return wrapAnsi(text, maxWidth, {
-      trim: false,
-      hard: true,
-    })
+    return cachedWrap(text, maxWidth, wrapType, () =>
+      wrapAnsi(text, maxWidth, {
+        trim: false,
+        hard: true,
+      }),
+    )
   }
 
   if (wrapType === 'wrap-trim') {
-    return wrapAnsi(text, maxWidth, {
-      trim: true,
-      hard: true,
-    })
+    return cachedWrap(text, maxWidth, wrapType, () =>
+      wrapAnsi(text, maxWidth, {
+        trim: true,
+        hard: true,
+      }),
+    )
   }
 
   if (wrapType!.startsWith('truncate')) {
@@ -74,7 +125,9 @@ export default function wrapText(
       position = 'start'
     }
 
-    return truncate(text, maxWidth, position)
+    return cachedWrap(text, maxWidth, wrapType, () =>
+      truncate(text, maxWidth, position),
+    )
   }
 
   return text

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -452,7 +452,10 @@ export function Chat({
         : -1
     }
   }, [isSticky, channel.rows])
-  const showPill = !isSticky && unseenCount > 0
+  // The pill shows whenever the view is off the bottom (one-click return
+  // home): with unseen rows it counts them, otherwise it is the plain
+  // "return to bottom" affordance (Enter/End/click all land it).
+  const showPill = !isSticky
 
   // Idle Ctrl+C: first press arms an exit, second press exits (CC's
   // double-press semantics, simplified). Under Windows ConPTY the key
@@ -2309,8 +2312,18 @@ export function Chat({
       // the collapsed line keeps the done/total count and the live task
       // preview, so long todo lists stop crowding the prompt.
       setTodoCollapsed(previous => !previous)
-    } else if (plainReturn && showPill) {
+    } else if (plainReturn && !isSticky) {
+      // Enter while scrolled up returns to the bottom (CC's pill: the
+      // affordance now exists whenever the view is off the bottom, not
+      // only with unseen rows).
       handle?.scrollToBottom()
+    } else if (key.end && !isSticky) {
+      // End = jump to bottom, less/vim semantics. Global on the chat
+      // screen (search/history overlays consume their own End first —
+      // cursor-to-line-end there). At the bottom already: no-op, so the
+      // key stays harmless in muscle memory.
+      handle?.scrollToBottom()
+      event.stopImmediatePropagation()
     } else if (extensionShortcuts !== undefined && extensionShortcuts.dispatch(input, key)) {
       // Plugin shortcut (tuiShortcuts seam): matched only after every
       // built-in global binding above declined — locals always win, and the
@@ -3012,7 +3025,11 @@ function NewMessagesPill({
         onMouseLeave={() =>{  setHover(false) }}
       >
         <Text color="inverseText" bold>
-          {' '}↓ {t(count === 1 ? 'new-message' : 'new-messages', { n: count })}{' '}
+          {' '}
+          {count > 0
+            ? t(count === 1 ? 'new-message' : 'new-messages', { n: count })
+            : t('back-to-bottom')}
+          {' '}
         </Text>
       </Box>
     </Box>

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -2507,6 +2507,12 @@ export function Chat({
           effort={channel.reasoningEffort}
           cwd={channel.displayCwd}
           whale={channel.whale}
+          // Resuming a long session skips the ~3.4s opening animation: it
+          // keeps firing low-frequency React commits that compete with the
+          // transcript mount batches (and the first wheel events) for the
+          // frame budget right when the user wants to read history. Fresh
+          // sessions keep the full intro; restored ones settle instantly.
+          skipIntro={channel.rows.length > 30}
         />
         {/* The startup loaded-context panel: before the first message the
             transcript is empty, so the inventory of what this conversation

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -27,7 +27,9 @@ import { useSelection } from '../ink/hooks/use-selection.js'
 import { NoSelect } from '../ink/components/NoSelect.js'
 import { LogoHeader, MessageList } from '../components/MessageList.js'
 import { TimelineRail } from '../components/TimelineRail.js'
+import { ScrollbarGutter } from '../components/ScrollbarGutter.js'
 import type { TimelineSnapshot } from '../ink/timeline-rail.js'
+import { normalizeScrollGutter } from '../tuiDisplayPrefs.js'
 import { OverlayAbove } from '../components/OverlayAbove.js'
 import { PromptInput, type PromptController } from '../components/PromptInput.js'
 import { GoalTodoPanel } from '../components/GoalTodoPanel.js'
@@ -1612,6 +1614,18 @@ export function Chat({
     }
     setForceMountRowId(rowId)
   }
+  /**
+   * Reveal-and-seek for a row folded behind the recent-rows window (the
+   * rail's tick for an old turn, the doc's revealAndSeekRow): expand the
+   * fold first, then the ordinary seek takes over — the completion effect
+   * below force-mounts the row and scrollToElement lands it once its ref
+   * (and Yoga top) exist. The fold toggle is idempotent, so calling this
+   * for an already-revealed row is harmless.
+   */
+  const revealAndSeekRow = (rowId: number): void => {
+    if (!showAllMessages) setShowAllMessages(true)
+    seekRow(rowId)
+  }
   React.useLayoutEffect(() => {
     if (forceMountRowId === null) return
     const el = rowRefsRef.current.get(forceMountRowId)
@@ -2521,15 +2535,30 @@ export function Chat({
           onOpenSubagent={(agentId) => setSubagentDetailId(agentId)}
         />
         </ScrollBox>
-        <TimelineRail
-          handle={handle}
-          turns={timeline.turns}
-          activeId={timeline.activeId}
-          upId={timeline.upId}
-          downId={timeline.downId}
-          terminalWidth={terminalColumns}
-          hoverEnabled={!promptSelectionActive}
-        />
+        {(() => {
+          // Gutter mode (settings `dsh-tui.scrollGutter`): the timeline
+          // rail (default), the proportional scrollbar, or nothing. The
+          // slot keeps its 2 columns in both rendered modes (Qwen's
+          // permanent-gutter rule — an appearing/disappearing gutter
+          // changes the transcript width and rewraps everything).
+          const gutter = normalizeScrollGutter(channel.scrollGutter)
+          if (gutter === 'hidden') return null
+          if (gutter === 'scrollbar') {
+            return <ScrollbarGutter handle={handle} terminalWidth={terminalColumns} />
+          }
+          return (
+            <TimelineRail
+              handle={handle}
+              turns={timeline.turns}
+              activeId={timeline.activeId}
+              upId={timeline.upId}
+              downId={timeline.downId}
+              terminalWidth={terminalColumns}
+              hoverEnabled={!promptSelectionActive}
+              onRevealTurn={revealAndSeekRow}
+            />
+          )
+        })()}
       </Box>
       {/* Bottom chrome (pill, spinners, dialogs, prompt, statusline): never
           let flex shrink squeeze these fixed-height rows — the ScrollBox

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -2537,6 +2537,7 @@ export function Chat({
           activityFrames={channel.activityFrames}
           showAll={showAllMessages}
           thinkingVisible={thinkingVisible}
+          historyPaintEnabled={!fullscreen}
           onToggleAll={() =>{  setShowAllMessages(previous => !previous) }}
           onLoadOlder={() => channel.loadOlder()}
           registerRowRef={registerRowRef}

--- a/src/tuiDisplayPrefs.ts
+++ b/src/tuiDisplayPrefs.ts
@@ -1,6 +1,16 @@
 /** Background treatment applied to tool-call cards. */
 export type ToolBackground = 'none' | 'subtle' | 'strong'
 
+/**
+ * What the fullscreen transcript's right gutter shows:
+ *  - `timeline`: Grok-style turn rail — one tick per user turn (conversation
+ *    order, not scroll proportion), active turn highlighted, click to jump;
+ *  - `scrollbar`: classic proportional thumb — position/size of the visible
+ *    window over the whole content, click the track to scroll there;
+ *  - `hidden`: no gutter; the transcript takes the full width.
+ */
+export type ScrollGutterMode = 'timeline' | 'scrollbar' | 'hidden'
+
 /** Individually selectable fields in the status footer. */
 export interface StatusBarConfig {
   /** Prefer the compact, single-line presentation when space permits. */
@@ -61,6 +71,7 @@ export const DEFAULT_STATUS_BAR: Readonly<StatusBarConfig> = Object.freeze({
 })
 
 const TOOL_BACKGROUNDS = new Set<ToolBackground>(['none', 'subtle', 'strong'])
+const SCROLL_GUTTERS = new Set<ScrollGutterMode>(['timeline', 'scrollbar', 'hidden'])
 const STATUS_BAR_KEYS = Object.keys(DEFAULT_STATUS_BAR) as (keyof StatusBarConfig)[]
 
 /** Normalize untrusted/config-layer values without mutating the input. */
@@ -68,6 +79,13 @@ export function normalizeToolBackground(value: unknown): ToolBackground {
   return typeof value === 'string' && TOOL_BACKGROUNDS.has(value as ToolBackground)
     ? value as ToolBackground
     : 'none'
+}
+
+/** Same normalize contract as toolBackground; `timeline` is the default. */
+export function normalizeScrollGutter(value: unknown): ScrollGutterMode {
+  return typeof value === 'string' && SCROLL_GUTTERS.has(value as ScrollGutterMode)
+    ? value as ScrollGutterMode
+    : 'timeline'
 }
 
 /** Merge a partial settings value over the stable status-bar defaults. */


### PR DESCRIPTION
## 概述

滚动导航与长会话性能主线：时间线 rail 覆盖全部轮次、一键回到底部、
scrollGutter 三态设置，以及一整条「真实会话打开/滚动/流式」性能优化线
（perf-real-open 基准驱动，含分配归零化、LRU 缓存、分帧补画）。
基于最新 main rebase（#462 chatOverlay reducer / #467-#473 CI 重构 /
#474 空文本过滤均已吸收）。

## 鼠标 / 滚动交互

- **rail 覆盖全部轮次（含折叠）**：折叠窗口内 ~5 轮可见时 rail 仍渲染
  全部 12 轮 tick；点击折叠 tick 揭示对应轮并滚动到位，━━ 锚点随动。
- **scrollGutter 三态设置**：timeline / scrollbar / hidden 三模式，
  gutter 占位与内容宽度协商，切换不闪烁、不塌行。
- **一键回到底部**：未钉底时 pill 常驻，End/Enter 回底；远距回底
  一步到位（100ms 级）且无空白带。
- **修复**：远距回底空白死锁、rail 悬停卡 dwell 门、输入批次合并。

## 性能优化（perf-real-open 基准 + 阶段 D 归因驱动）

- MessageList 每帧 O(n) 热路径**分配归零化**：slice+filter+margins 走
  指纹缓存（rows 身份 / 长度 / 流位 Uint8Array），3200 行会话每 16ms
  tick 省 ~200KB GC churn。
- wrapText 全局 LRU 缓存（跨挂载复用 wrap 结果）。
- 主屏打开分帧补画 + 渲染折叠窗口 300→120 行。
- 全屏打开只挂尾部窗口；markdown token 缓存 LRU 逐出。
- 长会话恢复跳过 whale 开场动画。
- 修复：上滚阅读 + 流式并发时不可见流式行的逐 chunk 重挂载。

## 修复

- **恢复历史会话落点**：/resume 后最新消息末行不可见且不可达——
  补画完成后的锚定终态保证末行可见、无幻影 pill。

## 与 #474 的融合说明

main 上 #474 的空文本过滤是无缓存管线的每渲染 filter；本分支的零分配
缓存管线下该写法会因 in-place 落定写入（rows 身份/长度不变）滞后失效。
按 95de47e 原方案融合：缓存指纹扩展 Uint8Array 流位（任何位翻转触发
重建）+ hasEmptyAssistant 快速预检（无空行时零 filter 分配）。
verify-empty-assistant 全绿（含落定翻转即时过滤断言）。

## 验证

- [x] pnpm run build 全绿
- [x] verify-empty-assistant / verify-scrollbar-gutter /
      verify-back-to-bottom / verify-timeline-rail /
      repro-resume-position / verify-scroll 本地全过
- [x] CI：四项新验证登记进 render-scroll 组（run-ci-group.mjs GROUPS，
      perf-*/probe-* 为本地分析工具不进 CI）
