### PR TITLE
feat(cli): dsh-tui doctor——启动前环境诊断（#509 ③/3）

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ CLI 子命令（`dsh-tui help` 查看完整用法）：
 | 命令 | 作用 |
 |---|---|
 | `dsh-tui update` | 升级 profile 到最新版本并对齐启动器（与 TUI 内 `/update` 同一套安装逻辑，不重启进 TUI） |
+| `dsh-tui doctor` | 启动前环境诊断：dsh/pnpm、profile 安装与版本对齐、密钥是否已设置（只报状态不报值）、配置文件存在性；与 TUI 内 `/doctor` 的会话内诊断互补 |
 | `dsh-tui version` | 显示启动器与 profile 两侧版本（`--version`/`-v` 等价） |
 | `dsh-tui help` | 显示用法（`--help`/`-h` 等价） |
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -106,6 +106,7 @@ CLI subcommands (`dsh-tui help` prints the full usage):
 | Command | Purpose |
 |---|---|
 | `dsh-tui update` | Update the profile to the latest release and align the launcher (same install logic as the in-TUI `/update`, without restarting into the TUI) |
+| `dsh-tui doctor` | Pre-flight environment checks: dsh/pnpm, profile install and version alignment, whether the API key is set (state only, never the value), config file presence; complements the in-TUI `/doctor` session diagnostics |
 | `dsh-tui version` | Show the launcher and profile versions (`--version`/`-v` are equivalent) |
 | `dsh-tui help` | Show usage (`--help`/`-h` are equivalent) |
 

--- a/bin/dsh-tui.js
+++ b/bin/dsh-tui.js
@@ -156,6 +156,30 @@ const MSG = {
     en: '(not installed)',
     zh: '（未安装）',
   },
