### PR TITLE
fix(test): 去除 repro-thinking / repro-paste-fold 的假信号（#528）

### DIFF
--- a/scripts/repro-paste-fold.tsx
+++ b/scripts/repro-paste-fold.tsx
@@ -75,6 +75,21 @@ function findText(s: string): { col: number; row: number } | null {
   }
   return null
 }
+/**
+ * Poll until the expected screen state appears (30ms × up to 4s), then let
+ * the caller assert it. Fixed sleeps flake on slow CI runners: the input →
+ * React → throttled render → async xterm parse pipeline can exceed any
+ * constant, and the old 300ms reads asserted a stale screen while the state
+ * was already correct (the follow-up submit assertions passed). A real
+ * regression still fails: the condition never turns true and the check
+ * fires after the timeout.
+ */
+async function settle(pred: () => boolean): Promise<void> {
+  for (let i = 0; i < 133; i++) {
+    if (pred()) return
+    await sleep(30)
+  }
+}
 
 const listeners = new Set<() => void>()
 let submitted = ''
@@ -143,7 +158,7 @@ const click = (col: number, row: number) => {
 try {
   // 1. A big bracketed paste folds into an atomic block chip.
   stdinObj.write(`\x1b[200~${pasted}\x1b[201~`)
-  await sleep(500)
+  await settle(() => screenHas('▸ 12 lines') && screenHas('fold-line-0'))
   check('big paste folds into block chip', screenHas('▸ 12 lines'), screenHas('▸ 12 lines') ? '' : 'no chip stats on screen')
   check('chip shows the first-line preview', screenHas('fold-line-0'))
   check('block text hides the later lines', !screenHas('FOURTH_MARKER'))
@@ -153,14 +168,16 @@ try {
   //    Clicking a card row expands the block into the editable input.
   let pos = findText('fold-line-0')
   if (pos) hover(pos.col + 1, pos.row + 1)
-  await sleep(400)
+  await settle(() => screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
   check('hover pops the peek card with block head',
     screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
   check('peek card caps the tail rows', !screenHas('EIGHTH_MARKER'))
   const cardPos = findText('FOURTH_MARKER')
   if (cardPos) click(cardPos.col + 1, cardPos.row + 1)
-  await sleep(400)
+  await settle(() => screenHas('EIGHTH_MARKER'))
   check('card click expands the block for editing', screenHas('EIGHTH_MARKER'))
+  // Stability probe (must NOT change): a settle would return immediately,
+  // so give any wrong repaint a fixed window to show up instead.
   hover(1, 1)
   await sleep(400)
   check('expansion stays after the mouse leaves', screenHas('EIGHTH_MARKER'))
@@ -169,17 +186,17 @@ try {
   //    caret to line 0, the window returns to the head and row 0 shows the
   //    prefix); then the chip click expands the block again.
   stdinObj.write('\x1b[A'.repeat(11))
-  await sleep(300)
+  await settle(() => findText('▾ 12 lines') !== null)
   let prefix = findText('▾ 12 lines')
   check('expanded input shows the ▾ fold prefix', prefix !== null)
   if (prefix) {
     click(prefix.col + 1, prefix.row + 1)
-    await sleep(400)
+    await settle(() => !screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
     check('▾ prefix folds the input into a block', !screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
   }
   pos = findText('fold-line-0')
   if (pos) click(pos.col + 1, pos.row + 1)
-  await sleep(400)
+  await settle(() => screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
   // The caret was dragged to the block's end when folding, so the expanded
   // input shows the TAIL window (EIGHTH_MARKER) — and no chip.
   check('chip click expands the block', screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
@@ -189,11 +206,11 @@ try {
   // Fold back for the typing test below (Up ×11 walks the caret to line 0
   // where the ▾ prefix is visible again).
   stdinObj.write('\x1b[A'.repeat(11))
-  await sleep(300)
+  await settle(() => findText('▾ 12 lines') !== null)
   prefix = findText('▾ 12 lines')
   if (prefix) {
     click(prefix.col + 1, prefix.row + 1)
-    await sleep(400)
+    await settle(() => screenHas('▸ 12 lines'))
     check('▾ prefix folds again', screenHas('▸ 12 lines'))
   }
 
@@ -204,66 +221,68 @@ try {
   //    Enter submits. Batch Backspace (several keys in one stdin read)
   //    must delete one char per key even with a block present.
   stdinObj.write('zzctrl')
-  await sleep(300)
+  await settle(() => screenHas('zzctrl'))
   stdinObj.write('\x7f'.repeat(3))
-  await sleep(300)
+  await settle(() => screenHas('zzc') && !screenHas('zzctrl'))
   check('control: batch Backspace deletes 3 chars, block stays',
     screenHas('zzc') && !screenHas('zzctrl') && screenHas('▸ 12 lines'))
   stdinObj.write('\x7f'.repeat(3))
-  await sleep(300)
+  await settle(() => !screenHas('zzc'))
   stdinObj.write('tail')
-  await sleep(400)
+  await settle(() => screenHas('tail'))
   check('typing keeps the block folded', screenHas('▸ 12 lines') && screenHas('tail'))
   stdinObj.write('\x7f'.repeat(4))
-  await sleep(300)
+  await settle(() => !screenHas('tail'))
   check('Backspace removes the typed char, block stays folded',
     screenHas('▸ 12 lines') && !screenHas('tail'))
   stdinObj.write('\x1b')
-  await sleep(400)
+  await settle(() => screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
   check('Esc expands the block (does not clear)', screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
   // Esc on the EXPANDED big input folds it back into a block — the toggle
   // is lossless; clearing a big draft goes through Backspace/Ctrl+C.
   stdinObj.write('\x1b')
-  await sleep(400)
+  await settle(() => screenHas('▸ 12 lines'))
   check('Esc on expanded big input folds it back', screenHas('▸ 12 lines'))
   stdinObj.write('\x1b')
-  await sleep(400)
+  await settle(() => !screenHas('▸ 12 lines') && screenHas('EIGHTH_MARKER'))
   check('Esc on the block expands again', !screenHas('▸ 12 lines') && screenHas('EIGHTH_MARKER'))
   stdinObj.write('\r')
-  await sleep(400)
+  await settle(() => submitted !== '')
   check('Enter submits the full text', submitted === pasted, `got ${submitted.length} chars`)
 
   // 5. Text typed BEFORE the block stays visible and is submitted with it.
   submitted = ''
   stdinObj.write('pre:')
-  await sleep(300)
+  await settle(() => screenHas('pre:'))
   stdinObj.write(`\x1b[200~${pasted}\x1b[201~`)
-  await sleep(500)
+  await settle(() => screenHas('▸ 12 lines') && screenHas('pre:'))
   check('paste after text folds; head text stays visible',
     screenHas('▸ 12 lines') && screenHas('pre:'))
   stdinObj.write('\r')
-  await sleep(400)
+  await settle(() => submitted !== '')
   check('submit includes the head text', submitted === 'pre:' + pasted)
 
   // 6. Backspace at the block's tail deletes the WHOLE block in one key;
   //    Enter on the now-empty prompt submits nothing.
   submitted = 'sentinel'
   stdinObj.write(`\x1b[200~${pasted}\x1b[201~`)
-  await sleep(500)
+  await settle(() => screenHas('▸ 12 lines'))
   check('paste folds again', screenHas('▸ 12 lines'))
   stdinObj.write('\x7f')
-  await sleep(400)
+  await settle(() => !screenHas('▸ 12 lines') && !screenHas('fold-line-0'))
   check('Backspace deletes the whole block',
     !screenHas('▸ 12 lines') && !screenHas('fold-line-0'))
+  // Negative probe (nothing may be submitted): a settle has no state change
+  // to wait for — keep a fixed window for a wrong submit to surface.
   stdinObj.write('\r')
   await sleep(400)
   check('Enter after block delete submits nothing', submitted === 'sentinel')
 
   // 7. Small (non-foldable) inputs keep the classic Esc = clear behavior.
   stdinObj.write('tiny')
-  await sleep(300)
+  await settle(() => screenHas('tiny'))
   stdinObj.write('\x1b')
-  await sleep(300)
+  await settle(() => !screenHas('tiny'))
   check('Esc clears a small (non-foldable) input', !screenHas('tiny'))
 } finally {
   await instance.unmount()

--- a/scripts/repro-thinking.tsx
+++ b/scripts/repro-thinking.tsx
@@ -10,7 +10,8 @@
  * 助手文本持续流式增长（强制内容增长 + stickyScroll），捕获全部帧字节，
  * 用 xterm-headless 回放后断言可见区干净：
  *
- * - 恰有 1 行含 'thinking'（spinner 行本身；灌入文本刻意不含该词）
+ * - 恰有 1 行以 spinner 状态 "· thinking)" 收尾（不能用裸词 'thinking'：
+ *   随机启动 tip 有 4/100 条文案含该词，撞上即误报）
  * - 无 'tthinking' 叠字
  * - 无孤立残影 't'（任意列，两侧为空白或行尾）
  *
@@ -147,28 +148,36 @@ const byteStream = stdout.frames.join('')
 try { instance.unmount() } catch {}
 
 // ── xterm-headless 回放 ──
+// write 是异步分块解析的：必须等回调而不是固定 sleep，否则慢机器上
+// 断言读到解析了一半的屏幕。
 const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 500, allowProposedApi: true })
-term.write(byteStream)
-await new Promise(r => setTimeout(r, 1200))
+await new Promise<void>(r => term.write(byteStream, r))
 
+// 扫可见视口（baseY 起的 ROWS 行）。裸 getLine(0..ROWS) 在有 scrollback 时
+// 读的是缓冲区开头：混入已滚出的旧行、漏掉视口底部 baseY 行——残影恰恰
+// 最容易出现在底部 spinner 附近。
 const buf = term.buffer.active
 const lines: string[] = []
 for (let y = 0; y < ROWS; y++) {
-  lines.push(buf.getLine(y)?.translateToString(true) ?? '')
+  lines.push(buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
 }
 
 // ── 残影检测 ──
 const problems: string[] = []
-let thinkingRows = 0
+let spinnerRows = 0
 lines.forEach((line, y) => {
-  if (line.includes('thinking')) thinkingRows++
+  // spinner 状态行以 "… · thinking)" 收尾；裸词 'thinking' 不能当指纹——
+  // 启动 tip 是 Math.random 抽的，100 条里 4 条文案含 'thinking'
+  // （如“工具卡/thinking/摘要点击展开”），抽中即误报（约 4%/次的假 flaky）。
+  if (/·\s*thinking\)/.test(line)) spinnerRows++
   if (/tthinking/.test(line)) problems.push(`row ${y}: 叠字残影 "tthinking" → ${JSON.stringify(line)}`)
-  // 孤立 't'：两侧为空白/行首行尾（灌入文本不含 ASCII 't'，出现即残影）
+  // 孤立 't'：两侧为空白/行首行尾（灌入文本与全部 tip 文案均不含孤立
+  // ASCII 't'，出现即残影）
   const m = line.match(/(?:^|\s)t(?=\s|$)/)
   if (m) problems.push(`row ${y}: 孤立残影 't' → ${JSON.stringify(line)}`)
 })
-if (thinkingRows !== 1) {
-  problems.push(`含 'thinking' 的行数为 ${thinkingRows}（期望 1，即 spinner 行本身）`)
+if (spinnerRows !== 1) {
+  problems.push(`spinner 状态行（"· thinking)" 结尾）数为 ${spinnerRows}（期望 1）`)
 }
 
 if (problems.length > 0) {
@@ -181,5 +190,5 @@ if (problems.length > 0) {
   process.exit(1)
 }
 
-console.log(`PASS: thinking spinner 无残影（${COLS}x${ROWS}，spinner 行恰 1 处 'thinking'）`)
+console.log(`PASS: thinking spinner 无残影（${COLS}x${ROWS}，spinner 状态行恰 1 行）`)
 process.exit(0)


### PR DESCRIPTION
# fix(test): 去除 repro-thinking / repro-paste-fold 的两类假信号

关联 issue：#528（完整取证在 issue 里）。渲染器无改动——两处都是测试自身的缺陷。

## repro-thinking（三处）

| 问题 | 修法 |
|---|---|
| 随机启动 tip 有 4/100 条文案含 'thinking'，撞上即把"恰一行"断言顶成 2（约 4%/次误报，与负载无关） | 断言指纹改为 spinner 状态行专属的 `· thinking)` 结尾；已扫描验证 100 条 tip 文案均不匹配该指纹，也不含孤立 t/tthinking |
| 回放用 `write` + 固定 `sleep(1200)`，慢机器可能断言解析一半的屏幕 | 等 `write` 回调（xterm 官方语义：回调触发时 buffer 才反映写入） |
| 残影扫描读缓冲区开头 ROWS 行，有 scrollback 时混入滚出行、漏掉视口底部（spinner 所在） | 改扫视口（`baseY` 起） |

## repro-paste-fold（一类）

固定 300–500ms sleep 等 stdin→React→节流渲染→xterm 解析流水线，慢机器超时即断言旧屏幕。改为 `settle()` 轮询（30ms × 上限 4s）等到预期屏幕状态再断言；条件永不满足则超时后断言照常失败，真回归仍会红。三处"状态不得改变"的稳定性探针（悬停离开不塌、空提交不发）保留固定窗口——轮询已成立的条件会立即返回，等于没测。

## 验证

| 检查 | 结果 |
|---|---|
| repro-thinking 红绿：伪造第二条 spinner 状态行 | ❌ 按预测失败（断言活着） |
| repro-thinking：强制抽中撞词 tip（修前 100% 失败，逐字复现 CI 输出） | ✅ 修后通过 |
| repro-thinking：正常 + 6 忙循环负载 ×6 | ✅ 6/6 |
| repro-paste-fold 红绿：修前 6 忙循环负载 ×8 | ❌ 1/8 失败，失败点与 CI 一致 |
| repro-paste-fold：修后同负载 ×8 | ✅ 8/8 |

## 范围

- `scripts/repro-thinking.tsx`
- `scripts/repro-paste-fold.tsx`

无 `src/` 改动，无需重建。
