### PR TITLE
fix(input): 流式期间 /skills 保持本地执行

### DIFF
--- a/scripts/verify-batched-prompt-input.mjs
+++ b/scripts/verify-batched-prompt-input.mjs
@@ -40,12 +40,21 @@ function makeStreams() {
 
 const submitted = []
 const steered = []
+const commands = []
+let commandHandled = true
 const channel = {
   mode: { id: 'default', plan: false },
   modeIndex: 0,
   cycleMode() {},
-  commandList: [],
-  commandCompletions: () => [],
+  commandList: [
+    { name: 'skills', description: 'List available skills' },
+    { name: 'model', description: 'Show the active model' },
+  ],
+  commandCompletions(input) {
+    if (input !== '/skills' && input !== '/model') return []
+    const name = input.slice(1)
+    return [{ name, description: name, commandLine: input, replacement: `${input} ` }]
+  },
   notifications: [],
   pending: [],
   working: false,
@@ -64,7 +73,7 @@ const instance = await render(
     channel,
     helpOpen: false,
     onToggleHelp() {},
-    onRunCommand: () => false,
+    onRunCommand(name) { commands.push(name); return commandHandled },
     selectionActive: false,
   }),
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
@@ -109,6 +118,71 @@ check(
   'batched Windows input while streaming preserves npm before steer',
   await settled(() => steered.length === 1 && steered[0] === 'npm'),
   JSON.stringify(steered),
+)
+
+// A command and Enter can arrive as win32-input-mode records in one stdin
+// read. React has not repainted the completion overlay yet, so PromptInput
+// must use the synchronous value mirror to keep safe live commands local.
+const win32Record = (virtualKey, scanCode, codePoint) =>
+  `\x1b[${virtualKey};${scanCode};${codePoint};1;0;1_`
+const batchedCommand = (letters) => [
+  win32Record(191, 53, 47),
+  ...letters.map(([virtualKey, scanCode, codePoint]) =>
+    win32Record(virtualKey, scanCode, codePoint)),
+  win32Record(13, 28, 13),
+].join('')
+
+// Keep separate physical Enter presses outside PromptInput's 80ms CR/LF
+// dedupe window; each command itself still arrives as one atomic batch.
+await sleep(100)
+stdin.write(batchedCommand([
+  [83, 31, 115],
+  [75, 37, 107],
+  [73, 23, 105],
+  [76, 38, 108],
+  [76, 38, 108],
+  [83, 31, 115],
+]))
+
+check(
+  'batched /skills while streaming executes locally before the overlay repaints',
+  await settled(() => commands.length === 1 && commands[0] === 'skills' && steered.length === 1),
+  `commands=${JSON.stringify(commands)} steered=${JSON.stringify(steered)}`,
+)
+
+await sleep(100)
+stdin.write(batchedCommand([
+  [77, 50, 109],
+  [79, 24, 111],
+  [68, 32, 100],
+  [69, 18, 101],
+  [76, 38, 108],
+]))
+
+check(
+  'batched idle-only commands keep the existing steer behavior while streaming',
+  await settled(() => commands.length === 1 && steered.length === 2 && steered[1] === '/model'),
+  `commands=${JSON.stringify(commands)} steered=${JSON.stringify(steered)}`,
+)
+
+// A registered local command may decline handling and explicitly ask the
+// input component to send the original text to the model instead.
+await sleep(100)
+commandHandled = false
+stdin.write(batchedCommand([
+  [83, 31, 115],
+  [75, 37, 107],
+  [73, 23, 105],
+  [76, 38, 108],
+  [76, 38, 108],
+  [83, 31, 115],
+]))
+
+check(
+  'declined /skills falls back to steer while streaming',
+  await settled(() => commands.length === 2 && commands[1] === 'skills'
+    && steered.length === 3 && steered[2] === '/skills'),
+  `commands=${JSON.stringify(commands)} steered=${JSON.stringify(steered)}`,
 )
 
 // Terminals that cannot report modified Enter keys still expose Ctrl+J as a

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -822,18 +822,18 @@ export function PromptInput({
         }
       }
       if (channel.working && value.trim() !== '') {
-        // CC's immediate-command semantics: /btw is exempt from steering —
-        // the side question never interrupts the running turn. Hidden
+        // CC's immediate-command semantics: /btw and /skills are exempt from
+        // steering — neither command interrupts the running turn. Hidden
         // UI-only easter eggs (e.g. /deepseek) are also safe to run while
         // streaming. Every other input keeps the steer behavior so /new
         // /model etc. stay idle-only.
         const parsed = value.startsWith('/') ? parseCommandName(value) : undefined
         if (parsed !== undefined && (
-          (parsed.name === 'btw' && channel.commandList.some(c => c.name === 'btw'))
+          ((parsed.name === 'btw' || parsed.name === 'skills')
+            && channel.commandList.some(c => c.name === parsed.name))
           || isHiddenCommandName(parsed.name)
         )) {
-          tryRunCommand(value)
-          return
+          if (tryRunCommand(value)) return
         }
         steerSend(value)
         return


### PR DESCRIPTION
### 动机

Closes #494

#498 已修复打包技能在源码与发布包中的定位和注册。本 PR 处理 #494 中剩余的输入路由问题：agent 正在工作时，如果终端把 `/skills` 和 Enter 作为同一批输入交给 React，completion overlay 尚未完成重绘，`/skills` 会被误当作普通 steer 消息发送给模型，而不是打开本地技能选择器。

### 改动

- agent 工作期间，已注册的 `/skills` 与 `/btw`、hidden commands 一样在本地执行。
- `/model` 等 idle-only 命令仍保持原有 steer 行为。
- 扩展 batched prompt 回归测试，覆盖同一批输入中的 `/skills` + Enter，并验证 `/model` 不会被误改为本地执行。

### 验证

- `pnpm build`
- `node scripts/verify-batched-prompt-input.mjs`
- `pnpm smoke`

PR 现在只包含输入路由及其回归测试；原先的 packaged-skills 变更已由 #498 覆盖。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added session-scoped Vim editing with INSERT and NORMAL modes.
  - Added Vim navigation, deletion, undo, line insertion, and a visible mode indicator.
  - Added controls for enabling or disabling Vim mode.
- **Bug Fixes**
  - `/skills` commands entered during an active response now execute locally without interruption.
  - `/model` commands are correctly routed for steering.
  - Unhandled commands now fall back to standard steering.
- **Tests**
  - Added coverage for batched Windows input and streaming command handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->