### PR TITLE
fix(test): trace-scene blank-gap 探针摆脱 4s 轮询窗口 flake

### DIFF
--- a/scripts/verify-trace-scene.tsx
+++ b/scripts/verify-trace-scene.tsx
@@ -533,12 +533,20 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   await sleep(400)
 
   // The settle paint is throttled behind the ink frame clock — poll for the
-  // markers instead of racing a fixed sleep.
+  // markers instead of racing a fixed sleep. The ceiling is generous (~15s)
+  // on purpose: this check asserts the FINAL LAYOUT (no blank band between
+  // the two sections), not paint latency, and the old 4s window straddled
+  // the settle-paint latency distribution — it failed with first=-1/
+  // second=-1 (markers not yet on screen) in ~1/3 of local runs while the
+  // very next assertion passed 400ms later. Green paths break out early;
+  // only a real layout regression (or a paint that never lands) pays the
+  // full ceiling.
+  const settlePollStart = Date.now()
   let lines: string[] = []
   let firstIndex = -1
   let secondIndex = -1
   let gap = Number.POSITIVE_INFINITY
-  for (let attempt = 0; attempt < 50; attempt++) {
+  for (let attempt = 0; attempt < 187; attempt++) {
     const buffer = term.buffer.active
     lines = Array.from({ length: buffer.length }, (_, row) =>
       buffer.getLine(row)?.translateToString(true) ?? '',
@@ -557,10 +565,14 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     if (firstIndex >= 0 && secondIndex >= 0 && gap <= 1) break
     await sleep(80)
   }
+  const settleWaitedMs = Date.now() - settlePollStart
   check(
     'reasoning that settles in the trajectory leaves no blank answer gap',
     firstIndex >= 0 && secondIndex >= 0 && gap <= 1,
-    `first=${firstIndex}, second=${secondIndex}, blank=${gap}, buffer=${lines.length}`,
+    `first=${firstIndex}, second=${secondIndex}, blank=${gap}, buffer=${lines.length}, waited=${settleWaitedMs}ms` +
+      (firstIndex < 0 || secondIndex < 0
+        ? ' (markers never painted within the 15s window — hung or lost frame, not a layout gap)'
+        : ''),
   )
 
   stdin.write('\x0f') // Ctrl+O


### PR DESCRIPTION
## 根因（连挂调查：cf5dd50 CI 两次 + 本地 main 一跑即中）

`verify-trace-scene` 的 "reasoning that settles … no blank answer gap"
断言在 **4s 轮询窗口**（50×80ms）内等 `FIRST/SECOND RESPONSE SECTION`
标记上屏。失败签名恒为 `first=-1, second=-1`——窗口内标记**根本没画
出来**，而紧随其后的断言 400ms 后即通过（Ctrl+O 能展开 reasoning
line 79）。即 settle 上屏耗时分布**跨界 4s**：通常 <400ms，偶尔 >4s。
与 AGENTS.md 登记的「本地约 1/3 复现」吻合。

该检查的意图是**布局终态**（两段之间空行 ≤1），不是上屏时延——
窗口太紧是 flake 的全部根源。

## 修法

- 轮询窗口 4s → **~15s**（50 → 187 次 × 80ms）
- 绿路径首轮命中即早退（本地实测 3/3 `waited=0ms`），零额外成本
- 只有真回归（标记永不上屏）才付满额窗口
- 失败诊断附带实际等待毫秒数，区分「布局空档」与「渲染挂起」

## 归置

留在 flaky-observation 隔离区（non-blocking 不变），攒稳定性证据后
再按登记方案移回 required 组。verify-resize-temporal（另一个隔离
flake，本次未连挂）不在本 PR 范围。

## 验证

- [x] 本地 3/3 全绿（含本断言与全脚本其余 40+ 断言）
- [x] CI（flaky-observation 组跑的就是改后的脚本）
