### PR TITLE
docs(contributing): 功能提案的等待期、生效范围与不要预写代码

### DIFF
--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -10,13 +10,24 @@ development contract for humans and coding agents working on `@deepseek-harness-
 - **Report bugs** through the bug issue form: version, terminal environment,
   and a minimal reproduction.
 - **Request features** in [Discussions Ideas](https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas).
-  Issues do not accept feature requests. Accepted proposals get a tracking issue.
+  Issues do not accept feature requests. Accepted proposals get a tracking issue,
+  and its assignee owns the implementation. **Do not start writing code before the
+  proposal is accepted** — OAuth, `/cost`, notifications, a plugin API and a remote
+  runtime were each written in full and then closed.
+  If a maintainer has not responded within 14 days, you may open a PR directly; it
+  gets the `unreviewed-proposal` label and is treated as unreviewed.
 - **Open a pull request** against `main`. Keep changes focused: one logical
   change per PR, with a Chinese or bilingual title and a description that
   covers motivation, what changed, and how it was verified.
 - **Run the verification matrix** below before requesting a review; CI runs
   the same commands.
 - New features should include or extend a focused regression script.
+
+### When the feature proposal flow takes effect
+
+It applies only to pull requests opened on or after 2026-08-24. Pull requests
+already open before that date follow the previous rules and need no Discussion
+or tracking issue.
 
 
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,11 +9,20 @@
 
 - **报告 bug**：用 bug 表单提交 issue，填写版本、终端环境与最短复现步骤。
 - **提功能建议**：发到 [Discussions Ideas](https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas)。
-  Issues 不接受功能请求。维护者认可后会开一个 issue 跟踪实现。
+  Issues 不接受功能请求。维护者认可后会开一个 issue 跟踪实现，实现由该 issue
+  的 assignee 负责。**拿到认可之前不要开始写代码**——被否的提案里已经有 OAuth、
+  `/cost`、通知、插件 API、remote runtime 几套写完整才被关掉的实现。
+  发出后 14 天没有维护者回应，可以直接提 PR，会被打上 `unreviewed-proposal`
+  标签，按未经审阅处理。
 - **提交 PR**：base 指向 `main`。保持改动聚焦——一个 PR 只做一个逻辑改动，
   标题用中文或中英对照，描述写清动机、改动点与验证方式。
 - **请求 review 前先跑验证矩阵**：CI 运行的就是下面这些命令。
 - 新功能应附带或扩展一个聚焦的回归脚本。
+
+### 功能提案流程的生效时间
+
+该流程只对 2026-08-24 起新建的 PR 生效。在此之前开着的 PR 按旧规则处理，
+不需要补 Discussion 或跟踪 issue。
 
 ## 范围（Scope）
 


### PR DESCRIPTION
补 #500 里拍板的三条，中英两版同步。原话在 https://github.com/ccch1mneyyy/dsh-TUI/pull/500#issuecomment-5388829479

## 改了什么

**1. 认可之前不要开始写代码**

#500 合并的表单只写了功能建议去 Discussions，没写「等认可」这一步。少了这句，写完才被否的浪费不会减少——被关掉的外部 PR 里有 OAuth（#399 #401）、`/cost`（#351）、通知（#349）、插件 API（#286）、remote runtime（#319），都是整套实现。

**2. 14 天无回应可直接提 PR**

打 `unreviewed-proposal` 标签，按未经审阅处理。

**3. 生效范围**

只对 2026-08-24 起新建的 PR 生效。现在开着的 31 个 PR 不动，不需要补 Discussion 或跟踪 issue。

**顺带一条：实现归属**

写明由跟踪 issue 的 assignee 负责。#422 和 #455 是同一个修复被两边并行做了一遍。

## 需要维护者做的事

`unreviewed-proposal` 标签仓库里还不存在。我没有仓库写权限，建不了。规则生效前需要建这个标签。

## 验证

纯文档改动。中英两版内容一致。

未验证：无可执行验证。
