### PR TITLE
docs(github): issue 表单——只收可复现 bug，功能建议走 Discussions（#487）

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,19 +1,23 @@
-name: Bug 报告 / Bug report
-description: 报告一个可复现的问题。功能建议请走 Discussions。
+name: Bug 报告
+description: 报告一个问题。功能建议请走 Discussions。
 title: "[Bug] "
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
       value: |
-        只接受可复现的 bug。功能建议、使用问题、插件推广请走 Discussions。
-        没有复现步骤的报告无法处理。
+        功能建议、使用问题、插件推广请走 Discussions。
+
+        间歇性问题也可以报，说明出现频率即可。
 
   - type: input
     id: version
     attributes:
       label: dsh-tui 版本
-      description: 运行 `npm ls -g @deepseek-harness-tui/dsh-tui`，或在 TUI 里执行 `/about`。
+      description: |
+        启动横幅右上角显示当前版本（`✦ dsh-TUI vX.Y.Z`）。
+        不要用 `npm ls -g` 的结果——全局启动器的版本不随 `/update` 前进，会落后于实际运行的版本。
+        查不到就填「不知道」。
       placeholder: "0.9.0"
     validations:
       required: true
@@ -22,7 +26,7 @@ body:
     id: env
     attributes:
       label: 终端与操作系统
-      description: 终端软件 + 版本，操作系统 + 版本。用 tmux / WSL / SSH 的请写明。
+      description: 终端软件 + 版本，操作系统 + 版本。用 tmux / WSL / SSH 的请写明。不确定就写你知道的部分。
       placeholder: "Windows Terminal 1.21 + WSL2 Ubuntu 24.04 / iTerm2 3.5 + macOS 15.5"
     validations:
       required: true
@@ -30,30 +34,34 @@ body:
   - type: textarea
     id: current
     attributes:
-      label: 现状
+      label: 现象
       description: 实际发生了什么。有截图或录屏请贴上来。
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: 期望
-      description: 应该发生什么。
     validations:
       required: true
 
   - type: textarea
     id: repro
     attributes:
-      label: 最短复现
-      description: 从干净启动开始，能触发问题的最少步骤。写明终端尺寸、是否全屏、按了哪些键。
+      label: 怎么触发的
+      description: |
+        从干净启动开始，你做了什么。写明终端尺寸、是否全屏、按了哪些键。
+        必现的话写出步骤；偶发的话写出现频率（例如「十次里有两三次」）。
       value: |
         1.
         2.
         3.
+
+        出现频率：
     validations:
       required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望（可选）
+      description: 应该发生什么。现象已经说清楚的话可以留空。
+    validations:
+      required: false
 
   - type: textarea
     id: analysis
@@ -75,7 +83,10 @@ body:
       options:
         - label: 我搜索过现有 issue，这不是重复。
           required: true
-        - label: 这是一个可复现的 bug，不是功能请求。
+        - label: 这是一个 bug，不是功能请求。
           required: true
