### PR TITLE
feat: 点击文件路径弹出操作菜单（打开 / 所在文件夹 / 复制路径）

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -334,6 +334,10 @@ const GROUPS = {
 // 插件场景渲染崩溃边界：Thrower 场景必须被 PluginSceneBoundary 接住——
 // onError 精确一次、崩溃场景停止绘制、进程存活；健康场景不受影响。
     ["verify-plugin-scene-boundary", ['node', '--import', 'tsx/esm', 'scripts/verify-plugin-scene-boundary.tsx']],
+// 终端点击目标回归（点击链接开浏览器 / 文件路径弹菜单）：路径判定、
+// dsh-file: URL 编解码、相对路径按 cwd 解析、file:// 转换、Windows
+// start 组装——fileTarget.ts / openExternal.ts 的纯函数部分。
+    ["verify-clickable-targets", ['node', '--import', 'tsx/esm', 'scripts/verify-clickable-targets.ts']],
   ],
   'flaky-observation': [
 // resize 时间稳定性（借鉴 Codex 的 resize 漂移维度）：落定后不得

--- a/scripts/verify-chat-overlay.ts
+++ b/scripts/verify-chat-overlay.ts
@@ -186,6 +186,32 @@ check('T8e preset gated on >0 options', [
 check('T8f tips still counts as overlay-open', dialogOverlayVisible({ kind: 'tips' }, gates), true)
 check('T8g search mounts the bar', dialogOverlayVisible({ kind: 'search' }, gates), true)
 
+// --- T9: file-actions (click-to-act file menu) ---------------------------
+const fileActions = (index: number, isDir = false): ChatOverlay =>
+  ({ kind: 'file-actions', path: 'C:\\repo\\src\\a.ts', index, isDir })
+check('T9a open from none', reduce(NO_OVERLAY, { type: 'open', overlay: fileActions(0) }), fileActions(0))
+check(
+  'T9b move wraps within the 3 actions',
+  [
+    reduce(fileActions(2), { type: 'move', delta: 1, count: 3 }),
+    reduce(fileActions(0), { type: 'move', delta: -1, count: 3 }),
+  ],
+  [fileActions(0), fileActions(2)],
+)
+check('T9c empty count is a no-op', reduce(fileActions(1), { type: 'move', delta: 1, count: 0 }), fileActions(1))
+check(
+  'T9d mouse pick sets the absolute row',
+  reduce(fileActions(1), { type: 'set-index', kind: 'file-actions', index: 2 }),
+  fileActions(2),
+)
+check(
+  'T9e stale set-index ignored after the menu closed',
+  reduce({ kind: 'theme', index: 0 }, { type: 'set-index', kind: 'file-actions', index: 2 }),
+  { kind: 'theme', index: 0 },
+)
+check('T9f close', reduce(fileActions(0), { type: 'close' }), { kind: 'none' })
+check('T9g overlay mounts by default (no data gate)', dialogOverlayVisible(fileActions(0), gates), true)
+
 if (failures > 0) {
   console.error(`\n${failures} failure(s)`)
   process.exit(1)

--- a/scripts/verify-clickable-targets.ts
+++ b/scripts/verify-clickable-targets.ts
@@ -1,0 +1,271 @@
+/**
+ * verify-clickable-targets — 终端点击目标的纯函数回归（审计后新增）。
+ *
+ * 覆盖 src/utils/fileTarget.ts 与 src/utils/openExternal.ts：
+ *   1. looksLikeFilePath 保守判定：锚定路径/扩展名路径为正，URL/分数/
+ *      日期/带空格文本为负；
+ *   2. linkifyFilePaths 扫描：span 提取、句尾标点留在链接外、wrap 回调
+ *      只收路径；
+ *   3. dsh-file: URL 编解码往返（含 CJK/空格/% 等需要 encodeURIComponent
+ *      的字符）；
+ *   4. resolveTargetPath：相对路径按 base 解析、~ 展开、绝对路径直通；
+ *   5. fileUrlToPath：合法 file:// 转路径，非法返回 undefined；
+ *   6. buildWin32StartSpawn：Windows `start "" <target>` 组装纯函数。
+ *
+ * 运行：node --import tsx/esm scripts/verify-clickable-targets.ts
+ */
+import {
+  FILE_LINK_SCHEME,
+  fileLinkUrl,
+  linkifyFilePaths,
+  looksLikeFilePath,
+  parseFileLinkUrl,
+  resolveTargetPath,
+  fileUrlToPath,
+} from '../src/utils/fileTarget.js'
+import { buildWin32OpenSpawn, buildWin32StartSpawn } from '../src/utils/openExternal.js'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  const mark = ok ? 'ok  ' : 'FAIL'
+  console.log(`${mark} ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures++
+}
+
+/** String-equality assertion for the linkify/encode helpers. */
+function checkEq(name: string, actual: string, expected: string): void {
+  const ok = actual === expected
+  const mark = ok ? 'ok  ' : 'FAIL'
+  console.log(`${mark} ${name}${ok ? '' : `\n      expected: ${JSON.stringify(expected)}\n      actual:   ${JSON.stringify(actual)}`}`)
+  if (!ok) failures++
+}
+
+// ── 1. looksLikeFilePath ────────────────────────────────────────────────
+const POSITIVE = [
+  'src/foo.ts',
+  'src/components/Box.tsx',
+  './a/b.txt',
+  '../up/x.js',
+  '/abs/path.md',
+  '~/cfg/x.json',
+  'C:\\repo\\src\\a.ts',
+  'C:/repo/src/a.ts',
+  'a/b/c.log',
+  'node_modules/x/index.js',
+  'src/foo.ts.',
+  'dist/app.js',
+]
+const NEGATIVE = [
+  'and/or',
+  '2024/01/15',
+  'https://example.com/a/b',
+  'http://x.io',
+  'www.example.com/x',
+  'a/b',
+  '1/2',
+  'owner/repo#123',
+  'hello world/file.ts',
+  'a/b.x',
+  'x.ts', // no slash
+  'github.com/foo/bar',
+  'src/foo.ts?query=1', // '?' rejected
+  '',
+  '  ',
+  'a'.repeat(300) + '/b.ts', // over length cap
+  'user@host/path',
+]
+for (const p of POSITIVE) {
+  check(`looksLikeFilePath('${p}') true`, looksLikeFilePath(p) === true, String(looksLikeFilePath(p)))
+}
+for (const p of NEGATIVE) {
+  check(`looksLikeFilePath('${p}') false`, looksLikeFilePath(p) === false, String(looksLikeFilePath(p)))
+}
+
+// ── 2. linkifyFilePaths ─────────────────────────────────────────────────
+const wrap = (path: string, display: string): string => `«${path}»(${display})`
+checkEq(
+  'linkify single path in prose',
+  linkifyFilePaths('check src/foo.ts and done', wrap),
+  'check «src/foo.ts»(src/foo.ts) and done',
+)
+checkEq(
+  'linkify trailing punctuation stays outside',
+  linkifyFilePaths('see ./a/b.txt.', wrap),
+  'see «./a/b.txt»(./a/b.txt).',
+)
+checkEq(
+  'linkify multiple paths',
+  linkifyFilePaths('a.ts src/x.ts b.ts src/y.json c.ts', wrap),
+  'a.ts «src/x.ts»(src/x.ts) b.ts «src/y.json»(src/y.json) c.ts',
+)
+checkEq(
+  'non-path spans untouched (URL, fraction, issue ref)',
+  linkifyFilePaths('go to https://x.com/a or 1/2 or owner/repo#123', wrap),
+  'go to https://x.com/a or 1/2 or owner/repo#123',
+)
+checkEq(
+  'URL slash run untouched (file:// too)',
+  linkifyFilePaths('see file:///tmp/x.ts and https://a.io/b/c.ts now', wrap),
+  'see file:///tmp/x.ts and https://a.io/b/c.ts now',
+)
+checkEq(
+  'anchor path after a colon still links (C: drive)',
+  linkifyFilePaths('on C:\\repo\\src\\a.ts here', wrap),
+  'on «C:\\repo\\src\\a.ts»(C:\\repo\\src\\a.ts) here',
+)
+checkEq('empty text unchanged', linkifyFilePaths('', wrap), '')
+
+// ── 3. dsh-file: URL round-trip ─────────────────────────────────────────
+const tricky = [
+  'src/foo.ts',
+  'C:\\Users\\张三\\我的 文件.ts', // CJK + space + backslash
+  'a/b/100%.md',
+  '~/.config/x.json',
+  'src/文件/测试.txt',
+]
+for (const p of tricky) {
+  const url = fileLinkUrl(p)
+  check(`round-trip '${p}'`, parseFileLinkUrl(url) === p, url)
+}
+check('scheme prefix', fileLinkUrl('x.ts').startsWith(FILE_LINK_SCHEME), fileLinkUrl('x.ts'))
+check('parse rejects non-scheme', parseFileLinkUrl('https://x.com/a') === undefined, '')
+check('parse rejects malformed encoding', parseFileLinkUrl(FILE_LINK_SCHEME + '%E0%A4%A') === undefined, '')
+
+// ── 4. resolveTargetPath ────────────────────────────────────────────────
+check(
+  'relative resolves against base',
+  resolveTargetPath('src/a.ts', 'C:\\repo'),
+  'C:\\repo\\src\\a.ts',
+)
+check(
+  'posix relative resolves against base',
+  resolveTargetPath('src/a.ts', '/repo'),
+  '/repo/src/a.ts',
+)
+check(
+  'windows drive path passes through',
+  resolveTargetPath('C:\\abs\\x.ts', '/repo'),
+  'C:\\abs\\x.ts',
+)
+check(
+  'absolute posix passes through',
+  resolveTargetPath('/abs/x.ts', 'C:\\repo'),
+  '/abs/x.ts',
+)
+check(
+  'tilde expands to home (not the base dir)',
+  (() => {
+    const tilde = resolveTargetPath('~/cfg/x.json', '/repo')
+    return !tilde.startsWith('/repo') && tilde.includes('cfg') && tilde.includes('x.json')
+  })(),
+  true,
+)
+check(
+  'tilde result is stable under re-resolution',
+  (() => {
+    const once = resolveTargetPath('~/cfg/x.json', '/repo')
+    return resolveTargetPath(once, '/repo') === once
+  })(),
+  true,
+)
+
+// ── 5. fileUrlToPath ────────────────────────────────────────────────────
+{
+  // Absolute file URLs are platform-shaped: Windows needs a drive letter.
+  const sample = process.platform === 'win32' ? 'file:///C:/tmp/foo.ts' : 'file:///tmp/foo.ts'
+  const p = fileUrlToPath(sample)
+  check('file URL to path', p !== undefined && p.endsWith('foo.ts'), String(p))
+}
+check('invalid file URL rejected', fileUrlToPath('file://%') === undefined, '')
+
+// ── 6. buildWin32StartSpawn (pure assembly) ─────────────────────────────
+{
+  // cross-spawn protocol: quotes are caret-escaped (`^"`); cmd consumes the
+  // carets at parse time, so the executed line is `start "" "C:\repo\a.ts"`.
+  const cmd = buildWin32StartSpawn('C:\\repo\\a.ts')
+  check('win32 start file is cmd', cmd.file.toLowerCase().endsWith('cmd.exe'), cmd.file)
+  const line = cmd.args.join(' ')
+  check(
+    'win32 start args carry title + quoted target',
+    line.includes('start ^"^"') && line.includes('^"C:\\repo\\a.ts^"'),
+    line,
+  )
+  check('win32 start verbatim', cmd.verbatim === true, '')
+  check('win32 start stays detached (field-proven channel)', cmd.detach === true, '')
+  // A space-carrying target still gets quoted (the caret-escape protocol
+  // covers spaces inside the quotes).
+  const spaced = buildWin32StartSpawn('C:\\My Folder\\a.ts')
+  const spacedLine = spaced.args.join(' ')
+  check(
+    'win32 start quotes space-carrying targets',
+    spacedLine.includes('start ^"^"') && spacedLine.includes('^"C:\\My') && spacedLine.includes('Folder\\a.ts^"'),
+    spacedLine,
+  )
+}
+
+// ── 7. buildWin32OpenSpawn (channel selection: dir → COM, else start) ──
+{
+  const fileSpawn = buildWin32OpenSpawn('C:\\repo\\a.ts')
+  check(
+    'open spawn for a file stays on start',
+    fileSpawn.file.toLowerCase().endsWith('cmd.exe') && fileSpawn.args.join(' ').includes('start ^"^"'),
+    fileSpawn.file + ' ' + fileSpawn.args.join(' '),
+  )
+  const urlSpawn = buildWin32OpenSpawn('https://example.com/a')
+  check(
+    'open spawn for a URL stays on start',
+    urlSpawn.file.toLowerCase().endsWith('cmd.exe'),
+    urlSpawn.file,
+  )
+  // Missing paths are not directories → start (openExternal then surfaces
+  // the failure to the opener, never an error dialog from us).
+  const missingSpawn = buildWin32OpenSpawn('C:\\no\\such\\dir')
+  check(
+    'open spawn for a missing path stays on start',
+    missingSpawn.file.toLowerCase().endsWith('cmd.exe'),
+    missingSpawn.file,
+  )
+  if (process.platform === 'win32') {
+    const dir = mkdtempSync(join(tmpdir(), 'dsh-open-'))
+    try {
+      const dirSpawn = buildWin32OpenSpawn(dir)
+      check(
+        'open spawn for a directory uses Shell.Application COM',
+        dirSpawn.file.toLowerCase().endsWith('powershell.exe')
+          && dirSpawn.args.join(' ').includes("Shell.Application).Open('"),
+        dirSpawn.file + ' ' + dirSpawn.args.join(' '),
+      )
+      // Regression (2026-08-24 无响应 bug): the COM powershell child must
+      // NOT be spawned detached — DETACHED_PROCESS (console-less
+      // PowerShell) silently drops the Shell.Application Open call, while
+      // windowsHide alone keeps it invisible AND functional.
+      check('COM channel is not detached (console-less PS drops the call)', dirSpawn.detach === false, '')
+      check(
+        'start channels stay detached',
+        buildWin32OpenSpawn('C:\\repo\\a.ts').detach === true,
+        '',
+      )
+      // Single quotes in the path must be doubled for the PS literal.
+      const squoteDir = dir + "'s dir"
+      mkdirSync(squoteDir)
+      const sqSpawn = buildWin32OpenSpawn(squoteDir)
+      check(
+        'open spawn doubles single quotes in the path',
+        sqSpawn.args.join(' ').includes("Open('" + squoteDir.replace(/'/g, "''") + "')"),
+        sqSpawn.args.join(' '),
+      )
+      rmSync(squoteDir, { recursive: true, force: true })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} failure(s)`)
+  process.exit(1)
+}
+console.log('\nverify-clickable-targets: all checks passed')

--- a/src/cc/hyperlink.ts
+++ b/src/cc/hyperlink.ts
@@ -11,6 +11,12 @@ export const OSC8_END = '\x07'
 
 type HyperlinkOptions = {
   supportsHyperlinks?: boolean
+  /**
+   * Override the default blue styling of the display text — callers that
+   * already painted the content (code spans keep their permission color)
+   * pass the identity here so the OSC 8 wrap does not recolor it.
+   */
+  style?: (text: string) => string
 }
 
 /**
@@ -21,7 +27,7 @@ type HyperlinkOptions = {
  * @param content - Optional content to display as the link text (only when hyperlinks are supported).
  *                  If provided and hyperlinks are supported, this text is shown as a clickable link.
  *                  If hyperlinks are not supported, content is ignored and only the URL is shown.
- * @param options - Optional overrides for testing (supportsHyperlinks)
+ * @param options - Optional overrides for testing (supportsHyperlinks, style)
  * @returns The OSC 8-wrapped blue link text, or the plain URL when the terminal lacks hyperlink support.
  */
 export function createHyperlink(
@@ -37,6 +43,7 @@ export function createHyperlink(
   // Apply basic ANSI blue color - wrap-ansi preserves this across line breaks
   // RGB colors (like theme colors) are NOT preserved by wrap-ansi with OSC 8
   const displayText = content ?? url
-  const coloredText = chalk.blue(displayText)
+  const style = options?.style ?? ((text: string) => chalk.blue(text))
+  const coloredText = style(displayText)
   return `${OSC8_START}${url}${OSC8_END}${coloredText}${OSC8_START}${OSC8_END}`
 }

--- a/src/cc/markdown.ts
+++ b/src/cc/markdown.ts
@@ -23,6 +23,7 @@ import { buildSyntaxTheme } from './syntaxTheme.js'
 import type { CliHighlight } from './cliHighlight.js'
 import { logForDebugging } from '../utils/debug.js'
 import { createHyperlink } from './hyperlink.js'
+import { fileLinkUrl, linkifyFilePaths, looksLikeFilePath } from '../utils/fileTarget.js'
 
 // '\n' is used unconditionally — os.EOL is '\r\n' on Windows, and the stray
 // '\r' breaks the character-to-segment mapping in applyStylesToWrappedText,
@@ -82,6 +83,37 @@ export function configureMarked(): void {
 /** Inline code is painted with the active theme's permission accent. */
 function paintInlineCode(text: string): string {
   return colorize(text, getActiveTheme().permission, 'foreground')
+}
+
+/**
+ * Inline code that reads as a file path becomes a clickable target (the
+ * OSC 8 wrap keeps the code's permission color via the identity style —
+ * createHyperlink's default blue would otherwise override it). Terminals
+ * without OSC 8 support keep the plain painted code span.
+ */
+function renderCodeSpan(token: Tokens.Codespan): string {
+  const painted = paintInlineCode(token.text)
+  if (!looksLikeFilePath(token.text)) return painted
+  if (!supportsHyperlinks()) return painted
+  return createHyperlink(fileLinkUrl(token.text), painted, {
+    style: (text: string) => text,
+  })
+}
+
+/**
+ * Linkify path-like text into clickable file targets, then issue
+ * references (owner/repo#123). File spans exclude `#`, so the two
+ * linkifiers cannot nest or overlap. Without OSC 8 support the text stays
+ * untouched (createHyperlink's URL fallback would show the raw encoded
+ * `dsh-file:` payload — worse than plain text).
+ */
+function linkifyText(text: string): string {
+  const withFiles = supportsHyperlinks()
+    ? linkifyFilePaths(text, (path, display) =>
+        createHyperlink(fileLinkUrl(path), display),
+      )
+    : text
+  return linkifyIssueReferences(withFiles)
 }
 
 /**
@@ -179,7 +211,7 @@ function isToken<K extends MarkedToken['type']>(
 function dispatch(token: Token, state: RenderState): string {
   if (isToken(token, 'blockquote')) return renderBlockquote(token, state)
   if (isToken(token, 'code')) return renderCodeBlock(token, state)
-  if (isToken(token, 'codespan')) return paintInlineCode(token.text)
+  if (isToken(token, 'codespan')) return renderCodeSpan(token)
   if (isToken(token, 'em')) return renderEmphasis(token, state)
   if (isToken(token, 'strong')) return renderStrong(token, state)
   if (isToken(token, 'heading')) return renderHeading(token, state)
@@ -331,14 +363,14 @@ function renderText(token: Tokens.Text, state: RenderState): string {
     const bullet = ordinal === null ? '-' : `${formatListMarker(listDepth, ordinal)}.`
     const body = token.tokens
       ? token.tokens.map(child => dispatch(child, withParent(state, token))).join('')
-      : linkifyIssueReferences(token.text)
+      : linkifyText(token.text)
     // Blue bullet marker: list structure gets a tint without loading the
     // whole item (kimi-style `•` in the accent color).
     const tinted = colorize(bullet, getActiveTheme().permission, 'foreground')
     return `${tinted} ${body}${EOL}`
   }
 
-  return linkifyIssueReferences(token.text)
+  return linkifyText(token.text)
 }
 
 function renderTable(token: Tokens.Table, state: RenderState): string {

--- a/src/components/FileActionsPanel.tsx
+++ b/src/components/FileActionsPanel.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { t } from '../i18n.js'
+import { Box, Text } from '../ui.js'
+import { Pane } from './design-system/Pane.js'
+import { Select, type SelectOption } from './Select.js'
+import { HintLine } from './design-system/HintLine.js'
+import { truncateToWidth } from '../ink/truncateToWidth.js'
+
+/**
+ * Click-to-act file menu (fullscreen): opened by clicking a file path in
+ * the transcript (tool cards, markdown code spans / plain text, file://
+ * links). Rows: open the target, reveal it in the file manager, copy its
+ * absolute path. The path shown is already resolved to an absolute path by
+ * the caller (Chat.tsx resolves against the channel cwd at click time).
+ * When the target is a directory, the first row reads "open folder" — the
+ * same action (default handler), just honest about what it opens.
+ */
+export const FILE_ACTION_COUNT = 3
+
+/** How many terminal cells of the path fit next to the title. */
+const PATH_DISPLAY_BUDGET = 48
+
+export function FileActionsPanel({
+  path,
+  isDir,
+  focusIndex,
+  onPick,
+}: {
+  /** Absolute path the actions operate on (caller-resolved). */
+  path: string
+  /** Whether the target exists on disk and is a directory. */
+  isDir: boolean
+  /** Index of the keyboard-focused row. */
+  focusIndex: number
+  /** Mouse pick (fullscreen): clicked row's absolute index. */
+  onPick?: (index: number) => void
+}): React.ReactNode {
+  const options = React.useMemo<SelectOption[]>(
+    () => [
+      { value: 'open', label: t(isDir ? 'file-actions-open-dir' : 'file-actions-open') },
+      { value: 'reveal', label: t('file-actions-reveal') },
+      { value: 'copy', label: t('file-actions-copy') },
+    ],
+    [isDir],
+  )
+  return (
+    <Pane color="permission">
+      <Box flexDirection="column">
+        <Box flexDirection="row" marginBottom={1}>
+          <Text color="remember" bold>
+            {t('file-actions-title')}
+          </Text>
+          <Text dimColor wrap="truncate-end">
+            {' '}{truncateToWidth(path, PATH_DISPLAY_BUDGET)}
+          </Text>
+        </Box>
+        <Select
+          options={options}
+          focusIndex={focusIndex}
+          selectedValue={undefined}
+          visibleOptionCount={FILE_ACTION_COUNT}
+          onPick={onPick ? index => onPick(index) : undefined}
+        />
+        <Text dimColor italic>
+          <HintLine text={t('hint-confirm-exit')} />
+        </Text>
+      </Box>
+    </Pane>
+  )
+}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -175,6 +175,7 @@ export function MessageList({
   failureHintRowId,
   failureHint,
   onOpenSubagent,
+  onOpenFile,
 }: {
   rows: readonly ChatRow[]
   expanded: boolean
@@ -253,6 +254,8 @@ export function MessageList({
   failureHint?: string
   /** 打开子代理详情场景（transcript 内点击子代理卡）。 */
   onOpenSubagent?: (agentId: string) => void
+  /** 点击工具卡内的文件路径（打开文件操作菜单）。 */
+  onOpenFile?: (path: string) => void
 }) {
   const hiddenCount = rows.length - MAX_RENDERED_ROWS
   // The thinking filter runs BEFORE virtualization so window indices line up.
@@ -1015,6 +1018,7 @@ export function MessageList({
               onToggleStreamFold={onToggleStreamFold}
               streamFolded={streamFoldedRows.has(row.id)}
               onOpenSubagent={onOpenSubagent}
+              onOpenFile={onOpenFile}
               setRowRef={setRowRef}
             />
           )
@@ -1080,6 +1084,7 @@ type MemoRowProps = {
   /** 该行是否被用户折叠（仅流式 reasoning 行消费）。 */
   streamFolded: boolean
   onOpenSubagent: ((agentId: string) => void) | undefined
+  onOpenFile: ((path: string) => void) | undefined
   setRowRef: (rowId: number, el: DOMElement | null) => void
 }
 
@@ -1136,6 +1141,7 @@ function TranscriptRow({
   onToggleStreamFold,
   streamFolded,
   onOpenSubagent,
+  onOpenFile,
   setRowRef,
 }: MemoRowProps): React.ReactNode {
   const ref = React.useCallback(
@@ -1282,6 +1288,7 @@ function TranscriptRow({
             diffLayout={diffLayout}
             toolBackground={toolBackground}
             onClick={foldOnClick}
+            onOpenFile={onOpenFile}
           />
         </Box>
       )

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -41,6 +41,13 @@ type Props = {
   diffLayout?: 'auto' | 'split' | 'unified'
   /** Background treatment for the ordinary, unselected tool card surface. */
   toolBackground?: ToolBackground
+  /**
+   * Click-to-act (fullscreen): opens the file-action menu for the tool's
+   * file path. When provided, the path in the card header (and diff path
+   * rows) renders underlined and clickable; the click stops propagation so
+   * the row's own fold-toggle does not fire.
+   */
+  onOpenFile?: (path: string) => void
 }
 
 /** Tool display names: DSH emits lowercase tool ids (`bash`); Claude Code
@@ -243,13 +250,17 @@ function clipHeaderArgs(args: string): string {
   return `${args.slice(0, HEADER_ARGS_BUDGET)}…`
 }
 
-function HeaderTitle({ name, title, isTerminal, displayArgs, argsLanguage, nameColor }: {
+function HeaderTitle({ name, title, isTerminal, displayArgs, argsLanguage, nameColor, filePath, onOpenFile }: {
   name: string
   title: string | undefined
   isTerminal: boolean
   displayArgs: string
   argsLanguage?: 'json'
   nameColor: keyof Theme
+  /** Clickable file target: when set and present in the title, the path
+   *  segment renders underlined and clickable (opens the file menu). */
+  filePath?: string
+  onOpenFile?: (path: string) => void
 }): React.ReactNode {
   if (title === undefined) {
     return (
@@ -287,6 +298,32 @@ function HeaderTitle({ name, title, isTerminal, displayArgs, argsLanguage, nameC
       </Box>
     )
   }
+  // Clickable path: when the caller resolved a file path that appears in
+  // the title (`Edit /path (1 - 100)`), render that segment underlined and
+  // clickable. The click stops propagation so the row's fold toggle does
+  // not fire. indexOf keeps the split exact even for paths with regex
+  // metacharacters.
+  if (onOpenFile !== undefined && filePath !== undefined && filePath !== '' && trimmed.includes(filePath)) {
+    const at = trimmed.indexOf(filePath)
+    const before = trimmed.slice(0, at)
+    const after = trimmed.slice(at + filePath.length)
+    return (
+      <Box flexWrap="nowrap">
+        <Text bold color={nameColor} wrap="truncate-end">{before}</Text>
+        <Box
+          onClick={(event: ClickEvent) => {
+            event.stopImmediatePropagation()
+            onOpenFile(filePath)
+          }}
+        >
+          <Text underline wrap="truncate-end">{filePath}</Text>
+        </Box>
+        {after !== '' && (
+          <Text bold={false} color="text" wrap="truncate-end">{after}</Text>
+        )}
+      </Box>
+    )
+  }
   const space = trimmed.indexOf(' ')
   const head = space === -1 ? trimmed : trimmed.slice(0, space)
   const tail = space === -1 ? '' : trimmed.slice(space)
@@ -316,6 +353,7 @@ export function AssistantToolUseMessage({
   footnote,
   diffLayout = 'auto',
   toolBackground = 'none',
+  onOpenFile,
 }: Props): React.ReactNode {
   const isRunning = tool.status === 'running'
   const isError = tool.status === 'error'
@@ -414,7 +452,7 @@ export function AssistantToolUseMessage({
             isError={isError}
             toolName={tool.name}
           />
-          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} argsLanguage={argsLanguage} nameColor={toolNameColor(tool.name)} />
+          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} displayArgs={displayArgs} argsLanguage={argsLanguage} nameColor={toolNameColor(tool.name)} filePath={filePath} onOpenFile={onOpenFile} />
           {!isRunning && (
             <Box flexWrap="nowrap">
               <Text dimColor={!hovered}>{elapsedText}</Text>
@@ -459,29 +497,42 @@ export function AssistantToolUseMessage({
                 </Text>
               </Box>
               <Box flexGrow={1}>
-                <Text
-                  color={
-                    line.tone === 'add'
-                      ? 'diffAddedWord'
-                      : line.tone === 'del'
-                        ? 'diffRemovedWord'
-                        : line.tone === 'error'
-                          ? 'error'
-                          : line.tone === 'hint'
-                            ? 'subtle'
-                            : line.tone === 'path'
-                              ? 'ide'
-                              : undefined
-                  }
-                  dimColor={line.tone === 'dim' && !(line.revealOnHover === true && hovered)}
-                  wrap="wrap"
-                >
-                  {line.tone === 'plain' && syntaxLanguage !== undefined ? (
-                    <SyntaxText text={line.text} sourceText={bodySource} lineIndex={index} language={syntaxLanguage} />
-                  ) : (
-                    line.text === '' ? ' ' : line.text
-                  )}
-                </Text>
+                {line.tone === 'path' && onOpenFile !== undefined ? (
+                  <Box
+                    onClick={(event: ClickEvent) => {
+                      // Stop propagation so the row's fold toggle does not
+                      // fire when clicking the path.
+                      event.stopImmediatePropagation()
+                      onOpenFile(line.text)
+                    }}
+                  >
+                    <Text color="ide" underline>{line.text}</Text>
+                  </Box>
+                ) : (
+                  <Text
+                    color={
+                      line.tone === 'add'
+                        ? 'diffAddedWord'
+                        : line.tone === 'del'
+                          ? 'diffRemovedWord'
+                          : line.tone === 'error'
+                            ? 'error'
+                            : line.tone === 'hint'
+                              ? 'subtle'
+                              : line.tone === 'path'
+                                ? 'ide'
+                                : undefined
+                    }
+                    dimColor={line.tone === 'dim' && !(line.revealOnHover === true && hovered)}
+                    wrap="wrap"
+                  >
+                    {line.tone === 'plain' && syntaxLanguage !== undefined ? (
+                      <SyntaxText text={line.text} sourceText={bodySource} lineIndex={index} language={syntaxLanguage} />
+                    ) : (
+                      line.text === '' ? ' ' : line.text
+                    )}
+                  </Text>
+                )}
               </Box>
             </Box>
           ))

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -543,6 +543,13 @@ const dict = {
   'hint-history-search': { zh: '↑/↓ 选择 · **Enter** 确认 · Esc 取消', en: '↑/↓ to navigate · **Enter** to select · Esc to cancel' },
   'hint-expand-ctrl-o': { zh: '（ctrl+o 展开）', en: '(ctrl+o to expand)' },
 
+  // ── components/FileActionsPanel.tsx（点击文件路径弹出的操作菜单）──
+  'file-actions-title': { zh: '文件操作', en: 'File actions' },
+  'file-actions-open': { zh: '打开文件', en: 'Open file' },
+  'file-actions-open-dir': { zh: '打开文件夹', en: 'Open folder' },
+  'file-actions-reveal': { zh: '打开所在文件夹', en: 'Reveal in folder' },
+  'file-actions-copy': { zh: '复制绝对路径', en: 'Copy absolute path' },
+
   // ── components/ModelPicker.tsx / ThemePicker.tsx / ActivityPicker.tsx / EffortSlider.tsx ──
   'picker-title-model': { zh: '模型', en: 'Model' },
   'picker-title-skills': { zh: '技能', en: 'Skills' },

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -69,6 +69,10 @@ import { BtwPanel } from '../components/BtwPanel.js'
 import { TipsPanel } from '../components/TipsPanel.js'
 import { SubagentDashboard } from '../components/SubagentDashboard.js'
 import { SubagentDetailScene } from '../components/SubagentDetailScene.js'
+import { FileActionsPanel, FILE_ACTION_COUNT } from '../components/FileActionsPanel.js'
+import { openExternal, openFile, revealInFileManager } from '../utils/openExternal.js'
+import { fileUrlToPath, parseFileLinkUrl, resolveTargetPath } from '../utils/fileTarget.js'
+import { statSync } from 'node:fs'
 import { setClipboard } from '../ink/termio/osc.js'
 import { TerminalWriteContext } from '../ink/useTerminalNotification.js'
 import instances from '../ink/instances.js'
@@ -424,6 +428,66 @@ export function Chat({
     ink?.invalidatePrevFrame()
     ink?.reanchorViewport()
   }, [])
+
+  /**
+   * Click-to-act targets: the Ink instance's hyperlink-open callback (wired
+   * in the effect below) resolves every clickable target the transcript
+   * renders — http(s) links open the browser, `dsh-file:`/`file://` paths
+   * open the file-action menu. `dsh-file:` payloads are RAW display paths
+   * (possibly relative), so they resolve against the CURRENT channel cwd
+   * at click time (read through a ref so this callback keeps a stable
+   * identity — it is threaded into memoized row components).
+   */
+  const cwdRef = React.useRef(channel.cwd)
+  React.useEffect(() => {
+    cwdRef.current = channel.cwd
+  }, [channel.cwd])
+  const openFileActions = React.useCallback((rawPath: string): void => {
+    const resolved = resolveTargetPath(rawPath, cwdRef.current)
+    // Whether the target is a directory decides the first menu row's label
+    // ("open file" vs "open folder"). Missing paths count as files.
+    let isDir = false
+    try {
+      isDir = statSync(resolved).isDirectory()
+    } catch {
+      isDir = false
+    }
+    dispatchOverlay({ type: 'open', overlay: { kind: 'file-actions', path: resolved, index: 0, isDir } })
+  }, [])
+
+  /** Run one file-action menu row: 0 = open file, 1 = reveal in file
+   *  manager, 2 = copy absolute path. */
+  const runFileAction = React.useCallback((index: number, path: string): void => {
+    if (index === 0) openFile(path)
+    else if (index === 1) revealInFileManager(path)
+    else void setClipboard(path)
+  }, [])
+
+  const handleOpenTarget = React.useCallback((url: string): void => {
+    const rawPath = parseFileLinkUrl(url)
+    if (rawPath !== undefined) {
+      openFileActions(rawPath)
+      return
+    }
+    const filePath = fileUrlToPath(url)
+    if (filePath !== undefined) {
+      openFileActions(filePath)
+      return
+    }
+    openExternal(url)
+  }, [openFileActions])
+
+  // Wire the click-to-open callback into the Ink instance (the field is
+  // otherwise never set — clicking links was a no-op). Re-wired whenever
+  // the handler changes (cwd moves), cleared on unmount.
+  React.useEffect(() => {
+    const ink = instances.get(process.stdout) ?? instances.values().next().value
+    if (ink) ink.onHyperlinkClick = handleOpenTarget
+    return () => {
+      const current = instances.get(process.stdout) ?? instances.values().next().value
+      if (current) current.onHyperlinkClick = undefined
+    }
+  }, [handleOpenTarget])
   /** `/` transcript search (less-style incsearch, ported from CC's REPL).
    *  Only the bar's open/closed mode lives in `overlay`; the query and match
    *  counters persist past the bar closing so n/N keep walking the matches. */
@@ -2320,6 +2384,20 @@ export function Chat({
       }
       return
     }
+    if (overlay.kind === 'file-actions') {
+      // Click-to-act file menu: ↑/↓ move, Enter runs the focused action,
+      // Esc closes.
+      if (key.upArrow || key.downArrow) {
+        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: FILE_ACTION_COUNT })
+      } else if (plainReturn) {
+        const path = overlay.path
+        dispatchOverlay({ type: 'close' })
+        runFileAction(overlay.index, path)
+      } else if (key.escape) {
+        dispatchOverlay({ type: 'close' })
+      }
+      return
+    }
     if (isMod(key) && input === 't') {
       // Ctrl+T opens the trajectory scene at any point in the session.
       openScene()
@@ -2666,6 +2744,7 @@ export function Chat({
           onUnseenCount={setUnseenCount}
           onTimeline={setTimeline}
           onOpenSubagent={(agentId) => setSubagentDetailId(agentId)}
+          onOpenFile={openFileActions}
         />
         </ScrollBox>
         {(() => {
@@ -3084,6 +3163,21 @@ export function Chat({
                   const mode = index === 0 ? null : (overlay.modes?.[index - 1]?.id ?? null)
                   dispatchOverlay({ type: 'close' })
                   void performRewind(row, mode)
+                }}
+              />
+            </Box>
+          )}
+          {overlay.kind === 'file-actions' && (
+            <Box flexDirection="column" marginTop={1}>
+              <FileActionsPanel
+                path={overlay.path}
+                isDir={overlay.isDir}
+                focusIndex={overlay.index}
+                onPick={(index) => {
+                  // 点击行直接执行该动作（与 Enter 同路径）
+                  const path = overlay.path
+                  dispatchOverlay({ type: 'close' })
+                  runFileAction(index, path)
                 }}
               />
             </Box>

--- a/src/screens/chatOverlay.ts
+++ b/src/screens/chatOverlay.ts
@@ -78,6 +78,14 @@ export type ChatOverlay =
   // closing so n/N keep walking the matches (CC semantics).
   | { kind: 'search' }
   | { kind: 'tips' }
+  /**
+   * Click-to-act file menu: opened by clicking a file path in the
+   * transcript (tool cards, markdown code spans / plain text, file://
+   * links). `index` is the focused action row (0 = open, 1 = reveal in
+   * file manager, 2 = copy absolute path). `isDir` tells the panel whether
+   * the target is a directory (first row reads "open folder").
+   */
+  | { kind: 'file-actions'; path: string; index: number; isDir: boolean }
 
 export const NO_OVERLAY: ChatOverlay = { kind: 'none' }
 
@@ -108,7 +116,7 @@ export type ChatOverlayAction =
    *  with the authoritative focus (model list / preset roster), or a mouse
    *  click on a row of a panel that stays open (effort slider, workspace
    *  flow). Ignored unless that panel is still up. */
-  | { type: 'set-index'; kind: 'model' | 'preset' | 'effort' | 'workspace-flow' | 'rewind'; index: number }
+  | { type: 'set-index'; kind: 'model' | 'preset' | 'effort' | 'workspace-flow' | 'rewind' | 'file-actions'; index: number }
   /** Edit the history-search draft (query text, caret, focused match). */
   | { type: 'history-edit'; query?: string; cursor?: number; focus?: number }
   /** Workspace flow: an action is running (keys except Esc are swallowed). */
@@ -176,6 +184,7 @@ export function chatOverlayReducer(state: ChatOverlay, action: ChatOverlayAction
         || state.kind === 'permission'
         || state.kind === 'plan'
         || state.kind === 'lang'
+        || state.kind === 'file-actions'
       ) {
         return { ...state, index: wrapIndex(state.index, action.delta, action.count) }
       }

--- a/src/utils/fileTarget.ts
+++ b/src/utils/fileTarget.ts
@@ -1,0 +1,177 @@
+/**
+ * Clickable file targets: turning path-like text in AI output into
+ * clickable targets, and resolving those targets back to absolute paths at
+ * click time.
+ *
+ * Two URL shapes are produced / accepted:
+ * - `dsh-file:<encodeURIComponent(path)>` — our own scheme. The payload is
+ *   the RAW displayed path (possibly relative, possibly Windows-style), so
+ *   nothing is lost in transit and it resolves against the CURRENT
+ *   workspace at click time (paths in a long-lived session may outlive the
+ *   cwd they were written under).
+ * - `file://…` — real file URLs the model may emit in markdown; decoded
+ *   with node:url and treated the same way.
+ *
+ * `looksLikeFilePath` is deliberately conservative: it must be obviously a
+ * path (slash + no whitespace + anchor or extension), otherwise prose like
+ * "and/or" or "2024/01/15" would light up as clickable everywhere.
+ */
+import { resolve } from 'node:path'
+import { homedir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { existsSync } from 'node:fs'
+
+/** Our custom OSC 8 scheme carrying a raw display path (URI-encoded). */
+export const FILE_LINK_SCHEME = 'dsh-file:'
+
+/** Encode a display path into a `dsh-file:` link URL. */
+export function fileLinkUrl(path: string): string {
+  return FILE_LINK_SCHEME + encodeURIComponent(path)
+}
+
+/**
+ * Decode a `dsh-file:` link URL back to the raw display path. Returns
+ * undefined for anything that is not a well-formed dsh-file URL.
+ */
+export function parseFileLinkUrl(url: string): string | undefined {
+  if (!url.startsWith(FILE_LINK_SCHEME)) return undefined
+  try {
+    return decodeURIComponent(url.slice(FILE_LINK_SCHEME.length))
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Resolve a target (raw display path) against the session's base directory:
+ * absolute paths and `~` pass through (with ~ expanded), everything else is
+ * joined onto the base. Pure, so it is unit-testable without a workspace.
+ */
+export function resolveTargetPath(path: string, baseDir: string): string {
+  if (path === '') return path
+  if (path.startsWith('~/')) return resolve(homedir(), path.slice(2))
+  if (path === '~') return homedir()
+  // Windows drive-absolute (`C:\…`, `C:/…`) is absolute regardless of
+  // platform; node:path.isAbsolute handles the current platform only, so
+  // probe both separators explicitly.
+  if (/^[A-Za-z]:[\\/]/.test(path) || path.startsWith('/') || path.startsWith('\\')) {
+    return path
+  }
+  return resolve(baseDir, path)
+}
+
+/**
+ * Convert a `file://` URL to a local path. Wraps node:url.fileURLToPath —
+ * undefined when the URL is not a valid file URL.
+ */
+export function fileUrlToPath(url: string): string | undefined {
+  try {
+    return fileURLToPath(url)
+  } catch {
+    return undefined
+  }
+}
+
+/** Known source/config/data file extensions — the conservative allowlist. */
+const FILE_EXTENSION_RE = /\.([A-Za-z0-9]{1,6})$/u
+
+/** A path is worth linking when it carries one of these anchors, or has a
+ *  known-extension tail. */
+const PATH_ANCHOR_RE = /^(\.{1,2}[\\/]|[\\/]|~[\\/]|[A-Za-z]:[\\/])/u
+
+/** Stoplist for extension-like tails that are TLDs / prose words, not
+ *  file extensions (`github.com/foo` must not link as a file). */
+const NON_EXTENSION_TAILS = new Set([
+  'com', 'org', 'net', 'io', 'dev', 'app', 'edu', 'gov', 'mil', 'co', 'uk', 'cn',
+])
+
+/** A dot-suffix of up to 6 alphanumerics is a plausible extension when at
+ *  least 4 chars precede it (`a/b.x`-style prose fragments and short
+ *  `x/y.ts` guesses must not false-positive). */
+function hasPlausibleExtension(stripped: string): boolean {
+  const extMatch = FILE_EXTENSION_RE.exec(stripped)
+  if (extMatch === null) return false
+  const ext = extMatch[1]!.toLowerCase()
+  if (NON_EXTENSION_TAILS.has(ext)) return false
+  return stripped.slice(0, extMatch.index).length >= 4
+}
+
+/**
+ * Conservative heuristic: does this text look like a file path worth
+ * making clickable? Requires a slash separator, no whitespace, no URL/email
+ * shape, and either a path anchor (`./`, `../`, `/`, `~/`, drive letter)
+ * with a real path shape (another separator or an extension — a bare
+ * anchored word like `/a` or `x.com/a` is too ambiguous), or a plausible
+ * file extension. Length-capped so huge tokens (base64, logs) never get
+ * linked.
+ */
+export function looksLikeFilePath(text: string): boolean {
+  const t = text.trim()
+  if (t.length < 2 || t.length > 200) return false
+  if (!t.includes('/') && !t.includes('\\')) return false
+  if (/\s/u.test(t)) return false
+  if (/[<>"'`|?*]/.test(t)) return false
+  // URLs (any scheme://, incl. file://) and emails are handled by their
+  // own linkifiers.
+  if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(t) || /^www\./iu.test(t)) return false
+  if (t.includes('@')) return false
+  if (/[#\u0000-\u001f]/u.test(t)) return false
+
+  // Strip one layer of trailing punctuation so "foo/bar.ts." still links.
+  const stripped = t.replace(/[.,;:!?]+$/u, '')
+  if (stripped === '') return false
+  const separators = (stripped.match(/[\\/]/gu) ?? []).length
+  if (PATH_ANCHOR_RE.test(stripped)) {
+    return separators >= 2 || hasPlausibleExtension(stripped)
+  }
+  return hasPlausibleExtension(stripped)
+}
+
+/**
+ * Best-effort existence hint: does `path` exist on disk? Used to decide
+ * whether to render a path as clickable in contexts where the raw text is
+ * ambiguous; never throws.
+ */
+export function pathExistsOnDisk(path: string): boolean {
+  try {
+    return existsSync(path)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Candidate-span scanner: anchored paths (`./`, `../`, `/`, `~/`, drive)
+ * run to the end of the word; everything else must contain a slash AND a
+ * dot-extension tail. This is only a pre-filter — every span is then
+ * verified by `looksLikeFilePath` before it becomes clickable.
+ */
+const PATH_SPAN_RE =
+  /(?:\.{1,2}[\\/]|[\\/]|~[\\/]|[A-Za-z]:[\\/])[^\s<>"'`|?#]*|(?:[^\s<>"'`|?#]*[\\/][^\s<>"'`|?#]*\.[A-Za-z0-9]{1,6})/gu
+
+/**
+ * Replace every path-looking span in `text` via `wrap(path, display)`.
+ * Trailing sentence punctuation stays OUTSIDE the wrapped display (so
+ * "src/foo.ts." links `src/foo.ts` and keeps the period). Spans that fail
+ * `looksLikeFilePath` are returned unchanged.
+ * @param text - plain text to scan (no ANSI).
+ * @param wrap - builds the clickable rendering for one path.
+ */
+export function linkifyFilePaths(
+  text: string,
+  wrap: (path: string, display: string) => string,
+): string {
+  return text.replace(PATH_SPAN_RE, (match, offset, full) => {
+    // The slash-anchor branch would otherwise match inside URLs
+    // (`https:/…` matches `/…`): a span glued to a scheme colon or a `//`
+    // run is part of a URL, never a path. offset is available because the
+    // regex has no capture groups.
+    if (offset > 0) {
+      const prev = full[offset - 1]!
+      if (prev === ':' || prev === '/') return match
+    }
+    const display = match.replace(/[.,;:!?]+$/u, '')
+    if (display === '' || !looksLikeFilePath(display)) return match
+    return wrap(display, display) + match.slice(display.length)
+  })
+}

--- a/src/utils/openExternal.ts
+++ b/src/utils/openExternal.ts
@@ -1,0 +1,172 @@
+/**
+ * Open URLs, files and folders with the platform's default handler, fully
+ * detached from the TUI process (fire-and-forget: no stdio pipes, no wait,
+ * child unref'd so the TUI can exit without waiting for the handler).
+ *
+ * Launch strategy per platform:
+ * - Windows files/URLs: `start` is a cmd.exe builtin, so everything goes
+ *   through `$comspec /d /s /c start "" "<target>"` using the vendored
+ *   cross-spawn quoting (shellQuote.ts) with windowsVerbatimArguments —
+ *   the same protocol externalEditor.ts uses for .cmd shims.
+ * - Windows DIRECTORIES: `powershell (New-Object -ComObject
+ *   Shell.Application).Open('<dir>')`. Explorer's single-instance
+ *   forwarding silently swallows "open folder" requests on many systems
+ *   (field-diagnosed: `start`, raw explorer and `/select,` all dead while
+ *   the COM API works), so folders bypass ShellExecute entirely. This
+ *   powershell child must NOT be spawned detached: libuv maps
+ *   `detached: true` to DETACHED_PROCESS (a console-less process) and in
+ *   that state the Shell.Application Open call silently does nothing
+ *   (field-diagnosed via spawn matrix: detached+hide dead, hide-only
+ *   works) — `windowsHide` alone (CREATE_NO_WINDOW) keeps it invisible
+ *   AND functional.
+ * - macOS: `open` (reveal adds `-R`).
+ * - Linux/other: `xdg-open`.
+ */
+import { spawn } from 'node:child_process'
+import { dirname } from 'node:path'
+import { existsSync, statSync } from 'node:fs'
+import { cmdEscapeArgument } from './shellQuote.js'
+import { logError } from './log.js'
+
+/**
+ * Spawn a fire-and-forget child: no stdio pipes, no wait, unref'd so the
+ * TUI can exit without waiting for the handler. On Windows `detach`
+ * controls the DETACHED_PROCESS flag — it must stay false for the
+ * Shell.Application COM channel (console-less PowerShell swallows the
+ * Open call; see buildWin32OpenSpawn). Failures are logged, never
+ * thrown — an unopenable target (missing handler, sandboxed desktop)
+ * must not disturb the TUI. `onError` lets callers degrade (e.g.
+ * reveal → open parent folder).
+ */
+function spawnDetached(
+  file: string,
+  args: readonly string[],
+  opts: { verbatim?: boolean; detach?: boolean; onError?: () => void } = {},
+): void {
+  const { verbatim = false, detach = true, onError } = opts
+  try {
+    const child = spawn(file, [...args], {
+      stdio: 'ignore',
+      detached: detach,
+      windowsHide: true,
+      windowsVerbatimArguments: verbatim,
+    })
+    child.on('error', error => {
+      logError(error)
+      onError?.()
+    })
+    child.unref()
+  } catch (error) {
+    logError(error)
+    onError?.()
+  }
+}
+
+/**
+ * Windows `start` via cmd.exe: `start "" "<target>"` (the empty quoted
+ * title is mandatory — start would otherwise treat a quoted target as the
+ * window title). Exported for tests: assembly is pure.
+ */
+export function buildWin32StartSpawn(target: string): { file: string; args: string[]; verbatim: true; detach: true } {
+  const line = ['start', cmdEscapeArgument(''), cmdEscapeArgument(target)].join(' ')
+  return {
+    file: process.env.ComSpec || 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${line}"`],
+    verbatim: true,
+    detach: true,
+  }
+}
+
+/** Whether `target` exists on disk as a directory (decides the open
+ *  channel: folders bypass the ShellExecute verb and go through the
+ *  Shell.Application COM API). Never throws. */
+export function isDirectory(target: string): boolean {
+  try {
+    return statSync(target).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The Windows spawn descriptor for opening `target` (pure, testable):
+ * directories go through `powershell (New-Object -ComObject
+ * Shell.Application).Open('<dir>')`, everything else (files, URLs) through
+ * `start`. Explorer's single-instance forwarding silently swallows
+ * "open folder" requests on many systems (diagnosed in the field: `start`,
+ * raw explorer, and `/select,` all dead while the COM API works), so the
+ * COM channel is the reliable folder opener; single quotes in the path are
+ * doubled for the PowerShell literal. The COM descriptor also carries
+ * `detach: false` — a DETACHED_PROCESS (console-less) PowerShell silently
+ * drops the Shell.Application Open call, so the channel only works with
+ * `windowsHide` (CREATE_NO_WINDOW) alone (field-diagnosed spawn matrix:
+ * detached+hide → dead, hide-only → works; start keeps working detached).
+ */
+export function buildWin32OpenSpawn(target: string): { file: string; args: string[]; verbatim: boolean; detach: boolean } {
+  if (isDirectory(target)) {
+    const literal = target.replace(/'/g, "''")
+    return {
+      file: 'powershell.exe',
+      args: ['-NoProfile', '-Command', `(New-Object -ComObject Shell.Application).Open('${literal}')`],
+      verbatim: false,
+      detach: false,
+    }
+  }
+  return buildWin32StartSpawn(target)
+}
+
+/** Open a URL, file or directory with the platform's default handler. */
+export function openExternal(target: string): void {
+  if (target === '') return
+  if (process.platform === 'win32') {
+    const cmd = buildWin32OpenSpawn(target)
+    // If the primary channel cannot even spawn (e.g. PowerShell missing on
+    // an exotic system), fall back to `start` — reliable on healthy boxes.
+    spawnDetached(cmd.file, cmd.args, {
+      verbatim: cmd.verbatim,
+      detach: cmd.detach,
+      onError: () => {
+        if (cmd.file !== (process.env.ComSpec || 'cmd.exe')) {
+          const fb = buildWin32StartSpawn(target)
+          spawnDetached(fb.file, fb.args, { verbatim: fb.verbatim })
+        }
+      },
+    })
+  } else if (process.platform === 'darwin') {
+    spawnDetached('open', [target])
+  } else {
+    spawnDetached('xdg-open', [target])
+  }
+}
+
+/** Open a file with its associated application (openExternal with a file). */
+export function openFile(path: string): void {
+  openExternal(path)
+}
+
+/**
+ * Open the folder containing `filePath` in the platform file manager.
+ *
+ * Windows and Linux open the parent DIRECTORY through openExternal —
+ * Windows routes folders through the Shell.Application COM channel (see
+ * buildWin32OpenSpawn). macOS uses `open -R` to select the file, degrading
+ * to the folder when the file is gone. No-op when neither the file nor its
+ * parent exists (a stale/hallucinated path must not spawn error dialogs).
+ */
+export function revealInFileManager(filePath: string): void {
+  if (filePath === '') return
+  const dir = dirname(filePath)
+  if (process.platform === 'darwin') {
+    if (existsSync(filePath)) {
+      spawnDetached('open', ['-R', filePath], {
+        onError: () => {
+          if (existsSync(dir)) openExternal(dir)
+        },
+      })
+      return
+    }
+    if (existsSync(dir)) openExternal(dir)
+    return
+  }
+  if (existsSync(dir)) openExternal(dir)
+}


### PR DESCRIPTION
## 概要
点击会话正文 / 工具卡中的文件路径，弹出三行操作菜单：打开文件（或文件夹）、打开所在文件夹、复制绝对路径。Enter / Esc / 鼠标均可操作；目录目标首行自动显示打开文件夹。

## 关键修复（本 PR 二轮迭代）
上版打开所在文件夹无响应的根因：spawn `detached: true` 在 Windows 映射为 DETACHED_PROCESS，该状态下 PowerShell 的 `Shell.Application.Open()` 静默无效。现场 spawn 矩阵实证：exec 基线 ✅ / detached+hide ❌ / 仅 windowsHide ✅。修复：COM 通道 `detach:false`（windowsHide 已足够隐藏且功能存活），start 通道保持 detached。

## 验证
- `pnpm build`（含 verify:build 门禁）✅
- channel-ui 组 34 项全过（含新增 verify-clickable-targets、verify-chat-overlay T9）✅
- 端到端实测：openExternal(目录) / revealInFileManager(文件) 均开出资源管理器窗口 ✅
- 用户实机重启 dsh-tui 验证菜单三项可用 ✅