### PR TITLE
feat: hover interactions + drag-select & resume-route fixes

### DIFF
--- a/scripts/repro-drag-select-streaming.tsx
+++ b/scripts/repro-drag-select-streaming.tsx
@@ -1,0 +1,210 @@
+/**
+ * repro-drag-select-streaming — 选区复制回归的重现脚本（issue：全屏模式
+ * 拖选复制失效，"只能复制一个字符 / 只有输入框文字能复制"）。
+ *
+ * 根因：TimelineRail / ScrollbarGutter 是屏幕右侧的 2 列 gutter，却用了
+ * NoSelect fromLeftEdge —— noSelect 区域被拉成 [第 0 列 → 盒子右缘]，
+ * 整个转录区每行都被标记为不可选取，extractRowText 全部跳过 → 复制为空。
+ * 输入框在 gutter 行布局之外，不受影响 —— 与用户"只有输入框文字能复制"
+ * 的症状完全吻合。
+ *
+ * 场景（真实 Chat 树，fullscreen + AlternateScreen）：
+ *   1. 对照组：静息状态（无流式）拖选尾部标记行 → OSC 52 应携带完整文本；
+ *   2. 回归组：上滚阅读到中部历史 + 尾部行 streaming 并发时，同样拖选
+ *      中部历史标记行 → OSC 52 应同样完整；
+ *   3. 流式结束后再拖一次 → 应恢复。
+ *
+ * 运行：node --import tsx/esm scripts/repro-drag-select-streaming.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+// 纯 OSC 52 路径：跳过 wl-copy/xclip 探测链，断言只依赖 stdout 帧
+process.env.SSH_CONNECTION = 'headless-repro'
+delete process.env.TMUX
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+const { default: instances } = await import('../src/ink/instances.js')
+const { stringWidth } = await import('../src/ink/stringWidth.js')
+
+const COLS = 100, ROWS = 40
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+const writes: string[] = []
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    writes.push(String(chunk))
+    term.write(String(chunk), cb)
+  }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+// ── fixture：40 轮对话；中部与尾部各埋一个可定位的 ASCII 标记行 ──
+const T0 = Date.now() - 600_000
+const HMARK = 'ZZMARKER_ABCDEFGHIJ'   // 中部历史标记（回归组拖这个）
+const TMARK = 'TTMARKER_KLMNOPQRST'   // 尾部标记（对照组拖这个）
+const chatRows: any[] = []
+for (let i = 0; i < 40; i++) {
+  chatRows.push({ id: i * 2, kind: 'user', text: `用户消息 ${i}：帮我看看这个问题`, time: T0 + i * 8000 })
+  const text = i === 20
+    ? `历史标记行：${HMARK} 其后是普通内容。`
+    : i === 39
+      ? `尾部标记行：${TMARK} 结束。`
+      : `助手回复 ${i}：这个问题看起来出在 ${'分析内容。'.repeat(6)}，建议从这几个方向排查。`
+  chatRows.push({ id: i * 2 + 1, kind: 'assistant', text, time: T0 + i * 8000 + 3000 })
+}
+
+const listeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows: chatRows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [],
+  subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+
+const tree = (
+  <AlternateScreen>
+    <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+  </AlternateScreen>
+)
+const inst = await render(tree, {
+  stdout: stdout as any, stdin: stdin as any, stderr: stderr as any,
+  exitOnCtrlC: false, patchConsole: false,
+})
+// useCopyOnSelect/useSelection 经 instances.get(process.stdout) 找实例；
+// 本 harness 渲染到假 stdout，挂载时 key 未命中 → 拿到的是 no-op stub。
+// 别名后重渲一次，让 hook 绑到真实实例（与 verify-copy-on-select 同法）。
+instances.set(process.stdout, instances.get(stdout)!)
+inst.rerender(tree)
+
+await sleep(900)
+
+function screenLines(): string[] {
+  const buf = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
+}
+
+function osc52Payloads(): string[] {
+  return [...writes.join('').matchAll(/\x1b\]52;c;([A-Za-z0-9+/=]+)/g)]
+    .map(m => Buffer.from(m[1]!, 'base64').toString('utf8'))
+}
+
+/**
+ * 在当前屏幕上定位 marker，从 marker 内偏移 a 拖到 b（0-indexed 单元格，
+ * 闭区间：press..release 列都包含在选区里）。SGR 坐标是单元格列；
+ * CJK 占 2 格而 indexOf 是字符索引，必须用 stringWidth 换算前缀宽度。
+ */
+async function dragOver(marker: string, a: number, b: number): Promise<void> {
+  const lines = screenLines()
+  const row = lines.findIndex(l => l.includes(marker))
+  if (row < 0) throw new Error(`marker ${marker} not on screen`)
+  const charIdx = lines[row]!.indexOf(marker)
+  const col0 = stringWidth(lines[row]!.slice(0, charIdx))
+  stdin.write(`\x1b[<0;${col0 + a + 1};${row + 1}M`)   // press
+  await sleep(80)
+  stdin.write(`\x1b[<32;${col0 + b + 1};${row + 1}M`)   // drag (motion)
+  await sleep(80)
+  stdin.write(`\x1b[<0;${col0 + b + 1};${row + 1}m`)    // release
+  await sleep(350)
+}
+
+// ── 对照组：静息（sticky 底部），拖选尾部标记 ──
+writes.length = 0
+await dragOver(TMARK, 2, 10)
+{
+  const payloads = osc52Payloads()
+  const expect = TMARK.slice(2, 10 + 1)
+  check('静息拖选 → OSC 52 携带完整选中文本', payloads.includes(expect),
+    `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
+}
+
+// ── 回归组：上滚阅读到中部历史 + 尾部流式并发 ──
+for (let i = 0; i < 90 && !screenLines().some(l => l.includes(HMARK)); i++) {
+  stdin.write('\x1b[<64;90;20M')  // wheel up，小步走到标记可见
+  await sleep(12)
+}
+await sleep(400)
+{
+  const lines = screenLines()
+  check('上滚后中部历史标记可见', lines.some(l => l.includes(HMARK)))
+}
+
+writes.length = 0
+const streamRow = chatRows[chatRows.length - 1]!
+streamRow.streaming = true
+const origText = streamRow.text
+const chunk = '流式增量段落：继续分析模块边界与常量折叠的正确性，覆盖深层嵌套与循环引用的边界情况。\n\n'
+let streamed = 0
+const streamStart = Date.now()
+const streamLoop = (async () => {
+  while (Date.now() - streamStart < 2600) {
+    streamRow.text = origText + chunk.repeat(++streamed)
+    channel.version++
+    listeners.forEach(l => l())
+    await sleep(33)
+  }
+})()
+
+await sleep(400)  // 流式已在跑
+try {
+  await dragOver(HMARK, 3, 11)
+} catch (e) {
+  check('流式期间标记行仍在视口', false, String(e))
+}
+await streamLoop
+streamRow.streaming = undefined
+await sleep(400)
+
+{
+  const payloads = osc52Payloads()
+  const expect = HMARK.slice(3, 11 + 1)
+  check('流式并发时拖选 → OSC 52 携带完整选中文本', payloads.includes(expect),
+    `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
+}
+
+// ── 附加：流式结束后（静息）再拖一次，看是否恢复 ──
+writes.length = 0
+await sleep(200)
+try {
+  await dragOver(HMARK, 3, 11)
+  const payloads = osc52Payloads()
+  const expect = HMARK.slice(3, 11 + 1)
+  check('流式结束后拖选 → 恢复完整', payloads.includes(expect),
+    `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
+} catch (e) {
+  check('流式结束后标记行仍可见', false, String(e))
+}
+
+await inst.unmount()
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -129,6 +129,11 @@ const GROUPS = {
 // 换名迁移回归（issue #120）：~/.dsh-cc → ~/.dsh-tui 首启复制迁移、
 // resume.txt 双写契约、旧 env 名检测（DSH_CC_RESUME_SESSION 双读不算废弃）。
     ["verify-legacy-rename", ['node', 'scripts/verify-legacy-rename.mjs']],
+// 拖选复制端到端回归（用户报告：全屏下拖选"只能复制一个字符，只有
+// 输入框文字能复制"）：右侧 gutter 误用 NoSelect fromLeftEdge 把整行
+// 转录拉进不可选取区。真实 Chat 树 + SGR 拖选注入，静息/上滚阅读+
+// 流式并发/流式结束后三场景断言 OSC 52 携带完整选中文本。
+    ["repro-drag-select-streaming", ['node', '--import', 'tsx/esm', 'scripts/repro-drag-select-streaming.tsx']],
   ],
   'session-workspace': [
 // 审批服务配置回归（issue #49 尾巴）：裸组合 cordis.yml 必须挂载
@@ -184,6 +189,11 @@ const GROUPS = {
 // /resume 会话管理回归（issue #112）：picker 重命名追加帧（seq 连续、
 // 已有字节不动、last-title-wins）、删除目录、路径穿越 id 拒绝。
     ["verify-resume-manage", ['node', 'scripts/verify-resume-manage.mjs']],
+// resume 模型路由回填回归：session 记录的 request/header 路由必须能被
+// resolvePersistedRoute 读回并喂给 agents.resume——provider-only 的
+// cordis.yml pin（issue #67）否则会让 options.model 缺位，连累子代理
+// 继承（{{model}} persona 变量装配失败）。
+    ["verify-resume-route", ['node', 'scripts/verify-resume-route.mjs']],
 // /resume 任意深度重命名回归：会话索引取消了标题解析窗口，最旧的一条
 // 也必须解析出自己的标题、改名后立即显示新名。stub 只提供 list（不给
 // listSnapshots/locate），因此同时覆盖降级路径。

--- a/scripts/verify-resume-route.mjs
+++ b/scripts/verify-resume-route.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Regression for the resume-model-route backfill (dsh-tui side of the
+ * subagent `{{model}}` failure): resume must feed the target session's
+ * recorded request/header route back into `agents.resume({ agentOptions })`
+ * so `options.model` is populated again. A provider-only cordis.yml pin
+ * (issue #67) otherwise leaves agentOptions.model undefined, which breaks
+ * the `{{model}}` persona variable for the resumed agent's own assembly
+ * AND for every subagent it spawns (dsh-subagent's resolveChildAgentOptions
+ * inherits `parent.options.model`).
+ *
+ * Verifies `resolvePersistedRoute` (src/dsh-adapter/presets.ts):
+ *   1. a session whose log records request/header returns that route;
+ *   2. a session whose log records request/header WITHOUT a model half
+ *      returns undefined (recordedModelRoute requires BOTH halves);
+ *   3. a session with no request/header at all returns undefined;
+ *   4. a missing/corrupt artifact returns undefined, not a throw;
+ *   5. a context without sessionPersistence returns undefined.
+ *
+ * Run with plain node against the compiled lib:
+ *   node scripts/verify-resume-route.mjs
+ */
+import assert from 'node:assert/strict'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const { resolvePersistedRoute } = await import('../lib/types/dsh-adapter/presets.js')
+
+const header = (provider, model) => ({
+  type: 'request/header',
+  seq: 1,
+  time: 1,
+  data: { header: { config: { provider, model } } },
+})
+
+const ctxOf = (load) => ({
+  get(key) {
+    return key === 'sessionPersistence' && load !== undefined
+      ? { load }
+      : undefined
+  },
+})
+
+const sid = '00000000-1111-2222-3333-444444444444'
+
+// 1. Full route recorded → returned.
+{
+  const route = await resolvePersistedRoute(ctxOf(async () => ({
+    meta: {},
+    events: [header('deepseek-official', 'deepseek-v4-flash')],
+  })), sid)
+  check(
+    'recorded request/header yields the full route',
+    route?.provider === 'deepseek-official' && route?.model === 'deepseek-v4-flash',
+    JSON.stringify(route),
+  )
+}
+
+// 2. Provider-only recorded (half pin) → undefined, never a half-merged route.
+{
+  const route = await resolvePersistedRoute(ctxOf(async () => ({
+    meta: {},
+    events: [header('deepseek-official', undefined)],
+  })), sid)
+  check('provider-only record yields undefined', route === undefined, JSON.stringify(route))
+}
+
+// 3. No request/header → undefined.
+{
+  const route = await resolvePersistedRoute(ctxOf(async () => ({
+    meta: {},
+    events: [{ type: 'user/message', seq: 1, time: 1, data: {} }],
+  })), sid)
+  check('bare log (no header) yields undefined', route === undefined, JSON.stringify(route))
+}
+
+// 4. Unreadable artifact → undefined, not a throw.
+{
+  const route = await resolvePersistedRoute(ctxOf(async () => { throw new Error('corrupt') }), sid)
+  check('unreadable artifact yields undefined', route === undefined, String(route))
+}
+
+// 5. No persistence service → undefined.
+{
+  const route = await resolvePersistedRoute(ctxOf(undefined), sid)
+  check('absent persistence yields undefined', route === undefined, String(route))
+}
+
+// 6. Last header wins (the route the session actually continues on).
+{
+  const route = await resolvePersistedRoute(ctxOf(async () => ({
+    meta: {},
+    events: [header('deepseek-official', 'deepseek-v4-flash'), header('other-provider', 'other-model')],
+  })), sid)
+  check(
+    'last request/header wins',
+    route?.provider === 'other-provider' && route?.model === 'other-model',
+    JSON.stringify(route),
+  )
+}
+
+console.log(failed === 0 ? 'verify-resume-route: all checks passed' : `verify-resume-route: ${failed} check(s) failed`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/ContextBarView.tsx
+++ b/src/components/ContextBarView.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { Box, Text } from '../ui.js'
+import type { Color } from '../ink/styles.js'
+import {
+  USED_SEGMENTS,
+  allocateBarColumns,
+  centeredText,
+  chooseLabel,
+  composeFreeSegmentText,
+  formatTokens,
+  type ContextSegments,
+} from '../screens/StatusMetrics.js'
+
+/** Free-segment colors, mirroring StatusMetrics' dark-theme defaults. */
+const FREE_FILL: Color = '#E8E8E8'
+const FREE_TEXT: Color = '#4A4A4A'
+const USED_TEXT: Color = '#FFFFFF'
+
+/**
+ * The hoverable JSX twin of `renderContextBar`: the same segmented context
+ * bar (same largest-remainder column split, same label fallback ladder,
+ * same free-segment readout), rendered as one Box per segment so each
+ * carries its own mouse handlers. Hovering a segment reports its key (or
+ * `free`) upward through `onHover`; the footer turns that into a detail
+ * readout on its supplemental row.
+ *
+ * Pixel parity with the ANSI path is the contract: this exists so the bar
+ * can react to the pointer, not to restyle it.
+ */
+export function ContextBarView({
+  segments,
+  usedTokens,
+  contextWindow,
+  width,
+  colors,
+  onHover,
+}: {
+  /** Used tokens per content type. */
+  segments: ContextSegments
+  /** Total used tokens, driving the usage readout. */
+  usedTokens: number
+  /** The context window size in tokens. */
+  contextWindow: number
+  /** Total bar width in terminal columns. */
+  width: number
+  /** Theme overrides for the free segment (light theme passes its own). */
+  colors?: { freeFill: Color; freeText: Color }
+  /** Hover signal: a segment key (`system`…`tools`), `free`, or null on
+   *  leave. Absent handlers render a static bar (tests, headless embeds). */
+  onHover?: (segment: string | null) => void
+}): React.ReactNode {
+  if (width <= 0 || contextWindow <= 0) return null
+
+  const freeTokens = Math.max(0, contextWindow - usedTokens)
+  const values = [...USED_SEGMENTS.map(segment => segments[segment.key]), freeTokens]
+  const columns = allocateBarColumns(values, width)
+  const percent = `${((usedTokens / contextWindow) * 100).toFixed(1)}%`
+  const total = `${formatTokens(usedTokens)}/${formatTokens(contextWindow)}`
+  const free = formatTokens(contextWindow - usedTokens)
+
+  const nodes: React.ReactNode[] = []
+  for (const [index, segment] of USED_SEGMENTS.entries()) {
+    const segmentWidth = columns[index] ?? 0
+    if (segmentWidth <= 0) continue
+    const label = chooseLabel(segment.labels, segmentWidth)
+    nodes.push(
+      <Box
+        key={segment.key}
+        width={segmentWidth}
+        height={1}
+        flexShrink={0}
+        backgroundColor={segment.color}
+        onMouseEnter={onHover === undefined ? undefined : () => onHover(segment.key)}
+        onMouseLeave={onHover === undefined ? undefined : () => onHover(null)}
+      >
+        <Text color={USED_TEXT}>
+          {label.length > 0 ? centeredText(label, segmentWidth) : ' '.repeat(segmentWidth)}
+        </Text>
+      </Box>,
+    )
+  }
+
+  const freeWidth = columns[USED_SEGMENTS.length] ?? 0
+  if (freeWidth > 0) {
+    nodes.push(
+      <Box
+        key="free"
+        width={freeWidth}
+        height={1}
+        flexShrink={0}
+        backgroundColor={colors?.freeFill ?? FREE_FILL}
+        onMouseEnter={onHover === undefined ? undefined : () => onHover('free')}
+        onMouseLeave={onHover === undefined ? undefined : () => onHover(null)}
+      >
+        <Text color={colors?.freeText ?? FREE_TEXT}>
+          {composeFreeSegmentText(
+            [
+              `ctx ${total} ${percent} ${free}`,
+              `${total} ${percent} ${free}`,
+              `${total} ${percent}`,
+              percent,
+            ],
+            freeWidth,
+          )}
+        </Text>
+      </Box>,
+    )
+  }
+
+  return (
+    <Box flexDirection="row" flexShrink={0} width={width}>
+      {nodes}
+    </Box>
+  )
+}

--- a/src/components/ScrollbarGutter.tsx
+++ b/src/components/ScrollbarGutter.tsx
@@ -6,6 +6,9 @@ import { RAIL_MIN_TERMINAL_WIDTH, RAIL_WIDTH } from '../ink/timeline-rail.js'
  *  deliberately distinct from the timeline's ━━ active tick. */
 const THUMB = '██'
 
+/** Rest time before the hover position chip pops (anti-flash sweep gate). */
+const CHIP_DWELL_MS = 250
+
 /**
  * Proportional scrollbar for the fullscreen transcript's gutter — the
  * `scrollbar` option of the `dsh-tui.scrollGutter` setting (the timeline
@@ -35,6 +38,26 @@ export function ScrollbarGutter({
   terminalWidth: number
 }): React.ReactNode {
   const [, setTick] = React.useState(0)
+  // Hover readout: the row under the pointer brightens the thumb when it is
+  // the hovered one, and floats a `62% · 340/540` chip left of the gutter
+  // naming the position a click there would jump to. The chip is
+  // dwell-gated (TimelineRail's preview-card rule): a sweep across the
+  // track brightens rows but never pops chips — only ~250ms of rest does.
+  // Once shown it follows row changes immediately; leaving hides it.
+  const [hoverRow, setHoverRow] = React.useState<number | null>(null)
+  const [chipRow, setChipRow] = React.useState<number | null>(null)
+  const dwellTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const clearDwell = (): void => {
+    if (dwellTimer.current !== null) {
+      clearTimeout(dwellTimer.current)
+      dwellTimer.current = null
+    }
+  }
+  const clearChip = (): void => {
+    clearDwell()
+    setChipRow(null)
+  }
+  React.useEffect(() => clearDwell, [])
   React.useEffect(() => {
     if (!handle) return
     return handle.subscribe(() => setTick(t => t + 1))
@@ -71,14 +94,66 @@ export function ScrollbarGutter({
         height={1}
         flexShrink={0}
         onClick={() => handle.scrollTo(trackScrollTop(y))}
+        onMouseEnter={() => {
+          setHoverRow(y)
+          // Resting pointer: chip follows immediately once dwell has
+          // opened it; a sweep re-arms the dwell instead of flashing.
+          clearDwell()
+          if (chipRow !== null) {
+            setChipRow(y)
+          } else {
+            dwellTimer.current = setTimeout(() => setChipRow(y), CHIP_DWELL_MS)
+          }
+        }}
+        onMouseLeave={() => {
+          setHoverRow(current => (current === y ? null : current))
+          clearChip()
+        }}
       >
-        <Text color={inThumb ? 'inactive' : undefined}>{inThumb ? THUMB : '  '}</Text>
+        <Text
+          color={
+            inThumb
+              ? hoverRow !== null && hoverRow >= thumbTop && hoverRow < thumbBottom
+                ? 'professionalBlue'
+                : 'inactive'
+              : undefined
+          }
+        >
+          {inThumb ? THUMB : '  '}
+        </Text>
       </Box>,
     )
   }
 
+  // The floating position chip, anchored left of the gutter on the
+  // dwell-armed row (TimelineRail's preview-card geometry, one line tall).
+  // Absolute + zero layout contribution: popping it never moves anything.
+  // Fenced with noSelect: it floats over selectable transcript text.
+  let hoverChip: React.ReactNode = null
+  if (chipRow !== null && maxScroll > 0) {
+    const jumpTop = trackScrollTop(chipRow)
+    const pct = Math.round((jumpTop / maxScroll) * 100)
+    const line = Math.min(content, jumpTop + 1)
+    hoverChip = (
+      <Box
+        position="absolute"
+        top={chipRow}
+        right={RAIL_WIDTH + 1}
+        flexShrink={0}
+        backgroundColor="toolCardBackgroundDim"
+        paddingX={1}
+        noSelect
+      >
+        <Text color="text">{`${pct}% · ${line}/${content}`}</Text>
+      </Box>
+    )
+  }
+
   return (
-    <NoSelect fromLeftEdge>
+    // Plain NoSelect (box region only): the scrollbar is a RIGHT-side
+    // gutter, so fromLeftEdge's [col 0 → box right edge] region would
+    // fence the ENTIRE transcript row out of copy-on-select.
+    <NoSelect>
       {/* Raw ink-box (not the themed Box): onWheel is a host-level prop
           (same as ScrollBox's viewport) — wheel over the gutter scrolls
           the transcript, the gutter has no scroll of its own. */}
@@ -89,6 +164,7 @@ export function ScrollbarGutter({
         style={{ flexDirection: 'column', flexShrink: 0, width: RAIL_WIDTH }}
       >
         {rows}
+        {hoverChip}
       </ink-box>
     </NoSelect>
   )

--- a/src/components/SubagentCard.tsx
+++ b/src/components/SubagentCard.tsx
@@ -16,9 +16,14 @@ export function SubagentCard({ subagent, focused, onClick }: SubagentCardProps):
   const running = subagent.status === 'running' || subagent.status === 'starting'
   const elapsed = subagent.completedAt ? subagent.completedAt - subagent.startedAt : Date.now() - subagent.startedAt
   const total = subagent.tokens?.total ?? ((subagent.tokens?.input ?? 0) + (subagent.tokens?.output ?? 0) || 0)
+  // Mouse affordance: clickable cards tint on hover; the keyboard-focused
+  // card keeps its brand-color header (no double highlight).
+  const [hovered, setHovered] = useState(false)
   // Live preview: the newest streamed line rides under the header while the
   // subagent runs, then folds away — the dashboard stays one line per settled
-  // subagent.
+  // subagent. Deliberately NOT revived on hover: an extra line would grow
+  // the card mid-gesture and reshuffle the whole dashboard list (user
+  // feedback: hover must never change layout). The hover tint stays.
   const liveLine = running ? subagent.output[subagent.output.length - 1] : undefined
   const minimal = isMinimalMode()
   const glyph = running ? (minimal ? '·' : '🟡')
@@ -28,9 +33,6 @@ export function SubagentCard({ subagent, focused, onClick }: SubagentCardProps):
     : running ? 'warning' as const
     : subagent.status === 'failed' || subagent.status === 'cancelled' ? 'error' as const
     : 'success' as const
-  // Mouse affordance: clickable cards tint on hover; the keyboard-focused
-  // card keeps its brand-color header (no double highlight).
-  const [hovered, setHovered] = useState(false)
   const hoverTint = onClick !== undefined && hovered && !focused
   return <Box
     flexDirection="column"

--- a/src/components/TimelineRail.tsx
+++ b/src/components/TimelineRail.tsx
@@ -257,8 +257,14 @@ export function TimelineRail({
                 flexShrink={0}
                 borderStyle="round"
                 borderColor="inactive"
-                backgroundColor="toolCardBackgroundDim"
                 paddingX={1}
+                // The card floats LEFT of the rail over selectable
+                // transcript text; fence its own rect so a drag that
+                // happens under a dwell-popped preview never copies the
+                // card's preview glyphs. On the box itself (not a NoSelect
+                // wrapper): absolute children don't contribute to a flow
+                // wrapper's layout, so a wrapper's region would be 0×0.
+                noSelect
               >
                 {lines.map((line, i) => (
                   <Text key={i} color="text" wrap="truncate-end">{line}</Text>
@@ -272,7 +278,12 @@ export function TimelineRail({
   }
 
   return (
-    <NoSelect fromLeftEdge>
+    // Plain NoSelect (box region only): the rail is a RIGHT-side gutter,
+    // so fromLeftEdge's [col 0 → box right edge] region would fence the
+    // ENTIRE transcript row — the copy-on-select regression where every
+    // drag copied ~nothing (the hover card below carries its own noSelect
+    // for the same reason: it floats over selectable transcript text).
+    <NoSelect>
       {/* Raw ink-box (not the themed Box): onWheel is a host-level prop
           (same as ScrollBox's viewport) — wheel over the rail scrolls the
           transcript, the rail has no scroll of its own. */}

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -96,7 +96,13 @@ function languageFromPath(path: string | undefined): string | undefined {
 
 /** `hint` is the trajectory pointer: recessive, never competing with output. */
 type BodyTone = 'add' | 'del' | 'dim' | 'plain' | 'error' | 'hint' | 'path'
-type BodyLine = { readonly text: string; readonly tone: BodyTone }
+type BodyLine = {
+  readonly text: string
+  readonly tone: BodyTone
+  /** The row's collapse hint: dim at rest, steps to text while hovered so the
+   *  toggle reads before the click (the compaction row's pattern). */
+  readonly revealOnHover?: boolean
+}
 
 /** CC's collapsed text body keeps 3 lines (renderTruncatedContent). */
 const TEXT_BODY_MAX_LINES = 3
@@ -216,7 +222,7 @@ function capLines(lines: BodyLine[], max: number, verbose: boolean): BodyLine[] 
   if (lines.length - max === 1) return lines
   return [
     ...lines.slice(0, max),
-    dim(`… +${lines.length - max} lines (ctrl+o to expand)`),
+    { ...dim(`… +${lines.length - max} lines (ctrl+o to expand)`), revealOnHover: true },
   ]
 }
 
@@ -375,6 +381,16 @@ export function AssistantToolUseMessage({
     : ordinaryToolBackground === 'strong'
       ? 'toolCardBackground'
       : undefined
+  // Hover affordance for the click-to-toggle row: the theme's tool-card blue
+  // face marks the call's content area while the pointer dwells (the
+  // toolBackground treatment steps up one level to the strong card face), the
+  // collapsed `(ctrl+o to expand)` hint steps from dim to text, the elapsed
+  // clock stops dimming, and a ▾/▴ discloses the row is a toggle.
+  // No layout change: the indicator is a fixed column on the header line, the
+  // body never moves.
+  const [hovered, setHovered] = React.useState(false)
+  const interactive = onClick !== undefined
+  const hoverTint = interactive && hovered && !isSelected
 
   return (
     <Box
@@ -386,9 +402,9 @@ export function AssistantToolUseMessage({
       onClick={onClick}
       // Only selection paints a highlight; the configured treatment applies
       // to an ordinary card. Diff line tints stay - they are content, not chrome.
-      // No hover tint: the card stays visually quiet until clicked (user
-      // feedback — row-hover color changes read as noise in the transcript).
-      backgroundColor={isSelected ? 'messageActionsBackground' : ordinaryBackground}
+      backgroundColor={isSelected ? 'messageActionsBackground' : hoverTint ? 'toolCardBackground' : ordinaryBackground}
+      onMouseEnter={interactive ? () => setHovered(true) : undefined}
+      onMouseLeave={interactive ? () => setHovered(false) : undefined}
     >
       <Box flexDirection="column" flexGrow={1}>
         <Box flexDirection="row" flexWrap="nowrap" minWidth={minWidth}>
@@ -401,7 +417,12 @@ export function AssistantToolUseMessage({
           <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} argsLanguage={argsLanguage} nameColor={toolNameColor(tool.name)} />
           {!isRunning && (
             <Box flexWrap="nowrap">
-              <Text dimColor>{elapsedText}</Text>
+              <Text dimColor={!hovered}>{elapsedText}</Text>
+            </Box>
+          )}
+          {hovered && (
+            <Box flexShrink={0}>
+              <Text dimColor>{isExpanded ? '▴' : '▾'}</Text>
             </Box>
           )}
         </Box>
@@ -452,7 +473,7 @@ export function AssistantToolUseMessage({
                               ? 'ide'
                               : undefined
                   }
-                  dimColor={line.tone === 'dim'}
+                  dimColor={line.tone === 'dim' && !(line.revealOnHover === true && hovered)}
                   wrap="wrap"
                 >
                   {line.tone === 'plain' && syntaxLanguage !== undefined ? (

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -41,7 +41,7 @@ import { readModelPref, writeModelPref } from '../modelPrefs.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ProviderSetupHost } from './providerWizard.js'
 import { readPresetPref, writePresetPref } from '../presetPrefs.js'
-import { composePreset, resolvePersistedPreset, rosterOf, runningPresetOf, serviceForAgent, type AgentPresetInfo } from './presets.js'
+import { composePreset, resolvePersistedPreset, resolvePersistedRoute, rosterOf, runningPresetOf, serviceForAgent, type AgentPresetInfo } from './presets.js'
 import { isPresetName, PRESET_NAMES } from '../components/activityFrames.js'
 import { existsSync, statSync, writeFileSync } from 'node:fs'
 import { logForDebugging } from '../utils/debug.js'
@@ -2921,10 +2921,20 @@ export function createChannel(
         provider: options.configuredProvider,
         model: options.configuredModel,
       })
+      // The recorded route feeds back into agentOptions too — not just the
+      // status line below: a provider-only cordis.yml pin (issue #67) leaves
+      // agentOptions.model undefined on resume, which breaks the `{{model}}`
+      // persona variable for the resumed agent's own assembly AND for every
+      // subagent it spawns (dsh-subagent's resolveChildAgentOptions inherits
+      // `parent.options.model`).
+      const recordedRoute = await resolvePersistedRoute(ctx, SessionId(sessionId))
       try {
         handle = await agents.resume({
           resumeSessionId: SessionId(sessionId),
-          agentOptions: { provider: resumeRoute?.provider, model: resumeRoute?.model },
+          agentOptions: {
+            provider: resumeRoute?.provider ?? recordedRoute?.provider,
+            model: resumeRoute?.model ?? recordedRoute?.model,
+          },
           ...(resumeComposed.setup === undefined ? {} : { setup: resumeComposed.setup }),
         })
       } catch (error) {

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -20,7 +20,7 @@ import { readModelPref } from '../modelPrefs.js'
 import { explicitModelRoute, recordedModelRoute, resolveModelRoute, validateModelRoute } from '../modelRoute.js'
 import type { ModelRoute } from '../modelRoute.js'
 import { readPresetPref } from '../presetPrefs.js'
-import { composePreset, filterMinimalPresetTools, resolvePersistedPreset, runningPresetOf } from './presets.js'
+import { composePreset, filterMinimalPresetTools, resolvePersistedPreset, resolvePersistedRoute, runningPresetOf } from './presets.js'
 import { ensurePackagedPresets } from './packaged-presets.js'
 import { ensureLegacySessionEventTypes } from './compat/index.js'
 import { clearResumeTarget, writeResumeTarget } from '../sessionHistory.js'
@@ -1062,9 +1062,13 @@ async function resolveAgent(
 ): Promise<{ agent: Agent; handle?: AgentHandle; agentPreset?: string; route?: ModelRoute }> {
   // Resume override (issue #67): cordis.yml overrides the target session's
   // recorded route only when it pins BOTH halves; undefined halves let the
-  // session's own request/header records win (issue #30).
+  // session's own request/header records win (issue #30). The recorded route
+  // is ALSO fed back into agentOptions (not just the status line): a resume
+  // whose cordis.yml pins only `provider` would otherwise leave
+  // agentOptions.model undefined, which breaks the `{{model}}` persona
+  // variable for the resumed agent's own assembly and for every subagent it
+  // spawns (dsh-subagent inherits `parent.options.model`).
   const resumeRoute = explicitModelRoute(configuredRoute)
-  const resumeOptions = { provider: resumeRoute?.provider, model: resumeRoute?.model }
   if (requestedSessionId !== undefined) {
     const resumeId = SessionId(requestedSessionId)
     const existing = ctx.agents.get(resumeId)
@@ -1081,6 +1085,11 @@ async function resolveAgent(
       // caller's current preference.
       const persisted = await resolvePersistedPreset(ctx, resumeId)
       const composed = await composePreset(ctx, persisted)
+      const recorded = await resolvePersistedRoute(ctx, resumeId)
+      const resumeOptions = {
+        provider: resumeRoute?.provider ?? recorded?.provider,
+        model: resumeRoute?.model ?? recorded?.model,
+      }
       const resumed = await ctx.agents.resume({
         resumeSessionId: resumeId,
         agentOptions: resumeOptions,

--- a/src/dsh-adapter/presets.ts
+++ b/src/dsh-adapter/presets.ts
@@ -21,6 +21,7 @@ import type { AgentSetup } from '@deepseek-ai/dsh-agent'
 import type { SessionId } from '@deepseek-ai/dsh-session'
 import type { PromptAssembly } from '@deepseek-ai/dsh-system-prompt'
 import { resolveSessionPreset } from '@deepseek-ai/dsh-agent-presets'
+import { recordedModelRoute, type ModelRoute } from '../modelRoute.js'
 
 const ASK_USER_TOOL = 'ask_user_question'
 
@@ -141,6 +142,42 @@ export function runningPresetOf(session: {
   events: readonly { type: string; data: unknown }[]
 }): string | undefined {
   return resolveSessionPreset(session as Parameters<typeof resolveSessionPreset>[0])
+}
+
+/**
+ * The route a PERSISTED session actually ran, read from its log: the last
+ * `request/header` snapshot. undefined when the log records none (a session
+ * that never started a turn) or the artifact is unreadable.
+ *
+ * Resume feeds this back into `agents.resume({ agentOptions })` so the
+ * resumed agent's `options.model` is populated again — a cordis.yml that
+ * pins only `provider` (issue #67: a half-pin never merges) leaves
+ * agentOptions.model undefined, which breaks the `{{model}}` persona variable
+ * for the resumed agent's own assembly AND for every subagent it spawns
+ * (dsh-subagent's `resolveChildAgentOptions` inherits `parent.options.model`).
+ *
+ * @param ctx - The plugin context (persistence lookup).
+ * @param sessionId - The persisted session to inspect.
+ * @returns The recorded model route, or undefined when unrecorded/unreadable.
+ */
+export async function resolvePersistedRoute(ctx: Context, sessionId: SessionId): Promise<ModelRoute | undefined> {
+  const persistence = ctx.get('sessionPersistence') as
+    | {
+        load(id: SessionId): Promise<{
+          meta: unknown
+          events: readonly { type: string; data?: unknown }[]
+        }>
+      }
+    | undefined
+  if (persistence === undefined) return undefined
+  try {
+    const { events } = await persistence.load(sessionId)
+    return recordedModelRoute(events)
+  } catch {
+    // A missing/corrupt artifact leaves resume itself to report the failure;
+    // the route lookup must not mask it with a second, misleading error.
+    return undefined
+  }
 }
 
 /**

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -516,6 +516,9 @@ const dict = {
   'statusline-hint-select': { zh: 'esc 返回输入', en: 'esc to return to input' },
   'statusline-hint-working': { zh: 'esc 中断', en: 'esc to interrupt' },
   'statusline-hint-shortcuts': { zh: '? 查看快捷键', en: '? for shortcuts' },
+  // ── 底栏字段 hover 明细（补充行读出；技术标签 ctx/free/read 等保持不译）──
+  'status-detail-of-window': { zh: '的窗口', en: 'of window' },
+  'status-detail-session-id': { zh: '会话日志目录与此 id 同名', en: 'the session log directory is named after this id' },
   'hint-ext-dialog-input': { zh: '**Enter** 确认 · Esc 取消', en: '**Enter** to confirm · Esc to cancel' },
   'hint-adjust-done': { zh: '**←/→** 调整 · Enter/Esc 完成', en: '**←/→** to adjust · Enter/Esc to done' },
   'hint-history-search': { zh: '↑/↓ 选择 · **Enter** 确认 · Esc 取消', en: '↑/↓ to navigate · **Enter** to select · Esc to cancel' },

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -1,21 +1,24 @@
 import React from 'react'
 import { Box, Text, useTerminalSize, useTheme } from '../ui.js'
+import type { Color } from '../ink/styles.js'
 import { formatTokens } from '../cc/format.js'
 import { t } from '../i18n.js'
 import { formatContextUsage, DEFAULT_STATUS_BAR, normalizeStatusBar, type StatusBarConfig } from '../tuiDisplayPrefs.js'
-import { Byline } from '../components/design-system/Byline.js'
 import { ActivityLine, contextPressurePct } from '../components/ActivityLine.js'
 import { GoalStatusChip } from '../components/GoalTodoPanel.js'
 import type { Channel } from '../dsh-adapter/channel.js'
 import { modeDisplayName } from '../sessionModes.js'
 import { MiniWake } from '../components/trajectory/MiniWake.js'
-import type { WaveBand } from '../dsh-adapter/types.js'
+import { ContextBarView } from '../components/ContextBarView.js'
 import {
-  renderContextBar,
+  USED_SEGMENTS,
+  renderMiniContextBar,
   renderTpsGauge,
   renderTpsSparkline,
   speedColor,
+  tpsStats,
 } from './StatusMetrics.js'
+import type { WaveBand } from '../dsh-adapter/types.js'
 
 /**
  * The footer under the prompt input, in Claude Code's PromptInputFooter
@@ -25,7 +28,73 @@ import {
  * right-aligned), and the
  * mode/hint line last. The right side of the footer shows the latest
  * transient notification (errors in red, warnings in amber — CC style).
+ *
+ * Every metric field is hover-aware (fullscreen mouse): dwelling on a field
+ * swaps the ctx readout for a mini pressure gauge and parks that field's
+ * detailed breakdown on the supplemental row where the idle hint lives —
+ * the footer stays one line tall, the detail is a peek, not a layout
+ * change. Hovering a context-bar segment does the same for that segment.
  */
+
+/** Footer fields that answer a hover with a supplemental-row detail.
+ *  Context-bar segments arrive as `segment:<key>` (see ContextBarView). */
+type HoverTarget =
+  | 'ctx'
+  | 'cache'
+  | 'tps'
+  | 'tokens'
+  | 'goal'
+  | 'sessionId'
+  | 'cwd'
+  | 'title'
+  | `segment:${string}`
+
+/** One inline footer field: `node` renders inside a shrinkable, optionally
+ *  hoverable Box; `key` doubles as the React key in its row. */
+type FieldPart = {
+  key: string
+  node: React.ReactNode
+  /** Present when the field shows a detail readout on hover. */
+  id?: HoverTarget
+}
+
+/**
+ * Render field parts as sibling shrinkable Boxes joined by the Byline
+ * separator (` · `). The Box-per-field layout is what makes individual
+ * fields hoverable — a Byline inside one Text cannot carry per-field mouse
+ * rects — at the cost of truncating each field on its own under pressure
+ * instead of truncating the joined string's tail.
+ */
+function FieldLine({
+  parts,
+  hoverProps,
+}: {
+  parts: readonly FieldPart[]
+  hoverProps: (id: HoverTarget) => {
+    onMouseEnter: () => void
+    onMouseLeave: () => void
+  }
+}): React.ReactNode {
+  const visible = parts.filter(
+    part => part.node !== null && part.node !== undefined && part.node !== false,
+  )
+  return (
+    <>
+      {visible.map((part, index) => (
+        <React.Fragment key={part.key}>
+          {index > 0 ? <Text dimColor> · </Text> : null}
+          <Box
+            flexShrink={1}
+            {...(part.id === undefined ? {} : hoverProps(part.id))}
+          >
+            <Text wrap="truncate">{part.node}</Text>
+          </Box>
+        </React.Fragment>
+      ))}
+    </>
+  )
+}
+
 export function StatusLine({
   channel,
   selectionActive = false,
@@ -48,6 +117,13 @@ export function StatusLine({
 }) {
   const { columns } = useTerminalSize()
   const [themeName] = useTheme()
+  const [hover, setHover] = React.useState<HoverTarget | null>(null)
+  const hoverProps = React.useCallback((id: HoverTarget) => ({
+    onMouseEnter: () => setHover(id),
+    // Guarded leave: a late leave from a field the pointer already left must
+    // not clobber the field it entered.
+    onMouseLeave: () => setHover(current => (current === id ? null : current)),
+  }), [])
 
   const statusBar: StatusBarConfig = channel.minimal
     // Minimal mode overrides every field switch: model + cwd only, so the
@@ -58,130 +134,184 @@ export function StatusLine({
   const contextUsed = usage === undefined
     ? undefined
     : usage.input + usage.cacheRead + usage.cacheWrite
-  const contextParts: React.ReactNode[] = []
+  const contextParts: FieldPart[] = []
 
   if (statusBar.thinking && channel.reasoningEffort !== undefined) {
-    contextParts.push(
-      <Text key="effort" color="inactiveShimmer">
-        {channel.reasoningEffort}
-      </Text>,
-    )
+    contextParts.push({
+      key: 'effort',
+      node: <Text color="inactiveShimmer">{channel.reasoningEffort}</Text>,
+    })
   }
   if (statusBar.mode && channel.modeIndex > 0) {
-    contextParts.push(
-      <Text
-        key="mode"
-        color={channel.mode.plan === true ? 'planMode' : 'warning'}
-      >
-        {modeDisplayName(channel.mode)}
-      </Text>,
-    )
+    contextParts.push({
+      key: 'mode',
+      node: (
+        <Text
+          color={channel.mode.plan === true ? 'planMode' : 'warning'}
+        >
+          {modeDisplayName(channel.mode)}
+        </Text>
+      ),
+    })
   }
+
   const formattedContext = statusBar.contextUsage
     ? formatContextUsage(contextUsed, channel.contextWindow, statusBar.compact)
     : undefined
-  const contextUsagePart = formattedContext === undefined
+  // The ctx field's two faces: the idle readout, and the hover state — an
+  // in-place pressure bar (the user-liked "text becomes a bar" morph).
+  //
+  // WIDTH-STABLE BY CONSTRUCTION: the idle variable part is
+  // `P + " (" + C + ")"` (either order; P = percent text, C = counts) —
+  // len(P)+len(C)+3 cells. The hover variant is `▕+bar+▏ + " " + P` —
+  // 3+barLen+len(P) cells. Sizing barLen = len(C) makes them equal, so the
+  // morph swaps glyphs in place and NO sibling field, separator, or the
+  // right-aligned group moves a single cell (the first attempt used a fixed
+  // 10-cell gauge and made the whole row jump).
+  const ctxParts = (() => {
+    if (formattedContext === undefined) return undefined
+    const open = formattedContext.indexOf(' (')
+    if (open < 0) return undefined
+    const first = formattedContext.slice(0, open)
+    const second = formattedContext.slice(open + 2, -1)
+    if (first.endsWith('%')) return { percent: first, counts: second }
+    if (second.endsWith('%')) return { percent: second, counts: first }
+    return undefined
+  })()
+  const ctxHoverBarWidth = ctxParts?.counts.length ?? 0
+  const ctxNode = formattedContext === undefined
     ? undefined
-    : (
-        <Text key="context" color="inactiveShimmer">
+    : hover === 'ctx' &&
+        ctxParts !== undefined &&
+        ctxHoverBarWidth > 0 &&
+        contextUsed !== undefined &&
+        channel.contextWindow !== undefined
+      ? (
+        <Text color="inactiveShimmer">
+          <Text dimColor>ctx </Text>
+          {renderMiniContextBar(contextUsed, channel.contextWindow, ctxHoverBarWidth)}
+          {' '}{ctxParts.percent}
+        </Text>
+      )
+      : (
+        <Text color="inactiveShimmer">
           <Text dimColor>ctx </Text>{formattedContext}
         </Text>
       )
   if (statusBar.cache) {
     const cacheRate = formatCacheHitRate(usage)
     if (cacheRate !== undefined) {
-      contextParts.push(
-        <Text key="cache" color="inactiveShimmer">
-          <Text dimColor>{t('status-cache-label')}</Text>{cacheRate}
-        </Text>,
-      )
+      contextParts.push({
+        key: 'cache',
+        id: 'cache',
+        node: (
+          <Text color="inactiveShimmer">
+            <Text dimColor>{t('status-cache-label')}</Text>{cacheRate}
+          </Text>
+        ),
+      })
     }
   }
 
-  const tpsParts: React.ReactNode[] = []
+  let tpsPart: FieldPart | undefined
   if (statusBar.tps && channel.tps !== undefined) {
     if (channel.working && channel.tpsSamples.length === 0) {
-      tpsParts.push(
-        <Text key="tps">
-          {renderTpsGauge(channel.tps, channel.tps)}{' '}
-          <Text dimColor>{Math.round(channel.tps)} tps</Text>
-        </Text>,
-      )
+      tpsPart = {
+        key: 'tps',
+        id: 'tps',
+        node: (
+          <Text>
+            {renderTpsGauge(channel.tps, channel.tps)}{' '}
+            <Text dimColor>{Math.round(channel.tps)} tps</Text>
+          </Text>
+        ),
+      }
     } else if (channel.tpsSamples.length > 0) {
       const peak = Math.max(...channel.tpsSamples.map(sample => sample.tps), channel.tps)
-      tpsParts.push(
-        <Text key="tps">
-          {channel.working
-            ? renderTpsGauge(channel.tps, peak)
-            : renderTpsSparkline(channel.tpsSamples)}{' '}
-          {speedColor(channel.tps, `${Math.round(channel.tps)}`)} tps
-        </Text>,
-      )
+      tpsPart = {
+        key: 'tps',
+        id: 'tps',
+        node: (
+          <Text>
+            {channel.working
+              ? renderTpsGauge(channel.tps, peak)
+              : renderTpsSparkline(channel.tpsSamples)}{' '}
+            {speedColor(channel.tps, `${Math.round(channel.tps)}`)} tps
+          </Text>
+        ),
+      }
     } else {
-      tpsParts.push(
-        <Text key="tps" dimColor>
-          {Math.round(channel.tps)} t/s
-        </Text>,
-      )
+      tpsPart = {
+        key: 'tps',
+        id: 'tps',
+        node: <Text dimColor>{Math.round(channel.tps)} t/s</Text>,
+      }
     }
   }
 
-  const leftParts = [
+  const leftFields: FieldPart[] = [
     ...(statusBar.model
-      ? [<Text key="model" color="inactiveShimmer">{channel.model}</Text>]
+      ? [{ key: 'model', node: <Text color="inactiveShimmer">{channel.model}</Text> }]
       : []),
-    ...tpsParts,
+    ...(tpsPart !== undefined ? [tpsPart] : []),
     ...contextParts,
     ...(statusBar.tokens
-      ? [
-          <Text key="tokens" color="inactiveShimmer">
-            {formatTokens(channel.tokens.input)}→{formatTokens(channel.tokens.output)}
-          </Text>,
-        ]
+      ? [{
+          key: 'tokens',
+          id: 'tokens' as const,
+          node: (
+            <Text color="inactiveShimmer">
+              {formatTokens(channel.tokens.input)}→{formatTokens(channel.tokens.output)}
+            </Text>
+          ),
+        }]
       : []),
   ]
 
-  const rightParts = [
+  const rightFields: FieldPart[] = [
     // Goal chip first: session-level state outranks repo/location details.
     ...(statusBar.goal && channel.goal !== undefined
-      ? [
-          <GoalStatusChip
-            key="goal"
-            goal={channel.goal}
-            minimal={channel.minimal}
-          />,
-        ]
+      ? [{
+          key: 'goal',
+          id: 'goal' as const,
+          node: <GoalStatusChip goal={channel.goal} minimal={channel.minimal} />,
+        }]
       : []),
     ...(statusBar.gitBranch && channel.gitBranch
       ? [
-          <Text key="git" color="professionalBlue">
-            {channel.gitBranch}
-          </Text>,
+          {
+            key: 'git',
+            node: <Text color="professionalBlue">{channel.gitBranch}</Text>,
+          },
         ]
       : []),
     ...(statusBar.cwd
-      ? [
-          <Text key="cwd" color="inactiveShimmer">
-            {statusBar.compact ? basename(channel.displayCwd) : channel.displayCwd}
-          </Text>,
-        ]
+      ? [{
+          key: 'cwd',
+          id: 'cwd' as const,
+          node: (
+            <Text color="inactiveShimmer">
+              {statusBar.compact ? basename(channel.displayCwd) : channel.displayCwd}
+            </Text>
+          ),
+        }]
       : []),
     ...(statusBar.sessionTitle && channel.sessionTitle
-      ? [
-          <Text key="title" dimColor>
-            {channel.sessionTitle}
-          </Text>,
-        ]
+      ? [{
+          key: 'title',
+          id: 'title' as const,
+          node: <Text dimColor>{channel.sessionTitle}</Text>,
+        }]
       : []),
     // Short id last: a provenance tag trails the content it identifies, and
     // the 8-char form is what the session log filename starts with, so a
     // truncated rendering still names the right log for --resume.
     ...(statusBar.sessionId && channel.agentId
-      ? [
-          <Text key="sessionId" dimColor>
-            {`#${channel.agentId.slice(0, 8)}`}
-          </Text>,
-        ]
+      ? [{
+          key: 'sessionId',
+          id: 'sessionId' as const,
+          node: <Text dimColor>{`#${channel.agentId.slice(0, 8)}`}</Text>,
+        }]
       : []),
   ]
 
