### PR TITLE
ci: 纯文档改动跳过编译与回归，ci-gate 按分流结果判定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 变更分流：纯文档 / issue 模板改动不需要编译与回归——docs/contributing.md
+  # 已经写了「纯文档、纯 workflow、纯 YAML 改动不需要重建」，这里是它的 CI 落地。
+  # 白名单之外的任何路径都算代码，包括 .github/workflows 本身（改 ci.yml 必须跑
+  # 全套）。push 与任何非 PR 事件一律按代码处理。
+  #
+  # 不能改用 paths-ignore 跳过整个 workflow：ci-gate 是 main 的 required check，
+  # workflow 不运行就永远不上报，文档 PR 会卡在 pending 无法合并。
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/github-script@v9
+        id: filter
+        with:
+          script: |
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('code', 'true')
+              core.notice('非 pull_request 事件，按代码改动处理')
+              return
+            }
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            })
+            const DOCS_ONLY = [
+              /^docs\//,
+              /^README(_EN)?\.md$/,
+              /^\.github\/ISSUE_TEMPLATE\//,
+              /^\.github\/PULL_REQUEST_TEMPLATE(\.md)?$/,
+              /^LICENSE$/,
+            ]
+            const paths = files.map(f => f.filename)
+            // 空改动集按代码处理：宁可多跑一轮，不要漏跑。
+            const code = paths.length === 0
+              || paths.some(p => !DOCS_ONLY.some(re => re.test(p)))
+            core.setOutput('code', String(code))
+            core.notice(`${paths.length} 个文件改动，code=${code}`)
+
   build:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       # Keep UI language deterministic for the repro/verify scripts: zh is the
@@ -258,6 +304,8 @@ jobs:
   # ci-gate、不阻塞合并），探明各平台差异后再逐步扩测并提升为
   # required。fail-fast: false 让两个平台都跑完。
   platform-smoke:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -300,18 +348,23 @@ jobs:
   # gate 仍然运行（被跳过的 check 不会阻塞合并，失败才会）；后续 CI 内部
   # 再拆组、改名、加 matrix，branch protection 只需盯住这一个稳定名字。
   ci-gate:
-    needs: [build, render-scroll, input-terminal, session-workspace, channel-ui]
+    needs: [changes, build, render-scroll, input-terminal, session-workspace, channel-ui]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Require every group to have succeeded
         env:
+          CODE: ${{ needs.changes.outputs.code }}
           BUILD: ${{ needs.build.result }}
           RENDER_SCROLL: ${{ needs.render-scroll.result }}
           INPUT_TERMINAL: ${{ needs.input-terminal.result }}
           SESSION_WORKSPACE: ${{ needs.session-workspace.result }}
           CHANNEL_UI: ${{ needs.channel-ui.result }}
         run: |
+          # 纯文档改动：期望每组都是 skipped。这里不能笼统地放行 skipped——
+          # build 失败时下游同样是 skipped，那种情况必须判失败。
+          if [ "${CODE}" = "true" ]; then expected=success; else expected=skipped; fi
+          echo "code=${CODE}，要求每组结束状态为 ${expected}"
           status=0
           for pair in "build:${BUILD}" \
                       "render-scroll:${RENDER_SCROLL}" \
@@ -321,8 +374,8 @@ jobs:
             name="${pair%%:*}"
             result="${pair#*:}"
             echo "${name}: ${result}"
-            if [ "${result}" != "success" ]; then
-              echo "::error title=CI gate::${name} 结束状态为 ${result}（要求 success）"
+            if [ "${result}" != "${expected}" ]; then
+              echo "::error title=CI gate::${name} 结束状态为 ${result}（要求 ${expected}）"
               status=1
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
     steps:
       - name: Require every group to have succeeded
         env:
+          CHANGES: ${{ needs.changes.result }}
           CODE: ${{ needs.changes.outputs.code }}
           BUILD: ${{ needs.build.result }}
           RENDER_SCROLL: ${{ needs.render-scroll.result }}
@@ -362,10 +363,18 @@ jobs:
           CHANNEL_UI: ${{ needs.channel-ui.result }}
         run: |
           # 纯文档改动：期望每组都是 skipped。这里不能笼统地放行 skipped——
