### PR TITLE
fix(transcript): 叙述-only 步骤渲染为孤立 ● —— 空行过滤改测剥叙述后的文本

### DIFF
--- a/scripts/verify-empty-assistant.tsx
+++ b/scripts/verify-empty-assistant.tsx
@@ -61,7 +61,13 @@ const rows: any[] = [
   { id: 0, kind: 'user', text: '帮我跑一下测试' },
   // 空文本 settled assistant（PR #383 的 bug 形状：模型直接调工具）
   { id: 1, kind: 'assistant', text: '', streaming: false },
+  // 叙述-only settled assistant（narrate 契约：⏵ 行 + 直接调工具）。
+  // 原文非空但渲染层 stripNarration 剥成空——旧过滤器测原文漏放行，
+  // 渲染成工具卡上方的孤立 ●（用户实测报告的形状）。
+  { id: 6, kind: 'assistant', text: '⏵ 正在跑测试', streaming: false },
   { id: 2, kind: 'tool', text: '', tool: { callId: 't1', name: 'Bash', argsText: '{"command": "npm test"}', argsFull: '{}', status: 'ok', startedAt: 0, durationMs: 42, resultText: 'all 12 tests passed' } },
+  // ⏵ 行 + 正文：叙述被剥但正文必须完整保留（不能误过滤）
+  { id: 7, kind: 'assistant', text: '⏵ 正在分析结果\n\n工具结果看起来全部通过 REALBODY2-END', streaming: false },
   { id: 3, kind: 'assistant', text: '测试全部通过，共 12 项。REALBODY-END', streaming: false },
   // 空文本但 streaming：必须保留（live dot）
   { id: 4, kind: 'assistant', text: '', streaming: true },
@@ -104,10 +110,14 @@ await sleep(700)
     '')
   check('工具卡正常渲染', screen.includes('Bash'), '')
   check('真实正文正常渲染', screen.includes('REALBODY-END'), '')
+  check('叙述-only settled 行被过滤（⏵ 行不渲染、上方无孤立 ●）', !screen.includes('⏵') && !dotAboveTool, '')
+  check('⏵ 行 + 正文混合行保留正文', screen.includes('REALBODY2-END'), '')
 }
 
-// 落定翻转：streaming true → false 原地写（rows 身份/长度不变）
-rows[4]!.streaming = false
+// 落定翻转：streaming true → false 原地写（rows 身份/长度不变）。
+// 按 id 定位流式行——数组顺序在该脚本演化过，索引翻转曾错翻到别的行。
+const streamRow = rows.find(r => r.id === 4)!
+streamRow.streaming = false
 channel.emit()
 await sleep(500)
 {

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -315,16 +315,24 @@ export function MessageList({
     // that is STILL STREAMING keeps its place even with empty text — the
     // live dot is the "model is answering" affordance and content may yet
     // arrive.
+    // The emptiness test must match what RENDERING shows: the `⏵`
+    // self-narration line (dsh-working-activity narrate contract) is
+    // stripped at render (stripNarration below), so a narration-only step —
+    // thinking, `⏵ …` line, straight to a tool call — has non-empty raw
+    // text but RENDERS as that same lone `●`. Test the stripped text, or
+    // the raw-text check lets the dot through forever.
+    const rendersEmptyAssistant = (row: ChatRow): boolean =>
+      row.kind === 'assistant' && row.streaming !== true && stripNarration(row.text ?? '').trim() === ''
     let hasEmptyAssistant = false
     for (const row of sliced) {
-      if (row.kind === 'assistant' && row.streaming !== true && (row.text ?? '').trim() === '') {
+      if (rendersEmptyAssistant(row)) {
         hasEmptyAssistant = true
         break
       }
     }
     const out = hasEmptyAssistant
       ? sliced.filter(row =>
-          !(row.kind === 'assistant' && row.streaming !== true && (row.text ?? '').trim() === '') &&
+          !rendersEmptyAssistant(row) &&
           (thinkingVisible || row.kind !== 'reasoning'),
         )
       : thinkingVisible


### PR DESCRIPTION
# fix(transcript): 叙述-only 步骤渲染为孤立 ●

## 用户实测形状

思考块之后、工具卡之前，出现一个**空圆点独占一行**，且一直不消失。

## 根因

过滤层与渲染层的文本视图不一致：

1. dsh-working-activity narrate 契约让每条回复顶部带一行 `⏵ 自述`；模型思考后常输出 `⏵ 正在做X` 就**直接调工具**（该步无正文）
2. channel 层 `row.text` 原文非空 → #383 的孤立 ● 过滤器（测**原文**）放行
3. 渲染层 `stripNarration()` 按契约剥掉 `⏵` 行 → 只剩 `●` + 空；行已落定（streaming=false 永不再翻转），孤立圆点一直占行

## 修复

`MessageList` 的空行判空改用 `stripNarration(row.text).trim()`——与渲染所见一致：

- 叙述-only 落定行被滤（思考块直接衔接工具卡）
- `⏵ 行 + 正文` 混合行保留正文不受影响
- streaming 空行的 live dot 语义不变

## 验证

| 检查 | 结果 |
|---|---|
| `verify-empty-assistant.tsx`（扩展 2 断言：叙述-only 必滤、混合行正文必留） | ✅ 9/9 |
| `pnpm build`（全部 verify:build 门禁） | ✅ exit 0 |
| `git diff --check` | ✅ 干净 |

🤖 Generated with [DeepSeek Harness](https://github.com/deepseek-ai/DeepSeek-Harness)