@@ -202,33 +332,44 @@ export function StatusLine({
   const showTrajectory = statusBar.trajectory && wake !== undefined
 
   const barWidth = columns - 4
-  let bar: string | null = null
-  const barColors =
+  const barColors: { freeFill: Color; freeText: Color } | undefined =
     themeName === 'light'
       ? undefined
       : { freeFill: '#2E3440', freeText: '#8D95A6' }
-  if (
+  const barVisible =
     statusBar.contextBar &&
     channel.contextBarEnabled &&
     barWidth >= 14 &&
     usage !== undefined &&
     channel.contextWindow !== undefined
-  ) {
-    bar = renderContextBar(
-      channel.contextSegments,
-      contextUsed ?? 0,
-      channel.contextWindow,
-      barWidth,
-      barColors,
-    )
-  }
 
-  const compactLeftParts = [...leftParts, ...rightParts]
-  const fullLeftParts = contextUsagePart === undefined
-    ? leftParts
-    : [...leftParts, contextUsagePart]
-  const hasStatusFields = compactLeftParts.length > 0 || contextUsagePart !== undefined
-  const showSupplementalRow = hint !== '' || showActivity || showTrajectory
+  // The supplemental-row readout for the hovered field: replaces the idle
+  // hint (never the activity line) while the pointer dwells on a field.
+  const detail = buildHoverDetail(hover, channel, usage, contextUsed)
+  const trailer: React.ReactNode = detail !== null
+    ? detail
+    : hint !== ''
+      ? <Text color="inactiveShimmer">{hint}</Text>
+      : null
+
+  const compactFields = [...leftFields, ...rightFields]
+  const fullLeftFields = [
+    ...leftFields,
+    ...(ctxNode !== undefined ? [{ key: 'context', id: 'ctx' as const, node: ctxNode }] : []),
+  ]
+  const hasStatusFields = compactFields.length > 0 || ctxNode !== undefined
+  // The supplemental row is PERMANENTLY mounted (height pinned to 1)
+  // whenever the footer carries hoverable chrome — mounting it from nothing
+  // on hover is what made the footer grow mid-gesture and shoved the
+  // transcript up (user feedback). Idle it may sit blank: a stable footer
+  // outranks a reclaimable row, and hovering only ever swaps this line's
+  // content. Minimal mode keeps the old contract — no hover details, the
+  // row appears only for real content (which its defaults never produce).
+  const showSupplementalRow =
+    (!channel.minimal && (hasStatusFields || barVisible)) ||
+    showActivity ||
+    showTrajectory ||
+    hint !== ''
 
   return (
     // Width is pinned to the terminal rather than inherited: `width="100%"`
@@ -244,39 +385,53 @@ export function StatusLine({
     <Box paddingX={1} width={columns} flexShrink={0}>
       <Box flexDirection="column" width="100%">
         {/* Row 1: segmented context bar, its own line, first (pi-nano-context
-            placement — the bar sits directly under the transcript). */}
-        {bar ? <Text>{bar}</Text> : null}
+            placement — the bar sits directly under the transcript). Rendered
+            as per-segment Boxes so each segment is hoverable; hovering one
+            parks its token breakdown on the supplemental row. */}
+        {barVisible ? (
+          <ContextBarView
+            segments={channel.contextSegments}
+            usedTokens={contextUsed ?? 0}
+            contextWindow={channel.contextWindow ?? 0}
+            width={barWidth}
+            colors={barColors}
+            onHover={segment =>
+              setHover(current =>
+                segment === null
+                  ? (current !== null && current.startsWith('segment:') ? null : current)
+                  : `segment:${segment}`)}
+          />
+        ) : null}
         {/* Row 2: optional status fields — every field is independently gated. */}
         {hasStatusFields ? statusBar.compact ? (
           <Box flexDirection="row" justifyContent="space-between" gap={2}>
-            <Box flexGrow={1} flexShrink={1}>
-              <Text wrap="truncate">
-                <Byline>{compactLeftParts}</Byline>
-              </Text>
+            <Box flexGrow={1} flexShrink={1} flexDirection="row" overflow="hidden">
+              <FieldLine parts={compactFields} hoverProps={hoverProps} />
             </Box>
-            {contextUsagePart ? (
-              <Box flexShrink={0}>
-                <Text wrap="truncate">
-                  <Byline>{[contextUsagePart]}</Byline>
-                </Text>
+            {ctxNode !== undefined ? (
+              <Box flexShrink={0} {...hoverProps('ctx')}>
+                <Text wrap="truncate">{ctxNode}</Text>
               </Box>
             ) : null}
           </Box>
         ) : (
           <Box flexDirection="row" justifyContent="space-between" gap={2}>
-            <Box flexGrow={1} flexShrink={1}>
-              <Text wrap="truncate">
-                <Byline>{fullLeftParts}</Byline>
-              </Text>
+            <Box flexGrow={1} flexShrink={1} flexDirection="row" overflow="hidden">
+              <FieldLine parts={fullLeftFields} hoverProps={hoverProps} />
             </Box>
-            <Box justifyContent="flex-end" flexShrink={2}>
-              <Text wrap="truncate">
-                <Byline>{rightParts}</Byline>
-              </Text>
+            <Box
+              justifyContent="flex-end"
+              flexShrink={2}
+              flexDirection="row"
+              overflow="hidden"
+            >
+              <FieldLine parts={rightFields} hoverProps={hoverProps} />
             </Box>
           </Box>
         ) : null}
-        {/* Row 3: one stable hint/activity area plus an optional wake. */}
+        {/* Row 3: one stable hint/activity/detail area plus an optional
+            wake. Permanently one line tall — hover swaps what it says,
+            never whether it exists. */}
         {showSupplementalRow ? <Box
           height={1}
           overflow="hidden"
@@ -287,7 +442,7 @@ export function StatusLine({
           <Box
             flexDirection="row"
             flexGrow={1}
-            justifyContent={showActivity && hint ? 'space-between' : 'flex-start'}
+            justifyContent={showActivity && trailer !== null ? 'space-between' : 'flex-start'}
             gap={2}
           >
             {showActivity && activity !== undefined ? (
@@ -299,14 +454,8 @@ export function StatusLine({
                   (contextPressurePct(usage, channel.contextWindow) ?? 0) >= 95
                 }
               />
-            ) : hint ? (
-              <Text color="inactiveShimmer">{hint}</Text>
-            ) : null}
-            {showActivity && hint ? (
-              <Text color="inactiveShimmer" wrap="truncate">
-                {hint}
-              </Text>
-            ) : null}
+            ) : trailer}
+            {showActivity ? trailer : null}
           </Box>
           {showTrajectory && wake !== undefined ? (
             <MiniWake band={wake.band} hint={wake.hint} tick={wake.tick} />
@@ -321,6 +470,125 @@ type UsageSnapshot = {
   input: number
   cacheRead: number
   cacheWrite: number
+}
+
+/**
+ * The supplemental-row readout for a hovered footer field. Technical label
+ * tokens (ctx, free, read, sys…) stay unlocalized like the footer fields
+ * themselves; sentences go through t(). Returns null when nothing is
+ * hovered (or the hover outlived its data, which the field gating makes
+ * near-impossible).
+ */
+function buildHoverDetail(
+  hover: HoverTarget | null,
+  channel: Channel,
+  usage: UsageSnapshot | undefined,
+  contextUsed: number | undefined,
+): React.ReactNode | null {
+  if (hover === null) return null
+  const window = channel.contextWindow
+  const dim = (label: string): React.ReactNode => <Text dimColor>{label}</Text>
+
+  if (hover.startsWith('segment:')) {
+    if (window === undefined || window <= 0 || contextUsed === undefined) return null
+    const key = hover.slice('segment:'.length)
+    const free = Math.max(0, window - contextUsed)
+    if (key === 'free') {
+      return (
+        <Text wrap="truncate">
+          {dim('free ')}{formatTokens(free)} · {((free / window) * 100).toFixed(1)}% {t('status-detail-of-window')}
+        </Text>
+      )
+    }
+    const segment = USED_SEGMENTS.find(s => s.key === key)
+    if (segment === undefined) return null
+    const tokens = channel.contextSegments[segment.key]
+    return (
+      <Text wrap="truncate">
+        {dim(`${segment.labels[1] ?? segment.key} `)}{formatTokens(tokens)} ·{' '}
+        {((tokens / window) * 100).toFixed(1)}% {t('status-detail-of-window')}
+      </Text>
+    )
+  }
+
+  switch (hover) {
+    case 'ctx': {
+      if (contextUsed === undefined || window === undefined || window <= 0) return null
+      const free = Math.max(0, window - contextUsed)
+      // The hover payoff for the ctx ask: percent + counts + free, then the
+      // segment breakdown as the truncate-able tail (no bar — the row's
+      // in-place morph and the segment bar above already carry the gauge).
+      const segments = USED_SEGMENTS.map(
+        segment => `${segment.labels[1] ?? segment.key} ${formatTokens(channel.contextSegments[segment.key])}`,
+      ).join(' · ')
+      return (
+        <Text wrap="truncate">
+          {((contextUsed / window) * 100).toFixed(1)}% ·{' '}
+          {formatTokens(contextUsed)}/{formatTokens(window)} · {dim('free ')}{formatTokens(free)}
+          {' · '}{segments}
+        </Text>
+      )
+    }
+    case 'cache': {
+      const rate = formatCacheHitRate(usage)
+      if (usage === undefined || rate === undefined) return null
+      return (
+        <Text wrap="truncate">
+          {dim('cache ')}{rate} · {dim('read ')}{formatTokens(usage.cacheRead)} ·{' '}
+          {dim('write ')}{formatTokens(usage.cacheWrite)} · {dim('input ')}{formatTokens(usage.input)}
+        </Text>
+      )
+    }
+    case 'tps': {
+      if (channel.tps === undefined) return null
+      const stats = tpsStats(channel.tpsSamples, Date.now())
+      return (
+        <Text wrap="truncate">
+          {dim('tps ')}{Math.round(channel.tps)} · {dim('avg60 ')}{stats.avg.toFixed(1)} ·{' '}
+          {dim('mean ')}{stats.mean.toFixed(1)} · {dim('p95 ')}{stats.p95.toFixed(1)}
+        </Text>
+      )
+    }
+    case 'tokens': {
+      const { input, output } = channel.tokens
+      return (
+        <Text wrap="truncate">
+          {dim('in ')}{input.toLocaleString()} · {dim('out ')}{output.toLocaleString()} ·{' '}
+          {dim('total ')}{(input + output).toLocaleString()}
+        </Text>
+      )
+    }
+    case 'goal': {
+      const goal = channel.goal
+      if (goal === undefined) return null
+      return (
+        <Text wrap="truncate">
+          {dim('goal ')}{goal.phase} · {dim('r')}{goal.roundsStarted}/{goal.maxGoalRounds} ·{' '}
+          {goal.objective}
+        </Text>
+      )
+    }
+    case 'sessionId':
+      return (
+        <Text wrap="truncate">
+          {dim('# ')}{channel.agentId} · {t('status-detail-session-id')}
+        </Text>
+      )
+    case 'cwd':
+      return (
+        <Text wrap="truncate">
+          {dim('cwd ')}{channel.displayCwd}
+        </Text>
+      )
+    case 'title':
+      return (
+        <Text wrap="truncate">
+          {dim('title ')}{channel.sessionTitle}
+        </Text>
+      )
+    default:
+      return null
+  }
 }
 
 /** Return the prompt-cache hit rate, or nothing when usage is unavailable. */

--- a/src/screens/StatusMetrics.ts
+++ b/src/screens/StatusMetrics.ts
@@ -9,8 +9,10 @@
  */
 
 /** Context bar segments — DeepSeek blue family (dark-theme friendly: deep
- *  navy → brand blue, neutral grey free segment; labels adapt to width). */
-const USED_SEGMENTS = [
+ *  navy → brand blue, neutral grey free segment; labels adapt to width).
+ *  Exported for the hoverable JSX bar (ContextBarView), which re-derives
+ *  the same column split this module's ANSI path renders. */
+export const USED_SEGMENTS = [
   { key: 'system', color: '#22305F', labels: ['system', 'sys', 's'] }, // deep navy
   { key: 'prompt', color: '#2B3D78', labels: ['prompt', 'pr', 'p'] }, // navy
   { key: 'assistant', color: '#344A92', labels: ['assistant', 'ast', 'a'] }, // indigo
@@ -56,7 +58,9 @@ export function formatTokens(count: number): string {
 
 // --- Context bar (pi-nano-context) ---
 
-function centeredText(text: string, width: number): string {
+/** Center `text` in `width` cells (plain spaces, no ANSI). Exported for
+ *  ContextBarView's JSX used-segment labels. */
+export function centeredText(text: string, width: number): string {
   const textWidth = plainWidth(text)
   if (textWidth > width) return ' '.repeat(width)
   const left = Math.floor((width - textWidth) / 2)
@@ -64,7 +68,9 @@ function centeredText(text: string, width: number): string {
   return `${' '.repeat(left)}${text}${' '.repeat(right)}`
 }
 
-function chooseLabel(labels: readonly string[], width: number): string {
+/** Pick the longest label that fits `width` cells. Exported for
+ *  ContextBarView's JSX segments (same fallback ladder as the ANSI path). */
+export function chooseLabel(labels: readonly string[], width: number): string {
   for (const label of labels) {
     if (plainWidth(label) <= width) return label
   }
@@ -97,11 +103,15 @@ function chooseRightAlignedText(
   return ''
 }
 
-function renderFreeSegment(
+/**
+ * Compose the free segment's plain text: the `free` label centered, the
+ * usage readout right-aligned into whatever width remains. Shared by the
+ * ANSI string path (renderContextBar) and the hoverable JSX bar
+ * (ContextBarView) so both render pixel-identical content.
+ */
+export function composeFreeSegmentText(
   options: readonly string[],
   width: number,
-  fill: string,
-  text: string,
 ): string {
   if (width <= 0) return ''
   const content = Array.from({ length: width }, () => ' ')
@@ -120,7 +130,17 @@ function renderFreeSegment(
       content[labelStart + offset] = char
     }
   }
-  return background(fill, foreground(text, content.join('')))
+  return content.join('')
+}
+
+function renderFreeSegment(
+  options: readonly string[],
+  width: number,
+  fill: string,
+  text: string,
+): string {
+  if (width <= 0) return ''
+  return background(fill, foreground(text, composeFreeSegmentText(options, width)))
 }
 
 /** Largest-remainder column allocation (pi-nano-context). */
@@ -142,8 +162,9 @@ function allocateProportionally(values: readonly number[], columns: number): num
   return allocatedColumns
 }
 
-/** Give every visible used segment at least one column before sharing the rest. */
-function allocateBarColumns(values: readonly number[], width: number): number[] {
+/** Give every visible used segment at least one column before sharing the
+ *  rest. Exported for ContextBarView (hoverable JSX twin of the bar). */
+export function allocateBarColumns(values: readonly number[], width: number): number[] {
   const visibleUsedSegments = USED_SEGMENTS
     .map((_, index) => index)
     .filter(index => (values[index] ?? 0) > 0)
@@ -197,6 +218,50 @@ export function renderContextBar(
     colors?.freeFill ?? FREE_SEGMENT_FILL,
     colors?.freeText ?? FREE_SEGMENT_TEXT,
   )}`
+}
+
+// --- Mini context bar (footer ctx-field hover) ---
+
+/** Context-pressure thresholds, shared with contextPressurePct's amber/red
+ *  footer convention (amber ≥ 80%, red ≥ 95%). */
+const PRESSURE_WARN = 80
+const PRESSURE_DANGER = 95
+
+/** Pressure-colored text: green below 80%, amber ≥ 80, red ≥ 95.
+ * @param pct - Context occupancy percent (0–100+).
+ * @param text - Text to color.
+ * @returns The ANSI 24-bit color-wrapped text.
+ */
+export function pressureColor(pct: number, text: string): string {
+  const key = pct >= PRESSURE_DANGER ? 'error' : pct >= PRESSURE_WARN ? 'warning' : 'success'
+  return `\x1b[38;2;${colorHex(key)}m${text}\x1b[39m`
+}
+
+/** Compact 1/8-cell context gauge for the footer's ctx field on hover:
+ *  `▕██████▋···▏`, fill proportional to context occupancy, colored by the
+ *  amber/red pressure thresholds. Same block ramp as the TPS gauge.
+ * @param usedTokens - Total context tokens in use.
+ * @param contextWindow - Context window size in tokens.
+ * @param width - Gauge width in terminal columns (fill cells, brackets excluded).
+ * @returns The ANSI gauge string, or '' for a non-positive window.
+ */
+export function renderMiniContextBar(
+  usedTokens: number,
+  contextWindow: number,
+  width = 10,
+): string {
+  if (contextWindow <= 0 || width <= 0) return ''
+  const pct = Math.min(100, Math.max(0, (usedTokens / contextWindow) * 100))
+  const frac = pct / 100
+  const eighths = Math.round(frac * width * 8)
+  const full = Math.floor(eighths / 8)
+  const rem = eighths % 8
+  let fill = '█'.repeat(Math.min(full, width))
+  if (full < width && rem > 0) {
+    fill += HBLOCKS[rem]
+  }
+  const track = TRACK.repeat(Math.max(0, width - fill.length))
+  return `▕${pressureColor(pct, fill)}${`\x1b[2m${track}\x1b[22m`}▏`
 }
 
 // --- TPS gauge + sparkline (pi-tps-meter) ---

--- a/src/tips.ts
+++ b/src/tips.ts
@@ -527,6 +527,12 @@ export const TIPS: readonly Tip[] = [
     en: 'Drag-select copies instantly in fullscreen; Esc cancels',
   },
   {
+    id: 'disp-hover-footer',
+    group: 'display',
+    zh: '悬停底栏字段：ctx 原地变等宽压力条，明细走常驻底行，布局不动',
+    en: 'Hover footer fields: ctx morphs in place into a same-width bar, details on a stable line',
+  },
+  {
     id: 'disp-wheel-sel',
     group: 'display',
     zh: '有文本选区时，滚轮平移选区而非滚动列表',


### PR DESCRIPTION
## 内容

一个 PR 收三条工作线：

### 1. Hover 交互（feat，fe2acd9）
- **底栏字段全面 hover 感知**：ctx 悬停原地变等宽压力条（零布局位移硬约束）；每个字段（cache/tps/tokens/goal/sessionId/cwd/标题）的明细走常驻补充行（不再"长出"一行）
- **分段上下文条**（ContextBarView）可逐段悬停
- **工具卡 hover**：蓝色卡面 + `(ctrl+o to expand)` 提示提亮 + `▾/▴` 展开指示 + 耗时提亮
- **时间线轨预览卡**去掉蓝底（透明底 + 圆角边框）
- 滚动槽位置 chip、子代理卡 hover 提亮

### 2. 拖选复制回归（fix，0c37109）
右侧 gutter 的 NoSelect fromLeftEdge 把整行转录拉进不可选区 → 全屏拖选只能复制一个字符。改为只围 gutter 本体，附带 repro 回归脚本（render-scroll 组）。

### 3. Resume 模型路由回填（fix，82b395f）
provider-only 的 cordis.yml pin（issue #67）让 resume 时 agentOptions.model 缺位，`{{model}}` persona 变量装配失败并连累子代理。从 session 日志读回记录路由喂给 agents.resume，附带 verify 脚本（session-workspace 组）。

## 验证
- `pnpm build` 全绿（编译 + verify:build 全部门禁）
- 新增回归已登记 CI 组：repro-drag-select-streaming（render-scroll）、verify-resume-route（session-workspace）