-          # build 失败时下游同样是 skipped，那种情况必须判失败。
-          if [ "${CODE}" = "true" ]; then expected=success; else expected=skipped; fi
+          # build 失败时下游同样是 skipped，那种情况必须判失败。因此只对明确的
+          # code=false 放行 skipped；changes 自身失败时 CODE 为空串，一律按代码
+          # 严查（fail-closed），否则一个零测试的代码 PR 会在 gate 误绿下合并。
+          if [ "${CODE}" = "false" ]; then expected=skipped; else expected=success; fi
           echo "code=${CODE}，要求每组结束状态为 ${expected}"
           status=0
+          # changes 是全链路的分类源头：它自己失败时所有下游都是 skipped，
+          # 必须在这里显式判失败，不能指望上面的期望值兜住。
+          if [ "${CHANGES}" != "success" ]; then
+            echo "::error title=CI gate::changes 结束状态为 ${CHANGES}（要求 success，无法分类改动）"
+            status=1
+          fi
           for pair in "build:${BUILD}" \
                       "render-scroll:${RENDER_SCROLL}" \
                       "input-terminal:${INPUT_TERMINAL}" \


### PR DESCRIPTION
纯文档 PR 现在跑满 9 个 job。#500 只改了 4 个 YAML 和 markdown 文件，零 TypeScript，跑了 build、4 个测试组、flaky-observation、macOS + Windows platform-smoke、ci-gate，约 12.5 分钟 runner 时间。

`docs/contributing.md` 里已经写了「纯文档、纯 workflow、纯 YAML 改动不需要重建」。这个 PR 把这句话落到 CI 上。

## 改了什么

新增 `changes` job，用 `pulls.listFiles` 判断 PR 是否只动了文档白名单：

```
docs/  README.md  README_EN.md  .github/ISSUE_TEMPLATE/  .github/PULL_REQUEST_TEMPLATE  LICENSE
```

白名单之外一律按代码处理。`.github/workflows` 算代码——改 ci.yml 必须跑全套。非 pull_request 事件算代码。空改动集算代码。

`build` 和 `platform-smoke` 按结果跳过。四个测试组经 `needs: build` 自动跟随，不用改。

## 为什么不用 paths-ignore

`ci-gate` 是 `main` 的 required check（ruleset `basic-no-push-to-main`，`strict` 模式）。`paths-ignore` 跳过整个 workflow 的话 `ci-gate` 不上报，required check 卡在 pending，文档 PR 永远合不了。

## ci-gate 的对应改动

原逻辑是每个上游 job 必须 `success`。job 被 `if:` 跳过会得到 `skipped`，直接判失败。

改成按 `changes.outputs.code` 选期望值：`true` 时要求每组 `success`，`false` 时要求每组 `skipped`。

不能笼统放行 `skipped`——`build` 失败时下游同样是 `skipped`，那种情况必须判失败。这是这个 PR 里最容易写错的一行。

## 验证

已验证：`yaml.parse` 解析通过，9 个 job 的 `needs` / `if` 关系符合预期。

已验证：过滤逻辑在 node 里用真实文件清单跑过 8 组用例。

| 输入 | 结果 |
|---|---|
| #500 的 4 个文件 | 跳过 |
| 本 PR 的 `.github/workflows/ci.yml` | 跑全套 |
| `README.md` + `README_EN.md` | 跳过 |
| `docs/contributing.md` + `src/screens/Chat.tsx` | 跑全套 |
| `package.json` | 跑全套 |
| `skills/review/SKILL.md` | 跑全套 |
| 空改动集 | 跑全套 |

未验证：`ci-gate` 在 `code=false` 分支上的实际行为。本 PR 改了 `ci.yml`，自己走的是 `code=true` 分支。要看 `code=false` 的实际效果，合并后 #500 那种纯文档 PR 会是第一个样本。

## 影响

文档 PR 的 CI 从约 12.5 分钟降到约 15 秒（只有 `changes` + `ci-gate` 两个 job）。

代码 PR 不受影响，多一个约 5 秒的 `changes` job。
