### PR TITLE
feat(cli): dsh-tui update——复用 /update 安装半程（#509 ②/3）

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,11 @@ CLI 子命令（`dsh-tui help` 查看完整用法）：
 
 | 命令 | 作用 |
 |---|---|
+| `dsh-tui update` | 升级 profile 到最新版本并对齐启动器（与 TUI 内 `/update` 同一套安装逻辑，不重启进 TUI） |
 | `dsh-tui version` | 显示启动器与 profile 两侧版本（`--version`/`-v` 等价） |
 | `dsh-tui help` | 显示用法（`--help`/`-h` 等价） |
 
-子命令在未安装 dsh、profile 未初始化时同样可用；其余参数保持原样透传给 `dsh --profile dsh-tui`。仓库根的 `dsh-tui.cmd` 是直连 `dsh --profile` 的启动 wrapper，不含子命令——子命令属于 npm 安装的 `dsh-tui` 命令。
+`help`/`version` 在未安装 dsh、profile 未初始化时同样可用；`update` 需要 dsh（缺失时给出安装指引）；其余参数保持原样透传给 `dsh --profile dsh-tui`。仓库根的 `dsh-tui.cmd` 是直连 `dsh --profile` 的启动 wrapper，不含子命令——子命令属于 npm 安装的 `dsh-tui` 命令。
 
 ### Herdr
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -105,10 +105,11 @@ CLI subcommands (`dsh-tui help` prints the full usage):
 
 | Command | Purpose |
 |---|---|
+| `dsh-tui update` | Update the profile to the latest release and align the launcher (same install logic as the in-TUI `/update`, without restarting into the TUI) |
 | `dsh-tui version` | Show the launcher and profile versions (`--version`/`-v` are equivalent) |
 | `dsh-tui help` | Show usage (`--help`/`-h` are equivalent) |
 
-Subcommands work even when dsh is missing or the profile is not initialized;
+`help`/`version` work even when dsh is missing or the profile is not initialized; `update` needs dsh (a missing dsh gets an install hint);
 every other argument is still forwarded verbatim to `dsh --profile dsh-tui`.
 The repository-root `dsh-tui.cmd` is a launch wrapper that goes straight to
 `dsh --profile` and carries no subcommands — subcommands belong to the

--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -31,7 +31,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const ownDir = dirname(here)
@@ -156,10 +156,19 @@ const MSG = {
     en: '(not installed)',
     zh: '（未安装）',
   },
