### PR TITLE
fix(dsh-adapter): 位置参数初始 prompt 兼容 cmdlineArgs 双形态（修复 #525） / Support both cmdlineArgs shapes for the positional initial prompt

### DIFF
--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1020,10 +1020,13 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   }
   // Positional command-line arguments are the initial prompt (issue #53):
   // `dsh-tui "run the tests"` forwards positionals through the dsh CLI,
-  // which mounts them as ctx.cmdlineArgs. Submit once the channel exists —
+  // which mounts them as ctx.cmdlineArgs. The service shape drifted across
+  // dsh-cmdline builds — `{ get() }` is the current contract, older builds
+  // exposed `{ args }` — so read both. Submit once the channel exists;
   // delivery goes through the normal pending/inbox chain, so no special
   // timing is needed; flag-shaped leftovers are not prompt text.
-  const cmdlineArgs = (ctx as { cmdlineArgs?: { args?: readonly string[] } }).cmdlineArgs?.args
+  const cmdline = (ctx as { cmdlineArgs?: { get?: () => readonly string[]; args?: readonly string[] } }).cmdlineArgs
+  const cmdlineArgs = cmdline?.get?.() ?? cmdline?.args
   const initialPrompt = cmdlineArgs?.filter(arg => !arg.startsWith('-')).join(' ').trim()
   if (initialPrompt) channel.submit(initialPrompt)
   // Attach the stderr reporter to the live channel and flush anything a


### PR DESCRIPTION
## 动机

修复 #525：`dsh-tui [workspace] "[prompt]"` 的位置参数 prompt 被静默丢弃——TUI 正常打开、工作区目标生效、session 创建，但 agent 从不收到初始 prompt、从不开始工作。

根因：dsh CLI 把调用内层参数经 `ctx.cmdlineArgs` 挂到树，该服务形态在 dsh-cmdline 各构建间漂移——当前契约是 `{ get(): readonly string[] }`，旧构建暴露 `{ args: readonly string[] }`。插件 `src/dsh-adapter/plugin.ts` 只读 `.args`（类型断言掩盖了不匹配），在 `{ get }` 契约下恒为 `undefined`，`channel.submit(initialPrompt)` 永不执行。

## 改动

- **`src/dsh-adapter/plugin.ts`**（+5/-2）：读取 `ctx.cmdlineArgs` 改为 `get?.() ?? args` 双形态兼容，过滤 flag 形 token 后 join 提交，行为不变。

## 验证

- `pnpm build` 全门禁通过（tsc + boundary/contract/patch-surface 等）。
- 真实 TTY 端到端：`dsh-tui [ws] "[prompt]"` 后 session 日志出现 `user/message`（内容正是位置参数 prompt）→ `turn/start` → `assistant/message`（回复 token）→ `finish`；修复前同一命令 35 秒只有 4 行基础事件。

## 相关

- Issue: #525（回归报告，含根因定位与修复前/后证据）
- 原始功能实现: #53（closed，位置 prompt 部分由维护者以 5b967920 实现）