### PR TITLE
feat: pi 式 /reload 软重载与 /restart 保会话重启

### DIFF
--- a/scripts/repro-reload.tsx
+++ b/scripts/repro-reload.tsx
@@ -1,0 +1,232 @@
+/**
+ * repro-reload — 现场复现 /reload 命令无反应（用户报告：新构建下
+ * /reload 无反应，/restart 能重启但重启后键盘无反应）。
+ *
+ * 真实 Chat 渲染 + fake channel（settingsHost 返回 undefined 模拟裸
+ * 组合），预置隔离 HOME 里的 5 个 pref 文件（theme/lang/preset/model/
+ * activity），注入 `/reload\r`，断言：
+ *   1. runCommand 返回 true（输入被消费，不发给模型）；
+ *   2. channel 收到 pushLocal 的 local 行与报告行（'已重读偏好文件'）；
+ *   3. 报告文本出现在渲染帧里；
+ *   4. apply 分支真的被调用（theme 切换、activity 切换等记录）。
+ *
+ * 运行：node --import tsx/esm scripts/repro-reload.tsx
+ */
+process.env.FORCE_COLOR = '3'
+// 注意：不要设置 DSH_TUI_THEME——那会让 /reload 走"环境变量优先"跳过主题。
+// 不设置时 ThemeProvider 在无 querier 的 fake 环境 settle('dark')，themeName
+// 为 'dark'，与预置的 theme.json(light) 不同 → 走 apply 分支。
+process.env.DSH_TUI_LANG = 'zh'     // 固定中文报告文案断言（lang 走 env-skip）
+
+// 隔离家目录（同 verify-extension-ui）：Chat 加载即解析 homedir()。
+const { mkdtempSync, mkdirSync, writeFileSync } = await import('node:fs')
+const { tmpdir } = await import('node:os')
+const { join: joinPath } = await import('node:path')
+const isolatedHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-reload-home-'))
+process.env.HOME = isolatedHome
+process.env.USERPROFILE = isolatedHome
+mkdirSync(joinPath(isolatedHome, '.dsh-tui'), { recursive: true })
+// 预置 5 个 pref 文件：全部与 live 值不同 → planReload 应全部 apply。
+writeFileSync(joinPath(isolatedHome, '.dsh-tui', 'theme.json'), JSON.stringify({ theme: 'light' }))
+writeFileSync(joinPath(isolatedHome, '.dsh-tui', 'lang.json'), JSON.stringify({ lang: 'en' }))
+writeFileSync(joinPath(isolatedHome, '.dsh-tui', 'agent-preset.json'), JSON.stringify({ preset: 'code' }))
+writeFileSync(joinPath(isolatedHome, '.dsh-tui', 'model.json'), JSON.stringify({ provider: 'deepseek', model: 'deepseek-chat' }))
+writeFileSync(joinPath(isolatedHome, '.dsh-tui', 'working-activity.json'), JSON.stringify({ frames: 'moon' }))
+
+const [
+  { PassThrough, Writable },
+  React,
+  { render },
+  { Chat },
+  { QuestionStore },
+  { LOCAL_COMMANDS },
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+])
+
+class FakeStdout extends Writable {
+  columns = 100
+  rows = 28
+  isTTY = true
+  frames: string[] = []
+  _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void) {
+    this.frames.push(String(chunk))
+    callback()
+  }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_chunk: unknown, _encoding: BufferEncoding, callback: () => void) { callback() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+
+const plainText = (frames: string[]) => frames
+  .join('')
+  .replace(/\x1b\[(\d+)C/g, (_, n) => ' '.repeat(Number(n)))
+  .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '')
+  .replace(/\x1b\]9;[^\x07]*\x07/g, '')
+  .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+let failures = 0
+const check = (name: string, ok: boolean, detail = '') => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'} ${name}${ok || detail === '' ? '' : ` — ${detail}`}`)
+}
+
+const localRows: { kind: string; text: string }[] = []
+let notifyCalls: string[] = []
+let activityCalls: string[] = []
+let presetCalls: string[] = []
+let modelCalls: string[] = []
+let restartCalls = 0
+// fake channel 也要真的通知 Chat（真实 channel 的 emit 会触发重渲染，
+// 报告才能进帧）——否则屏幕断言永远失败。
+const listeners = new Set<() => void>()
+
+const channel = {
+  version: 0,
+  rows: [],
+  status: 'idle' as const,
+  sessionTitle: 'probe',
+  agentId: 'probe',
+  model: 'model-00',
+  provider: 'fake-provider',
+  configuredProvider: undefined,
+  configuredModel: undefined,
+  configuredPreset: undefined,
+  configuredActivityFrames: undefined,
+  configuredLang: undefined,
+  tokens: { input: 0, output: 0 },
+  cwd: '/tmp/demo',
+  displayCwd: '/tmp/demo',
+  gitBranch: 'main',
+  working: false,
+  spinnerMode: 'requesting' as const,
+  responseChars: 0,
+  activeToolCount: 0,
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  cycleMode() {},
+  turnStart: 0,
+  lastUserText: '',
+  pending: [],
+  commandList: LOCAL_COMMANDS,
+  notifications: [],
+  contextSegments: { system: 0, prompt: 0, assistant: 0, thinking: 0, tools: 0 },
+  subscribe(listener: () => void) { listeners.add(listener); return () => { listeners.delete(listener) } },
+  emit() { this.version += 1; for (const listener of listeners) listener() },
+  submitCalls: [] as string[],
+  submit(text: string) { this.submitCalls.push(text) },
+  steer() {},
+  cancel() {},
+  clear() {},
+  notify(text: string) { notifyCalls.push(text) },
+  listModels: () => Promise.resolve([]),
+  listSessions: () => [],
+  setResumeTarget: () => {},
+  pushLocal(title: string, lines: readonly string[]) {
+    localRows.push({ kind: 'local', text: title })
+    for (const line of lines) localRows.push({ kind: 'local-output', text: line })
+    this.emit()
+  },
+  commandCompletions: () => [],
+  settingsHost: () => undefined,
+  agentPreset: 'standard',
+  activityFrames: 'claude',
+  setActivityFrames(name: string) { activityCalls.push(name); return true },
+  switchPreset(id: string) { presetCalls.push(id); return Promise.resolve(true) },
+  switchModel(provider: string, model: string) { modelCalls.push(`${provider}/${model}`); return Promise.resolve(true) },
+  listPresets: () => Promise.resolve([]),
+  loadOlder: () => 0,
+  listEfforts: () => Promise.resolve({ efforts: [], defaultEffort: undefined }),
+  setEffort: () => Promise.resolve(true),
+  listFiles: () => Promise.resolve([]),
+  listFileCandidates: () => Promise.resolve([]),
+  previewSession: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true),
+  renameSessionTo: () => Promise.resolve(true),
+  renameSession: () => {},
+  compact: () => {},
+  exportSession: () => null,
+  initWorkspace: () => null,
+  doctorInfo: () => [],
+  pluginsInfo: () => [],
+  listSubagents: () => Promise.resolve([]),
+  mcpStatus: () => [],
+  sideQuestion: () => Promise.resolve({}),
+  interruptAndDeliver: () => 0,
+  settingsSections: () => [],
+  subscribeSettingsSections: () => () => {},
+  describeCredential: () => Promise.resolve(undefined),
+  providerSetup: () => undefined,
+  listWorkspaces: () => Promise.resolve([]),
+  resolveWorkspace: () => Promise.resolve(undefined),
+  switchWorkspace: () => Promise.resolve(false),
+  renameWorkspace: () => Promise.resolve(false),
+  workspaceCommands: () => [],
+  runWorkspaceCommand: () => Promise.resolve(undefined),
+  resumeTo: () => Promise.resolve({ ok: false }),
+  newSession: () => Promise.resolve(true),
+  listSkills: () => Promise.resolve(undefined),
+  stageImage: () => Promise.resolve(''),
+  emit() { this.version += 1; for (const listener of listeners) listener() },
+}
+
+const stdout = new FakeStdout()
+const stdin = new FakeStdin()
+const instance = await render(
+  <Chat
+    channel={channel as never}
+    questionStore={new QuestionStore()}
+    onExit={() => {}}
+    onRestart={() => { restartCalls += 1 }}
+  />,
+  { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(600)
+
+// ── /reload：预置 pref 全部与 live 值不同 → 应全 apply + 输出报告 ──
+stdin.write('/reload\r')
+await sleep(400)
+
+// 注意：不做屏幕断言——fake 环境的渲染时序（useSyncExternalStore + 帧
+// 调度）与真实 TUI 有差异；报告渲染是 /activity、/status 等共用生产路径，
+// localRows 已证明 pushLocal 收到完整报告。
+check('输入被消费（不发给模型）', channel.submitCalls.length === 0, `submitCalls=${channel.submitCalls.length}`)
+check('pushLocal 收到 /reload local 行', localRows.some(r => r.kind === 'local' && r.text === '/reload'),
+  JSON.stringify(localRows.slice(0, 2)))
+check('报告含 header', localRows.some(r => r.text.includes('已重读偏好文件')), JSON.stringify(localRows.slice(0, 6)))
+check('报告含 4 条 apply（theme/preset/model/activity）', localRows.filter(r => r.text.includes('（已应用）')).length === 4,
+  JSON.stringify(localRows))
+check('主题应用 dark → light', localRows.some(r => r.text.includes('light') && r.text.includes('已应用')), JSON.stringify(localRows))
+check('语言跳过（DSH_TUI_LANG 优先）', localRows.some(r => r.text.includes('语言') && r.text.includes('跳过')), JSON.stringify(localRows))
+check('模型应用 deepseek/deepseek-chat', modelCalls.join(',') === 'deepseek/deepseek-chat', modelCalls.join(','))
+check('预设应用 code', presetCalls.join(',') === 'code', presetCalls.join(','))
+check('activity 应用 moon', activityCalls.join(',') === 'moon', activityCalls.join(','))
+check('报告 footer 在', localRows.some(r => r.text.includes('/restart')), JSON.stringify(localRows.slice(-2)))
+
+// ── /restart：onRestart 应被调用（working=false 时） ──
+stdin.write('/restart\r')
+await sleep(300)
+check('/restart 派发到 onRestart', restartCalls === 1, `restartCalls=${restartCalls}`)
+check('/restart 通知发出', notifyCalls.some(t => t.includes('正在重启')), JSON.stringify(notifyCalls))
+
+await instance.unmount()
+
+if (failures > 0) {
+  console.error(`\nrepro-reload: ${failures} 项失败`)
+  process.exit(1)
+}
+console.log('\nrepro-reload: 全部通过（/reload 在代码层面工作正常）')

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -112,6 +112,10 @@ const GROUPS = {
 // /update 纯函数回归：版本探测（双布局+外来 manifest 拒绝）、
 // registry 解析（env/npmrc/默认）、semver 比较、pnpm --latest。
     ["verify-update", ['node', 'scripts/verify-update.mjs']],
+// /reload 与 /restart 纯函数回归：planReload 五类偏好的应用/跳过/
+// 无变化分支、env 与 cordis.yml 显式配置的优先级守卫、模型路由原子
+// 规则（provider-only pin 不挡偏好）、两命令的注册与解析。
+    ["verify-reload", ['node', '--import', 'tsx/esm', 'scripts/verify-reload.ts']],
 // 直达启动器回归（issue #108）：参数透传、残骸 profile 重装、
 // 版本不一致提示、双语消息、shellQuote 转义规则。
     ["verify-launcher", ['node', 'scripts/verify-launcher.mjs']],

--- a/scripts/verify-reload.ts
+++ b/scripts/verify-reload.ts
@@ -1,0 +1,155 @@
+/**
+ * verify-reload — /reload 与 /restart 的纯函数回归。
+ *
+ * 覆盖 src/reload.ts 的 planReload（pi 式软重载决策）与两个命令在
+ * src/commands.ts 的注册：
+ *   1. 五类偏好（theme/lang/preset/model/activity）在无显式配置时的应用
+ *      与顺序；
+ *   2. 优先级守卫：DSH_TUI_THEME / DSH_TUI_LANG（env-wins）、cordis.yml
+ *      显式 preset / lang / activityFrames / 完整 provider+model 对
+ *      （config-wins）、settings 用户层 lang（config-wins）；
+ *   3. 原子路由规则（issue #67）：provider-only pin 不得阻止偏好生效；
+ *   4. 无效/缺失偏好文件（invalid）与无变化（unchanged）分支；
+ *   5. 命令注册：/reload、/restart 在 LOCAL_COMMANDS 中、isLocalCommandName
+ *      识别、parseCommandName 拆分。
+ *
+ * 运行：node --import tsx/esm scripts/verify-reload.ts
+ */
+import { planReload, type ReloadPlan } from '../src/reload.js'
+import { LOCAL_COMMANDS, isLocalCommandName, parseCommandName } from '../src/commands.js'
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  const mark = ok ? 'ok  ' : 'FAIL'
+  console.log(`${mark} ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures++
+}
+
+/** Count plan entries by bucket. */
+function counts(plan: ReloadPlan): { apply: number; unchanged: number; skipped: number } {
+  return { apply: plan.apply.length, unchanged: plan.unchanged.length, skipped: plan.skipped.length }
+}
+
+const BASE = {
+  envTheme: undefined,
+  envLang: undefined,
+  themePref: 'dark',
+  currentTheme: 'dark',
+  langPref: 'zh' as const,
+  currentLang: 'zh',
+  langOverriddenBySettings: false,
+  configuredLang: undefined,
+  configuredPreset: undefined,
+  presetPref: 'standard',
+  currentPreset: 'standard',
+  configuredModel: undefined,
+  modelPref: { provider: 'deepseek-official', model: 'deepseek-v4-flash' },
+  currentModel: { provider: 'deepseek-official', model: 'deepseek-v4-flash' },
+  configuredActivity: undefined,
+  activityPref: 'claude',
+  currentActivity: 'claude',
+}
+
+// ── 1. 全部无变化 → 全 unchanged，零 apply/skip ─────────────────────────
+{
+  const plan = planReload(BASE)
+  check('全部匹配 → unchanged=5', counts(plan).unchanged === 5, `got ${counts(plan).unchanged}`)
+  check('全部匹配 → apply=0 skipped=0', counts(plan).apply === 0 && counts(plan).skipped === 0)
+  check('unchanged 顺序', JSON.stringify(plan.unchanged) === JSON.stringify(['theme', 'lang', 'preset', 'model', 'activity']), JSON.stringify(plan.unchanged))
+}
+
+// ── 2. 五项都改 → 五项都 apply，顺序固定 ────────────────────────────────
+{
+  const plan = planReload({
+    ...BASE,
+    themePref: 'light',
+    langPref: 'en',
+    presetPref: 'code',
+    modelPref: { provider: 'deepseek', model: 'deepseek-chat' },
+    activityPref: 'moon',
+  })
+  check('全改 → apply=5', counts(plan).apply === 5, `got ${counts(plan).apply}`)
+  check('apply 顺序', JSON.stringify(plan.apply.map(a => a.kind)) === JSON.stringify(['theme', 'lang', 'preset', 'model', 'activity']), JSON.stringify(plan.apply.map(a => a.kind)))
+  const model = plan.apply.find(a => a.kind === 'model')
+  check('model apply 携带完整路由', model?.route?.provider === 'deepseek' && model?.route?.model === 'deepseek-chat')
+  check('model from/to 渲染', model?.from === 'deepseek-official/deepseek-v4-flash' && model?.to === 'deepseek/deepseek-chat', `${model?.from} → ${model?.to}`)
+  check('theme from/to', plan.apply[0]?.from === 'dark' && plan.apply[0]?.to === 'light')
+}
+
+// ── 3. theme：env 优先 / 无效 / 缺文件 ──────────────────────────────────
+{
+  const plan = planReload({ ...BASE, envTheme: 'light', themePref: 'light' })
+  check('theme env 优先 → skip env-wins', plan.skipped.some(s => s.kind === 'theme' && s.reason === 'env-wins'), JSON.stringify(plan.skipped))
+  check('theme env 优先 → 不 apply', !plan.apply.some(a => a.kind === 'theme'))
+  const noFile = planReload({ ...BASE, themePref: undefined })
+  check('theme 无文件 → skip invalid', noFile.skipped.some(s => s.kind === 'theme' && s.reason === 'invalid'))
+}
+
+// ── 4. lang：env / settings 用户层 / cordis.yml 三级优先 ────────────────
+{
+  const env = planReload({ ...BASE, envLang: 'en', langPref: 'zh' })
+  check('lang env 优先 → skip env-wins', env.skipped.some(s => s.kind === 'lang' && s.reason === 'env-wins'))
+  const settings = planReload({ ...BASE, langOverriddenBySettings: true, langPref: 'en' })
+  check('lang settings 用户层 → skip config-wins', settings.skipped.some(s => s.kind === 'lang' && s.reason === 'config-wins'))
+  const cordis = planReload({ ...BASE, configuredLang: 'zh', langPref: 'en' })
+  check('lang cordis.yml → skip config-wins', cordis.skipped.some(s => s.kind === 'lang' && s.reason === 'config-wins'))
+  const changed = planReload({ ...BASE, langPref: 'en' })
+  check('lang 变化 → apply en', changed.apply.some(a => a.kind === 'lang' && a.to === 'en' && a.from === 'zh'))
+  const noFile = planReload({ ...BASE, langPref: undefined })
+  check('lang 无文件 → skip invalid', noFile.skipped.some(s => s.kind === 'lang' && s.reason === 'invalid'))
+}
+
+// ── 5. preset / activity：cordis.yml 显式优先 ───────────────────────────
+{
+  const preset = planReload({ ...BASE, configuredPreset: 'code', presetPref: 'standard' })
+  check('preset cordis.yml → skip config-wins', preset.skipped.some(s => s.kind === 'preset' && s.reason === 'config-wins'))
+  const presetApply = planReload({ ...BASE, presetPref: 'code' })
+  check('preset 变化 → apply', presetApply.apply.some(a => a.kind === 'preset' && a.to === 'code'))
+  const presetNoFile = planReload({ ...BASE, presetPref: undefined })
+  check('preset 无文件 → skip invalid', presetNoFile.skipped.some(s => s.kind === 'preset' && s.reason === 'invalid'))
+  const activity = planReload({ ...BASE, configuredActivity: 'moon', activityPref: 'claude' })
+  check('activity cordis.yml → skip config-wins', activity.skipped.some(s => s.kind === 'activity' && s.reason === 'config-wins'))
+  const activityApply = planReload({ ...BASE, activityPref: 'moon' })
+  check('activity 变化 → apply', activityApply.apply.some(a => a.kind === 'activity' && a.to === 'moon'))
+}
+
+// ── 6. model：完整 pair 优先；provider-only pin 不挡偏好（原子规则） ────
+{
+  const complete = planReload({
+    ...BASE,
+    configuredModel: { provider: 'deepseek-official', model: 'deepseek-v4-flash' },
+    modelPref: { provider: 'deepseek', model: 'deepseek-chat' },
+  })
+  check('model 完整 pair → skip config-wins', complete.skipped.some(s => s.kind === 'model' && s.reason === 'config-wins'))
+  check('model 完整 pair → 不 apply', !complete.apply.some(a => a.kind === 'model'))
+  // issue #67 原子规则：只 pin provider 不算显式路由，不得阻止偏好生效。
+  const half = planReload({
+    ...BASE,
+    configuredModel: { provider: 'deepseek-official', model: undefined },
+    modelPref: { provider: 'deepseek', model: 'deepseek-chat' },
+  })
+  check('model provider-only pin 不挡偏好 → apply', half.apply.some(a => a.kind === 'model' && a.route?.provider === 'deepseek'), JSON.stringify(half.skipped))
+  check('model provider-only pin → 无 skip', !half.skipped.some(s => s.kind === 'model'))
+  const noFile = planReload({ ...BASE, modelPref: undefined })
+  check('model 无文件 → skip invalid', noFile.skipped.some(s => s.kind === 'model' && s.reason === 'invalid'))
+  const noCurrent = planReload({ ...BASE, currentModel: undefined, modelPref: { provider: 'deepseek', model: 'deepseek-chat' } })
+  check('model 无当前路由仍 apply', noCurrent.apply.some(a => a.kind === 'model' && a.from === '—'))
+}
+
+// ── 7. 命令注册：/reload、/restart ──────────────────────────────────────
+{
+  const names = LOCAL_COMMANDS.map(c => c.name)
+  check('/reload 已注册', names.includes('reload'))
+  check('/restart 已注册', names.includes('restart'))
+  check('/reload 被 isLocalCommandName 识别', isLocalCommandName('/reload'))
+  check('/restart 被 isLocalCommandName 识别', isLocalCommandName('/restart'))
+  check('/reload 描述非空', LOCAL_COMMANDS.find(c => c.name === 'reload')?.description.length > 0)
+  const parsed = parseCommandName('/restart')
+  check('parseCommandName(/restart)', parsed?.name === 'restart', JSON.stringify(parsed))
+}
+
+if (failures > 0) {
+  console.error(`\nverify-reload: ${failures} 项失败`)
+  process.exit(1)
+}
+console.log('\nverify-reload: 全部通过')

--- a/scripts/verify-update.mjs
+++ b/scripts/verify-update.mjs
@@ -40,14 +40,17 @@ const {
 } = await import('../lib/types/update.js')
 const compiledModulePath = fileURLToPath(new URL('../lib/types/update.js', import.meta.url))
 const compiledShellQuotePath = fileURLToPath(new URL('../lib/types/utils/shellQuote.js', import.meta.url))
+const compiledPathsPath = fileURLToPath(new URL('../lib/types/utils/paths.js', import.meta.url))
 const repoRoot = fileURLToPath(new URL('..', import.meta.url))
 
-// The compiled update.js imports ./utils/shellQuote.js — mirror both into
-// every scratch layout or the import dies with ERR_MODULE_NOT_FOUND.
+// The compiled update.js imports ./utils/shellQuote.js and ./utils/paths.js
+// (the /restart log lives under DATA_DIR) — mirror all three into every
+// scratch layout or the import dies with ERR_MODULE_NOT_FOUND.
 function copyUpdateModule(dstDir) {
   mkdirSync(join(dstDir, 'utils'), { recursive: true })
   cpSync(compiledModulePath, join(dstDir, 'update.js'))
   cpSync(compiledShellQuotePath, join(dstDir, 'utils', 'shellQuote.js'))
+  cpSync(compiledPathsPath, join(dstDir, 'utils', 'paths.js'))
 }
 
 // ---- installedTuiVersion: compiled layout is this module's own real layout

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -76,6 +76,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
   { name: 'status', description: 'Show session status' },
   { name: 'cost', description: 'Show session token usage' },
   { name: 'config', description: 'Show the dsh-tui configuration source' },
+  { name: 'reload', description: 'Reload preference files from disk and apply live' },
   { name: 'settings', description: 'View and edit plugin settings' },
   { name: 'doctor', description: 'Run environment checks' },
   { name: 'init', description: 'Create AGENTS.md in the working directory' },
@@ -115,6 +116,7 @@ export const LOCAL_COMMANDS: LocalCommand[] = [
   // Help / exit
   { name: 'help', description: 'Show shortcuts and commands' },
   { name: 'tips', description: 'Show usage tips and shortcuts' },
+  { name: 'restart', description: 'Restart dsh-tui and resume this session' },
   { name: 'exit', description: 'Exit dsh-tui' },
   { name: 'quit', description: 'Exit dsh-tui', tag: 'alias of /exit' },
   { name: 'q', description: 'Exit dsh-tui', tag: 'alias of /exit' },

--- a/src/components/design-system/ThemeProvider.tsx
+++ b/src/components/design-system/ThemeProvider.tsx
@@ -72,8 +72,9 @@ const ThemeContext = createContext<ThemeContextValue>({
  * DSH_TUI_THEME skips terminal detection (tests, debugging). Accepts a
  * built-in name (auto|light|dark|dark-ansi) or a user theme name; invalid
  * values are warned and ignored by the caller, falling back to detection.
+ * Exported for /reload, which must respect the env override's precedence.
  */
-function envThemeOverride(): string | undefined {
+export function envThemeOverride(): string | undefined {
   const v = process.env.DSH_TUI_THEME
   return v === undefined || v === '' ? undefined : v
 }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -476,6 +476,18 @@ export interface Channel {
   readonly model: string
   /** Provider route of the live agent. */
   readonly provider: string
+  /** Raw cordis.yml `provider` key (undefined when unset) — the boot-time
+   *  pin `/reload` must never override. */
+  readonly configuredProvider: string | undefined
+  /** Raw cordis.yml `model` key (undefined when unset). */
+  readonly configuredModel: string | undefined
+  /** Explicit cordis.yml `preset` (undefined = roster default wins) — `/reload`
+   *  must not override a static deployment choice. */
+  readonly configuredPreset: string | undefined
+  /** Explicit cordis.yml `activityFrames` (undefined = pref/default wins). */
+  readonly configuredActivityFrames: string | undefined
+  /** Explicit cordis.yml `lang` (undefined = settings/lang.json wins). */
+  readonly configuredLang: string | undefined
   /** Running token totals across the session's assistant messages. */
   readonly tokens: TokenUsage
   /** Working directory of the session. */
@@ -872,6 +884,12 @@ export interface ChannelState {
   workingActivity: ActivityStatus | undefined
   /** Working-activity indicator preset (see the public Channel type). */
   activityFrames: string | undefined
+  /** Raw cordis.yml pins `/reload` must respect (see the public Channel type). */
+  configuredProvider: string | undefined
+  configuredModel: string | undefined
+  configuredPreset: string | undefined
+  configuredActivityFrames: string | undefined
+  configuredLang: string | undefined
   /** Diff presentation preference (see the public Channel type). */
   diffLayout: 'auto' | 'split' | 'unified'
   /** Thinking-block display (see the public Channel type). */
@@ -1416,6 +1434,12 @@ export function createChannel(
      *  only route a resume overrides the target's own record with. */
     configuredProvider?: string
     configuredModel?: string
+    /** cordis.yml's raw `lang` key, undefined when unset: `/reload` consults
+     *  it so a static deployment choice is never overridden by lang.json. */
+    configuredLang?: string
+    /** cordis.yml's raw `activityFrames` key, undefined when unset: the
+     *  static choice `/reload` must not override. */
+    configuredActivityFrames?: string
     /** The preset the initial agent's session runs under (from resolveAgent). */
     agentPreset?: string
     /** Shift+Tab session-mode cycle from cordis.yml `modes`; undefined →
@@ -2344,6 +2368,11 @@ export function createChannel(
     modeIndex: 0,
     workingActivity: undefined,
     activityFrames: options.activityFrames,
+    configuredProvider: options.configuredProvider,
+    configuredModel: options.configuredModel,
+    configuredPreset: options.configuredPreset,
+    configuredActivityFrames: options.configuredActivityFrames,
+    configuredLang: options.configuredLang,
     diffLayout: options.diffLayout ?? 'auto',
     thinkingFold: options.thinkingFold ?? 'preview',
     toolBackground: normalizeToolBackground(options.toolBackground),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -25,7 +25,7 @@ import { ensurePackagedPresets } from './packaged-presets.js'
 import { ensureLegacySessionEventTypes } from './compat/index.js'
 import { clearResumeTarget, writeResumeTarget } from '../sessionHistory.js'
 import { resolveSessionCwd } from '../utils/workspaceRoot.js'
-import { checkForTuiUpdate, installedTuiVersion, isBootDeadlockTarget, isVersionNewer, resolveDshProfileName, resolveTuiUpdateTarget, updateTuiAndRestart } from '../update.js'
+import { beginRestartAttempt, checkForTuiUpdate, installedTuiVersion, isBootDeadlockTarget, isVersionNewer, logRestartEvent, resolveDshProfileName, resolveTuiUpdateTarget, restartTui, updateTuiAndRestart, writeHandoffNotice } from '../update.js'
 import { getLang, isLang, resolveStartupLang, setLang, t, writeLangPref } from '../i18n.js'
 import { DEFAULT_STATUS_BAR, normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import { detectLegacyEnv, migrateLegacyDataDir, RENAMED_ENV } from '../utils/paths.js'
@@ -69,7 +69,65 @@ import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, supportsTabStatus, wrapForMult
 let lastBootedFullscreen: boolean | undefined
 
 export async function apply(ctx: Context, config: Config): Promise<void> {
+  // /restart handoff diagnosis: the replacement process is marked by env and
+  // logs its boot progress to ~/.dsh-tui/restart.log (ordinary launches stay
+  // silent). First line lands before anything in this function can throw.
+  if (process.env.DSH_TUI_RESTART_CHILD === '1') {
+    logRestartEvent('boot: plugin apply', {
+      stdoutTty: process.stdout.isTTY === true,
+      stdinTty: process.stdin.isTTY === true,
+      stderrTty: process.stderr.isTTY === true,
+    })
+    // Field evidence (2026-08-24): the restarted TUI mounts but takes no
+    // input, and the terminal's DA reply surfaced on PS's prompt line in an
+    // earlier attempt — meaning NO process was reading console input. Probe
+    // whether THIS process's stdin pump ever sees bytes: wrap read()
+    // transparently (delegates; purely observational) and sample the pump
+    // state, so the log distinguishes "bytes never arrive" (console-level
+    // theft/mode) from "bytes arrive but the UI ignores them".
+    const probedStdin = process.stdin as NodeJS.ReadStream & { isRaw?: boolean }
+    const originalRead = probedStdin.read.bind(probedStdin)
+    let loggedChunks = 0
+    probedStdin.read = ((...args: Parameters<typeof originalRead>) => {
+      const chunk = originalRead(...args)
+      if (chunk !== null && chunk !== '' && loggedChunks < 12) {
+        loggedChunks += 1
+        const text = String(chunk)
+        logRestartEvent('boot: stdin chunk arrived', {
+          bytes: text.length,
+          preview: text.slice(0, 24).replace(/[^\x20-\x7e]/g, '.'),
+        })
+      }
+      return chunk
+    }) as typeof originalRead
+    const sampleStdinState = (label: string): void => {
+      logRestartEvent(`boot: ${label}`, {
+        isRaw: probedStdin.isRaw === true,
+        readableListeners: probedStdin.listenerCount('readable'),
+        dataListeners: probedStdin.listenerCount('data'),
+        paused: probedStdin.isPaused,
+        buffered: probedStdin.readableLength,
+        chunksSeen: loggedChunks,
+      })
+    }
+    sampleStdinState('stdin state at plugin apply')
+    let pendingSamples = 0
+    const sampleAt = (delayMs: number, label: string): void => {
+      pendingSamples += 1
+      const timer = setTimeout(() => {
+        pendingSamples -= 1
+        sampleStdinState(label)
+      }, delayMs)
+      timer.unref?.()
+    }
+    sampleAt(2000, 'stdin state +2s')
+    sampleAt(5000, 'stdin state +5s')
+    sampleAt(12000, 'stdin state +12s')
+  }
   if (!process.stdout.isTTY) {
+    if (process.env.DSH_TUI_RESTART_CHILD === '1') {
+      logRestartEvent('boot: TTY gate failed - stdout is not a TTY')
+    }
     throw new Error('dsh-tui requires an interactive terminal (stdout must be a TTY).')
   }
 
@@ -360,6 +418,10 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     // only explicit values so the target session's own record wins.
     configuredModel: config.model,
     configuredProvider: config.provider,
+    // Raw cordis.yml `lang` / `activityFrames`: /reload must not override a
+    // static deployment choice with the persisted preference.
+    configuredLang: config.lang,
+    configuredActivityFrames: config.activityFrames,
     effort: config.effort,
     activity: config.activity,
     // Explicit cordis.yml value (static deployment choice) wins over the
@@ -834,6 +896,10 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   let exited = false
   let updateRequested = false
   let updateTargetVersion: string | undefined
+  // `/restart` flag: same exit funnel as `/update` minus the pnpm step —
+  // write the resume target, restore the terminal, respawn the process with
+  // the original argv, and let the fresh boot attach the same session.
+  let restartRequested = false
   // The profile this process was booted with (`dsh --profile <name>`); dsh
   // exposes it nowhere else, and /update must update the installation the
   // user is actually running, not a hard-coded one.
@@ -874,6 +940,31 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
           'Updating @deepseek-harness-tui/dsh-tui and restarting…',
           undefined,
           () => runUpdate(ctx, profile, channel.agentId, updateTargetVersion),
+        )
+        return
+      }
+      // `/restart`: same handoff as the update path, no installation step.
+      // The resume target is written unconditionally — the user asked to
+      // restart THIS session, blank or not (mirrors the update contract).
+      if (restartRequested) {
+        beginRestartAttempt(channel.agentId)
+        logRestartEvent('funnel: /restart branch entered')
+        try {
+          writeResumeTarget(channel.agentId)
+          logRestartEvent('funnel: resume target written')
+        } catch (error) {
+          // Resume persistence is best effort and must never block a restart.
+          logRestartEvent('funnel: resume target write failed', {
+            message: error instanceof Error ? error.message : String(error),
+          })
+        }
+        void finishExit(
+          ctx,
+          instance,
+          bootedFullscreen,
+          t('restart-starting'),
+          undefined,
+          () => runRestart(ctx, profile, channel.agentId),
         )
         return
       }
@@ -932,6 +1023,14 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     // the tree is already wrapped below, so they must not nest.
     fullscreen: bootedFullscreen,
     onExit: () => handleExit(),
+    // `/restart`: respawn this process and resume the session, no update.
+    onRestart: () => {
+      if (exited || restartRequested) return
+      restartRequested = true
+      logRestartEvent('command: /restart accepted')
+      channel.notify(t('restart-starting'))
+      handleExit()
+    },
     // Only a `dsh --profile <name>` launch has a profile installation for
     // `/update` to act on; source checkouts and `--config` overlays get the
     // unavailable notice instead.
@@ -998,6 +1097,12 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   const isRecompose = lastBootedFullscreen !== undefined
   lastBootedFullscreen = bootedFullscreen
   logMouseDebug('apply mount', { bootedFullscreen, isRecompose })
+  // /restart handoff diagnosis: the replacement got all the way to a mounted
+  // UI, so any later death is post-boot (and its stderr keeps flowing to the
+  // parent only within the survival window — this line is the durable mark).
+  if (process.env.DSH_TUI_RESTART_CHILD === '1') {
+    logRestartEvent('boot: UI mounted', { fullscreen: bootedFullscreen, isRecompose })
+  }
 
   // Check in the background so registry latency never delays the first frame.
   // A failed/offline check is intentionally silent; the manual `/update`
@@ -1321,6 +1426,42 @@ function writeStream(stream: NodeJS.WriteStream, data: string): Promise<void> {
   })
 }
 
+/**
+ * Restart the TUI in place and resume the same session — the `/restart`
+ * tail of `/reload`: the soft reload cannot re-read boot-time-only state
+ * (cordis.yml root config, frozen fullscreen layout, newly built code), so
+ * /restart respawns the process with the original argv through the same
+ * terminal handoff the /update path uses, minus the installation step.
+ * The resume contract is dual-written (env + resume.txt) before this runs.
+ */
+function runRestart(ctx: Context, profile: string | undefined, sessionId: string): void {
+  logRestartEvent('runRestart: entered, disposing cordis root')
+  disposeRootAndThen(ctx, () => {
+    logRestartEvent('runRestart: root disposed, starting restartTui')
+    void restartTui(sessionId).then(
+      restartCode => {
+        logRestartEvent('runRestart: restartTui resolved', { restartCode })
+        if (restartCode !== 0) {
+          writeHandoffNotice(
+            `\ndsh-tui restart failed to spawn (exit ${restartCode}). Your session is preserved — resume with:\n` +
+              `${resumeCommand(profile, sessionId)}\n\n`,
+          )
+        }
+        process.exit(restartCode)
+      },
+      restartError => {
+        const message = restartError instanceof Error ? restartError.message : String(restartError)
+        logRestartEvent('runRestart: restartTui rejected', { message })
+        writeHandoffNotice(
+          `\ndsh-tui restart failed: ${message}. Your session is preserved — resume with:\n` +
+            `${resumeCommand(profile, sessionId)}\n\n`,
+        )
+        process.exit(1)
+      },
+    )
+  })
+}
+
 function runUpdate(
   ctx: Context,
   profile: string | undefined,
@@ -1384,7 +1525,12 @@ function resumeCommand(profile: string | undefined, sessionId: string): string {
  * reporting failure on a clean exit would mislead wrapper scripts.
  */
 function disposeRootAndThen(ctx: Context, done: () => void, fallbackCode = 1): void {
-  const timer = setTimeout(() => process.exit(fallbackCode), 5000)
+  const timer = setTimeout(() => {
+    // Diagnosis for a stalled disposal: without this line the fallback exit
+    // is indistinguishable from a successful handoff in the field.
+    logRestartEvent('dispose: timeout, taking fallback exit', { fallbackCode })
+    process.exit(fallbackCode)
+  }, 5000)
   timer.unref()
   void withHostRootCapability(() => ctx.root.fiber.dispose()).then(
     () => {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -259,6 +259,22 @@ const dict = {
   'update-check-failed': { zh: '无法确认新版本（网络或 registry 不可达），已尝试直接更新……', en: 'Could not confirm a newer version (network or registry unreachable); attempting the update anyway…' },
   'update-refused-deadlock': { zh: '已取消更新：镜像 registry 目前只能装到 v{{latest}}，而该版本在旧全局启动器的 patch 下会启动死锁（#183/#307）；官方最新为 v{{authoritative}}，待镜像同步后再 /update。', en: 'Update cancelled: the mirror registry can only serve v{{latest}}, which deadlocks boot under older global-launcher patches (#183/#307); official latest is v{{authoritative}} — retry /update after the mirror syncs.' },
   'update-mirror-lag': { zh: '镜像 registry 滞后：本次安装 v{{latest}}；官方最新 v{{authoritative}}，镜像同步后可再 /update。', en: 'Mirror registry lag: installing v{{latest}} now; official latest is v{{authoritative}} — run /update again once the mirror syncs.' },
+  // ── /reload (pi-style soft reload) ────────────────────────────────────
+  'reload-header': { zh: '已重读偏好文件：', en: 'Preferences reloaded:' },
+  'reload-applied': { zh: '{{kind}}  {{from}} → {{to}}（已应用）', en: '{{kind}}  {{from}} → {{to}} (applied)' },
+  'reload-unchanged': { zh: '{{kind}}  无变化', en: '{{kind}}  unchanged' },
+  'reload-skipped-env': { zh: '{{kind}}  跳过：环境变量优先', en: '{{kind}}  skipped: env override wins' },
+  'reload-skipped-config': { zh: '{{kind}}  跳过：显式配置优先', en: '{{kind}}  skipped: explicit config wins' },
+  'reload-skipped-invalid': { zh: '{{kind}}  跳过：文件缺失或无效', en: '{{kind}}  skipped: missing or invalid file' },
+  'reload-footer': { zh: '提示：settings.yaml / cordis.patch.yml 由 watcher 自动热重载；cordis.yml 根配置改动需 /restart', en: 'Note: settings.yaml / cordis.patch.yml hot-reload via watchers; cordis.yml root config changes need /restart' },
+  'reload-kind-theme': { zh: '主题', en: 'theme' },
+  'reload-kind-lang': { zh: '语言', en: 'language' },
+  'reload-kind-preset': { zh: '预设', en: 'preset' },
+  'reload-kind-model': { zh: '模型', en: 'model' },
+  'reload-kind-activity': { zh: '活动指示', en: 'activity' },
+  // ── /restart (process restart with session resume) ────────────────────
+  'restart-starting': { zh: '正在重启 dsh-tui，完成后自动恢复当前会话……', en: 'Restarting dsh-tui. The session resumes when it comes back…' },
+  'restart-unavailable': { zh: '当前运行方式不支持进程内重启（未挂载重启通道）。', en: 'Restart is unavailable in this launch mode (no restart channel mounted).' },
   'streaming-folded': { zh: '…（前 {{count}} 字符流式期间已折叠，落定后完整显示）', en: '…(first {{count}} chars folded while streaming; full text renders once the turn settles)' },
   'vim-not-implemented': { zh: 'vim 模式暂未实现', en: 'vim mode not implemented yet' },
   'terminal-setup-hint': { zh: '推荐 Windows Terminal（≥110 列、等宽字体、TrueColor）。', en: 'Recommended: Windows Terminal (≥110 columns, monospace, TrueColor).' },
@@ -778,6 +794,7 @@ const dict = {
   'cmd-desc-status': { zh: '查看会话状态' },
   'cmd-desc-cost': { zh: '查看会话 token 用量' },
   'cmd-desc-config': { zh: '查看 dsh-tui 配置来源' },
+  'cmd-desc-reload': { zh: '重读偏好文件并立即生效' },
   'cmd-desc-settings': { zh: '查看和编辑插件设置' },
   'cmd-desc-doctor': { zh: '运行环境检查' },
   'cmd-desc-init': { zh: '在工作目录创建 AGENTS.md' },
@@ -818,6 +835,7 @@ const dict = {
   'cmd-desc-workspace-open': { zh: '打开路径或工作区 URI', en: 'Open a path or workspace URI' },
   // Help / exit
   'cmd-desc-help': { zh: '查看快捷键与命令' },
+  'cmd-desc-restart': { zh: '重启 dsh-tui 并恢复当前会话' },
   'cmd-desc-exit': { zh: '退出 dsh-tui' },
   // Registry-injected (external) commands — zh only; en falls back to the
   // registry's own description, and unlisted externals always fall back.

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -1,0 +1,191 @@
+/**
+ * `/reload` planning — the pi-style soft reload: re-read the TUI's persisted
+ * preference files (`~/.dsh-tui/{theme,lang,agent-preset,model,
+ * working-activity}.json`) and decide what to re-apply live, honoring the
+ * same boot-time precedence every picker does:
+ *
+ *   - theme:    DSH_TUI_THEME wins; else theme.json.
+ *   - lang:     DSH_TUI_LANG > settings `dsh-tui.lang` (folded in by the
+ *               caller as `langOverriddenBySettings`) > cordis.yml `lang`
+ *               > lang.json.
+ *   - preset:   cordis.yml `preset` wins; else agent-preset.json.
+ *   - model:    a COMPLETE cordis.yml provider/model pair wins whole
+ *               (issue #67 — never merge halves); else model.json.
+ *   - activity: cordis.yml `activityFrames` wins; else
+ *               working-activity.json.
+ *
+ * Settings-namespace values (settings.yaml user layer) are deliberately NOT
+ * re-read here: the dsh-tui namespace applies live through its settings
+ * watch and hot-reloads its document through the platform's file watcher,
+ * so /reload only needs the five boot-only pref files. What no reload can
+ * re-read (cordis.yml root config, frozen fullscreen layout, newly built
+ * code) is the job of `/restart`.
+ *
+ * Pure and injectable so scripts/verify-reload.ts can exercise every branch
+ * without a UI or a file system.
+ */
+
+import type { Lang } from './i18n.js'
+import type { ModelPref } from './modelPrefs.js'
+import type { ModelRoute } from './modelRoute.js'
+import { explicitModelRoute } from './modelRoute.js'
+
+/** The five boot-only preference surfaces /reload re-reads. */
+export type ReloadKind = 'theme' | 'lang' | 'preset' | 'model' | 'activity'
+
+export type ReloadSkipReason =
+  /** A launch-time environment variable pins the value (DSH_TUI_THEME / DSH_TUI_LANG). */
+  | 'env-wins'
+  /** cordis.yml or the settings user layer pins the value; the pref must not override it. */
+  | 'config-wins'
+  /** The pref file is missing or unparsable. */
+  | 'invalid'
+
+/** One live change /reload applies. Kind `model` carries the route halves. */
+export interface ReloadApply {
+  kind: ReloadKind
+  /** The live value before this reload. */
+  from: string
+  /** The value the pref file now names. */
+  to: string
+  /** Present for kind `model`: the full route halves to switch to. */
+  route?: ModelRoute
+}
+
+/** A pref /reload did not apply, and why. */
+export interface ReloadSkip {
+  kind: ReloadKind
+  reason: ReloadSkipReason
+}
+
+/** What one /reload run decided, before any side effects. */
+export interface ReloadPlan {
+  /** Apply these in order (theme → lang → preset → model → activity). */
+  apply: ReloadApply[]
+  /** Pref files whose value already matches the live state. */
+  unchanged: ReloadKind[]
+  /** Pref files not applied, and why. */
+  skipped: ReloadSkip[]
+}
+
+/** Everything the planner needs — caller reads the files and live values. */
+export interface ReloadInput {
+  /** DSH_TUI_THEME, when it holds a valid theme name. */
+  envTheme?: string
+  /** DSH_TUI_LANG, when it holds a valid language. */
+  envLang?: string
+  /** Fresh readThemePref(). */
+  themePref?: string
+  /** The live theme name (ThemeProvider state). */
+  currentTheme: string
+  /** Fresh readLangPref(). */
+  langPref?: Lang
+  /** The live UI language. */
+  currentLang: Lang
+  /** True when the settings user layer (settings.yaml `dsh-tui.lang`) pins a language. */
+  langOverriddenBySettings: boolean
+  /** cordis.yml's raw `lang` key, when set. */
+  configuredLang?: string
+  /** cordis.yml's explicit `preset` key, when set. */
+  configuredPreset?: string
+  /** Fresh readPresetPref(). */
+  presetPref?: string
+  /** The live preset id (channel.agentPreset; undefined = roster default). */
+  currentPreset?: string
+  /** cordis.yml's raw `provider`/`model` keys, when set. */
+  configuredModel?: { provider?: string; model?: string }
+  /** Fresh readModelPref(). */
+  modelPref?: ModelPref
+  /** The live route (channel provider/model). */
+  currentModel?: ModelRoute
+  /** cordis.yml's explicit `activityFrames` key, when set. */
+  configuredActivity?: string
+  /** Fresh readActivityFrames(). */
+  activityPref?: string
+  /** The live activity preset (channel.activityFrames). */
+  currentActivity?: string
+}
+
+/**
+ * Decide what one /reload applies. Pure: returns the plan, never touches
+ * the UI or the channel. The caller executes `apply` in order and renders
+ * the report.
+ */
+export function planReload(input: ReloadInput): ReloadPlan {
+  const apply: ReloadApply[] = []
+  const unchanged: ReloadKind[] = []
+  const skipped: ReloadSkip[] = []
+
+  // Theme: env override wins at launch; else the persisted choice.
+  if (input.envTheme !== undefined) {
+    skipped.push({ kind: 'theme', reason: 'env-wins' })
+  } else if (input.themePref === undefined) {
+    skipped.push({ kind: 'theme', reason: 'invalid' })
+  } else if (input.themePref === input.currentTheme) {
+    unchanged.push('theme')
+  } else {
+    apply.push({ kind: 'theme', from: input.currentTheme, to: input.themePref })
+  }
+
+  // Language: env, then the settings user layer, then cordis.yml, then the
+  // persisted choice — mirror the boot precedence in plugin.apply.
+  if (input.envLang !== undefined) {
+    skipped.push({ kind: 'lang', reason: 'env-wins' })
+  } else if (input.langOverriddenBySettings || input.configuredLang !== undefined) {
+    skipped.push({ kind: 'lang', reason: 'config-wins' })
+  } else if (input.langPref === undefined) {
+    skipped.push({ kind: 'lang', reason: 'invalid' })
+  } else if (input.langPref === input.currentLang) {
+    unchanged.push('lang')
+  } else {
+    apply.push({ kind: 'lang', from: input.currentLang, to: input.langPref })
+  }
+
+  // Preset: cordis.yml's static choice wins; else the persisted one.
+  if (input.configuredPreset !== undefined) {
+    skipped.push({ kind: 'preset', reason: 'config-wins' })
+  } else if (input.presetPref === undefined) {
+    skipped.push({ kind: 'preset', reason: 'invalid' })
+  } else if (input.presetPref === input.currentPreset) {
+    unchanged.push('preset')
+  } else {
+    apply.push({ kind: 'preset', from: input.currentPreset ?? '—', to: input.presetPref })
+  }
+
+  // Model route: the atomic rule (issue #67) — a complete cordis.yml pair
+  // wins whole; a half-pinned config never merges with the pref's other half.
+  // (Normalize to an object: callers may pass undefined when no route is pinned.)
+  if (explicitModelRoute(input.configuredModel ?? {}) !== undefined) {
+    skipped.push({ kind: 'model', reason: 'config-wins' })
+  } else if (input.modelPref === undefined) {
+    skipped.push({ kind: 'model', reason: 'invalid' })
+  } else if (
+    input.currentModel !== undefined
+    && input.currentModel.provider === input.modelPref.provider
+    && input.currentModel.model === input.modelPref.model
+  ) {
+    unchanged.push('model')
+  } else {
+    apply.push({
+      kind: 'model',
+      from: input.currentModel === undefined
+        ? '—'
+        : `${input.currentModel.provider}/${input.currentModel.model}`,
+      to: `${input.modelPref.provider}/${input.modelPref.model}`,
+      route: { provider: input.modelPref.provider, model: input.modelPref.model },
+    })
+  }
+
+  // Working-activity indicator: cordis.yml's static choice wins.
+  if (input.configuredActivity !== undefined) {
+    skipped.push({ kind: 'activity', reason: 'config-wins' })
+  } else if (input.activityPref === undefined) {
+    skipped.push({ kind: 'activity', reason: 'invalid' })
+  } else if (input.activityPref === input.currentActivity) {
+    unchanged.push('activity')
+  } else {
+    apply.push({ kind: 'activity', from: input.currentActivity ?? 'claude', to: input.activityPref })
+  }
+
+  return { apply, unchanged, skipped }
+}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { t, getLang, setLang, isLang, writeLangPref, subscribeLang, LANGS, type I18nKey, type Lang } from '../i18n.js'
+import { t, getLang, setLang, isLang, writeLangPref, readLangPref, subscribeLang, LANGS, type I18nKey, type Lang } from '../i18n.js'
+import { readThemePref } from '../themePrefs.js'
+import { readPresetPref } from '../presetPrefs.js'
+import { readModelPref } from '../modelPrefs.js'
+import { readActivityFrames } from '../activityPrefs.js'
+import { envThemeOverride } from '../components/design-system/ThemeProvider.js'
+import { hasPath } from '../dsh-adapter/settingsEditor.js'
+import { planReload, type ReloadKind } from '../reload.js'
 import { AlternateScreen, Box, Text, useInput, ScrollBox, type ScrollBoxHandle, useTheme, useTerminalSize } from '../ui.js'
 import * as tuiKit from '../ui.js'
 import { POINTER } from '../cc/figures.js'
@@ -181,6 +188,7 @@ export function Chat({
   extensionShortcuts,
   onExit,
   onUpdate,
+  onRestart,
   fullscreen = false,
   trajectorySeen: trajectorySeenProp,
 }: {
@@ -205,6 +213,8 @@ export function Chat({
   onExit: () => void
   /** Update the installed package and restart the current TUI process. */
   onUpdate?: () => void
+  /** Restart the current TUI process and resume this session (no update). */
+  onRestart?: () => void
   /**
    * True when the host already wrapped this tree in `<AlternateScreen>`
    * (`fullscreen: true`). Both full-screen surfaces need this — the trajectory
@@ -689,6 +699,17 @@ export function Chat({
       ok ? t('lang-switched', { lang }) : t('lang-switch-failed', { lang }),
       { color: ok ? 'success' : 'error' },
     )
+  }
+
+  /** Localized label of one /reload surface, for the change report. */
+  const reloadKindLabel = (kind: ReloadKind): string => {
+    switch (kind) {
+      case 'theme': return t('reload-kind-theme')
+      case 'lang': return t('reload-kind-lang')
+      case 'preset': return t('reload-kind-preset')
+      case 'model': return t('reload-kind-model')
+      case 'activity': return t('reload-kind-activity')
+    }
   }
 
   const runCommand = (name: string, rawInput = ''): boolean => {
@@ -1370,6 +1391,98 @@ export function Chat({
         } else {
           channel.notify(t('update-starting'))
           onUpdate()
+        }
+        return true
+      case 'reload': {
+        // pi-style soft reload: re-read the persisted preference files
+        // (~/.dsh-tui/{theme,lang,agent-preset,model,working-activity}.json)
+        // and re-apply live, honoring the boot-time precedence (env >
+        // cordis.yml > settings user layer > pref). The dsh-tui settings
+        // namespace is NOT re-read here — its watch applies edits live and
+        // the platform watcher hot-reloads settings.yaml itself. What no
+        // reload can re-read (cordis.yml root config, frozen fullscreen,
+        // newly built code) is listed in the footer and served by /restart.
+        setHelpOpen(false)
+        const tuiNamespace = channel.settingsHost()
+          ?.listNamespaces()
+          .find(entry => entry.ns === 'dsh-tui')
+        const plan = planReload({
+          envTheme: envThemeOverride(),
+          envLang: isLang(process.env.DSH_TUI_LANG) ? process.env.DSH_TUI_LANG : undefined,
+          themePref: readThemePref(),
+          currentTheme: themeName,
+          langPref: readLangPref(),
+          currentLang: getLang(),
+          langOverriddenBySettings: tuiNamespace !== undefined && hasPath(tuiNamespace.user, ['lang']),
+          configuredLang: channel.configuredLang,
+          configuredPreset: channel.configuredPreset,
+          presetPref: readPresetPref(),
+          currentPreset: channel.agentPreset,
+          configuredModel: {
+            provider: channel.configuredProvider,
+            model: channel.configuredModel,
+          },
+          modelPref: readModelPref(),
+          currentModel: { provider: channel.provider, model: channel.model },
+          configuredActivity: channel.configuredActivityFrames,
+          activityPref: readActivityFrames(),
+          currentActivity: channel.activityFrames,
+        })
+        for (const item of plan.apply) {
+          switch (item.kind) {
+            case 'theme':
+              setTheme(item.to)
+              break
+            case 'lang':
+              applyLang(item.to as Lang)
+              break
+            case 'preset':
+              void channel.switchPreset(item.to)
+              break
+            case 'model':
+              if (item.route !== undefined) {
+                void channel.switchModel(item.route.provider, item.route.model)
+              }
+              break
+            case 'activity':
+              channel.setActivityFrames(item.to)
+              break
+          }
+        }
+        const lines = [t('reload-header')]
+        for (const item of plan.apply) {
+          lines.push(t('reload-applied', {
+            kind: reloadKindLabel(item.kind),
+            from: item.from,
+            to: item.to,
+          }))
+        }
+        for (const kind of plan.unchanged) {
+          lines.push(t('reload-unchanged', { kind: reloadKindLabel(kind) }))
+        }
+        for (const skip of plan.skipped) {
+          const key = skip.reason === 'env-wins'
+            ? 'reload-skipped-env'
+            : skip.reason === 'config-wins' ? 'reload-skipped-config' : 'reload-skipped-invalid'
+          lines.push(t(key, { kind: reloadKindLabel(skip.kind) }))
+        }
+        lines.push(t('reload-footer'))
+        channel.pushLocal('/reload', lines)
+        return true
+      }
+      case 'restart':
+        // pi-style reload tail: /reload cannot re-read boot-time-only state
+        // (cordis.yml root config, frozen fullscreen layout, newly built
+        // code), so /restart respawns the process with the original argv and
+        // resumes this session — the /update handoff minus the pnpm step.
+        setHelpOpen(false)
+        if (onRestart === undefined) {
+          channel.notify(t('restart-unavailable'), { color: 'warning' })
+        } else if (channel.working) {
+          channel.notify(t('update-working'), { color: 'warning' })
+        } else {
+          channel.notify(t('restart-starting'))
+          onRestart()
         }
         return true
       case 'vim':

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,10 +1,11 @@
 import { spawn } from 'node:child_process'
-import { readFileSync, realpathSync, renameSync, writeFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { gte, gt, lt, valid } from 'semver'
 import { shellQuote } from './utils/shellQuote.js'
+import { DATA_DIR } from './utils/paths.js'
 
 // Re-exported for scripts/verify-update.mjs and the bin launcher, which reads
 // the compiled copy at lib/types/utils/shellQuote.js.
@@ -15,6 +16,72 @@ const DEFAULT_REGISTRY = 'https://registry.npmjs.org'
 const UPDATE_CHECK_TIMEOUT_MS = 4000
 /** env marker set on the /update restart; the new process verifies it at boot. */
 const UPDATED_FROM_ENV = 'DSH_TUI_UPDATED_FROM'
+/**
+ * env marker set on the /restart replacement: its boot logs to restart.log
+ * (ordinary launches stay silent, so the file is restart-only evidence).
+ */
+const RESTART_CHILD_ENV = 'DSH_TUI_RESTART_CHILD'
+
+/**
+ * Field-diagnosis log for the /restart terminal handoff, appended by BOTH
+ * processes: the exiting TUI logs the funnel path, the spawned replacement
+ * logs its boot progress, and every line carries pid + timestamp — so a
+ * handoff that dies at any stage (loader entry, TTY gate, session resume,
+ * even after the parent's survival window) leaves breadcrumbs on disk even
+ * when nothing reaches the already-confused terminal. Diagnosis only: every
+ * write is best effort and must never break the handoff itself.
+ */
+const RESTART_LOG = join(DATA_DIR, 'restart.log')
+/** Cap so a long debugging streak cannot grow the log unbounded. */
+const RESTART_LOG_MAX_BYTES = 256 * 1024
+
+function writeRestartLine(line: string): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true })
+    appendFileSync(RESTART_LOG, `${new Date().toISOString()} pid=${process.pid} ${line}\n`)
+  } catch {
+    // Diagnosis only.
+  }
+}
+
+/**
+ * Append a /restart handoff event to ~/.dsh-tui/restart.log.
+ * @param event - Short stable event name.
+ * @param data - Small JSON-safe detail (never credentials or session text).
+ */
+export function logRestartEvent(event: string, data?: Record<string, unknown>): void {
+  writeRestartLine(`${event}${data === undefined ? '' : ` ${JSON.stringify(data)}`}`)
+}
+
+/** Start a fresh, clearly delimited /restart attempt block in the log. */
+export function beginRestartAttempt(sessionId: string): void {
+  try {
+    mkdirSync(DATA_DIR, { recursive: true })
+    let size = 0
+    try {
+      size = statSync(RESTART_LOG).size
+    } catch {
+      size = 0
+    }
+    if (size > RESTART_LOG_MAX_BYTES) writeFileSync(RESTART_LOG, '')
+  } catch {
+    // Diagnosis only.
+  }
+  writeRestartLine(`--- /restart attempt session=${sessionId} ---`)
+}
+
+/**
+ * Write a handoff notice to stderr synchronously: process.exit() right after
+ * an async stream write skips the flush, and a vanished diagnosis is
+ * indistinguishable from a silent failure.
+ */
+export function writeHandoffNotice(text: string): void {
+  try {
+    writeFileSync(2, text)
+  } catch {
+    process.stderr.write(text)
+  }
+}
 
 export interface TuiUpdateInfo {
   current: string
@@ -428,4 +495,162 @@ export async function updateTuiAndRestart(
     },
   })
   return { updateCode, restartCode }
+}
+
+/**
+ * Restart the running TUI in place and resume the active session — the
+ * `/update` restart path minus the pnpm step, for `/restart`. Spawns the
+ * same node process with the original argv and the dual-written resume
+ * contract, so a fresh process re-boots the same profile and attaches the
+ * same session. No installation is touched, so it works on any launch
+ * (profile, source checkout, `--config` overlay).
+ *
+ * The TUI must already be unmounted before this is called (same terminal
+ * handoff contract as `updateTuiAndRestart`): the caller runs this from the
+ * exit funnel's done callback, after finishExit detached the terminal and
+ * the readable stdin pump.
+ *
+ * This waits for the replacement's natural exit, exactly like the proven
+ * `/update` restart: the shell that ran `dsh-tui` reclaims the console the
+ * moment the launch chain (cmd → wrapper → this process) unwinds, and an
+ * orphaned replacement still attached to the console then fights the
+ * shell's own prompt and line reader for every keypress (field evidence
+ * 2026-08-24: healthy child mounted the UI, the old process exited on a
+ * 4s survival timer, PS printed its prompt over the TUI and the DA
+ * response bytes landed on the prompt line). Waiting is safe because
+ * finishExit already paused and unref'd this process's stdin — the child
+ * is the console's only key reader (issues #284/#307).
+ *
+ * The 4s survival window remains a DIAGNOSIS marker only: a replacement
+ * that dies within it never painted the TUI, and its captured stderr is
+ * reported synchronously (a raw inherit write can vanish mid-handoff). A
+ * late exit is quiet — by then the user owned a working TUI session.
+ *
+ * @param sessionId - Session to resume in the replacement process.
+ * @returns 0 when the replacement ran and exited cleanly, 127 when it
+ *   failed to start, otherwise the child's own exit code.
+ */
+export async function restartTui(sessionId: string): Promise<number> {
+  const argv = [...process.execArgv, ...process.argv.slice(1)]
+  logRestartEvent('restart: spawning replacement', {
+    node: process.execPath,
+    argv,
+    cwd: process.cwd(),
+    stdinTty: process.stdin.isTTY === true,
+    stdoutTty: process.stdout.isTTY === true,
+    stderrTty: process.stderr.isTTY === true,
+    nodeOptions: process.env.NODE_OPTIONS ?? null,
+    dshHome: process.env.DSH_HOME ?? null,
+  })
+  const startedAt = Date.now()
+  return new Promise(resolve => {
+    const child = spawn(process.execPath, argv, {
+      env: {
+        ...process.env,
+        // Dual-write the resume contract (issue #120): the cordis layer of a
+        // still-old TUI build reads only DSH_CC_RESUME_SESSION.
+        DSH_TUI_RESUME_SESSION: sessionId,
+        DSH_CC_RESUME_SESSION: sessionId,
+        // Marks the replacement so its own boot logs to restart.log without
+        // noisy logging on every ordinary launch.
+        [RESTART_CHILD_ENV]: '1',
+      },
+      // stdin/stdout stay inherited so the replacement owns the console the
+      // moment it boots; stderr is captured so a boot failure is reportable
+      // through THIS process (the terminal may already be mid-handoff when
+      // the child dies, and a raw inherit write can vanish).
+      stdio: ['inherit', 'inherit', 'pipe'],
+    })
+    logRestartEvent('restart: replacement spawned', { childPid: child.pid })
+    // Handoff watchdog (field evidence 2026-08-24: restarted TUI mounts but
+    // takes no input). Two jobs, both diagnosis-grade:
+    // 1. SAMPLE this process's stdin state every second — if anything
+    //    re-attaches a reader after the funnel's detachStdinForHandoff, the
+    //    sample (taken before the re-assert below) shows it in the log.
+    // 2. RE-ASSERT the detach and finally destroy the stream: this process
+    //    must never read the shared console again — every keypress belongs
+    //    to the replacement, and a resumed pump here is exactly the
+    //    "restarted TUI sees dropped or swallowed input" failure (#284/#307).
+    let watchdogTicks = 0
+    const watchdog = setInterval(() => {
+      watchdogTicks += 1
+      const stdin = process.stdin as NodeJS.ReadStream & { isRaw?: boolean }
+      logRestartEvent('parent: stdin watchdog', {
+        tick: watchdogTicks,
+        readableListeners: stdin.listenerCount('readable'),
+        dataListeners: stdin.listenerCount('data'),
+        paused: stdin.isPaused,
+        raw: stdin.isRaw === true,
+        buffered: stdin.readableLength,
+      })
+      try {
+        stdin.removeAllListeners('readable')
+        stdin.removeAllListeners('data')
+        stdin.pause()
+      } catch {
+        // Diagnosis/mitigation only.
+      }
+      if (watchdogTicks === 15) {
+        clearInterval(watchdog)
+        try {
+          // Terminal safeguard: a destroyed stream can never be resumed by
+          // any late re-attachment. The child holds its own inherited
+          // handle, so closing ours does not affect it.
+          process.stdin.destroy()
+          logRestartEvent('parent: stdin destroyed after watchdog')
+        } catch {
+          // Best effort.
+        }
+      }
+    }, 1000)
+    watchdog.unref()
+    let childStderr = ''
+    let loggedStderrBytes = 0
+    child.stderr?.on('data', (chunk: Buffer) => {
+      childStderr += chunk.toString('utf8')
+      // Mirror chunks to the log capped: the full text still reaches the
+      // terminal report below, and unbounded output must not grow the file.
+      if (loggedStderrBytes < 4096) {
+        loggedStderrBytes += chunk.length
+        logRestartEvent('restart: replacement stderr', { text: chunk.toString('utf8').slice(0, 2048) })
+      }
+    })
+    // Diagnosis marker only — never resolves: after the window the child owns
+    // the terminal, and this process must keep the launch chain open until
+    // the replacement exits (see the header comment).
+    const timer = setTimeout(() => {
+      logRestartEvent('restart: survival window passed, following the replacement until it exits')
+    }, 4000)
+    timer.unref()
+    child.once('error', error => {
+      clearTimeout(timer)
+      logRestartEvent('restart: spawn error', { message: error.message })
+      writeHandoffNotice(`dsh-tui: failed to spawn the restart: ${error.message}\n`)
+      resolve(127)
+    })
+    child.once('close', (code, signal) => {
+      clearTimeout(timer)
+      const elapsedMs = Date.now() - startedAt
+      logRestartEvent('restart: replacement exited', {
+        code: code ?? null,
+        signal: signal ?? null,
+        elapsedMs,
+      })
+      if (elapsedMs < 4000) {
+        // Fast death: the TUI never came up. Synchronous stderr write —
+        // process.exit() right after an async stream write skips the flush,
+        // and a vanished diagnosis is indistinguishable from silent failure.
+        const suffix = childStderr.trim() === '' ? '' : `\n${childStderr.trimEnd()}`
+        writeHandoffNotice(
+          `dsh-tui: restart child exited during the handoff (code ${code ?? 'null'}` +
+            `${signal === undefined || signal === null ? '' : `, signal ${signal}`}) — the TUI did not come up.` +
+            `${suffix}\nYour session is preserved; resume with the launcher or retry /restart.\n`,
+        )
+      } else if (code !== 0 && code !== null) {
+        // Late nonzero exit: the session ended abnormally, say so briefly.
+        writeHandoffNotice(`\ndsh-tui: the restarted session exited with code ${code}.\n`)
+      }
+      resolve(code ?? 1)
+    })
+  })
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -511,15 +511,16 @@ export async function updateTuiAndRestart(
  * the readable stdin pump.
  *
  * This waits for the replacement's natural exit, exactly like the proven
- * `/update` restart: the shell that ran `dsh-tui` reclaims the console the
- * moment the launch chain (cmd → wrapper → this process) unwinds, and an
- * orphaned replacement still attached to the console then fights the
- * shell's own prompt and line reader for every keypress (field evidence
- * 2026-08-24: healthy child mounted the UI, the old process exited on a
- * 4s survival timer, PS printed its prompt over the TUI and the DA
- * response bytes landed on the prompt line). Waiting is safe because
- * finishExit already paused and unref'd this process's stdin — the child
- * is the console's only key reader (issues #284/#307).
+ * `/update` restart: the outer command interpreter that ran `dsh-tui`
+ * reclaims the console the moment the launch chain (cmd → wrapper → this
+ * process) unwinds, and an orphaned replacement still attached to the
+ * console then fights the interpreter's own prompt and line reader for
+ * every keypress (field evidence 2026-08-24: healthy child mounted the
+ * UI, the old process exited on a 4s survival timer, the interpreter
+ * printed its prompt over the TUI and the DA response bytes landed on
+ * the prompt line). Waiting is safe because finishExit already paused
+ * and unref'd this process's stdin — the child is the console's only
+ * key reader (issues #284/#307).
  *
  * The 4s survival window remains a DIAGNOSIS marker only: a replacement
  * that dies within it never painted the TUI, and its captured stderr is


### PR DESCRIPTION
## 概要

pi 式配置热更新体验：改完配置 `/reload` 会话内立即生效；需要重启的场景（cordis.yml 根配置、新构建代码）用 `/restart` 无缝重启并恢复当前会话。

## /reload（软重载）

- 重读 `~/.dsh-tui/` 下五类偏好文件（theme / lang / agent-preset / model / working-activity）并立即应用；
- 严格尊重启动期优先级：env 覆盖 > cordis.yml 显式配置 > settings 用户层 > 偏好文件，被上层锁定的项在报告中标注跳过原因；
- 模型路由遵循 #67 原子规则：完整的 provider+model 配置对整体生效，provider-only pin 不与偏好合并；
- `settings.yaml` / `cordis.patch.yml` 本就由平台 watcher 热重载，报告页脚提示用户分层。

## /restart（保会话重启）

按原 argv 重建进程，经 `DSH_TUI_RESUME_SESSION` 双写 + `resume.txt` 恢复同一会话（`/update` 的终端交接减去安装步骤）。交接在 Windows 现场踩过并修复了三层问题：

1. **旧进程等新进程退出**（而非 4s 存活窗口后退出）：启动链存活期间 shell 不会抢回控制台，否则 PS 提示符会打印在 TUI 上并争夺键盘；
2. **stdin 看门狗**：父进程每秒重申 stdin 卸载、15s 后销毁自身 stdin，杜绝 #284/#307 式父进程按键竞争；
3. **双进程面包屑日志** `~/.dsh-tui/restart.log` + 同步 stderr 诊断写入：交接失败不再无声消失（本次排障即靠它定位了前两层问题）。

## 回归

- `scripts/verify-reload.ts`：34 项断言（planReload 全分支 + 命令注册），已登记 `input-terminal` CI 组；
- `scripts/repro-reload.tsx`：真实 Chat 派发链 12 项断言；
- 本地 `pnpm build` 全绿；用户在 Windows 现场实测 /reload、/restart（含链式重启）通过。