+  updateUnavailable: {
+    en:
+      `[dsh-tui] \`update\` needs the profile's compiled copy, but it is missing or too old to carry the CLI entry.\n` +
+      `Update manually instead:\n  dsh plugin --profile ${PROFILE} add ${PACKAGE}@latest`,
+    zh:
+      `[dsh-tui] \`update\` 需要 profile 的编译产物，但它缺失或版本过旧、不含 CLI 入口。\n` +
+      `请改用手工升级：\n  dsh plugin --profile ${PROFILE} add ${PACKAGE}@latest`,
+  },
   helpText: {
     en:
       `Usage: dsh-tui [command] [options] [path|url]\n\n` +
       `Commands:\n` +
+      `  update                 Update the ${PROFILE} profile to the latest release\n` +
       `  version                Show launcher and profile versions\n` +
       `  help                   Show this help\n\n` +
       `Options:\n` +
@@ -170,6 +179,7 @@ const MSG = {
     zh:
       `用法：dsh-tui [命令] [选项] [路径|URL]\n\n` +
       `命令：\n` +
+      `  update                 将 ${PROFILE} profile 升级到最新版本\n` +
       `  version                显示启动器与 profile 版本\n` +
       `  help                   显示本帮助\n\n` +
       `选项：\n` +
@@ -281,6 +291,37 @@ const bootstrapProfile = () => {
   }
 }
 
+// ─── 子命令：update ──────────────────────────────────────────────────────────
+// 顶层处理、两种角色同一条路径——不放进委托链。委托会把 update 交给
+// profile 内的旧 bin：旧副本不认识这个词，只会当参数透传，恰好是「profile
+// 落后、最需要升级」的用户永远到不了新入口。这里统一动态 import **profile
+// 的**编译产物（不是本副本的——DSH_TUI_NO_DELEGATE 下两者不同包，读本副本
+// 会拿全局包版本误判 already-latest/half-updated）；瘦壳零 lib 静态依赖的
+// 迁移契约不变。profile 未初始化时先走既有自举（dsh/pnpm 预检在其中）；
+// 编译产物缺失或没有 cliUpdate 导出（半更新的旧版）给手工升级指引退出 1。
+// 判定先于工作区目标嗅探：cwd 里名为 update 的文件不再被当成路径。
+if (subcommand === 'update') {
+  if (!profileReady()) bootstrapProfile()
+  {
+    const probe = spawnSync(...cmd('dsh', ['--version']), { stdio: 'pipe', ...shellOpt })
+    if (probe.error || probe.status !== 0) {
+      console.error(msg('noDsh'))
+      process.exit(1)
+    }
+  }
+  let cliUpdate
+  try {
+    ;({ cliUpdate } = await import(pathToFileURL(join(profilePkgDir, 'lib', 'types', 'update.js')).href))
+  } catch {
+    cliUpdate = undefined
+  }
+  if (typeof cliUpdate !== 'function') {
+    console.error(msg('updateUnavailable'))
+    process.exit(1)
+  }
+  process.exit(await cliUpdate(PROFILE))
+}
+
 // ─── 全局副本：瘦壳角色 ───────────────────────────────────────────────────────
 // DSH_TUI_NO_DELEGATE=1 是测试/调试逃生口：强制走完整逻辑（verify-launcher
 // 的沙箱用它直接驱动全量路径；现场排查委托链时同样可用）。
@@ -310,6 +351,7 @@ if (!runningInsideProfile && ownVersion !== undefined && process.env.DSH_TUI_NO_
       process.exit(1)
     }
   }