-        - label: 我没有为一个已经写好的 PR 补开这个 issue。
-          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        已经写好修复的话，直接提 PR 并和本 issue 互相链接。修 bug 不需要事先批准。

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug 报告 / Bug report
+description: 报告一个可复现的问题。功能建议请走 Discussions。
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        只接受可复现的 bug。功能建议、使用问题、插件推广请走 Discussions。
+        没有复现步骤的报告无法处理。
+
+  - type: input
+    id: version
+    attributes:
+      label: dsh-tui 版本
+      description: 运行 `npm ls -g @deepseek-harness-tui/dsh-tui`，或在 TUI 里执行 `/about`。
+      placeholder: "0.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: 终端与操作系统
+      description: 终端软件 + 版本，操作系统 + 版本。用 tmux / WSL / SSH 的请写明。
+      placeholder: "Windows Terminal 1.21 + WSL2 Ubuntu 24.04 / iTerm2 3.5 + macOS 15.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: 现状
+      description: 实际发生了什么。有截图或录屏请贴上来。
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望
+      description: 应该发生什么。
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: 最短复现
+      description: 从干净启动开始，能触发问题的最少步骤。写明终端尺寸、是否全屏、按了哪些键。
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: analysis
+    attributes:
+      label: 分析（可选）
+      description: |
+        定位到具体 commit、函数、代码行的分析对处理很有帮助。
+        每条结论请标注「已验证」或「未验证」。未标注的按未验证处理。
+      placeholder: |
+        已验证：git bisect 定位到 a643ee2，父提交 457dbba 通过，两侧各手动复核 3 次。
+        未验证：怀疑与流式行高变化时的宽度失效有关，没有证据。
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: 确认
+      options:
+        - label: 我搜索过现有 issue，这不是重复。
+          required: true
+        - label: 这是一个可复现的 bug，不是功能请求。
+          required: true
+        - label: 我没有为一个已经写好的 PR 补开这个 issue。
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_en.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_en.yml
@@ -1,0 +1,92 @@
+name: Bug report (English)
+description: Report a problem. Feature requests belong in Discussions.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests, usage questions and plugin announcements belong in Discussions.
+
+        Intermittent problems are welcome — just state how often they happen.
+
+  - type: input
+    id: version
+    attributes:
+      label: dsh-tui version
+      description: |
+        The startup banner shows it in the top right corner (`✦ dsh-TUI vX.Y.Z`).
+        Do not use `npm ls -g` — the global launcher version does not move with `/update`
+        and will lag behind what is actually running. Write "unknown" if you cannot find it.
+      placeholder: "0.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Terminal and OS
+      description: Terminal app + version, OS + version. Mention tmux / WSL / SSH if you use them. Partial information is fine.
+      placeholder: "Windows Terminal 1.21 + WSL2 Ubuntu 24.04 / iTerm2 3.5 + macOS 15.5"
+    validations:
+      required: true
+
+  - type: textarea
+    id: current
+    attributes:
+      label: What happens
+      description: The actual behavior. Screenshots or recordings help.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to trigger it
+      description: |
+        What you did, starting from a clean launch. Include terminal size, inline vs fullscreen, and which keys you pressed.
+        If it always happens, list the steps. If it is intermittent, state how often (for example "two or three times out of ten").
+      value: |
+        1.
+        2.
+        3.
+
+        Frequency:
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior (optional)
+      description: Leave empty if the description above already makes it clear.
+    validations:
+      required: false
+
+  - type: textarea
+    id: analysis
+    attributes:
+      label: Analysis (optional)
+      description: |
+        Analysis that points at a specific commit, function or line is genuinely useful.
+        Mark every claim as "verified" or "unverified". Unmarked claims are treated as unverified.
+      placeholder: |
+        Verified: git bisect points at a643ee2; parent 457dbba passes. Re-checked 3 times on each side.
+        Unverified: possibly related to width invalidation when streaming changes row height. No evidence.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and this is not a duplicate.
+          required: true
+        - label: This is a bug, not a feature request.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        If you already have a fix, open a PR and cross-link it with this issue. Bug fixes do not need prior approval.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 功能建议 / Feature request
+    url: https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas
+    about: 新功能、行为变更、交互改进请发到 Discussions Ideas。维护者认可后会开 issue 跟踪。
+  - name: 使用问题 / Question
+    url: https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=q-a
+    about: 安装、配置、用法问题请发到 Discussions Q&A。
+  - name: 插件 / 主题 / 收录 / Show and tell
+    url: https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=show-and-tell
+    about: 周边插件、主题包、收录通知请发到 Discussions Show and tell。

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -7,8 +7,10 @@ development contract for humans and coding agents working on `@deepseek-harness-
 
 ## How To Contribute
 
-- **Report bugs or request features** by opening an issue with a clear
-  reproduction and the terminal environment you use.
+- **Report bugs** through the bug issue form: version, terminal environment,
+  and a minimal reproduction.
+- **Request features** in [Discussions Ideas](https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas).
+  Issues do not accept feature requests. Accepted proposals get a tracking issue.
 - **Open a pull request** against `main`. Keep changes focused: one logical
   change per PR, with a Chinese or bilingual title and a description that
   covers motivation, what changed, and how it was verified.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,7 +7,9 @@
 
 ## 如何贡献
 
-- **报告 bug 或请求功能**：提交 issue，附上清晰的复现步骤与你使用的终端环境。
+- **报告 bug**：用 bug 表单提交 issue，填写版本、终端环境与最短复现步骤。
+- **提功能建议**：发到 [Discussions Ideas](https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas)。
+  Issues 不接受功能请求。维护者认可后会开一个 issue 跟踪实现。
 - **提交 PR**：base 指向 `main`。保持改动聚焦——一个 PR 只做一个逻辑改动，
   标题用中文或中英对照，描述写清动机、改动点与验证方式。
 - **请求 review 前先跑验证矩阵**：CI 运行的就是下面这些命令。


### PR DESCRIPTION
对应 #487 的第一步。只做 issue 入口，不含 PR 白名单。

## 改了什么

| 文件 | 作用 |
|---|---|
| `bug_report.yml` / `bug_report_en.yml` | 中英各一份。版本、终端+OS、现象、触发方式必填；期望、分析可选 |
| `config.yml` | 关掉空白 issue；功能建议、使用问题、插件推广三个入口指向 Discussions |
| `contributing.md` / `.en.md` | 同步口径：Issues 不接受功能请求 |

## 为什么

现在 188 个 issue 混着可复现 bug（#479）、功能建议（#484）、带实现方案的提议（#445）、推广（#458）、合作推销（#482）。维护者对每条都要判断问题是否存在、是否要做。

标题前缀解决不了这个。188 个 issue 里 51 个（27%）自发带了前缀，`【功能建议】`、`[feature request]`、`[提议]`、`🎉 收录` 照样开在 Issues 里。做拦截的是 `blank_issues_enabled: false` 加上只提供 bug 表单。

## 几处设计取舍

**版本字段读启动横幅，不用 `npm ls -g`。** 全局启动器是瘦壳，版本不随 `/update` 前进（`bin/dsh-tui.js:8-11`，第 285 行专门检测两者不一致）。本机实测 `npm ls -g` 返回 `0.6.1`，仓库版本是 `0.9.0`。可靠来源是启动横幅右上角 `✦ dsh-TUI vX.Y.Z`（`LogoV2.tsx:67`，`getting-started.md:163` 已写明这是确认版本的方式）。

**中英两份表单。** 仓库有 `README_EN.md` 和 `contributing.en.md`，实际也有英文报告（#492 #494）。

**偶发问题同样接受，要求写出现频率。** 仓库有 `flaky-observation` CI 分组，时序类问题同样是 bug。必现步骤填不出来的问题不该被挡在门外。

**分析栏保留。** #487 原文写的是「禁止填写方案、patch、调查报告」。这里改成可选的分析栏，要求每条结论标注「已验证」或「未验证」。理由：#416 把路径 bug 定位到 #145 refactor 多算一级，#493 bisect 到 6681913，#466 的评论 bisect 到 a643ee2——这些直接给出了修复位置。要挡的是未经验证的猜测，用标注处理。

**修 bug 不需要事先批准。** 表单末尾写明已有修复直接提 PR 并与 issue 互相链接。外部贡献占已合并 PR 的 65%（133/204），这条路不动。

## 验证

三个 YAML `yaml.parse` 解析通过，字段结构符合 GitHub issue forms schema。必填字段 `version` `env` `current` `repro`，确认框 2 个。

`bug` 标签仓库里已存在。三条 contact_links 指向的 Discussions 分类（ideas / q-a / show-and-tell）已确认存在。

未验证：表单在 GitHub 上的实际渲染。issue forms 只有合到默认分支才生效。

## 现有 issue 不受影响

表单只在新建 issue 时生效。62 个开着的 issue 不会被改标题或改标签。

## 前置条件

草稿状态。#487 目前是零评论，合并前需要在那里有一句公开的认可，让后续被引导到 Discussions 的人能看到规则出处。

## 下一步（不在本 PR 内）

1. 给几个高合并量贡献者 Triage 权限，处理 94 个零评论 issue
2. `accepted` 标签 + PR 模板，先人工跑一周
3. 最后写 pr-gate CI