+  doctorLabels: {
+    en: {
+      dshMissing: 'not found — install it first:  npm install -g @deepseek-ai/dsh',
+      pnpmMissing: 'not found — needed for install/update:  npm install -g pnpm',
+      profileMissing: 'not installed — run `dsh-tui` once to bootstrap it',
+      aligned: 'aligned',
+      profileNewer: v => `profile is newer — align the launcher:  npm install -g ${PACKAGE}@${v}`,
+      profileOlder: v => `profile is older — align it:  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${v}`,
+      keySet: 'set',
+      keyMissing: 'not set — interactive launch reads DEEPSEEK_API_KEY',
+      missing: 'missing',
+    },
+    zh: {
+      dshMissing: '未找到——请先安装：  npm install -g @deepseek-ai/dsh',
+      pnpmMissing: '未找到——安装/升级需要它：  npm install -g pnpm',
+      profileMissing: '未安装——运行一次 `dsh-tui` 即可自举',
+      aligned: '已对齐',
+      profileNewer: v => `profile 较新——对齐启动器：  npm install -g ${PACKAGE}@${v}`,
+      profileOlder: v => `profile 较旧——对齐它：  dsh plugin --profile ${PROFILE} add ${PACKAGE}@${v}`,
+      keySet: '已设置',
+      keyMissing: '未设置——交互启动读取 DEEPSEEK_API_KEY',
+      missing: '缺失',
+    },
+  },
   updateUnavailable: {
     en:
       `[dsh-tui] \`update\` needs the profile's compiled copy, but it is missing or too old to carry the CLI entry.\n` +
@@ -169,6 +193,7 @@ const MSG = {
       `Usage: dsh-tui [command] [options] [path|url]\n\n` +
       `Commands:\n` +
       `  update                 Update the ${PROFILE} profile to the latest release\n` +
+      `  doctor                 Pre-flight environment checks (dsh/pnpm/profile/key)\n` +
       `  version                Show launcher and profile versions\n` +
       `  help                   Show this help\n\n` +
       `Options:\n` +
@@ -180,6 +205,7 @@ const MSG = {
       `用法：dsh-tui [命令] [选项] [路径|URL]\n\n` +
       `命令：\n` +
       `  update                 将 ${PROFILE} profile 升级到最新版本\n` +
+      `  doctor                 启动前环境诊断（dsh/pnpm/profile/密钥）\n` +
       `  version                显示启动器与 profile 版本\n` +
       `  help                   显示本帮助\n\n` +
       `选项：\n` +
@@ -226,6 +252,60 @@ if (subcommand === 'version' || subcommand === '--version' || subcommand === '-v
 if (subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
   console.log(msg('helpText'))
   process.exit(0)
+}
+// ─── 子命令：doctor ──────────────────────────────────────────────────────────
+// 启动前环境诊断——针对「TUI 起不来」的故障域（装不上、update 后版本不
+// 同步、密钥没配），与 TUI 内 /doctor 的会话内诊断互补。零 lib 依赖、
+// 不委托、不自举：profile 残缺时它必须还能跑。密钥红线：只报告是否已
+// 设置，绝不输出值。仅 dsh 缺失记为硬失败（其余检查全部照常打印后再
+// 以退出码 1 收束）。
+if (subcommand === 'doctor') {
+  const L = msg('doctorLabels')
+  let hardFailure = false
+  const report = (ok, label, detail) => console.log(`${ok ? '✓' : '✗'} ${label}: ${detail}`)
+  console.log(`dsh-tui doctor · ${PACKAGE} ${ownVersion ?? 'unknown'}`)
+  report(true, 'node', `${process.version} · ${process.platform} ${process.arch}`)
+  const probeVersion = command => {
+    const probe = spawnSync(...cmd(command, ['--version']), { stdio: 'pipe', encoding: 'utf8', ...shellOpt })
+    if (probe.error || probe.status !== 0) return undefined
+    // 白名单校验：只回显版本号形状的首行。诊断输出的红线是绝不泄露密钥，
+    // 而 PATH 上的 wrapper 理论上可以把任意环境变量 echo 进 --version——
+    // 不匹配版本形状的输出一律不转印。
+    const line = String(probe.stdout ?? '').trim().split('\n')[0] ?? ''
+    return /^v?\d[\w.+-]*$/.test(line) ? line : '(version unreadable)'
+  }
+  const dshVersion = probeVersion('dsh')
+  if (dshVersion === undefined) {
+    hardFailure = true
+    report(false, 'dsh', L.dshMissing)
+  } else {
+    report(true, 'dsh', dshVersion)
+  }
+  const pnpmVersion = probeVersion('pnpm')
+  report(pnpmVersion !== undefined, 'pnpm', pnpmVersion ?? L.pnpmMissing)
+  const profileVersion = readJson(installedPkgPath)?.version
+  if (profileVersion === undefined) {
+    report(false, 'profile', `${L.profileMissing}  (${profileDir})`)
+  } else {
+    report(true, 'profile', `${profileVersion}  (${profileDir})`)
+    if (ownVersion !== undefined && !runningInsideProfile) {
+      if (profileVersion === ownVersion) {
+        report(true, 'launcher ↔ profile', L.aligned)
+      } else if (isVersionNewer(profileVersion, ownVersion)) {
+        report(false, 'launcher ↔ profile', L.profileNewer(profileVersion))
+      } else {
+        report(false, 'launcher ↔ profile', L.profileOlder(ownVersion))
+      }
+    }
+  }
+  // truthiness 而非 !== undefined：空字符串的 key 同样发不了请求，且 TUI 内
+  // /doctor（channel.doctorInfo）按 truthiness 报告——两个 doctor 不许分叉。
+  const keySet = Boolean(process.env.DEEPSEEK_API_KEY)
+  report(keySet, 'DEEPSEEK_API_KEY', keySet ? L.keySet : L.keyMissing)
+  for (const candidate of [join(homedir(), '.dsh-tui', 'cordis.yml'), join(profileDir, 'cordis.patch.yml')]) {
+    report(existsSync(candidate), 'config', `${candidate}${existsSync(candidate) ? '' : `  ${L.missing}`}`)
+  }
+  process.exit(hardFailure ? 1 : 0)
 }
 
 const forwardExit = child => {

--- a/scripts/verify-cli-subcommands.mjs
+++ b/scripts/verify-cli-subcommands.mjs
@@ -180,6 +180,48 @@ for (const alias of ['version', '--version', '-v']) {
   check('空 profile 时 update 先自举再 import profile lib', r.status === 0 && r.stdout.includes('boot-cli-update profile=dsh-tui'), `status=${r.status}`)
 }
 
+// --- doctor -------------------------------------------------------------------
+{
+  // 无 dsh：诊断照常打印全表，但以退出码 1 收束（dsh 缺失是唯一硬失败）。
+  const r = run(['doctor'])
+  check('doctor 无 dsh 时退出 1 且标注缺失', r.status === 1 && r.stdout.includes('✗ dsh'), `status=${r.status}`)
+}
+{
+  // stub dsh/pnpm：退出 0；profile 已装（前面的用例写入了 1.2.3-stub）；
+  // 密钥红线——设置了值时只报告状态，stdout 绝不含密钥本身。
+  const stubDir = join(tmp, 'doctor-stub')
+  mkdirSync(stubDir, { recursive: true })
+  writeFileSync(join(stubDir, 'dsh'), '#!/bin/sh\necho 9.9.9-dsh-stub\nexit 0\n')
+  writeFileSync(join(stubDir, 'pnpm'), '#!/bin/sh\necho 9.9.9-pnpm-stub\nexit 0\n')
+  ;(await import('node:fs')).chmodSync(join(stubDir, 'dsh'), 0o755)
+  ;(await import('node:fs')).chmodSync(join(stubDir, 'pnpm'), 0o755)
+  const SECRET = 'sk-hunt-secret-marker'
+  const r = run(['doctor'], { PATH: stubDir, DEEPSEEK_API_KEY: SECRET })
+  check('doctor 有 dsh/pnpm 时退出 0 并打印版本', r.status === 0 && r.stdout.includes('9.9.9-dsh-stub') && r.stdout.includes('9.9.9-pnpm-stub'), `status=${r.status}`)
+  check('doctor 报告 profile 版本', r.stdout.includes('1.2.3-stub'))
+  check('doctor 报告密钥已设置', r.stdout.includes('已设置'))
+  check('doctor 绝不输出密钥值（红线）', !r.stdout.includes(SECRET) && !r.stderr.includes(SECRET))
+  const r2 = run(['doctor'], { PATH: stubDir })
+  check('doctor 报告密钥未设置', r2.status === 0 && r2.stdout.includes('未设置'))
+  // 版本错位提示：profile(1.2.3-stub) vs 启动器(ownVersion)——不对齐时给指引。
+  check('doctor 报告启动器与 profile 版本错位', r2.stdout.includes('launcher ↔ profile') && r2.stdout.includes('✗'))
+  // 空字符串密钥：发不了请求，且 TUI 内 /doctor 按 truthiness 报未配置——
+  // 两个 doctor 结论必须一致。
+  const r3 = run(['doctor'], { PATH: stubDir, DEEPSEEK_API_KEY: '' })
+  check('doctor 空字符串密钥按未设置报告', r3.stdout.includes('未设置'))
+  // 探针输出白名单：PATH 上的 wrapper 把环境变量 echo 进 --version 时，
+  // 非版本形状的首行不得转印（密钥红线的探针侧）。
+  const leakDir = join(tmp, 'doctor-leak-stub')
+  mkdirSync(leakDir, { recursive: true })
+  writeFileSync(join(leakDir, 'dsh'), '#!/bin/sh\necho "$DEEPSEEK_API_KEY"\nexit 0\n')
+  ;(await import('node:fs')).chmodSync(join(leakDir, 'dsh'), 0o755)
+  const r4 = run(['doctor'], { PATH: leakDir, DEEPSEEK_API_KEY: SECRET })
+  check(
+    'doctor 探针输出非版本形状时不转印（wrapper 泄密场景）',
+    !r4.stdout.includes(SECRET) && !r4.stderr.includes(SECRET) && r4.stdout.includes('(version unreadable)'),
+  )
+}
+
 // --- 只认第一个参数 ------------------------------------------------------------
 {
   // 独立的全新 DSH_HOME：前面的用例已在 emptyHome 写入 profile 残骸，


### PR DESCRIPTION
**依赖 #514、#515**（stacked：只需 review 最后一个 commit `c732334`；前序合并后我会 rebase 收窄）。

## 动机

安装/升级故障是仓库最大的 issue 类别（#430/#459/#392/#338/#284/#479/#483）。这些场景 TUI 起不来，TUI 内的 `/doctor` 够不着——它需要一个已成功启动的会话。两个 doctor 同名互补：CLI 侧管启动前，`/doctor` 管会话内。

## 改动

`bin/dsh-tui.js` 新增 `doctor`：零 lib 依赖、不委托、不自举（profile 残缺时诊断命令必须还能跑），探测复用 bin 内既有的 `cmd`/`shellOpt`/`isVersionNewer` 内联工具。检查项：

- node 版本与平台；
- dsh / pnpm 是否可用及版本；
- profile 是否安装；启动器与 profile 版本对齐（错位时给方向性对齐命令）；
- `DEEPSEEK_API_KEY` 是否已设置；
- 两个配置文件候选的存在性。

全表打印完后才收束退出码：仅 dsh 缺失记为硬失败（退出 1），其余为提示。

密钥红线（只报状态、绝不输出值）的两道防线：

1. 状态判定按 truthiness——空字符串同样报未设置，与 TUI 内 `/doctor`（`channel.doctorInfo`）的判定一致，两个 doctor 不分叉；
2. `--version` 探针输出经版本形状白名单（`/^v?\d[\w.+-]*$/`）过滤——PATH 上的 wrapper 把环境变量 echo 进探针时，非版本形状的首行不转印，只显示 (version unreadable)。

## 验证

`verify-cli-subcommands.mjs` 新增 8 例：无 dsh 硬失败、stub 版本打印、profile 版本与错位提示、密钥已设/未设/空串、密钥值绝不出现在任何输出、wrapper 泄密场景不转印。`verify-launcher.mjs`、`verify:build`、`verify:package` 全绿。README 中英同步补 `doctor` 行与 help 文本。

## 经过两轮 Codex 审查

第一轮 2 条相关意见（探针可转印 wrapper stdout【按密钥红线处理】、空字符串 key 与 `/doctor` 结论漂移）均已修复并有对应回归；第二轮判定本 commit 相对其父 merge-ready。