+
   let installedVersion
   try {
     installedVersion = JSON.parse(readFileSync(installedPkgPath, 'utf8')).version

--- a/scripts/verify-cli-subcommands.mjs
+++ b/scripts/verify-cli-subcommands.mjs
@@ -98,6 +98,88 @@ for (const alias of ['version', '--version', '-v']) {
   check('profile 已安装时打印 profile 版本', r.status === 0 && r.stdout.includes('1.2.3-stub'))
 }
 
+// --- update（顶层分发：不委托、import profile 的 lib）----------------------------
+{
+  // update 在顶层处理：即使是全局瘦壳，也直接 import **profile 的**编译
+  // 产物执行——委托给旧 profile bin 会让不认识 update 的旧副本把它当参数
+  // 透传（恰好是最需要升级的用户到不了新入口）。用仓库 bin（瘦壳角色）
+  // 驱动，profile 里只放 stub lib，断言：控制权交给 cliUpdate、退出码
+  // 透传、且没有发生委托（stub bin 不存在，委托会 delegateFailed）。
+  const updateHome = join(tmp, 'update-home')
+  const pkgDir = join(updateHome, 'profiles', 'dsh-tui', 'node_modules', '@deepseek-harness-tui', 'dsh-tui')
+  mkdirSync(join(pkgDir, 'lib', 'types'), { recursive: true })
+  writeFileSync(join(pkgDir, 'package.json'), '{"name":"@deepseek-harness-tui/dsh-tui","version":"9.9.9","type":"module"}')
+  writeFileSync(
+    join(pkgDir, 'lib', 'types', 'update.js'),
+    'export async function cliUpdate(profile) { console.log(`stub-cli-update profile=${profile}`); return 42 }\n',
+  )
+  const stubDir = join(tmp, 'stub-bin')
+  mkdirSync(stubDir, { recursive: true })
+  writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\nexit 0\n')
+  ;(await import('node:fs')).chmodSync(join(stubDir, 'dsh'), 0o755)
+  const r = run(['update'], { PATH: stubDir, DSH_HOME: updateHome })
+  check(
+    'update 顶层交给 profile lib 的 cliUpdate 并透传退出码（不经委托）',
+    r.status === 42 && r.stdout.includes('stub-cli-update profile=dsh-tui'),
+    `status=${r.status}`,
+  )
+  // 旧版编译产物：update.js 存在但没有 cliUpdate 导出（半更新残留）——
+  // 必须走同一条双语指引退出 1，而不是解构 undefined 的裸 TypeError。
+  writeFileSync(join(pkgDir, 'lib', 'types', 'update.js'), 'export const somethingElse = 1\n')
+  const r2 = run(['update'], { PATH: stubDir, DSH_HOME: updateHome })
+  check(
+    '旧版 lib 无 cliUpdate 导出时给手工升级指引并退出 1',
+    r2.status === 1 && r2.stderr.includes('dsh plugin --profile dsh-tui add'),
+    `status=${r2.status}`,
+  )
+  // lib 整体缺失（未构建源码/损坏安装）：同一条指引。
+  rmSync(join(pkgDir, 'lib'), { recursive: true, force: true })
+  const r3 = run(['update'], { PATH: stubDir, DSH_HOME: updateHome })
+  check(
+    'lib 缺失时 update 给手工升级指引并退出 1',
+    r3.status === 1 && r3.stderr.includes('dsh plugin --profile dsh-tui add'),
+    `status=${r3.status}`,
+  )
+  // 无 dsh：update 需要 dsh（README 如实声明），止于预检。
+  const r4 = run(['update'], { DSH_HOME: updateHome })
+  check('无 dsh 时 update 止于预检并给安装指引', r4.status === 1 && r4.stderr.includes('@deepseek-ai/dsh'), `status=${r4.status}`)
+  // DSH_TUI_NO_DELEGATE 不改变路径：分发在角色分支之前，import 的仍是
+  // profile 的 lib（不是本副本的——两者版本可能不同，读错包会误判）。
+  mkdirSync(join(pkgDir, 'lib', 'types'), { recursive: true })
+  writeFileSync(
+    join(pkgDir, 'lib', 'types', 'update.js'),
+    'export async function cliUpdate(profile) { console.log(`stub-cli-update profile=${profile}`); return 42 }\n',
+  )
+  const r5 = run(['update'], { PATH: stubDir, DSH_HOME: updateHome, DSH_TUI_NO_DELEGATE: '1' })
+  check('DSH_TUI_NO_DELEGATE 下 update 仍 import profile lib', r5.status === 42 && r5.stdout.includes('stub-cli-update'), `status=${r5.status}`)
+}
+{
+  // 空 profile → 先走既有自举、再 import 自举出的 profile lib。stub dsh 的
+  // plugin 分支模拟真实安装：创建判定文件与带 cliUpdate 的 lib。
+  const bootHome = join(tmp, 'boot-home')
+  mkdirSync(bootHome, { recursive: true })
+  const bootStub = join(tmp, 'boot-stub')
+  mkdirSync(bootStub, { recursive: true })
+  writeFileSync(
+    join(bootStub, 'dsh'),
+    '#!/bin/sh\n' +
+      // 沙箱 PATH 只含 stub 目录——coreutils（mkdir/printf 的外部实现）要
+      // 显式借系统路径，否则 stub 在自己的沙箱里连目录都建不出来。
+      'PATH=/usr/bin:/bin\n' +
+      'if [ "$1" = "plugin" ]; then\n' +
+      '  d="$DSH_HOME/profiles/dsh-tui/node_modules/@deepseek-harness-tui/dsh-tui"\n' +
+      '  mkdir -p "$d/lib/types"\n' +
+      '  printf \'{"name":"@deepseek-harness-tui/dsh-tui","version":"9.9.9","type":"module"}\' > "$d/package.json"\n' +
+      '  printf \'export async function cliUpdate(profile) { console.log(`boot-cli-update profile=${profile}`); return 0 }\' > "$d/lib/types/update.js"\n' +
+      'fi\nexit 0\n',
+  )
+  writeFileSync(join(bootStub, 'pnpm'), '#!/bin/sh\nexit 0\n')
+  ;(await import('node:fs')).chmodSync(join(bootStub, 'dsh'), 0o755)
+  ;(await import('node:fs')).chmodSync(join(bootStub, 'pnpm'), 0o755)
+  const r = run(['update'], { PATH: bootStub, DSH_HOME: bootHome })
+  check('空 profile 时 update 先自举再 import profile lib', r.status === 0 && r.stdout.includes('boot-cli-update profile=dsh-tui'), `status=${r.status}`)
+}
+
 // --- 只认第一个参数 ------------------------------------------------------------
 {
   // 独立的全新 DSH_HOME：前面的用例已在 emptyHome 写入 profile 残骸，
@@ -109,6 +191,7 @@ for (const alias of ['version', '--version', '-v']) {
   for (const [label, args] of [
     ['后位 --help', ['/no/such/path', '--help']],
     ['后位 version', ['/no/such/path', 'version']],
+    ['后位 update', ['/no/such/path', 'update']],
     ['后位 help', ['--resume', 'help']],
   ]) {
     const r = run(args, { DSH_HOME: freshHome })

--- a/scripts/verify-update.mjs
+++ b/scripts/verify-update.mjs
@@ -23,7 +23,7 @@
  *
  * Run: node scripts/verify-update.mjs
  */
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -271,11 +271,14 @@ check(
 )
 // The --latest fallback (preflight failed) can also land on the deadlock
 // range on a stale mirror: the post-install guard must refuse a restart
-// into a version that JUST moved into 0.7.0–0.7.1. Two occurrences = the
-// export plus the call inside updateTuiAndRestart.
+// into a version that JUST moved into 0.7.0–0.7.1. Three occurrences = the
+// export + the post-install guard in updateTui + the CLI preflight refusal
+// in cliUpdate — a plain count would pass with the guard deleted, so pin
+// the guard's own call shape too.
 check(
   'deadlock: post-install guard refuses a fresh landing on the range',
-  (compiledSource.match(/isBootDeadlockTarget/g) ?? []).length >= 2,
+  (compiledSource.match(/isBootDeadlockTarget/g) ?? []).length >= 3
+    && /installedNow !== updatedFrom && isBootDeadlockTarget\(installedNow\)/.test(compiledSource),
 )
 
 // ---- launcher bridge (0.8.3): the compiled runtime must keep the
@@ -422,9 +425,10 @@ try {
 }
 
 // ---- recovery wiring (issue #479): the EEXIST signature and the stale
-// install removal must be reachable from updateTuiAndRestart, and the
-// /update restart tail must ride the hardened restartTui handoff (#483).
-const updateFnStart = compiledSource.indexOf('export async function updateTuiAndRestart')
+// install removal must be reachable from the shared install half (updateTui,
+// which updateTuiAndRestart delegates to), and the /update restart tail must
+// ride the hardened restartTui handoff (#483).
+const updateFnStart = compiledSource.indexOf('export async function updateTui')
 const restartFnStart = compiledSource.indexOf('export async function restartTui')
 const updateSegment = compiledSource.slice(updateFnStart, restartFnStart)
 check(
@@ -443,6 +447,63 @@ check(
   'restartTui: update kind skips the /restart boot-diagnosis marker',
   /kind === 'restart' \? \{ \[RESTART_CHILD_ENV\]: '1' \} : \{\}/.test(compiledSource),
 )
+
+// ---- CLI update（issue #509）：安装半程与 /update 共用同一实现 ----------------
+// updateTui 是 updateTuiAndRestart 的安装半程，cliUpdate 是 bin 启动器
+// 动态 import 的无头入口——两者必须存在于编译产物，且 updateTuiAndRestart
+// 委托 updateTui 而不是保留一份拷贝（DRY 契约：装机逻辑只有一份）。
+{
+  const mod = await import('../lib/types/update.js')
+  check('cli: updateTui is exported from the compiled lib', typeof mod.updateTui === 'function')
+  check('cli: cliUpdate is exported from the compiled lib', typeof mod.cliUpdate === 'function')
+  check(
+    'cli: updateTuiAndRestart delegates to updateTui (single install path)',
+    /updateTuiAndRestart[\s\S]{0,400}await updateTui\(/.test(compiledSource),
+  )
+}
+
+// ---- cli: 真实 cliUpdate 的「版本未前进」路径（预检失败 + --latest no-op）------
+// 拷贝的编译模块 + 版本固定的 manifest：registry 指向必然拒绝连接的地址
+// （预检 → unknown → --latest 兜底），stub dsh 什么都不装、返回 0。安装前后
+// installedTuiVersion 相同——必须如实打印 version did not advance，绝不打印
+// 虚假的 updated X → X。真实模块、真实子进程，只有网络与 dsh 是假的。
+{
+  const scratch3 = mkdtempSync(join(tmpdir(), 'verify-update-cli-'))
+  const ENV_BACKUP = { reg: process.env.NPM_CONFIG_REGISTRY, regL: process.env.npm_config_registry, path: process.env.PATH }
+  try {
+    symlinkSync(join(repoRoot, 'node_modules'), join(scratch3, 'node_modules'))
+    const pkgRoot = join(scratch3, 'pkg')
+    copyUpdateModule(join(pkgRoot, 'lib', 'types'))
+    writeFileSync(join(pkgRoot, 'package.json'), JSON.stringify({ name: '@deepseek-harness-tui/dsh-tui', version: '2.0.0', type: 'module' }))
+    const stubDir = join(scratch3, 'stub-bin')
+    mkdirSync(stubDir, { recursive: true })
+    writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\nexit 0\n')
+    chmodSync(join(stubDir, 'dsh'), 0o755)
+    process.env.NPM_CONFIG_REGISTRY = 'http://127.0.0.1:1'
+    delete process.env.npm_config_registry
+    process.env.PATH = stubDir
+    const cliMod = await import(`${pathToFileURL(join(pkgRoot, 'lib', 'types', 'update.js'))}?probe=cli`)
+    let captured = ''
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = chunk => { captured += String(chunk); return true }
+    let code
+    try {
+      code = await cliMod.cliUpdate('dsh-tui')
+    } finally {
+      process.stdout.write = origWrite
+    }
+    check('cli: no-op --latest 兜底以 0 退出', code === 0, `code=${code}`)
+    check('cli: 版本未前进时如实提示', captured.includes('version did not advance'), JSON.stringify(captured.slice(0, 120)))
+    check('cli: 不打印虚假的 updated X → X', !captured.includes('updated 2.0.0'))
+  } finally {
+    if (ENV_BACKUP.reg === undefined) delete process.env.NPM_CONFIG_REGISTRY
+    else process.env.NPM_CONFIG_REGISTRY = ENV_BACKUP.reg
+    if (ENV_BACKUP.regL === undefined) delete process.env.npm_config_registry
+    else process.env.npm_config_registry = ENV_BACKUP.regL
+    process.env.PATH = ENV_BACKUP.path
+    rmSync(scratch3, { recursive: true, force: true })
+  }
+}
 
 if (failed > 0) {
   console.error(`\n${failed} check(s) failed`)

--- a/src/update.ts
+++ b/src/update.ts
@@ -478,29 +478,31 @@ export function migrateGlobalLauncher(): boolean {
   return false
 }
 
+/** Outcome of the install-only half of an update (no restart). */
+export interface TuiUpdateOutcome {
+  /** 0 = the profile now runs the intended version; non-zero = failed. */
+  code: number
+  /** Version installed before the update ran (the #307 stamp). */
+  updatedFrom: string
+  /** Version installed after the update ran, when readable. */
+  installed?: string
+}
+
 /**
- * Update the installed dsh-tui package and restart the same launcher while
- * preserving the active session. The TUI must already be unmounted before
- * this is called so pnpm output cannot corrupt the rendered terminal frame.
+ * Install-only half of `/update`: run `dsh plugin add`, refuse boot-deadlock
+ * targets, verify the profile actually advanced, and migrate the global
+ * launcher. No restart — `updateTuiAndRestart` layers the session-preserving
+ * restart on top, and the `dsh-tui update` CLI stops here.
  *
- * When the preflight registry check resolved an exact target, pass that
- * version to pnpm instead of resolving `latest` a second time. This avoids a
- * stale mirror/dist-tag response between the check and install. If preflight
- * failed, retain the `--latest` fallback: a plain `pnpm update` stays inside
- * the manifest range and can restart unchanged across minor releases.
- *
- * @param sessionId - Session to resume in the replacement process.
- * @param profile - The dsh profile this TUI was launched with; updating any
- *   other profile would leave the running install untouched.
- * @param targetVersion - Exact version returned by the preflight registry
- *   check, or undefined when that check failed and pnpm should resolve latest.
- * @returns Exit codes for the update run and the replacement process.
+ * @param profile - The dsh profile to update.
+ * @param targetVersion - Exact version from the preflight registry check, or
+ *   undefined when that check failed and pnpm should resolve latest.
+ * @returns The update exit code plus the before/after versions.
  */
-export async function updateTuiAndRestart(
-  sessionId: string,
+export async function updateTui(
   profile: string,
   targetVersion?: string,
-): Promise<TuiUpdateResult> {
+): Promise<TuiUpdateOutcome> {
   // Stamp the pre-update version BEFORE pnpm runs: it reads this package's
   // manifest from disk, which the update replaces on the fly — a
   // post-update read already sees the NEW version, and the restarted
@@ -537,7 +539,7 @@ export async function updateTuiAndRestart(
     updateStderr = ''
     updateCode = await runProcess(dsh, updateArgs, { shell: true, onStderr: capture })
   }
-  if (updateCode !== 0) return { updateCode, restartCode: updateCode }
+  if (updateCode !== 0) return { code: updateCode, updatedFrom }
 
   // A --latest fallback (preflight failed) on a stale mirror can still land
   // on the 0.7.0–0.7.1 hard-inject range — restarting into it under an older
@@ -553,7 +555,7 @@ export async function updateTuiAndRestart(
         `  dsh plugin --profile ${profile} add ${PACKAGE_NAME}@latest\n` +
         `(if the mirror has not synced the latest release yet, retry later)\n`,
     )
-    return { updateCode: 1, restartCode: 1 }
+    return { code: 1, updatedFrom, installed: installedNow }
   }
 
   // Post-update verification (issue #225): pnpm can report success yet leave
@@ -573,7 +575,7 @@ export async function updateTuiAndRestart(
           `(expected ${targetVersion}) — the profile is half-updated. Repair manually with:\n` +
           `  dsh plugin --profile ${profile} add ${PACKAGE_NAME}@${targetVersion}\n`,
       )
-      return { updateCode: 1, restartCode: 1 }
+      return { code: 1, updatedFrom, installed }
     }
   }
 
@@ -584,6 +586,36 @@ export async function updateTuiAndRestart(
   if (migrateGlobalLauncher()) {
     process.stderr.write('dsh-tui: global launcher aligned to the delegating shim (no manual npm i -g needed anymore).\n')
   }
+
+  return { code: 0, updatedFrom, installed: installedTuiVersion() }
+}
+
+/**
+ * Update the installed dsh-tui package and restart the same launcher while
+ * preserving the active session. The TUI must already be unmounted before
+ * this is called so pnpm output cannot corrupt the rendered terminal frame.
+ *
+ * When the preflight registry check resolved an exact target, pass that
+ * version to pnpm instead of resolving `latest` a second time. This avoids a
+ * stale mirror/dist-tag response between the check and install. If preflight
+ * failed, retain the `--latest` fallback: a plain `pnpm update` stays inside
+ * the manifest range and can restart unchanged across minor releases.
+ *
+ * @param sessionId - Session to resume in the replacement process.
+ * @param profile - The dsh profile this TUI was launched with; updating any
+ *   other profile would leave the running install untouched.
+ * @param targetVersion - Exact version returned by the preflight registry
+ *   check, or undefined when that check failed and pnpm should resolve latest.
+ * @returns Exit codes for the update run and the replacement process.
+ */
+export async function updateTuiAndRestart(
+  sessionId: string,
+  profile: string,
+  targetVersion?: string,
+): Promise<TuiUpdateResult> {
+  const outcome = await updateTui(profile, targetVersion)
+  const { updatedFrom } = outcome
+  if (outcome.code !== 0) return { updateCode: outcome.code, restartCode: outcome.code }
 
   // Restart through the same hardened handoff as /restart (issues
   // #284/#307/#483): wait for the replacement's natural exit (the outer
@@ -596,7 +628,64 @@ export async function updateTuiAndRestart(
     env: { [UPDATED_FROM_ENV]: updatedFrom },
     kind: 'update',
   })
-  return { updateCode, restartCode }
+  return { updateCode: 0, restartCode }
+}
+
+/**
+ * Headless `dsh-tui update`: the `/update` decision flow (preflight, deadlock
+ * refusal, mirror-lag note, `--latest` fallback) followed by the install-only
+ * half — no TUI, no restart. The bin launcher dynamic-imports this from the
+ * profile copy's compiled lib.
+ *
+ * @param profile - The dsh profile to update.
+ * @returns Process exit code: 0 on success or already-latest, 1 otherwise.
+ */
+export async function cliUpdate(profile: string): Promise<number> {
+  const target = await resolveTuiUpdateTarget()
+  if (target.kind === 'latest') {
+    process.stdout.write(`dsh-tui: already the latest version (${target.current}).\n`)
+    return 0
+  }
+  let targetVersion: string | undefined
+  if (target.kind === 'update') {
+    // Mirror the /update flow exactly: refuse the 0.7.0–0.7.1 hard-inject
+    // range (permanent boot deadlock under older launcher patches, #183/#307)
+    // instead of installing it.
+    if (isBootDeadlockTarget(target.latest)) {
+      process.stderr.write(
+        `dsh-tui: refusing to update onto ${target.latest} — that range can permanently deadlock boot ` +
+          `(#183/#307). Latest on the official registry: ${target.authoritative ?? target.latest}. ` +
+          `If you use a mirror, retry after it syncs.\n`,
+      )
+      return 1
+    }
+    if (target.authoritative !== undefined) {
+      process.stdout.write(
+        `dsh-tui: note — your registry serves ${target.latest} while npmjs.org has ${target.authoritative} (mirror lag).\n`,
+      )
+    }
+    targetVersion = target.latest
+    process.stdout.write(`dsh-tui: updating ${target.current} → ${target.latest}…\n`)
+  } else {
+    process.stdout.write('dsh-tui: version check failed (offline or unreadable install) — falling back to `--latest`.\n')
+  }
+  const outcome = await updateTui(profile, targetVersion)
+  if (outcome.code === 0) {
+    // A preflight-less run (`--latest` fallback) can "succeed" as a pnpm
+    // no-op: same manifest before and after. Say so instead of printing a
+    // vacuous `updated X → X` — the /update path surfaces the same state via
+    // the DSH_TUI_UPDATED_FROM stamp on restart.
+    if (targetVersion === undefined && outcome.installed !== undefined && outcome.installed === outcome.updatedFrom) {
+      process.stdout.write(
+        `dsh-tui: version did not advance (still ${outcome.installed}) — already the latest, or the registry has no newer release yet.\n`,
+      )
+    } else {
+      process.stdout.write(
+        `dsh-tui: updated ${outcome.updatedFrom || '(unknown)'} → ${outcome.installed ?? '(unreadable)'}.\n`,
+      )
+    }
+  }
+  return outcome.code
 }
 
 /**


### PR DESCRIPTION
**依赖 #514**（stacked：diff 含 #514 的 commit，只需 review 最后一个 commit `97b9598`；#514 合并后我会 rebase 收窄）。

## 动机

升级此前只能在 TUI 内 `/update`。TUI 因旧版本问题起不来时（#284/#483/#479 的现场），用户只能手敲 `dsh plugin` 命令自救；脚本化升级也没有入口。

## 改动

**src/update.ts**：把 `updateTuiAndRestart` 拆成两半——`updateTui` 承担安装半程（`dsh plugin add`、Windows tmp-rename 瞬态重试 #225、0.7.0–0.7.1 死锁目标拒绝 #183/#307、半更新校验、启动器迁移），`updateTuiAndRestart` 在其上叠加保会话重启。`/update` 行为不变，安装逻辑只有一份。新增 `cliUpdate`：`/update` 的决策流（预检、already-latest 短路、镜像滞后提示、`--latest` 兜底）接安装半程；预检失败且安装后版本未变时如实打印 version did not advance，不打印虚假的 updated X → X。

**bin/dsh-tui.js**：`update` 在顶层分发、两种角色同一条路径，动态 import **profile 的**编译产物执行。三个理由：

1. 不能走委托——旧 profile bin 不认识 `update`，只会当参数透传，恰好是「profile 落后、最需要升级」的用户到不了新入口；
2. 读 profile 的 lib 而非本副本的——`DSH_TUI_NO_DELEGATE` 与全局角色下两者不是同一个包，读错会误判 already-latest / half-updated；
3. 以全局命令运行时 `process.argv[1]` 指向全局 bin，`migrateGlobalLauncher` 的对齐路径可达。

瘦壳零 lib 静态依赖的迁移契约不变（无静态 import；profile 的 lib 与其 bin 同版本共存）。profile 未初始化先走既有自举；编译产物缺失或过旧（无 `cliUpdate` 导出）给双语手工升级指引退出 1。子命令判定先于工作区目标嗅探——cwd 里名为 `update` 的文件现在按命令处理（要打开同名目录传 `./update`）。

`cliUpdate` 的运行期输出沿用 `src/update.ts` 既有的英文惯例（与 `updateTuiAndRestart` 的现有输出一致）；bin 侧新增文案全部走 MSG 双语表。

## 验证

- `verify-update.mjs`：新增导出断言、单一安装路径断言（`updateTuiAndRestart` 委托 `updateTui`）、**真实 `cliUpdate` 的 no-op fixture**（registry 指向拒绝连接地址 → `--latest` 兜底 → stub dsh no-op → 断言打印 version did not advance）；对编译产物的顺序断言（dsh spawn 先于 node spawn、`[UPDATED_FROM_ENV]: updatedFrom`）原样通过；deadlock 计数收紧到 ≥3 并锚定安装后 guard 的调用形状（原 ≥2 在删除 guard 后仍会通过）。
- `verify-cli-subcommands.mjs`：新增 7 例——顶层接线不经委托、退出码透传、旧版 lib 无导出、lib 缺失、无 dsh 预检、`DSH_TUI_NO_DELEGATE` 仍 import profile lib、空 profile 先自举再 import、后位 `update` 不截获。
- `verify-launcher.mjs`、`verify:build` 全套、`verify:package` 全绿。
- README 中英同步：`update` 行 + 如实声明 `update` 需要 dsh（`help`/`version` 零环境可用）。

## 经过两轮 Codex 审查

第一轮 6 条相关意见（委托吞掉 update【blocking】、NO_DELEGATE 读错包、migrate 不可达、旧 lib 裸 TypeError、no-advance 误报成功、README 过度声明）全部修复；第二轮确认实现无运行时缺陷，指出的 2 条测试覆盖缺口（no-advance 真实回归、dispatch 组合覆盖）已补齐。

留给维护者的一条：`cliUpdate` 与 `/update`（plugin.ts）各自持有 latest/unknown/deadlock 分支的一份决策代码，只共享安装半程。抽一个共享的 update-plan helper 需要动 plugin.ts 的 UI 通知流，本 PR 未做。