### PR TITLE
refactor(test): 回归脚本等待/读屏公共设施 + 52 个脚本去固定 sleep（#532）

### DIFF
--- a/scripts/lib/term-test.mjs
+++ b/scripts/lib/term-test.mjs
@@ -1,0 +1,87 @@
+/**
+ * 回归脚本的公共等待与屏幕读取辅助（issue #532）。
+ *
+ * 三个系统性错误写法的替代品，全部围绕同一条流水线：
+ * stdin 解析 → React 状态 → 节流渲染 → xterm 异步解析。它没有固定上界，
+ * 所以「固定 sleep 后断言」在慢 runner 上会断言到旧屏幕。
+ *
+ * - settle(pred)      取代「sleep 后断言」：轮询到预期状态出现再让调用方
+ *                     断言。超时不抛错——紧随其后的断言用同一条件失败，
+ *                     并打印脚本自己的诊断；真回归仍然会红。
+ * - writeParsed(term) 取代「write + sleep」：xterm 的 write 异步分块解析，
+ *                     buffer 只在回调触发后才反映写入（官方文档语义）。
+ * - viewportLines()   取代「getLine(0..ROWS) 直扫」：inline 模式有
+ *                     scrollback 时（baseY > 0）直扫读的是缓冲区开头——
+ *                     混入已滚出的行、漏掉视口底部。alt-screen 下
+ *                     baseY 恒为 0，两种写法等价。
+ *
+ * 纯 ESM JS（无类型编译），.mjs 与 .tsx 脚本都能直接 import。
+ * 注意：「状态不得改变」的稳定性探针（悬停离开不塌、空提交不发）不要
+ * 换成 settle——对已成立的条件轮询会立即返回，等于没测；保留固定窗口。
+ */
+
+/** @param {number} ms */
+export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * 轮询到 pred() 为真（30ms 间隔，默认上限 4s）。超时静默返回，由调用方
+ * 紧随其后的断言以同一条件失败。
+ * @param {() => boolean} pred
+ * @param {{ timeoutMs?: number, stepMs?: number }} [opts]
+ */
+export async function settle(pred, opts = {}) {
+  const stepMs = opts.stepMs ?? 30
+  const deadline = Date.now() + (opts.timeoutMs ?? 4000)
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await sleep(stepMs)
+  }
+}
+
+/**
+ * write 并等 xterm 解析完（回调触发时 buffer 才反映写入）。
+ * @param {import('@xterm/headless').Terminal} term
+ * @param {string} data
+ */
+export function writeParsed(term, data) {
+  return new Promise(resolve => term.write(data, resolve))
+}
+
+/**
+ * 读可见视口（baseY 起 rows 行），右侧空白已裁剪。
+ * @param {import('@xterm/headless').Terminal} term
+ * @param {number} [rows] 默认 term.rows
+ * @returns {string[]}
+ */
+export function viewportLines(term, rows) {
+  const buffer = term.buffer.active
+  const height = rows ?? term.rows
+  return Array.from(
+    { length: height },
+    (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '',
+  )
+}
+
+/**
+ * 视口内是否有包含 text 的行。
+ * @param {import('@xterm/headless').Terminal} term
+ * @param {string} text
+ */
+export function screenHas(term, text) {
+  return viewportLines(term).some(line => line.includes(text))
+}
+
+/**
+ * text 在视口内首次出现的 0 起坐标（鼠标 SGR 序列用时 +1）。
+ * @param {import('@xterm/headless').Terminal} term
+ * @param {string} text
+ * @returns {{ col: number, row: number } | null}
+ */
+export function findText(term, text) {
+  const lines = viewportLines(term)
+  for (let row = 0; row < lines.length; row++) {
+    const col = lines[row].indexOf(text)
+    if (col >= 0) return { col, row }
+  }
+  return null
+}

--- a/scripts/repro-askpanel.tsx
+++ b/scripts/repro-askpanel.tsx
@@ -8,12 +8,13 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }, { settle, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/components/questions/AskUserQuestionPanel.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 90
@@ -36,10 +37,7 @@ const stdin = new FakeStdin()
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 /** The real terminal screen, line by line. */
 function screen(): string {
-  const buf = term.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < ROWS; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
-  return lines.join('\n')
+  return viewportLines(term, ROWS).join('\n')
 }
 
 let answer: unknown
@@ -61,7 +59,7 @@ const app = await render(
   }),
   { stdout, stdin, stderr: new FakeStdout(), debug: true, exitOnCtrlC: false },
 )
-await sleep(300)
+await settle(() => screen().includes('自定义回答') && screen().includes('输入文字附带回答'))
 
 let failures = 0
 const results: string[] = []
@@ -78,7 +76,7 @@ check('提示行说明可直接输入', s1.includes('输入文字附带回答'))
 // 2. Type on the focused "我有" option: text lands in the input row, the
 //    option list stays (no jump), and the label is attached.
 stdin.write('sk-test123')
-await sleep(300)
+await settle(() => screen().includes('sk-test123') && screen().includes('（附加：我有）'))
 const s2 = screen()
 check('输入内容出现在输入行', s2.includes('sk-test123'))
 check('视图不跳转（选项列表仍在）', s2.includes('我没有'))
@@ -86,7 +84,7 @@ check('输入行标注附加标签「我有」', s2.includes('（附加：我有
 
 // 3. Enter right there → the answer carries BOTH the label and the text.
 stdin.write('\r')
-await sleep(300)
+await settle(() => answer !== undefined)
 const a1 = answer as { selected?: string[]; custom?: string } | undefined
 check('提交同时携带 selected + custom', a1?.selected?.join() === '我有' && a1?.custom === 'sk-test123')
 
@@ -99,16 +97,16 @@ app.rerender(
     question: { question: '还有别的要说吗？', options: [{ label: '有' }, { label: '没有' }] },
   }),
 )
-await sleep(300)
+await settle(() => screen().includes('还有别的要说吗？'))
 stdin.write('[B') // ↓
 stdin.write('[B') // ↓ → input row
 await sleep(200)
 stdin.write('随便说说')
-await sleep(200)
+await settle(() => screen().includes('随便说说'))
 const s4 = screen()
 check('输入行内联编辑（视图仍不跳转）', s4.includes('随便说说') && s4.includes('没有'))
 stdin.write('\r')
-await sleep(300)
+await settle(() => answer !== undefined)
 const a2 = answer as { selected?: string[]; custom?: string } | undefined
 check('输入行直接提交为纯自定义（无标签）', a2?.selected?.length === 0 && a2?.custom === '随便说说')
 
@@ -126,13 +124,13 @@ app.rerender(
     },
   }),
 )
-await sleep(300)
+await settle(() => screen().includes('要哪些口味？'))
 stdin.write(' ') // check 甜
 await sleep(150)
 stdin.write('少放糖')
-await sleep(200)
+await settle(() => screen().includes('少放糖'))
 stdin.write('\r')
-await sleep(300)
+await settle(() => answer !== undefined)
 const a3 = answer as { selected?: string[]; custom?: string } | undefined
 check('多选：勾选 + 文本一起提交', a3?.selected?.join() === '甜' && a3?.custom === '少放糖')
 

--- a/scripts/repro-clipboard.tsx
+++ b/scripts/repro-clipboard.tsx
@@ -15,7 +15,7 @@ process.env.FORCE_COLOR = '3'
 // language before any module import resolves the startup lang.
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { mkdtempSync, writeFileSync, rmSync }, { tmpdir }, { join }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { mkdtempSync, writeFileSync, rmSync }, { tmpdir }, { join }, termTest] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -25,6 +25,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('node:fs'),
   import('node:os'),
   import('node:path'),
+  import('./lib/term-test.mjs'),
 ])
 
 if (process.platform !== 'linux') {
@@ -69,14 +70,11 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-function screenHas(s: string): boolean {
-  const buf = term.buffer.active
-  for (let y = 0; y < ROWS; y++) {
-    if ((buf.getLine(y)?.translateToString(true) ?? '').includes(s)) return true
-  }
-  return false
-}
+// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
+// sleep 在慢 runner 上会断言到旧屏幕。alt-screen 下 baseY 恒 0，视口读取
+// 与旧的 getLine(0..ROWS) 直扫等价。
+const { sleep, settle } = termTest
+const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 
 const listeners = new Set<() => void>()
 const channel: any = {
@@ -127,19 +125,19 @@ const check = (name: string, ok: boolean, extra = '') => {
 try {
   // 1. '?' opens the help overlay; Ctrl+V must close it up front.
   stdinObj.write('?')
-  await sleep(400)
+  await settle(() => screenHas('? for this help'))
   check('? opens the help overlay', screenHas('? for this help'))
   stdinObj.write('\x16')
-  await sleep(300)
+  await settle(() => !screenHas('? for this help'))
   check('Ctrl+V closes the help overlay before the read resolves', !screenHas('? for this help'))
 
   // 2. The stub clipboard text lands in the prompt.
-  await sleep(600)
+  await settle(() => screenHas('UI粘贴内容'))
   check('clipboard text lands in the prompt', screenHas('UI粘贴内容'))
 
   // 3. Busy latch released: a second Ctrl+V pastes again (doubled text).
   stdinObj.write('\x16')
-  await sleep(800)
+  await settle(() => screenHas('UI粘贴内容UI粘贴内容'))
   check('second Ctrl+V pastes again (busy latch released)', screenHas('UI粘贴内容UI粘贴内容'))
 } finally {
   await instance.unmount()

--- a/scripts/repro-collapse-shrink.tsx
+++ b/scripts/repro-collapse-shrink.tsx
@@ -21,15 +21,14 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }, { sleep, settle }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
     import('@xterm/headless'),
     import('../src/ui.js'),
+    import('./lib/term-test.mjs'),
   ])
-
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 let failed = 0
 function check(name: string, ok: boolean, extra = ''): void {
@@ -111,13 +110,15 @@ async function run(): Promise<void> {
     exitOnCtrlC: false,
     patchConsole: false,
   })
-  await sleep(400)
+  await settle(() => live.screen().length >= ROWS - 1)
   check('the expanded frame is taller than the viewport', live.screen().length >= ROWS - 1,
     `${live.screen().length} rows visible of ${ROWS}`)
 
   const mark = live.writes.length
   setOpen?.(false)
-  await sleep(600)
+  await settle(() =>
+    !live.screen().some(line => line.includes('body line'))
+    && live.screen().filter(line => line.includes('panel header')).length === 1)
   if (process.env.DBG_SHRINK === '1') {
     live.writes.slice(mark).forEach((w, i) => {
       console.log(`[w${i}] ${JSON.stringify(w.slice(0, 160))}`)
@@ -137,7 +138,7 @@ async function run(): Promise<void> {
     exitOnCtrlC: false,
     patchConsole: false,
   })
-  await sleep(400)
+  await settle(() => cold.screen().join('\n') === collapsed.join('\n'))
   const fresh = cold.screen()
   coldInstance.unmount()
   cold.term.dispose()

--- a/scripts/repro-ctrlc.tsx
+++ b/scripts/repro-ctrlc.tsx
@@ -9,13 +9,14 @@ process.env.FORCE_COLOR = '3'
 // module import resolves the startup lang (env > persisted > locale).
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, termTest] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -38,14 +39,11 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-function screenHas(s: string): boolean {
-  const buf = term.buffer.active
-  for (let y = 0; y < ROWS; y++) {
-    if ((buf.getLine(y)?.translateToString(true) ?? '').includes(s)) return true
-  }
-  return false
-}
+// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
+// sleep 在慢 runner 上会断言到旧屏幕。alt-screen 下 baseY 恒 0，视口读取
+// 与旧的 getLine(0..ROWS) 直扫等价。
+const { sleep, settle } = termTest
+const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 
 const listeners = new Set<() => void>()
 const channel: any = {
@@ -96,23 +94,23 @@ const check = (name: string, ok: boolean, extra = '') => {
 
 // 1. type text, ctrl+c → cleared, no exit, no exit-arm notification
 stdinObj.write('hello world')
-await sleep(400)
+await settle(() => screenHas('hello world'))
 check('typed text visible in prompt', screenHas('hello world'))
 stdinObj.write('\x03')
-await sleep(400)
+await settle(() => !screenHas('hello world'))
 check('ctrl+c clears non-empty input', !screenHas('hello world'))
 check('ctrl+c with text does not exit', !exited)
 check('ctrl+c with text does not arm exit', !screenHas('Press Ctrl+C again'), JSON.stringify(channel.notifications))
 
 // 2. ctrl+c on empty input → arms exit
 stdinObj.write('\x03')
-await sleep(400)
+await settle(() => screenHas('Press Ctrl+C again') || channel.notifications.length > 0)
 check('ctrl+c on empty input arms exit', screenHas('Press Ctrl+C again') || channel.notifications.length > 0, JSON.stringify(channel.notifications))
 check('first press does not exit', !exited)
 
 // 3. second press exits
 stdinObj.write('\x03')
-await sleep(400)
+await settle(() => exited)
 check('second ctrl+c exits', exited)
 
 await instance.unmount()

--- a/scripts/repro-drag-select-streaming.tsx
+++ b/scripts/repro-drag-select-streaming.tsx
@@ -23,7 +23,7 @@ process.env.DSH_TUI_LANG = 'zh'
 process.env.SSH_CONNECTION = 'headless-repro'
 delete process.env.TMUX
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, termTest] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -31,12 +31,16 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 const { default: instances } = await import('../src/ink/instances.js')
 const { stringWidth } = await import('../src/ink/stringWidth.js')
 
 const COLS = 100, ROWS = 40
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
+// sleep 在慢 runner 上会断言到旧屏幕。alt-screen 下 baseY 恒 0，视口读取
+// 与直扫等价。
+const { sleep, settle } = termTest
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -110,8 +114,7 @@ inst.rerender(tree)
 await sleep(900)
 
 function screenLines(): string[] {
-  const buf = term.buffer.active
-  return Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
+  return termTest.viewportLines(term, ROWS)
 }
 
 function osc52Payloads(): string[] {
@@ -135,15 +138,15 @@ async function dragOver(marker: string, a: number, b: number): Promise<void> {
   stdin.write(`\x1b[<32;${col0 + b + 1};${row + 1}M`)   // drag (motion)
   await sleep(80)
   stdin.write(`\x1b[<0;${col0 + b + 1};${row + 1}m`)    // release
-  await sleep(350)
 }
 
 // ── 对照组：静息（sticky 底部），拖选尾部标记 ──
 writes.length = 0
 await dragOver(TMARK, 2, 10)
 {
-  const payloads = osc52Payloads()
   const expect = TMARK.slice(2, 10 + 1)
+  await settle(() => osc52Payloads().includes(expect))
+  const payloads = osc52Payloads()
   check('静息拖选 → OSC 52 携带完整选中文本', payloads.includes(expect),
     `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
 }
@@ -153,6 +156,8 @@ for (let i = 0; i < 90 && !screenLines().some(l => l.includes(HMARK)); i++) {
   stdin.write('\x1b[<64;90;20M')  // wheel up，小步走到标记可见
   await sleep(12)
 }
+// 稳定性窗口（不得改变）：上面的轮询循环已见到 HMARK，settle 会立即返回
+// 等于没测——固定窗口让滚轮连发后的错误重绘（标记被冲掉）有机会暴露。
 await sleep(400)
 {
   const lines = screenLines()
@@ -186,8 +191,9 @@ streamRow.streaming = undefined
 await sleep(400)
 
 {
-  const payloads = osc52Payloads()
   const expect = HMARK.slice(3, 11 + 1)
+  await settle(() => osc52Payloads().includes(expect))
+  const payloads = osc52Payloads()
   check('流式并发时拖选 → OSC 52 携带完整选中文本', payloads.includes(expect),
     `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
 }
@@ -197,8 +203,9 @@ writes.length = 0
 await sleep(200)
 try {
   await dragOver(HMARK, 3, 11)
-  const payloads = osc52Payloads()
   const expect = HMARK.slice(3, 11 + 1)
+  await settle(() => osc52Payloads().includes(expect))
+  const payloads = osc52Payloads()
   check('流式结束后拖选 → 恢复完整', payloads.includes(expect),
     `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
 } catch (e) {

--- a/scripts/repro-external-editor.tsx
+++ b/scripts/repro-external-editor.tsx
@@ -21,7 +21,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { writeFileSync, mkdtempSync, rmSync }, { tmpdir }, { join }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { writeFileSync, mkdtempSync, rmSync }, { tmpdir }, { join }, { render }, { Chat }, { QuestionStore }, termTest] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -31,6 +31,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { writeFileSync, m
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -65,14 +66,11 @@ class FakeStdin extends PassThrough {
   unref() { return this }
 }
 const stdinObj = new FakeStdin()
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-function screenHas(s: string): boolean {
-  const buf = term.buffer.active
-  for (let y = 0; y < ROWS; y++) {
-    if ((buf.getLine(y)?.translateToString(true) ?? '').includes(s)) return true
-  }
-  return false
-}
+// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
+// sleep 在慢 runner 上会断言到旧屏幕；inline 模式有 scrollback 时视口从
+// baseY 起，getLine(0..ROWS) 直扫会混入已滚出的行。
+const { sleep, settle, writeParsed } = termTest
+const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 
 const listeners = new Set<() => void>()
 let rowId = 0
@@ -136,11 +134,11 @@ const check = (name: string, ok: boolean, extra = '') => {
 // 输入框打上草稿。
 channel.rows.push({ id: rowId++, kind: 'user', text: 'transcript-anchor-历史消息' })
 bump()
-await sleep(300)
+await settle(() => screenHas('transcript-anchor'))
 check('预备: transcript 历史消息可见', screenHas('transcript-anchor'))
 
 stdinObj.write('什么是cordis')
-await sleep(300)
+await settle(() => screenHas('什么是cordis'))
 check('预备: 草稿已入输入框', screenHas('什么是cordis'))
 
 // Ctrl+G → 假编辑器（600ms 后写盘退出）
@@ -152,7 +150,7 @@ stdinObj.write('\x1b\x1b')
 await sleep(100)
 // 模拟 nvim 的 rmcup：终端被弹回主屏，随后我们的 2J 将落在主屏上。
 // write 回调在 xterm 解析完毕后触发，保证与后续 2J 的先后顺序。
-await new Promise<void>(resolve => term.write('\x1b[?1049l', resolve))
+await writeParsed(term, '\x1b[?1049l')
 
 // 等回填完成（编辑器 600ms 写盘 + 往返）
 let roundTripped = false
@@ -161,7 +159,9 @@ for (let i = 0; i < 100; i++) {
   if (screenHas('什么是cordis EDITED')) { roundTripped = true; break }
 }
 check('往返: 编辑结果回填输入框', roundTripped)
-// 让晚到乱码（FakeStdout 注入）与任何延迟副作用落定
+// 让晚到乱码（FakeStdout 注入）与任何延迟副作用落定。
+// 稳定性探针（不得改变）：下面的 bug1-3 断言的是"东西仍在/没被触发"，
+// 对已成立条件轮询会立即返回等于没测——保留固定窗口。
 await sleep(600)
 
 check('bug1: transcript 历史消息仍可见（全量重绘）', screenHas('transcript-anchor'))
@@ -171,7 +171,7 @@ check('bug3: 终端应答残片未落入界面', !screenHas('48;93') && !screenH
 
 // 活性：抑制窗口已过的正常输入必须可用
 stdinObj.write('X')
-await sleep(300)
+await settle(() => screenHas('什么是cordis EDITEDX'))
 check('活性: 抑制窗口结束后输入正常', screenHas('什么是cordis EDITEDX'))
 
 if (savedEditor === undefined) delete process.env.EDITOR

--- a/scripts/repro-inline-thirdparty.tsx
+++ b/scripts/repro-inline-thirdparty.tsx
@@ -17,13 +17,14 @@ process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'WezTerm'
 process.env.DSH_TUI_THEME = 'dark'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep, settle, writeParsed }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -48,7 +49,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 function viewportLines(): string[] {
   const buf = term.buffer.active
   const start = Math.max(0, buf.length - ROWS)
@@ -107,8 +107,7 @@ const golden = viewportLines()
 
 // ★ 静止期注入第三方输出（真机 #17 场景：mcp 子进程 stderr 直写 tty，
 //   打在空闲时的输入框下方——之后没有大重绘来自愈）。
-term.write('\r\n[5764] Error: Non-HTTPS URLs are only allowed for localhost\r\n[35540] Usage: npx tsx proxy.ts <https://server-url>\r\n')
-await sleep(100)
+await writeParsed(term, '\r\n[5764] Error: Non-HTTPS URLs are only allowed for localhost\r\n[35540] Usage: npx tsx proxy.ts <https://server-url>\r\n')
 
 // 之后只有轻微 UI 活动（通知/指标 tick 级别的小 diff）——真实空闲场景。
 channel.responseChars += 7; bump()
@@ -128,7 +127,11 @@ const { default: instances } = await import('../src/ink/instances.js')
 const ink: any = instances.get(stdoutObj as any)
 check('前置：取到 ink 实例', !!ink)
 ink?.reassertTerminalModes?.()
-await sleep(400)
+await settle(() => {
+  const lines = viewportLines()
+  return !lines.some(l => l.includes('[5764] Error') || l.includes('[35540] Usage'))
+    && Array.from({ length: 12 }, (_, i) => `概览要点第 ${i + 1} 条`).every(t => lines.some(l => l.includes(t)))
+})
 
 const healed = viewportLines()
 console.log('=== 自愈后对照（G=干净基准 H=重锚后） ===')

--- a/scripts/repro-model-switch-scrollback.tsx
+++ b/scripts/repro-model-switch-scrollback.tsx
@@ -28,7 +28,7 @@ const reproHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-repro-home-'))
 process.env.HOME = reproHome
 process.env.USERPROFILE = reproHome
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { createChannel }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { createChannel }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -36,6 +36,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/dsh-adapter/channel.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -173,11 +174,13 @@ const instance = await render(
   <Chat channel={channel as never} questionStore={new QuestionStore()} onExit={() => {}} />,
   { stdout: stdoutObj, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(1200)
 
 const SPLASH = '探索未至之境'
 const HIST0 = '历史问题 0：检查一下构建配置'
 const HIST1 = '历史回答 1：'
+// boot 落定：轮询到 splash 与历史行都上屏再断言（原固定 1200ms 在慢
+// runner 上会断言到未画完的缓冲区）。
+await settle(() => countMarker(SPLASH) === 1 && countMarker(HIST0) === 1 && countMarker(HIST1) === 1)
 
 console.log(`boot: buffer=${term.buffer.active.length} 行 (视口 ${ROWS})`)
 check('boot 后 splash 恰好一份', countMarker(SPLASH) === 1, `实际 ${countMarker(SPLASH)}`)
@@ -204,6 +207,8 @@ bufLen('picker open')
 stdin.write('\x1b[B')        // ↓ 选中下一个模型
 await sleep(200)
 stdin.write('\r')            // 确认 → fork + replay
+// 稳定性探针保留固定窗口：「恰好一份」断言防的是切换后追加帧的多余沉积，
+// 对已成立条件（count===1）轮询立即返回等于没测。
 await sleep(1500)
 bufLen('switched')
 
@@ -224,6 +229,7 @@ await sleep(600)
 stdin.write('\x1b[B')
 await sleep(200)
 stdin.write('\r')
+// 同上：沉积探针保留固定窗口。
 await sleep(1500)
 check('二次切换后 splash 恰好一份', countMarker(SPLASH) === 1, `实际 ${countMarker(SPLASH)}`)
 
@@ -250,6 +256,8 @@ await sleep(200)
 stdin.write('\r')            // 打开 picker
 await sleep(600)
 stdin.write('\x1b')          // Esc：只关闭，不切换
+// 稳定性探针保留固定窗口：Esc 不切换/历史仍在/缓冲区零增长都是「状态不得
+// 改变」断言，轮询已成立条件立即返回等于没测。
 await sleep(600)
 check('Esc 不改动模型', channel.model === modelBeforeEsc, `实际 ${channel.model}`)
 check('Esc 关闭后被覆盖历史行仍在',

--- a/scripts/repro-paste-fold.tsx
+++ b/scripts/repro-paste-fold.tsx
@@ -28,13 +28,14 @@ const dataDir = mkdtempSync(join(tmpdir(), 'repro-paste-fold-data-'))
 process.env.HOME = dataDir
 process.env.USERPROFILE = dataDir
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, termTest] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -57,39 +58,14 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-function screenHas(s: string): boolean {
-  const buf = term.buffer.active
-  for (let y = 0; y < ROWS; y++) {
-    if ((buf.getLine(y)?.translateToString(true) ?? '').includes(s)) return true
-  }
-  return false
-}
-/** 0-indexed position of the first occurrence of `s` on the screen. */
-function findText(s: string): { col: number; row: number } | null {
-  const buf = term.buffer.active
-  for (let row = 0; row < ROWS; row++) {
-    const line = buf.getLine(row)?.translateToString(true) ?? ''
-    const col = line.indexOf(s)
-    if (col >= 0) return { col, row }
-  }
-  return null
-}
-/**
- * Poll until the expected screen state appears (30ms × up to 4s), then let
- * the caller assert it. Fixed sleeps flake on slow CI runners: the input →
- * React → throttled render → async xterm parse pipeline can exceed any
- * constant, and the old 300ms reads asserted a stale screen while the state
- * was already correct (the follow-up submit assertions passed). A real
- * regression still fails: the condition never turns true and the check
- * fires after the timeout.
- */
-async function settle(pred: () => boolean): Promise<void> {
-  for (let i = 0; i < 133; i++) {
-    if (pred()) return
-    await sleep(30)
-  }
-}
+// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——
+// 固定 sleep 在慢 runner 上会断言到旧屏幕（旧 300ms 版本挂过 CI，而
+// 后续 submit 断言通过，证明状态早已正确）；真回归仍会红（条件永不
+// 满足则超时后断言照常失败）。alt-screen 下 baseY 恒 0，视口读取与
+// 旧的 getLine(0..ROWS) 直扫等价。
+const { sleep, settle } = termTest
+const screenHas = (s: string): boolean => termTest.screenHas(term, s)
+const findText = (s: string): { col: number; row: number } | null => termTest.findText(term, s)
 
 const listeners = new Set<() => void>()
 let submitted = ''

--- a/scripts/repro-picker-windowing.tsx
+++ b/scripts/repro-picker-windowing.tsx
@@ -66,6 +66,7 @@ const [
   { createChannel },
   { listWindow },
   { ListItem },
+  { settle, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -76,6 +77,7 @@ const [
   import('../src/dsh-adapter/channel.js'),
   import('../src/components/listWindow.js'),
   import('../src/components/design-system/ListItem.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -241,11 +243,12 @@ for (const c of winCases) {
     </Box>,
     { stdout: new FakeStdout2(), stdin: new FakeStdin(), stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(300)
-  const lines2: string[] = []
-  for (let y = term2.buffer.active.baseY; y < term2.buffer.active.baseY + ROWS; y++) {
-    lines2.push(term2.buffer.active.getLine(y)?.translateToString(true) ?? '')
-  }
+  // 落定：等全部标记行（M0..M4）上屏再取快照断言（原固定 300ms）。
+  await settle(() => {
+    const ls = viewportLines(term2, ROWS)
+    return ['M0', 'M1', 'M2', 'M3', 'M4'].every(m => ls.some(l => l.includes(m)))
+  })
+  const lines2 = viewportLines(term2, ROWS)
   const rowOf2 = (needle: string) => lines2.findIndex(l => l.includes(needle))
   check('契约：顶层字符串换行压平（恰 1 行）',
     rowOf2('M1') === rowOf2('M0') + 2 && (lines2[rowOf2('M0') + 1] ?? '').includes('Foo Bar'),
@@ -333,14 +336,14 @@ const typeKeys = async (s: string, stepMs = 40) => {
   await typeKeys('/model')
   await sleep(200)
   stdin.write('\r')
-  await sleep(600)
+  await settle(() => focusLineVisible('Model 00'))
   // 焦点初始落在当前模型 model-00（索引 0）：每项 2 行也必须留在屏内。
   check('/model 焦点 0 在屏（带描述，每项 2 行）', focusLineVisible('Model 00'))
   check('/model 打开缓冲区零增长', term.buffer.active.length === bufBefore,
     `${bufBefore} → ${term.buffer.active.length}`)
   dump('model focus 0')
   for (let i = 0; i < 20; i++) { stdin.write('\x1b[B'); await sleep(25) }
-  await sleep(400)
+  await settle(() => focusLineVisible('Model 20'))
   check('/model ↓×20 焦点 20 在屏', focusLineVisible('Model 20'))
   dump('model focus 20')
   stdin.write('\x1b')
@@ -351,7 +354,7 @@ const typeKeys = async (s: string, stepMs = 40) => {
 {
   const bufBefore = term.buffer.active.length
   stdin.write('\x12') // ctrl+r
-  await sleep(500)
+  await settle(() => focusLineVisible('/model'))
   // 历史新→旧：最新一条是上一阶段真实键入的 '/model'（appendHistory 落盘），
   // 之后才是预置的 histcmd-29…00。焦点 0 = '/model'。
   check('ctrl+r 焦点 0 在屏（2 行项 + gap）', focusLineVisible('/model'))
@@ -359,12 +362,12 @@ const typeKeys = async (s: string, stepMs = 40) => {
     `${bufBefore} → ${term.buffer.active.length}`)
   dump('history focus 0')
   stdin.write('\x1b[A') // ↑ 从 0 回绕到末项
-  await sleep(300)
+  await settle(() => focusLineVisible('histcmd-00'))
   check('ctrl+r ↑ 回绕末项焦点在屏', focusLineVisible('histcmd-00'))
   stdin.write('\x1b[B') // ↓ 回绕回 0
   await sleep(200)
   for (let i = 0; i < 15; i++) { stdin.write('\x1b[B'); await sleep(25) }
-  await sleep(300)
+  await settle(() => focusLineVisible('histcmd-15'))
   // 索引 15 = histcmd-15（索引 0 是 '/model'，索引 1 才是 histcmd-29）。
   check('ctrl+r ↓×15 焦点 15 在屏', focusLineVisible('histcmd-15'))
   dump('history focus 15')
@@ -380,7 +383,11 @@ const typeKeys = async (s: string, stepMs = 40) => {
   await typeKeys('/theme')
   await sleep(200)
   stdin.write('\r')
-  await sleep(600)
+  await settle(() => {
+    const ls = screenLines()
+    const row = ls.findIndex(l => l.includes('Foo Bar NL'))
+    return row !== -1 && (ls[row] ?? '').includes('██')
+  })
   const lines = screenLines()
   const nameRow = lines.findIndex(l => l.includes('Foo Bar NL'))
   check('/theme 换行 displayName 单行渲染且色块同行',
@@ -399,7 +406,7 @@ const typeKeys = async (s: string, stepMs = 40) => {
   stdin.write('\x1b') // 双击 Esc（空输入）打开 rewind
   await sleep(100)
   stdin.write('\x1b')
-  await sleep(600)
+  await settle(() => focusLineVisible('rewind 消息 29'))
   // 焦点 0 = 最新用户消息；首项带 'last message' 描述（2 行）。
   check('rewind 焦点 0 在屏（首项 2 行）', focusLineVisible('rewind 消息 29'))
   check('rewind 首项描述行在屏', screenLines().some(l => l.includes('最近一条消息')))
@@ -407,12 +414,12 @@ const typeKeys = async (s: string, stepMs = 40) => {
     `${bufBefore} → ${term.buffer.active.length}`)
   dump('rewind focus 0')
   stdin.write('\x1b[A') // ↑ 回绕到末项 = 最老一条
-  await sleep(300)
+  await settle(() => focusLineVisible('rewind 消息 00'))
   check('rewind ↑ 回绕末项焦点在屏', focusLineVisible('rewind 消息 00'))
   stdin.write('\x1b[B') // ↓ 回绕回 0
   await sleep(200)
   for (let i = 0; i < 15; i++) { stdin.write('\x1b[B'); await sleep(25) }
-  await sleep(300)
+  await settle(() => focusLineVisible('rewind 消息 14'))
   // 索引 15 = rewind 消息 14（索引 0 是最新的 29）。
   check('rewind ↓×15 焦点 15 在屏', focusLineVisible('rewind 消息 14'))
   dump('rewind focus 15')

--- a/scripts/repro-pill.tsx
+++ b/scripts/repro-pill.tsx
@@ -10,13 +10,14 @@ process.env.FORCE_COLOR = '3'
 // module import resolves the startup lang (env > persisted > locale).
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -95,6 +96,9 @@ const instance = await render(
   </AlternateScreen>,
   { stdout: new FakeStdout(), stdin: stdinObj, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
+// Startup wait stays a fixed window: the first assertion is a negative probe
+// (no pill may exist) — settling on an already-true condition would return on
+// a blank screen and test nothing.
 await sleep(600)
 
 // SGR mouse: 64=wheel up, 65=wheel down; position inside the scroll area.
@@ -114,11 +118,14 @@ check('at bottom: no pill initially', pillText() === '', JSON.stringify(pillText
 wheel('up', 6)
 await sleep(500)
 addRows(8)
-await sleep(500)
+await settle(() => /8 new messages/.test(pillText()))
 const pill0 = pillText()
 check('pill appears with the new-message count', /8 new messages/.test(pill0), pill0)
 
-// wheel down in small steps: the count must DECREASE monotonically
+// wheel down in small steps: the count must DECREASE monotonically.
+// The per-step sleeps stay fixed: this loop SAMPLES the pill after each step
+// (there is no target state to settle on — the samples themselves are the
+// data the monotonicity assertions consume).
 const seen: string[] = []
 let prev = 8
 let monotonic = true

--- a/scripts/repro-resize-blank.tsx
+++ b/scripts/repro-resize-blank.tsx
@@ -9,7 +9,7 @@ process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'Orca'
 process.env.DSH_TUI_THEME = 'dark'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -17,6 +17,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/ink/instances.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 let COLS = 232
@@ -109,7 +110,9 @@ await render(
 const ink: any = instances.get(stdout)
 if (!ink) { console.log('FAIL 未找到 Ink 实例'); process.exit(1) }
 ink.setAltScreenActive(true, true)
-await sleep(1200)
+// boot 是唯一的 false→true 等待（消息区从空到有内容）；后面全部 resize
+// 断言是「不得空白」稳定性探针，保留固定窗口。
+await settle(() => density() >= 3)
 check('alt-screen 已激活', ink.isAltScreenActive === true)
 assertVisible('启动落定 400 行')
 
@@ -121,6 +124,8 @@ function doResize(w: number, h: number) {
 }
 
 // ---- 现场形态的 burst ----
+// 各落定/闲置等待保留固定 sleep：断言的 density>=3 平时恒真（空白才是
+// 回归症状），对已成立条件轮询立即返回等于没测。
 const bursts: Array<Array<[number, number]>> = [
   [[231, 71], [232, 71]],
   [[235, 71]],

--- a/scripts/repro-resume-position.tsx
+++ b/scripts/repro-resume-position.tsx
@@ -26,7 +26,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -34,6 +34,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100, ROWS = 40
@@ -169,7 +170,7 @@ function assertLanded(tag: string, ms: number): void {
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
   const t0 = performance.now()
-  await sleep(700)
+  await settle(() => screenLines().join('\n').includes('TAILMARK_Q7X'))
   assertLanded('S1 boot--resume', performance.now() - t0)
   await inst.unmount()
 }
@@ -181,19 +182,25 @@ for (const [tag, scrollFirst] of [['S2 resume(at-bottom)', false], ['S3 resume(s
     <AlternateScreen><Chat channel={channel} questionStore={new QuestionStore()} fullscreen /></AlternateScreen>,
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(700)
+  await settle(() => screenLines().join('\n').includes('问题 15'))
   if (scrollFirst) {
     for (let i = 0; i < 12; i++) { stdin.write('\x1b[<64;50;20M'); await sleep(16) }
-    await sleep(250)
+    await settle(() => !screenLines().join('\n').includes('问题 15'))
     check(`${tag}: 前置——上滚后视口离开底部`, !screenLines().join('\n').includes('问题 15'))
   }
   // /resume → 浏览器 → Enter 恢复聚焦会话
+  // 两处保留固定 sleep（排序用途）：紧随的 Enter 依赖补全浮层/浏览器的按键
+  // 就绪状态，这不是屏幕可观察内容——settle 到「历史会话」上屏就发 Enter
+  // 会被尚未就绪的浏览器吞掉（实测卡在浏览器不恢复）。
   stdin.write('/resume')
   await sleep(300)
   stdin.write('\r')
   await sleep(500)
   check(`${tag}: 浏览器打开`, screenLines().some(l => l.includes('历史会话')), '')
   stdin.write('\r') // Enter → resumeTo → onClose
+  // 保留固定 sleep：紧随的「滚 1 上 2 下」自愈探针依赖行高测量已静息——
+  // settle 到 TAILMARK 首次上屏就开滚，滚回底部的格数会因高度仍在估算而
+  // 差出容差（实测探针失败）。
   const t0 = performance.now()
   await sleep(700)
   assertLanded(tag, performance.now() - t0)
@@ -204,7 +211,7 @@ for (const [tag, scrollFirst] of [['S2 resume(at-bottom)', false], ['S3 resume(s
   stdin.write('\x1b[<65;50;20M')
   await sleep(120)
   stdin.write('\x1b[<65;50;20M')
-  await sleep(400)
+  await settle(() => screenLines().join('\n').includes('TAILMARK_Q7X'))
   const healed = screenLines().join('\n').includes('TAILMARK_Q7X')
   check(`${tag}: 滚离后滚回底部，最新消息可见`, healed)
   if (!healed) {

--- a/scripts/repro-settings.tsx
+++ b/scripts/repro-settings.tsx
@@ -20,7 +20,7 @@ process.env.FORCE_COLOR = '3'
 // module import resolves the startup lang (env > persisted > locale).
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { ApprovalStore }, commandModule] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { ApprovalStore }, commandModule, { settle, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -29,6 +29,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
   import('../src/dsh-adapter/questions.js'),
   import('../src/dsh-adapter/approvals.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -53,6 +54,9 @@ class FakeStdin extends PassThrough {
 }
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 function screenText(): string {
+  // 刻意读缓冲区开头而非视口：本 inline harness 下 /settings 屏的标题行会被
+  // 滚进 scrollback（baseY 上方），断言以完整首帧内容为目标——换成 baseY 视口
+  // 读取会丢标题（实测 'Plugin settings' 断言失败）。
   const buf = term.buffer.active
   const lines: string[] = []
   for (let y = 0; y < ROWS; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
@@ -179,13 +183,16 @@ const instance = await render(
   <Chat fullscreen channel={channel} questionStore={new QuestionStore()} approvalStore={new ApprovalStore()} />,
   { stdout: new FakeStdout(), stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(600)
+await settle(() => screenText().includes('Explore the uncharted'))
 
 // 1. /settings opens the screen with the section and its seeded values.
+// The 200ms below stays a fixed ordering sleep: the Enter that follows needs
+// the slash-completion overlay to be key-ready, which is not observable as
+// screen content.
 stdin.write('/settings')
 await sleep(200)
 stdin.write('\r')
-await sleep(500)
+await settle(() => screenText().includes('Plugin settings'))
 assert(screenText().includes('Plugin settings'), 'screen opens with the title')
 assert(screenText().includes('Demo settings') && screenText().includes('(demo-plugin)'), 'section header renders')
 assert(screenText().includes('Enabled') && screenText().includes('true'), 'boolean field shows its value')
@@ -193,10 +200,10 @@ assert(screenText().includes('overridden'), 'user-layer presence marks the overr
 
 // 2. Enter stages a boolean toggle; `s` saves it as a fenced set op.
 stdin.write('\r')
-await sleep(300)
+await settle(() => screenText().includes('unsaved'))
 assert(screenText().includes('unsaved'), 'staged toggle marks the section dirty')
 stdin.write('s')
-await sleep(400)
+await settle(() => mutations.length === 1)
 assert(mutations.length === 1, 'save wrote exactly one mutation')
 const first = mutations[0]
 assert(first?.ns === 'demo-plugin' && first.expected === 3, 'write fenced by the seeded revision')
@@ -216,10 +223,13 @@ await sleep(200)
 stdin.write('10')
 await sleep(200)
 stdin.write('\r')
+// Fixed sleep kept: '10' is already on screen while the edit is open, so a
+// settle on the assertion's condition would return before the Enter is
+// processed — and the next key ('s') would land inside the editor.
 await sleep(200)
 assert(screenText().includes('10'), 'staged number draft renders')
 stdin.write('s')
-await sleep(400)
+await settle(() => mutations.length === 2)
 assert(mutations.length === 2, 'second save wrote')
 const secondOps = mutations[1]?.ops as { op: string; path: readonly string[]; value?: unknown }[]
 assert(secondOps?.[0]?.op === 'set' && secondOps[0].path.join('.') === 'limit' && secondOps[0].value === 10, 'number draft became a numeric set op')
@@ -238,7 +248,7 @@ await sleep(150)
 stdin.write('\x1b[B') // ↓ into other-plugin's Mode field
 await sleep(300)
 stdin.write('\x1b') // Esc: focused section is clean, demo-plugin is dirty
-await sleep(400)
+await settle(() => screenText().includes('Discarded all unsaved edits'))
 assert(screenText().includes('Discarded all unsaved edits'), 'Esc discards staged edits across ALL sections')
 assert(screenText().includes('Other settings'), 'screen stays open after the discard')
 assert(mutations.length === 2, 'discard wrote nothing')
@@ -248,6 +258,8 @@ assert(mutations.length === 2, 'discard wrote nothing')
 // (unstable host identity re-firing host-keyed effects) shows up as
 // unbounded growth; a settled screen makes no calls at all. The bound is
 // generous — a real loop runs thousands of renders in this window.
+// Stability probe (calls must NOT grow): polling an already-true condition
+// would return immediately and test nothing — keep the fixed window.
 const quietCalls = settingsHostCalls
 await sleep(600)
 assert(settingsHostCalls - quietCalls < 50, 'idle screen settles (no render loop through the host)')
@@ -258,7 +270,7 @@ assert(settingsHostCalls - quietCalls < 50, 'idle screen settles (no render loop
 // (SessionBrowser shows the same artifact; pre-existing renderer behavior,
 // not this screen's doing).
 stdin.write('\x1b')
-await sleep(900)
+await settle(() => screenText().includes('Explore the uncharted'))
 assert(screenText().includes('Explore the uncharted'), 'second Esc returns to the conversation')
 
 await instance.unmount()
@@ -276,10 +288,7 @@ class GroupStdout extends Writable {
   _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { groupTerm.write(String(chunk), cb) }
 }
 function groupScreenText(): string {
-  const buf = groupTerm.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < GROUP_ROWS; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
-  return lines.join('\n')
+  return viewportLines(groupTerm, GROUP_ROWS).join('\n')
 }
 docs['group-plugin'] = {
   revision: 5,
@@ -302,13 +311,13 @@ const groupInstance = await render(
   <Settings channel={groupChannel} onClose={() => { groupClosed = true }} />,
   { stdout: new GroupStdout(), stdin: groupStdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(600)
+await settle(() => groupScreenText().includes('Name') && groupScreenText().includes('Advanced'))
 assert(groupScreenText().includes('Name') && groupScreenText().includes('Advanced'), 'group root renders ungrouped fields and group entry', groupScreenText())
 assert(!groupScreenText().includes('Endpoint'), 'group root hides grouped fields', groupScreenText())
 groupStdin.write('\x1b[B') // ↓ from Name to Advanced
 await sleep(200)
 groupStdin.write('\r')
-await sleep(400)
+await settle(() => groupScreenText().includes('Endpoint') && groupScreenText().includes('Esc back'))
 // The headless renderer leaves the first row stale across in-place screen
 // transitions, so assert navigation through group-only content and its hint.
 assert(groupScreenText().includes('Endpoint') && groupScreenText().includes('Esc back'), 'Enter opens the group page', groupScreenText())
@@ -322,18 +331,21 @@ for (let i = 0; i < 3; i++) {
 groupStdin.write('new')
 await sleep(150)
 groupStdin.write('\r')
+// Fixed sleep kept: 'new' is already on screen inside the open editor, so a
+// settle on the assertion's condition would return before the Enter staged
+// the draft — and the next key would land in the wrong mode.
 await sleep(300)
 assert(groupScreenText().includes('new'), 'group field draft is staged', groupScreenText())
 groupStdin.write('\x1b')
-await sleep(300)
+await settle(() => groupScreenText().includes('unsaved') && !groupScreenText().includes('Endpoint'))
 assert(groupScreenText().includes('unsaved') && !groupScreenText().includes('Endpoint'), 'Esc returns to root without dropping the staged edit', groupScreenText())
 groupStdin.write('\x1b[B')
 await sleep(200)
 groupStdin.write('\r')
-await sleep(300)
+await settle(() => groupScreenText().includes('new'))
 assert(groupScreenText().includes('new'), 're-entering the group restores the staged draft', groupScreenText())
 groupStdin.write('s')
-await sleep(400)
+await settle(() => mutations.length === 3)
 const groupMutation = mutations[2]
 const groupOps = groupMutation?.ops as { op: string; path: readonly string[]; value?: unknown }[]
 assert(groupMutation?.ns === 'group-plugin' && groupMutation.expected === 5, 'group save is revision-fenced')
@@ -342,7 +354,7 @@ assert((docs['group-plugin']?.value.advanced as Record<string, unknown> | undefi
 groupStdin.write('\x1b')
 await sleep(200)
 groupStdin.write('\x1b')
-await sleep(300)
+await settle(() => groupClosed)
 assert(groupClosed, 'clean group screen exits from the root page')
 await groupInstance.unmount()
 
@@ -363,10 +375,7 @@ class SmallStdout extends Writable {
   _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { smallTerm.write(String(chunk), cb) }
 }
 function smallScreenText(): string {
-  const buf = smallTerm.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < SMALL_ROWS; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
-  return lines.join('\n')
+  return viewportLines(smallTerm, SMALL_ROWS).join('\n')
 }
 docs['long-plugin'] = {
   revision: 1,
@@ -385,7 +394,7 @@ const smallInstance = await render(
   <Settings channel={smallChannel} onClose={() => { smallClosed = true }} />,
   { stdout: new SmallStdout(), stdin: smallStdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(600)
+await settle(() => smallScreenText().includes('Long settings'))
 assert(smallScreenText().includes('Long settings'), 'small terminal opens the screen', smallScreenText())
 assert(smallScreenText().includes('Field 0') && !smallScreenText().includes('Field 15'), 'top of the list renders first', smallScreenText())
 for (let i = 0; i < 15; i++) {
@@ -395,7 +404,7 @@ for (let i = 0; i < 15; i++) {
 assert(smallScreenText().includes('Field 15'), 'focus on the last field scrolls it into view', smallScreenText())
 assert(!smallScreenText().includes('Field 0'), 'scrolled-out fields leave the viewport', smallScreenText())
 smallStdin.write('\x1b')
-await sleep(400)
+await settle(() => smallClosed)
 assert(smallClosed, 'Esc on a clean screen closes it')
 await smallInstance.unmount()
 
@@ -408,10 +417,7 @@ class GroupedSmallStdout extends Writable {
   _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { groupedSmallTerm.write(String(chunk), cb) }
 }
 function groupedSmallScreenText(): string {
-  const buf = groupedSmallTerm.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < SMALL_ROWS; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
-  return lines.join('\n')
+  return viewportLines(groupedSmallTerm, SMALL_ROWS).join('\n')
 }
 docs['long-group-plugin'] = {
   revision: 1,
@@ -430,10 +436,10 @@ const groupedSmallInstance = await render(
   <Settings channel={groupedSmallChannel} onClose={() => {}} />,
   { stdout: new GroupedSmallStdout(), stdin: groupedSmallStdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(500)
+await settle(() => groupedSmallScreenText().includes('Advanced fields') && !groupedSmallScreenText().includes('Grouped field 0'))
 assert(groupedSmallScreenText().includes('Advanced fields') && !groupedSmallScreenText().includes('Grouped field 0'), 'short group root hides grouped fields', groupedSmallScreenText())
 groupedSmallStdin.write('\r')
-await sleep(300)
+await settle(() => groupedSmallScreenText().includes('Grouped field 0') && !groupedSmallScreenText().includes('Grouped field 15'))
 assert(groupedSmallScreenText().includes('Grouped field 0') && !groupedSmallScreenText().includes('Grouped field 15'), 'short group page starts at its first field', groupedSmallScreenText())
 for (let i = 0; i < 15; i++) {
   groupedSmallStdin.write('\x1b[B')

--- a/scripts/repro-thinking.tsx
+++ b/scripts/repro-thinking.tsx
@@ -20,7 +20,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { render }, { Chat }, { QuestionStore }, { Terminal: XTerm }, fs] =
+const [{ PassThrough, Writable }, React, { render }, { Chat }, { QuestionStore }, { Terminal: XTerm }, fs, { writeParsed, viewportLines }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -29,6 +29,7 @@ const [{ PassThrough, Writable }, React, { render }, { Chat }, { QuestionStore }
     import('../src/dsh-adapter/questions.js'),
     import('@xterm/headless'),
     import('node:fs'),
+    import('./lib/term-test.mjs'),
   ])
 
 const COLS = Number(process.env.COLS ?? 100)
@@ -151,16 +152,12 @@ try { instance.unmount() } catch {}
 // write 是异步分块解析的：必须等回调而不是固定 sleep，否则慢机器上
 // 断言读到解析了一半的屏幕。
 const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 500, allowProposedApi: true })
-await new Promise<void>(r => term.write(byteStream, r))
+await writeParsed(term, byteStream)
 
 // 扫可见视口（baseY 起的 ROWS 行）。裸 getLine(0..ROWS) 在有 scrollback 时
 // 读的是缓冲区开头：混入已滚出的旧行、漏掉视口底部 baseY 行——残影恰恰
 // 最容易出现在底部 spinner 附近。
-const buf = term.buffer.active
-const lines: string[] = []
-for (let y = 0; y < ROWS; y++) {
-  lines.push(buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
-}
+const lines = viewportLines(term, ROWS)
 
 // ── 残影检测 ──
 const problems: string[] = []
@@ -184,7 +181,7 @@ if (problems.length > 0) {
   const dump = '/tmp/repro-thinking-frames.bin'
   fs.writeFileSync(dump, byteStream)
   console.error(`FAIL: thinking spinner 残影回归（帧字节已存 ${dump}）`)
-  console.error(`=== xterm-headless replay: ${COLS}x${ROWS} (viewport baseY=${buf.baseY}) ===`)
+  console.error(`=== xterm-headless replay: ${COLS}x${ROWS} (viewport baseY=${term.buffer.active.baseY}) ===`)
   lines.forEach((line, y) => console.error(`${String(y).padStart(3)}|${line}`))
   for (const p of problems) console.error(`- ${p}`)
   process.exit(1)

--- a/scripts/repro-toolcards.tsx
+++ b/scripts/repro-toolcards.tsx
@@ -8,12 +8,13 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }] = await Promise.all([
+const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/components/messages/AssistantToolUseMessage.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 90
@@ -92,12 +93,16 @@ const editTool = {
 }
 
 const app = await render(card('edit', editTool), { stdout, debug: true, exitOnCtrlC: false })
-await sleep(250)
+await settle(() => rowOf('- const a = 1') >= 0 && rowOf('+ const a = 2') >= 0)
 
-/** Swap the rendered card; key forces a clean remount per scenario. */
-async function show(key: string, tool: Record<string, unknown>, verbose = false): Promise<void> {
+/**
+ * Swap the rendered card; key forces a clean remount per scenario. `ready`
+ * is polled until the new card's distinctive content is parsed (the old
+ * fixed 250ms could sample a half-parsed screen on slow runners).
+ */
+async function show(key: string, tool: Record<string, unknown>, ready: () => boolean, verbose = false): Promise<void> {
   app.rerender(card(key, tool, verbose))
-  await sleep(250)
+  await settle(ready)
 }
 
 // 1. Settled Edit: diff body, red `- ` / green `+ ` lines under the ⎿ gutter.
@@ -120,7 +125,7 @@ await show('write', {
     title: 'Write /tmp/new.ts',
     diffs: [{ path: '/tmp/new.ts', oldText: null, newText: 'hello\nworld' }],
   },
-})
+}, () => screen().includes('+ hello') && screen().includes('+ world'))
 {
   const s = screen()
   check('新建文件标题为「Write /tmp/new.ts」', s.includes('Write /tmp/new.ts'))
@@ -134,7 +139,7 @@ await show('bash', {
   callView: { card: 'terminal', title: 'ls -la' },
   resultView: { card: 'terminal', output: 'total 8\nfile1\nfile2', exitCode: 0 },
   resultFull: 'total 8\nfile1\nfile2',
-})
+}, () => screen().includes('Bash(ls -la)') && rowOf('total 8') >= 0)
 {
   const s = screen()
   check('终端卡标题为「Bash(ls -la)」', s.includes('Bash(ls -la)'))
@@ -148,7 +153,7 @@ await show('bash-err', {
   callView: { card: 'terminal', title: 'false' },
   resultView: { card: 'terminal', output: '', exitCode: 1 },
   resultFull: '',
-})
+}, () => rowOf('Exit code 1') >= 0)
 check('非零退出显示 Exit code 行', rowOf('Exit code 1') >= 0)
 
 // 5. Read 卡：正文剥离 <path>/<content> 信封。
@@ -161,7 +166,7 @@ await show('read', {
     content: [{ type: 'text', text: 'line one\nline two' }],
   },
   resultFull: '<path>/tmp/x.ts</path>\n<content>\nline one\nline two\n</content>',
-})
+}, () => rowOf('line one') >= 0)
 {
   const s = screen()
   check('Read 正文无信封标签', s.includes('line one') && !s.includes('<content>') && !s.includes('<path>'))
@@ -173,7 +178,7 @@ await show('read', {
 await show('fallback', {
   name: 'read',
   resultFull: 'raw output here',
-})
+}, () => rowOf('raw output here') >= 0)
 {
   const s = screen()
   check('无视图时回退 Name(args) 标题', s.includes('Read({"file_path":"/tmp/a.ts"})'))
@@ -187,7 +192,7 @@ await show('cap', {
   callView: { card: 'terminal', title: 'seq 6' },
   resultView: { card: 'terminal', output: '1\n2\n3\n4\n5\n6', exitCode: 0 },
   resultFull: '1\n2\n3\n4\n5\n6',
-})
+}, () => screen().includes('… +3 lines (ctrl+o to expand)'))
 {
   const s = screen()
   check('文本正文折叠为 3 行 + 提示', s.includes('… +3 lines (ctrl+o to expand)') && rowOf('4') === -1)
@@ -197,7 +202,7 @@ await show('cap-open', {
   callView: { card: 'terminal', title: 'seq 6' },
   resultView: { card: 'terminal', output: '1\n2\n3\n4\n5\n6', exitCode: 0 },
   resultFull: '1\n2\n3\n4\n5\n6',
-}, true)
+}, () => rowOf('6') >= 0 && !screen().includes('ctrl+o to expand'), true)
 check('verbose 不折叠', rowOf('6') >= 0 && !screen().includes('ctrl+o to expand'))
 
 // 8. 错误卡：errorText 红色缩进。
@@ -205,7 +210,7 @@ await show('error', {
   name: 'read',
   status: 'error',
   errorText: 'Error: ENOENT',
-})
+}, () => rowOf('Error: ENOENT') >= 0)
 {
   const row = rowOf('Error: ENOENT')
   check('错误行带 ⎿ 缩进', row >= 0 && lines()[row]!.startsWith(' ⎿ Error: ENOENT'))
@@ -221,26 +226,30 @@ await show('running-diff', {
     title: 'Edit /tmp/a.ts',
     diffs: [{ path: '/tmp/a.ts', oldText: 'old', newText: 'new' }],
   },
-})
+}, () => rowOf('- old') >= 0 && rowOf('+ new') >= 0)
 check('运行中展示待定 diff', rowOf('- old') >= 0 && rowOf('+ new') >= 0)
 
 // 10. 状态点：分类定色、失败红 ✗。
-await show('dot-bash', { name: 'bash', argsText: '{"command":"ls"}' })
+await show('dot-bash', { name: 'bash', argsText: '{"command":"ls"}' },
+  () => rowOf('Bash') >= 0 && (lines()[rowOf('Bash')] ?? '').includes('•'))
 {
   const row = rowOf('Bash')
   check('bash 点为鼠尾草绿小点', row >= 0 && lines()[row]!.includes('•') && fgAt(lines()[row]!.indexOf('•'), row) === 0x7fae99)
 }
-await show('dot-read', { name: 'read' })
+await show('dot-read', { name: 'read' },
+  () => rowOf('Read') >= 0 && (lines()[rowOf('Read')] ?? '').includes('•'))
 {
   const row = rowOf('Read')
   check('read 点为青蓝小点', row >= 0 && fgAt(lines()[row]!.indexOf('•'), row) === 0x82b8c7)
 }
-await show('dot-edit', { name: 'edit' })
+await show('dot-edit', { name: 'edit' },
+  () => rowOf('Edit') >= 0 && (lines()[rowOf('Edit')] ?? '').includes('•'))
 {
   const row = rowOf('Edit')
   check('edit 点为雾紫小点', row >= 0 && fgAt(lines()[row]!.indexOf('•'), row) === 0xb3a0d4)
 }
-await show('dot-error', { name: 'bash', status: 'error', errorText: 'boom' })
+await show('dot-error', { name: 'bash', status: 'error', errorText: 'boom' },
+  () => rowOf('Bash') >= 0 && (lines()[rowOf('Bash')] ?? '').includes('✗'))
 {
   const row = rowOf('Bash')
   check('失败点变红 ✗', row >= 0 && lines()[row]!.includes('✗') && fgAt(lines()[row]!.indexOf('✗'), row) === 0xda8a93)
@@ -262,7 +271,7 @@ await show('multi-hunk', {
       { path: '/tmp/a.ts', oldText: 'l9', newText: 'l9c' },
     ],
   },
-})
+}, () => rowOf('⋯') >= 0 && rowOf('- l1') >= 0 && rowOf('+ l9c') >= 0)
 check('多 hunk 用 ⋯ 分隔', rowOf('⋯') >= 0 && rowOf('- l1') >= 0 && rowOf('+ l9c') >= 0)
 
 // 11. Grep 搜索卡：按文件分组的 matches。
@@ -277,7 +286,7 @@ await show('grep', {
     total: 7,
   },
   resultFull: 'src/a.ts:12: // TODO fix',
-})
+}, () => rowOf('12: // TODO fix') >= 0 && rowOf('(7 total)') >= 0)
 {
   const s = screen()
   check('搜索卡标题回退到 call 标题', s.includes('Grep TODO in src'))
@@ -296,7 +305,7 @@ await show('glob', {
     total: 2,
   },
   resultFull: 'src/a.ts\nsrc/b.ts',
-})
+}, () => rowOf('src/b.ts') >= 0)
 check('Glob paths 逐行列出', rowOf('src/a.ts') >= 0 && rowOf('src/b.ts') >= 0)
 
 app.unmount()

--- a/scripts/verify-askpanel-hide-custom-input.tsx
+++ b/scripts/verify-askpanel-hide-custom-input.tsx
@@ -11,12 +11,13 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }, { settle, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/components/questions/AskUserQuestionPanel.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 90
@@ -38,10 +39,7 @@ const stdout = new FakeStdout()
 const stdin = new FakeStdin()
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 function screen(): string {
-  const buf = term.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < ROWS; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
-  return lines.join('\n')
+  return viewportLines(term, ROWS).join('\n')
 }
 
 let answer: unknown
@@ -55,7 +53,7 @@ const app = await render(
   }),
   { stdout, stdin, stderr: new FakeStdout(), debug: true, exitOnCtrlC: false },
 )
-await sleep(200)
+await settle(() => screen().includes('占位'))
 
 let failures = 0
 const check = (name: string, ok: boolean, extra = '') => {
@@ -64,9 +62,13 @@ const check = (name: string, ok: boolean, extra = '') => {
 }
 const eq = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b)
 
-/** Remount the panel with a fresh question (key forces clean state). */
+/**
+ * Remount the panel with a fresh question (key forces clean state). `ready`
+ * is polled until the new panel's distinctive content is parsed (the old
+ * fixed 200ms could sample a half-parsed screen on slow runners).
+ */
 let mountSeq = 0
-async function mount(question: Record<string, unknown>): Promise<void> {
+async function mount(question: Record<string, unknown>, ready: () => boolean): Promise<void> {
   answer = undefined
   cancelled = false
   app.rerender(React.createElement(AskUserQuestionPanel, {
@@ -76,7 +78,7 @@ async function mount(question: Record<string, unknown>): Promise<void> {
     onCancel: () => { cancelled = true },
     question,
   }))
-  await sleep(200)
+  await settle(ready)
 }
 
 // ── 1. 纯选择题 + hideCustomInput ─────────────────────────────────────
@@ -84,11 +86,13 @@ await mount({
   question: '要添加哪种模型提供方？',
   options: [{ label: '内置 provider' }, { label: '自定义 API 端点' }],
   hideCustomInput: true,
-})
+}, () => screen().includes('内置 provider') && !screen().includes('自定义回答'))
 check('1 hide: 无「自定义回答」输入行', !screen().includes('自定义回答'))
 check('1 hide: hint 无输入提示', !screen().includes('输入回答') && !screen().includes('输入文字附带回答'))
 check('1 hide: 选项照常渲染', screen().includes('内置 provider') && screen().includes('自定义 API 端点'))
 
+// Tab/可打印字符「应被忽略」是状态不得改变的稳定性探针：轮询已成立条件会
+// 立即返回等于没测，键间保留固定窗口。
 stdin.write('\x1b[B') // ↓ → 第二项
 await sleep(100)
 stdin.write('\t')    // Tab 应被忽略（无输入行可跳）
@@ -96,7 +100,7 @@ await sleep(100)
 stdin.write('x')     // 可打印字符应被忽略
 await sleep(100)
 stdin.write('\r')    // Enter 提交焦点项
-await sleep(200)
+await settle(() => eq(answer, { selected: ['自定义 API 端点'] }))
 check('1 hide: Enter 只提交 selected，无 custom',
   eq(answer, { selected: ['自定义 API 端点'] }), JSON.stringify(answer))
 
@@ -104,12 +108,14 @@ check('1 hide: Enter 只提交 selected，无 custom',
 await mount({
   question: '输入 API key',
   hideCustomInput: true,
-})
+  // patchConsole 会把前面 check 消息（含「自定义回答」字样）渲染进终端，
+  // 只盯它会立即返回——用新题独有的问题文本当挂载完成信号。
+}, () => screen().includes('输入 API key'))
 check('2 text-only: hide 被忽略，输入行仍在', screen().includes('自定义回答'))
 stdin.write('sk-secret')
-await sleep(100)
+await settle(() => screen().includes('sk-secret'))
 stdin.write('\r')
-await sleep(200)
+await settle(() => eq(answer, { selected: [], custom: 'sk-secret' }))
 check('2 text-only: 文本照常提交',
   eq(answer, { selected: [], custom: 'sk-secret' }), JSON.stringify(answer))
 
@@ -118,14 +124,16 @@ await mount({
   question: '选择要启用的模型',
   options: [{ label: 'deepseek-chat' }, { label: 'deepseek-reasoner' }],
   multiSelect: true,
-})
+  // 上一屏已含「自定义回答」，settle 只盯它会立即返回——加新题独有的选项
+  // 文本当挂载完成信号。
+}, () => screen().includes('deepseek-chat') && screen().includes('自定义回答'))
 check('3 multi: 输入行保留', screen().includes('自定义回答'))
 stdin.write(' ')      // 勾选第一项
 await sleep(100)
 stdin.write('extra-model') // 输入行补充
-await sleep(100)
+await settle(() => screen().includes('extra-model'))
 stdin.write('\r')
-await sleep(200)
+await settle(() => eq(answer, { selected: ['deepseek-chat'], custom: 'extra-model' }))
 check('3 multi: 勾选 + 自定义补充同时生效',
   eq(answer, { selected: ['deepseek-chat'], custom: 'extra-model' }), JSON.stringify(answer))
 

--- a/scripts/verify-askpanel-layout.tsx
+++ b/scripts/verify-askpanel-layout.tsx
@@ -12,13 +12,14 @@ export {} // 模块边界：避免顶层 await/全局名与其他 verify 脚本�
 
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
@@ -152,7 +153,7 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
   )
   await sleep(600)
   void store.ask({ questions: [EXACT_QUESTION] } as never)
-  await sleep(600)
+  await settle(() => REQUIRED.every(t => screen().includes(t)))
   check(`静态渲染（${name}）`, screen())
   app.unmount()
   await sleep(100)
@@ -211,7 +212,7 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
     stdout.emit('resize')
     await sleep(90)
   }
-  await sleep(800)
+  await settle(() => REQUIRED.every(t => screen().includes(t)))
   check('resize 风暴后（130x42）', screen())
   app.unmount()
   await sleep(100)

--- a/scripts/verify-askpanel-long-list.tsx
+++ b/scripts/verify-askpanel-long-list.tsx
@@ -8,12 +8,13 @@
 process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal }, { render }, { AskUserQuestionPanel }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal }, { render }, { AskUserQuestionPanel }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/components/questions/AskUserQuestionPanel.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 class FakeStdin extends PassThrough {
@@ -54,19 +55,23 @@ function viewport(): string {
     buffer.getLine(buffer.viewportY + y)?.translateToString(true) ?? '').join('\n')
 }
 
-await delay(400)
+// 每个快照 settle 到「焦点标签在屏且恰一个 ●」——断言的同一条件；只盯焦点
+// 标签会在旧焦点行尚未擦除的半解析帧上提前返回。
+const settled = (label: string): boolean =>
+  viewport().includes(label) && viewport().split('\n').filter(line => line.includes('●')).length === 1
+await settle(() => settled('● provider-00'))
 const initial = viewport()
 for (let index = 0; index < 25; index += 1) {
   stdin.write('\x1b[B')
   await delay(20)
 }
-await delay(300)
+await settle(() => settled('● provider-25'))
 const moved = viewport()
 
 terminal.resize(90, 18)
 stdout.rows = 18
 stdout.emit('resize')
-await delay(300)
+await settle(() => settled('● provider-25'))
 const resized = viewport()
 
 let failures = 0

--- a/scripts/verify-back-to-bottom.tsx
+++ b/scripts/verify-back-to-bottom.tsx
@@ -16,7 +16,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -24,6 +24,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100, ROWS = 40
@@ -77,6 +78,8 @@ const inst = await render(
   </AlternateScreen>,
   { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
 )
+// 启动等待保留固定窗口：首个断言是「钉底无 pill」的稳定性探针，对已成立
+// 条件（空屏也无 pill）轮询立即返回等于没测。
 await sleep(700)
 
 function screenLines(): string[] {
@@ -97,13 +100,18 @@ const wheel = async (up: boolean, times: number) => {
     await sleep(150)
   }
 }
-const pressKey = async (name: string) => {
+/**
+ * 按键后等待：给 until 则 settle 到该条件（断言的同一条件）；不给则保留
+ * 固定 400ms——「钉底按 End 无操作」这类稳定性探针必须要固定窗口。
+ */
+const pressKey = async (name: string, until?: () => boolean) => {
   const seqs: Record<string, string> = {
     end: '\x1b[F',
     enter: '\r',
   }
   stdin.write(seqs[name]!)
-  await sleep(400)
+  if (until) await settle(until)
+  else await sleep(400)
 }
 
 // ── 1. 钉底：无 pill ──
@@ -119,14 +127,17 @@ await wheel(true, 6)
 rows.push({ id: 17, kind: 'user', text: '问题 9' })
 rows.push({ id: 18, kind: 'assistant', text: '回复 9 第 1 行\n回复 9 第 2 行' })
 emitChannel()
-await sleep(500)
+await settle(() => {
+  const p = pillText()
+  return p !== null && /2 条新消息/.test(p)
+})
 {
   const p = pillText()
   check('新消息后 pill 切计数', p !== null && /2 条新消息/.test(p), `pill=${JSON.stringify(p)}`)
 }
 
 // ── 3. End 键回底 ──
-await pressKey('end')
+await pressKey('end', () => lastTurnVisible() && pillText() === null)
 {
   check('End 后回到底部（末轮可见）', lastTurnVisible())
   check('End 后 pill 消失', pillText() === null, `pill=${JSON.stringify(pillText())}`)
@@ -137,7 +148,7 @@ await wheel(true, 8)
 {
   check('再次上滚 pill 重现', pillText() !== null, `pill=${JSON.stringify(pillText())}`)
 }
-await pressKey('enter')
+await pressKey('enter', () => lastTurnVisible() && pillText() === null)
 {
   check('Enter 后回到底部', lastTurnVisible() && pillText() === null,
     `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
@@ -157,13 +168,14 @@ await wheel(true, 8)
   if (pillRow !== -1) {
     stdin.write(`\x1b[<0;${pillCol + 2};${pillRow + 1}M`)
     stdin.write(`\x1b[<0;${pillCol + 2};${pillRow + 1}m`)
-    await sleep(500)
+    await settle(() => lastTurnVisible() && pillText() === null)
     check('点击 pill 后回到底部', lastTurnVisible() && pillText() === null,
       `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
   }
 }
 
 // ── 6. 钉底按 End：无操作不崩 ──
+// 稳定性探针：期望状态不变（已在底部），不传 until、保留固定窗口。
 await pressKey('end')
 {
   check('钉底按 End 无操作', lastTurnVisible() && pillText() === null)
@@ -187,7 +199,7 @@ await inst.unmount()
     </AlternateScreen>,
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(700)
+  await settle(() => screenLines().some(l => l.includes('问题 20')))
   // 上滚 30 格 → 中部（跳底距离 ≈ 150 行 ≫ 视口）
   for (let i = 0; i < 30; i++) {
     stdin.write('\x1b[<64;90;30M')

--- a/scripts/verify-batched-prompt-input.mjs
+++ b/scripts/verify-batched-prompt-input.mjs
@@ -14,6 +14,7 @@ import { PassThrough, Writable } from 'node:stream'
 import React from 'react'
 import { render } from '../lib/types/ui.js'
 import { PromptInput } from '../lib/types/components/PromptInput.js'
+import { settle } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -73,7 +74,7 @@ await new Promise(resolve => setTimeout(resolve, 500))
 stdin.write('a\x1b[Db')
 await new Promise(resolve => setTimeout(resolve, 200))
 stdin.write('\r')
-await new Promise(resolve => setTimeout(resolve, 300))
+await settle(() => submitted.length === 1 && submitted[0] === 'ba')
 
 check(
   'batched text, cursor movement, text, and Enter submit the composed value',
@@ -87,7 +88,7 @@ check(
 stdin.write('\x1b[65;30;20320;1;0;1_\x1b[65;30;22909;1;0;1_')
 await new Promise(resolve => setTimeout(resolve, 200))
 stdin.write('\r')
-await new Promise(resolve => setTimeout(resolve, 300))
+await settle(() => submitted.length === 2 && submitted[1] === '你好')
 
 check(
   'batched Termy win32 IME records preserve every committed character',
@@ -102,7 +103,7 @@ channel.working = true
 stdin.write('\x1b[78;49;110;1;0;1_\x1b[80;25;112;1;0;1_\x1b[77;50;109;1;0;1_')
 await new Promise(resolve => setTimeout(resolve, 200))
 stdin.write('\r')
-await new Promise(resolve => setTimeout(resolve, 300))
+await settle(() => steered.length === 1 && steered[0] === 'npm')
 
 check(
   'batched Windows input while streaming preserves npm before steer',
@@ -127,7 +128,8 @@ for (const [index, [label, newlineKey, prefix]] of multilineCases.entries()) {
   stdin.write(`${prefix} second`)
   await new Promise(resolve => setTimeout(resolve, 100))
   stdin.write('\r')
-  await new Promise(resolve => setTimeout(resolve, 300))
+  await settle(() => submitted.length === index + 3
+    && submitted[index + 2] === `${prefix} first\n${prefix} second`)
 
   check(
     `${label} inserts a newline before Enter submits the multiline draft`,

--- a/scripts/verify-child-stderr.tsx
+++ b/scripts/verify-child-stderr.tsx
@@ -19,6 +19,7 @@ process.env.DSH_TUI_LANG = 'zh'
 
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
+import { settle } from './lib/term-test.mjs'
 
 const SELF = fileURLToPath(import.meta.url)
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
@@ -90,37 +91,43 @@ async function runDriver(): Promise<void> {
   reporter.push(failing)
   reporter.push(failing)
   reporter.push(failing)
+  // 稳定性探针（不得多出通知）：settle 会在第一条通知出现时立即返回，
+  // 测不到「只出一条」的上界——保留固定窗口。
   await sleep(150)
   check('去重：同一行连发 3 次只出一条通知', notices.length === 1)
   check('去重：通知带重复计数（重复 3 次）', notices[0]?.includes('重复 3 次') ?? false)
 
   reporter.push(failing)
+  // 稳定性探针（冷却期内不得出新通知）：条件在 push 前就成立，轮询等于
+  // 没测——保留固定窗口。
   await sleep(150)
   check('冷却：刚通知过的行在冷却期内静默', notices.length === 1)
 
+  // 纯排序等待：冷却窗口是墙钟时间，没有可观察的状态翻转——保留。
   await sleep(400)
   reporter.push(failing)
-  await sleep(150)
+  await settle(() => notices.length === 2)
   check('冷却结束：同一行可再次通知', notices.length === 2)
 
   reporter.push('Usage: tsx proxy.ts <url>')
-  await sleep(150)
+  await settle(() => notices.length === 3 && (notices[2]?.includes('Usage:') ?? false))
   check('不同的行各自成条通知', notices.length === 3 && (notices[2]?.includes('Usage:') ?? false))
 
   reporter.push('\x1b[31mred-line\x1b[39m')
-  await sleep(150)
+  await settle(() => (notices.at(-1) ?? '').includes('red-line') && !(notices.at(-1) ?? '').includes('\x1b'))
   const ansiNotice = notices.at(-1) ?? ''
   check('ANSI 转义被剥离', ansiNotice.includes('red-line') && !ansiNotice.includes('\x1b'))
 
   const longLine = 'x'.repeat(100)
   reporter.push(longLine)
-  await sleep(150)
+  await settle(() => (notices.at(-1) ?? '').includes('…') && !(notices.at(-1) ?? '').includes(longLine))
   const longNotice = notices.at(-1) ?? ''
   check('超长行被截断（带省略号）', longNotice.includes('…') && !longNotice.includes(longLine))
 
   const countBefore = notices.length
   reporter.push('   ')
   reporter.push('')
+  // 稳定性探针（空行不得产生通知）：条件在 push 前就成立——保留固定窗口。
   await sleep(150)
   check('空行/纯空白行被丢弃', notices.length === countBefore)
 

--- a/scripts/verify-cjk-truncate.tsx
+++ b/scripts/verify-cjk-truncate.tsx
@@ -8,7 +8,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render }, { FileSuggestions }, { stringWidth }, { truncateToWidth }] = await Promise.all([
+const [{ Writable }, React, { Terminal: XTerm }, { render }, { FileSuggestions }, { stringWidth }, { truncateToWidth }, { settle, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -16,6 +16,7 @@ const [{ Writable }, React, { Terminal: XTerm }, { render }, { FileSuggestions }
   import('../src/components/FileSuggestions.js'),
   import('../src/ink/stringWidth.js'),
   import('../src/ink/truncateToWidth.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
@@ -81,14 +82,14 @@ const app = await render(
   React.createElement(FileSuggestions, { files, selectedIndex: 0, columns: COLS }),
   { stdout: new FakeStdout(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(300)
+await settle(() => viewportLines(term, ROWS).some(line => line.includes('…')))
 app.unmount()
 await sleep(100)
 
-const buf = term.buffer.active
+const lines = viewportLines(term, ROWS)
 let sawEllipsis = false
 for (let y = 0; y < ROWS; y++) {
-  const line = buf.getLine(y)?.translateToString(true) ?? ''
+  const line = lines[y] ?? ''
   if (line.trim() === '') continue
   const w = stringWidth(line)
   assert(w <= COLS, `第 ${y} 行宽 ${w} ≤ 终端宽 ${COLS}：'${line.trimEnd()}'`)

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -18,7 +18,7 @@ process.env.FORCE_COLOR = '3'
 // locale, none of which a runner is obliged to agree with.
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settle }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -26,6 +26,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
     import('../src/ui.js'),
     import('../src/screens/Chat.js'),
     import('../src/dsh-adapter/questions.js'),
+    import('./lib/term-test.mjs'),
   ])
 const instances = (await import('../src/ink/instances.js')).default
 
@@ -201,14 +202,14 @@ const panelHeader = (text: string): string =>
     rows: [],
     pushLocal: (title: string, lines: readonly string[]) => { localReports.push({ title, lines }) },
   }))
-  await sleep(500)
+  await settle(() => /已加载上下文/.test(harness.screen()))
 
   const summary = harness.screen()
   check('the startup context panel is on screen', /已加载上下文/.test(summary))
   check('the collapsed panel claims Ctrl+P', panelHeader(summary).includes('Ctrl+P'), panelHeader(summary).trim())
 
   harness.stdin.write(CTRL_P)
-  await sleep(500)
+  await settle(() => harness.screen().includes('你是 dsh'))
   const expanded = harness.screen()
   check('Ctrl+P expands the panel before the first message', expanded.includes('你是 dsh'),
     expanded.split('\n')[0]?.trim() ?? '')
@@ -216,21 +217,21 @@ const panelHeader = (text: string): string =>
     expanded.split('\n').filter(line => line.includes('/context')).join(' | '))
 
   harness.stdin.write(CTRL_P)
-  await sleep(500)
+  await settle(() => !harness.screen().includes('你是 dsh'))
   check('Ctrl+P collapses the panel again', !harness.screen().includes('你是 dsh'),
     panelHeader(harness.screen()).trim())
 
   harness.stdin.write(CTRL_T)
-  await sleep(500)
+  await settle(() => isScene(harness.screen()))
   check('Ctrl+T opens the trajectory even before the first message', isScene(harness.screen()),
     harness.screen().split('\n')[0]?.trim())
 
   harness.stdin.write('q')
-  await sleep(400)
+  await settle(() => /已加载上下文/.test(harness.screen()))
   check('q returns to the context summary', /已加载上下文/.test(harness.screen()))
 
   harness.stdin.write('/context\r')
-  await sleep(400)
+  await settle(() => localReports.at(-1)?.title === '/context')
   const report = localReports.at(-1)
   check('/context emits one local report', report?.title === '/context')
   check('the report contains loaded-context details',
@@ -249,17 +250,19 @@ const panelHeader = (text: string): string =>
     harness,
     makeChannel({ rows: [{ id: 1, kind: 'user', text: '第一条消息' }] }),
   )
+  // 稳定性探针（面板不得出现）：条件从挂载起就成立，轮询会立即返回，
+  // 测不到「不再出现」——保留固定窗口。
   await sleep(500)
 
   const before = harness.screen()
   check('the startup panel is gone once a row exists', !/已加载上下文/.test(before))
 
   harness.stdin.write(CTRL_T)
-  await sleep(500)
+  await settle(() => isScene(harness.screen()))
   check('Ctrl+T opens the trajectory scene', isScene(harness.screen()), harness.screen().split('\n')[0]?.trim())
 
   harness.stdin.write('q')
-  await sleep(400)
+  await settle(() => !isScene(harness.screen()))
   check('q returns to the conversation', !isScene(harness.screen()))
 
   instance.unmount()

--- a/scripts/verify-effort-accent.tsx
+++ b/scripts/verify-effort-accent.tsx
@@ -21,6 +21,7 @@ const [
   { render },
   { EffortChargeGlyph },
   { ClockProvider },
+  { settle },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -28,6 +29,7 @@ const [
   import('../src/ui.js'),
   import('../src/components/EffortChargeGlyph.js'),
   import('../src/ink/components/ClockContext.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
@@ -102,6 +104,8 @@ render(<Driver />, {
   patchConsole: false,
 })
 
+// 稳定性/时窗探针（切档前不得出现 accent）：条件从挂载起就成立，轮询会
+// 立即返回，等于没测；且必须在 t=300ms 切档前采样——保留固定窗口。
 await sleep(200)
 check('off the top tier: plain prefix, no accent', firstRow().startsWith('❯') && !prefixFgTruecolor() && !prefixBold())
 
@@ -126,9 +130,11 @@ check('charge ramps dark→full (sampled, monotone)',
   && samples.slice(1).some((value, index) => luma(value) >= luma(samples[index]!)),
   `${samples.length} samples, luma ${samples.length ? Math.round(luma(samples[0]!)) : '?'}→${samples.length ? Math.round(luma(samples[samples.length - 1]!)) : '?'}`)
 
+// 稳定性探针（accent 必须持续存在）：条件此刻已成立，轮询会立即返回，
+// 测不到「保持」——保留固定窗口。
 await sleep(300)
 check('past the charge window: accent stays solid', prefixFgTruecolor() && prefixBold())
-await sleep(500)
+await settle(() => !prefixFgTruecolor() && !prefixBold())
 check('off the top tier again: accent gone', !prefixFgTruecolor() && !prefixBold())
 
 if (failures > 0) {

--- a/scripts/verify-effort-slider-ui.mjs
+++ b/scripts/verify-effort-slider-ui.mjs
@@ -24,6 +24,7 @@ const { Terminal: XTerm } = xtermHeadless
 import { render } from '../lib/types/ui.js'
 import { Chat } from '../lib/types/screens/Chat.js'
 import { setLang } from '../lib/types/i18n.js'
+import { settle, viewportLines } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -202,13 +203,9 @@ const instance = await render(
 )
 await sleep(700)
 
-const screen = () => {
-  const lines = []
-  for (let row = 0; row < term.rows; row += 1) {
-    lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '')
-  }
-  return lines.join('\n')
-}
+// inline 模式下有 scrollback 时 getLine(0..rows) 直扫读的是缓冲区开头；
+// 改用公共辅助按 baseY 读可见视口（issue #532）。
+const screen = () => viewportLines(term).join('\n')
 
 // Pin the UI language so the assertions below don't depend on the host's
 // persisted /lang choice or OS locale (the slider chrome is localized).
@@ -219,17 +216,17 @@ setLang('en')
 stdin.write('/help')
 await sleep(250)
 stdin.write('\r')
-await sleep(350)
+await settle(() => /scroll|commands:/.test(screen()))
 check('en: Help opens before slider', /scroll|commands:/.test(screen()), '')
 stdin.write('\x1b')
-await sleep(300)
+await settle(() => !/commands:/.test(screen()))
 check('en: Esc closes Help only', !/commands:/.test(screen()), '')
 
 // 1. /effort bare → slider opens with the current level (High) checked.
 stdin.write('/effort')
 await sleep(250)
 stdin.write('\r')
-await sleep(400)
+await settle(() => /Reasoning effort/.test(screen()))
 let s = screen()
 check('slider opens with Reasoning effort title', /Reasoning effort/.test(s), '')
 check('slider lists all three levels', /Off/.test(s) && /High/.test(s) && /Max/.test(s), '')
@@ -237,14 +234,15 @@ check('current level marked', /High\s*✓/.test(s) || /✓/.test(s), '')
 
 // 2. → moves focus and applies immediately.
 stdin.write('\x1b[C')
-await sleep(300)
+await settle(() => channel.setEffortCalls.length === 1 && channel.setEffortCalls[0] === 'max')
 check('right arrow applied setEffort(max)', channel.setEffortCalls.length === 1 && channel.setEffortCalls[0] === 'max', JSON.stringify(channel.setEffortCalls))
+await settle(() => /max/.test(screen()))
 s = screen()
 check('statusline effort shows max', /max/.test(s), '')
 
 // 3. Esc closes.
 stdin.write('\x1b')
-await sleep(300)
+await settle(() => !/Reasoning effort/.test(screen().slice(-4000)))
 s = screen()
 check('Esc closed the slider', !/Reasoning effort/.test(s.slice(-4000)), '')
 
@@ -252,19 +250,19 @@ check('Esc closed the slider', !/Reasoning effort/.test(s.slice(-4000)), '')
 stdin.write('/effort off')
 await sleep(200)
 stdin.write('\r')
-await sleep(300)
+await settle(() => channel.setEffortCalls.includes('off'))
 check('/effort off applied', channel.setEffortCalls.includes('off'), JSON.stringify(channel.setEffortCalls))
 
 // 5. Shift+Tab cycles the mode; StatusLine shows the label.
 stdin.write('\x1b[Z')
-await sleep(300)
+await settle(() => screen().includes('计划模式') || /plan mode/.test(screen()))
 s = screen()
 check('statusline shows mode label', s.includes('计划模式') || /plan mode/.test(s), s.slice(-300))
 stdin.write('\x1b[Z')
-await sleep(300)
+await settle(() => channel.mode.id === 'full')
 check('second backtab → full', channel.mode.id === 'full', channel.mode.id)
 stdin.write('\x1b[Z')
-await sleep(300)
+await settle(() => channel.modeIndex === 0)
 check('third backtab → default (no segment)', channel.modeIndex === 0, String(channel.modeIndex))
 
 // 6. zh locale: the slider chrome hot-swaps to the localized strings
@@ -273,21 +271,21 @@ setLang('zh')
 stdin.write('/help')
 await sleep(250)
 stdin.write('\r')
-await sleep(350)
+await settle(() => /命令：/.test(screen()))
 check('zh: Help opens before slider', /命令：/.test(screen()), '')
 stdin.write('\x1b')
-await sleep(300)
+await settle(() => !/命令：/.test(screen()))
 check('zh: Esc closes Help only', !/命令：/.test(screen()), '')
 stdin.write('/effort')
 await sleep(250)
 stdin.write('\r')
-await sleep(400)
+await settle(() => screen().includes('推理强度'))
 s = screen()
 check('zh: slider title 推理强度', s.includes('推理强度'), '')
 check('zh: hint line localized', s.includes('调整') && s.includes('完成'), '')
 // Read the xterm visible screen after the repaint, not the raw output backlog.
 stdin.write('\x1b')
-await sleep(300)
+await settle(() => !screen().includes('推理强度'))
 s = screen()
 check('zh: Esc closed the slider', !s.includes('推理强度'), '')
 setLang('en')

--- a/scripts/verify-empty-assistant.tsx
+++ b/scripts/verify-empty-assistant.tsx
@@ -16,7 +16,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -24,6 +24,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100, ROWS = 40
@@ -95,7 +96,10 @@ const inst = await render(
   <AlternateScreen><Chat channel={channel} questionStore={new QuestionStore()} fullscreen /></AlternateScreen>,
   { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(700)
+await settle(() => {
+  const screen = screenLines().join('\n')
+  return screen.includes('Bash') && screen.includes('REALBODY-END') && screen.includes('REALBODY2-END')
+})
 
 {
   const lines = screenLines()
@@ -119,7 +123,7 @@ await sleep(700)
 const streamRow = rows.find(r => r.id === 4)!
 streamRow.streaming = false
 channel.emit()
-await sleep(500)
+await settle(() => loneDotLines(screenLines()).length === 0)
 {
   const lines = screenLines()
   check('落定翻转后空 assistant 行被过滤（缓存流位指纹生效）', loneDotLines(lines).length === 0,
@@ -129,6 +133,8 @@ await sleep(500)
 // 用户空文本行不受影响（kind 限定）：一个空 user 行仍渲染其气泡形状
 rows.push({ id: 5, kind: 'user', text: '' })
 channel.emit()
+// 稳定性探针（界面必须仍存活）：❯ 在 emit 前就在屏上，轮询会立即返回，
+// 测不到「没有崩掉」——保留固定窗口让潜在崩溃有时间显形。
 await sleep(400)
 check('空 user 行不受 assistant 过滤影响（无崩溃、界面存活）', screenLines().some(l => l.includes('❯')))
 

--- a/scripts/verify-extension-events.tsx
+++ b/scripts/verify-extension-events.tsx
@@ -85,6 +85,7 @@ const [
   { Chat },
   { QuestionStore },
   { createChannel },
+  { settle },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -93,6 +94,7 @@ const [
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/dsh-adapter/channel.js'),
+  import('./lib/term-test.mjs'),
 ])
 const { mountAdmitted, testManifest, DECISION_COORDINATE } = await import('./plugin-test-utils.js')
 const pluginHostRow = await import('../src/dsh-adapter/plugin-host.js')
@@ -308,7 +310,7 @@ await sleep(800)
   })
   await sleep(150)
   channel.submit('穿透检查')
-  await sleep(400)
+  await settle(() => captured.followupTexts.some(text => text.includes('穿透检查')))
   check('decision guard (no extensions row): ungranted plugin subscription denied',
     captured.followupTexts.some(text => text.includes('穿透检查')),
     JSON.stringify(captured.followupTexts))
@@ -321,7 +323,7 @@ await sleep(800)
     return undefined
   })
   channel.submit('原始输入')
-  await sleep(300)
+  await settle(() => captured.followupTexts.some(text => text.includes('改写后的输入')))
   check('tui/input transform: delivered text is the plugin substitute',
     captured.followupTexts.some(text => text.includes('改写后的输入')),
     JSON.stringify(captured.followupTexts))
@@ -336,7 +338,7 @@ await sleep(800)
   const dispose = decisionCtx.on('tui/input', event =>
     event.text === '别发这个' ? { cancel: true, reason: '插件拦截了这条输入' } : undefined)
   channel.submit('别发这个')
-  await sleep(300)
+  await settle(() => plainText(stdout.frames).includes('插件拦截了这条输入'))
   check('tui/input cancel: nothing delivered', captured.followupTexts.length === before)
   check('tui/input cancel: reason toasted',
     plainText(stdout.frames).includes('插件拦截了这条输入'))
@@ -350,7 +352,9 @@ await sleep(800)
   const dispose = decisionCtx.on('tui/input', event =>
     event.text === '消毒检查' ? { cancel: true, reason: '拦截\x1b[31m\x07原因' } : undefined)
   channel.submit('消毒检查')
-  await sleep(300)
+  await settle(() => notified('拦截 [31m 原因')
+    && !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
+      .some(item => item.text.includes('\x1b')))
   check('tui/input cancel: reason sanitized before toasting',
     notified('拦截 [31m 原因')
     && !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
@@ -365,10 +369,10 @@ await sleep(800)
     return { cancel: true, reason: '慢否决落地' } as const
   })
   channel.submit('慢决定')
-  await sleep(550)
+  await settle(() => notified('正在等待插件决定（tui/input）'))
   check('pending decision: parked indicator toasted past 400ms',
     notified('正在等待插件决定（tui/input）'))
-  await sleep(400)
+  await settle(() => notified('慢否决落地') && !captured.followupTexts.some(text => text.includes('慢决定')))
   check('pending decision: the slow veto still lands',
     notified('慢否决落地') && !captured.followupTexts.some(text => text.includes('慢决定')))
   // …and the indicator is dismissed the moment the decision lands — it must
@@ -384,7 +388,8 @@ await sleep(800)
   const disposeCancel = decisionCtx.on('tui/input', event =>
     event.text === '无声拦截' ? { cancel: true } : undefined)
   channel.submit('无声拦截')
-  await sleep(400)
+  await settle(() => notified('操作已被插件取消')
+    && !captured.followupTexts.some(text => text.includes('无声拦截')))
   check('tui/input cancel without reason: host fallback toasted',
     notified('操作已被插件取消')
     && !captured.followupTexts.some(text => text.includes('无声拦截')))
@@ -393,7 +398,8 @@ await sleep(800)
   const disposeHandled = decisionCtx.on('tui/input', event =>
     event.text === '无声接管' ? { handled: true } : undefined)
   channel.submit('无声接管')
-  await sleep(400)
+  await settle(() => notified('输入已由插件处理')
+    && !captured.followupTexts.some(text => text.includes('无声接管')))
   check('tui/input handled without notice: host fallback toasted',
     notified('输入已由插件处理')
     && !captured.followupTexts.some(text => text.includes('无声接管')))
@@ -408,7 +414,11 @@ await sleep(800)
   })
   channel.submit('慢条甲')
   channel.submit('快条乙')
-  await sleep(900)
+  await settle(() => {
+    const indexA = captured.followupTexts.findIndex(text => text.includes('慢条甲'))
+    const indexB = captured.followupTexts.findIndex(text => text.includes('快条乙'))
+    return indexA !== -1 && indexB !== -1 && indexA < indexB
+  })
   const indexA = captured.followupTexts.findIndex(text => text.includes('慢条甲'))
   const indexB = captured.followupTexts.findIndex(text => text.includes('快条乙'))
   check('fifo: a slow decision on A does not let B overtake',
@@ -423,13 +433,14 @@ await sleep(800)
   const before = captured.followupTexts.length
   const cancelBefore = captured.cancelCalls
   channel.interruptAndDeliver(['插队文本'])
-  await sleep(700) // the fake has no whenIdle → 200ms fallback timer + decision
+  // the fake has no whenIdle → 200ms fallback timer + decision
+  await settle(() => captured.followupTexts.length === before && notified('插队被拦截'))
   check('interruptAndDeliver: the tui/input veto applies to the Ctrl+Enter path',
     captured.followupTexts.length === before && notified('插队被拦截'))
   dispose()
 
   channel.interruptAndDeliver(['插队放行'])
-  await sleep(700)
+  await settle(() => captured.followupTexts.some(text => text.includes('插队放行')))
   check('interruptAndDeliver: the re-queue delivers without a veto',
     captured.followupTexts.some(text => text.includes('插队放行')))
   check('interruptAndDeliver: a vetoed retry remains deliverable and cancel runs once',
@@ -443,7 +454,8 @@ await sleep(800)
     { type: 'turn/end', data: { turn: 99, reason: { kind: 'completed' } } },
   )
   channel.interruptAndDeliver(['终止后新插队'])
-  await sleep(700)
+  await settle(() => captured.cancelCalls === cancelBefore + 2
+    && captured.followupTexts.some(text => text.includes('终止后新插队')))
   check('interruptAndDeliver: turn/end permits a fresh cancel',
     captured.cancelCalls === cancelBefore + 2 && captured.followupTexts.some(text => text.includes('终止后新插队')),
     JSON.stringify({ cancelCalls: captured.cancelCalls, followups: captured.followupTexts }))
@@ -455,7 +467,7 @@ await sleep(800)
     throw new Error('plugin exploded')
   })
   channel.submit('照常发送')
-  await sleep(300)
+  await settle(() => captured.followupTexts.some(text => text.includes('照常发送')))
   check('tui/input crash: a throwing listener degrades to no-opinion',
     captured.followupTexts.some(text => text.includes('照常发送')))
   dispose()
@@ -473,7 +485,7 @@ await sleep(800)
     event.text === '空白改写' ? { cancel: true, reason: '安全否决生效' } : undefined)
   const before = captured.followupTexts.length
   channel.submit('空白改写')
-  await sleep(300)
+  await settle(() => captured.followupTexts.length === before && notified('安全否决生效'))
   check('serial chain: blank rewrite does NOT bail the chain (veto still runs)',
     captured.followupTexts.length === before && notified('安全否决生效'))
   disposeBlank()
@@ -488,7 +500,7 @@ await sleep(800)
   const disposeVeto2 = decisionCtx.on('tui/input', event =>
     event.text === '崩溃在前' ? { cancel: true, reason: '崩溃后的否决生效' } : undefined)
   channel.submit('崩溃在前')
-  await sleep(300)
+  await settle(() => !captured.followupTexts.some(text => text.includes('崩溃在前')) && notified('崩溃后的否决生效'))
   check('serial chain: a throwing listener does NOT skip the later veto',
     !captured.followupTexts.some(text => text.includes('崩溃在前')) && notified('崩溃后的否决生效'))
   disposeThrow()
@@ -500,7 +512,7 @@ await sleep(800)
   const disposeTransform = decisionCtx.on('tui/input', event =>
     event.text === '垃圾返回' ? { text: '垃圾已被改写' } : undefined)
   channel.submit('垃圾返回')
-  await sleep(300)
+  await settle(() => captured.followupTexts.some(text => text.includes('垃圾已被改写')))
   check('serial chain: junk primitive return is skipped, later transform wins',
     captured.followupTexts.some(text => text.includes('垃圾已被改写')))
   disposeJunk()
@@ -521,7 +533,7 @@ await sleep(800)
   const disposeVeto3 = decisionCtx.on('tui/input', event =>
     event.text === '敌意返回' ? { cancel: true, reason: '敌意后的否决生效' } : undefined)
   channel.submit('敌意返回')
-  await sleep(300)
+  await settle(() => !captured.followupTexts.some(text => text.includes('敌意返回')) && notified('敌意后的否决生效'))
   check('serial chain: a throwing-getter return is skipped, later veto still runs',
     !captured.followupTexts.some(text => text.includes('敌意返回')) && notified('敌意后的否决生效'))
   disposeHostile()
@@ -558,13 +570,16 @@ await sleep(800)
   stdin.write('\x1b')
   await sleep(120)
   stdin.write('\x1b')
-  await sleep(400)
+  await settle(() => plainText(stdout.frames.slice(-30)).includes('消息 09'))
   const listShown = plainText(stdout.frames.slice(-30)).includes('消息 09')
   check('rewind picker opens on double-Esc', listShown)
 
   // Enter on the newest message → the plugin decision resolves → mode list.
   stdin.write('\r')
-  await sleep(400)
+  await settle(() => {
+    const tail = plainText(stdout.frames.slice(-40))
+    return tail.includes('回退会话 + 恢复文件') && tail.includes('仅回退会话')
+  })
   const afterEnter = plainText(stdout.frames.slice(-40))
   check('rewind confirm renders plugin modes',
     afterEnter.includes('回退会话 + 恢复文件') && afterEnter.includes('仅回退会话'),
@@ -577,7 +592,7 @@ await sleep(800)
   stdin.write('\x1b[B')
   await sleep(150)
   stdin.write('\r')
-  await sleep(600)
+  await settle(() => seen.doneMode === 'files' && notified('已恢复 2 个文件') && seen.switchedKind === 'rewind')
   check('picked mode id threaded to tui/rewind-done', seen.doneMode === 'files', String(seen.doneMode))
   check('tui/rewind-done summary toasted', notified('已恢复 2 个文件'))
   check("tui/session-switched fired with kind 'rewind'", seen.switchedKind === 'rewind')
@@ -600,7 +615,7 @@ await sleep(800)
   stdin.write('\x1b')
   await sleep(400)
   stdin.write('\r') // Enter on the newest message → veto
-  await sleep(400)
+  await settle(() => notified('该消息不可回退'))
   const tail = plainText(stdout.frames.slice(-40))
   check('tui/rewind-prompt cancel: reason toasted', notified('该消息不可回退'))
   check('tui/rewind-prompt cancel: picker still open (list visible)', tail.includes('消息 09'))
@@ -627,7 +642,7 @@ await sleep(800)
   })
   const switched = await channel.newSession()
   check('/new succeeds without the veto', switched === true)
-  await sleep(200)
+  await settle(() => seen.includes('switched:new'))
   check("tui/session-switched fired with kind 'new'", seen.includes('switched:new'), seen.join(','))
   disposeSwitched()
 }
@@ -636,13 +651,13 @@ await sleep(800)
 {
   const dispose = decisionCtx.on('tui/compact', () => ({ cancel: true, reason: '禁止压缩' }))
   channel.compact()
-  await sleep(300)
+  await settle(() => notified('禁止压缩'))
   check('tui/compact veto: compaction never ran', captured.compactCalls.length === 0)
   check('tui/compact veto: reason toasted', notified('禁止压缩'))
   dispose()
 
   channel.compact()
-  await sleep(400)
+  await settle(() => captured.compactCalls.length === 1)
   check('tui/compact without the veto: compaction runs on the live agent',
     captured.compactCalls.length === 1, JSON.stringify(captured.compactCalls))
 }
@@ -657,7 +672,7 @@ await sleep(800)
   const switched = await channel.newSession()
   check('compact stale-drop setup: /new succeeded mid-await', switched === true)
   release(undefined)
-  await sleep(400)
+  await settle(() => notified('压缩已取消'))
   check('compact stale-drop: the old session’s compaction never ran',
     captured.compactCalls.length === 1, JSON.stringify(captured.compactCalls))
   check('compact stale-drop: stale notice toasted', notified('压缩已取消'))
@@ -681,6 +696,8 @@ await sleep(800)
   const resumed = await channel.resumeTo('s-a1')
   check('compact ABA setup: /resume back to the origin session succeeded', resumed.ok === true)
   release(undefined)
+  // 稳定性探针（陈旧压缩不得复活）：条件在 release 前就成立，轮询会立即
+  // 返回，测不到「没有跑」——保留固定窗口。
   await sleep(400)
   check('compact ABA: id reuse does NOT revive the stale compaction',
     captured.compactCalls.length === 1, JSON.stringify(captured.compactCalls))
@@ -725,6 +742,8 @@ await sleep(800)
   const switched = await channel.newSession()
   check('enqueue origin setup: /new succeeded while the predecessor parked', switched === true)
   release(undefined)
+  // 稳定性探针（两条都不得投递）：条件在 release 前就成立，轮询会立即
+  // 返回，测不到「没被投递」——保留固定窗口。
   await sleep(500)
   check('enqueue-time origin: the parked predecessor is dropped as stale',
     !captured.followupTexts.some(text => text.includes('旧会话首条')),
@@ -775,7 +794,7 @@ await sleep(800)
   check('rewind-done decoupled: session-switched did not wait for the listener',
     switchedKinds.includes('rewind'), switchedKinds.join(','))
   release('迟到摘要')
-  await sleep(300)
+  await settle(() => notified('迟到摘要'))
   check('rewind-done decoupled: the late summary still toasts', notified('迟到摘要'))
   disposeDone()
   disposeSwitched()
@@ -788,16 +807,19 @@ await sleep(800)
   const gate = new Promise<undefined>(resolve => { release = resolve })
   const dispose = decisionCtx.on('tui/input', event => (event.text === '超长等待' ? gate : undefined))
   channel.submit('超长等待')
-  await sleep(600) // past the 400ms threshold: the indicator is up
+  // past the 400ms threshold: the indicator is up
+  await settle(() => notified('正在等待插件决定（tui/input）'))
   check('pending indicator: raised past the threshold', notified('正在等待插件决定（tui/input）'))
   // The standard single-handler deadline is 1s. The indicator must remain
   // visible until that deadline resolves the never-settling callback; it is
   // not allowed to disappear on the ordinary 4s notification timer first.
+  // 稳定性探针（指示条必须还挂着）：条件此刻已成立，轮询会立即返回，
+  // 测不到「保持」——保留固定窗口。
   await sleep(250)
   check('pending indicator: still up while the bounded decision is parked',
     notified('正在等待插件决定（tui/input）'))
   release(undefined)
-  await sleep(500)
+  await settle(() => captured.followupTexts.some(text => text.includes('超长等待')))
   check('pending indicator: dismissed when the deadline settles the decision',
     !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
       .some(item => item.text.includes('正在等待插件决定')))

--- a/scripts/verify-extension-ui.tsx
+++ b/scripts/verify-extension-ui.tsx
@@ -43,6 +43,7 @@ const [
   { dispatchTuiDecision, normalizeCancelDecision },
   { stringWidth },
   { KNOWN_SESSION_EVENT_TYPES },
+  { settle },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -58,6 +59,7 @@ const [
   import('../src/dsh-adapter/extension-events.js'),
   import('../src/ink/stringWidth.js'),
   import('@deepseek-ai/dsh-session'),
+  import('./lib/term-test.mjs'),
 ])
 const { mountAdmitted, testManifest, DECISION_COORDINATE } = await import('./plugin-test-utils.js')
 const pluginHostRow = await import('../src/dsh-adapter/plugin-host.js')
@@ -476,7 +478,7 @@ const plugin = pluginCtx
   let fired = 0
   plugin.tuiShortcuts.register('alt+z', { description: 'fire', handler: () => { fired += 1 } })
   check('tuiShortcuts.dispatch: matching key consumed', shortcutHost.dispatch('z', { meta: true }) === true)
-  await sleep(20)
+  await settle(() => fired === 1)
   check('tuiShortcuts.dispatch: handler ran', fired === 1)
   check('tuiShortcuts.dispatch: non-matching key passes through', shortcutHost.dispatch('q', { ctrl: true }) === false)
 
@@ -488,7 +490,7 @@ const plugin = pluginCtx
     handler: () => { throw new Error('handler exploded') },
   })
   shortcutHost.dispatch('y', { meta: true })
-  await sleep(20)
+  await settle(() => errored === 'alt+y')
   check('tuiShortcuts.dispatch: handler error routed to onError', errored === 'alt+y')
   removeErrorHandler()
 
@@ -624,7 +626,7 @@ const plugin = pluginCtx
     { order: 'ui-observe' },
   )
   await dispatchTuiDecision(guardCtx, 'tui/session-switched', { sessionId: 'ui-session' }, () => undefined)
-  await sleep(20)
+  await settle(() => observed && !guardWarnings.some(line => line.includes('tui/session-switched')))
   check('decision guard: observe-class events stay ungated',
     observed && !guardWarnings.some(line => line.includes('tui/session-switched')))
   observeRelease()
@@ -702,14 +704,14 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
       { id: 'second', label: '第二项', description: '带描述' },
     ],
   })
-  await sleep(300)
+  await settle(() => screen().includes('挑一个') && screen().includes('第二项'))
   check('ui: select dialog renders title + options',
     screen().includes('挑一个') && screen().includes('第二项'), screen().slice(-200))
   stdin.write('\x1b[B')
   await sleep(150)
   stdin.write('\r')
   check('ui: select ↓+Enter resolves the second id', (await pending) === 'second')
-  await sleep(200)
+  await settle(() => dialogStore.getSnapshot() === null)
   check('ui: dialog closed after settle', dialogStore.getSnapshot() === null)
 }
 
@@ -717,13 +719,13 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 {
   const first = plugin.tuiDialogs.confirm({ title: '确认一下', message: '要做吗' })
   const second = plugin.tuiDialogs.select({ title: '排队的选择', options: [{ id: 'only', label: '唯一' }] })
-  await sleep(300)
+  await settle(() => screen().includes('确认一下') && screen().includes('要做吗'))
   check('ui: confirm renders with message + localized defaults',
     screen().includes('确认一下') && screen().includes('要做吗'), screen().slice(-200))
   check('ui: FIFO — second dialog still queued', dialogStore.getSnapshot()?.kind === 'confirm')
   stdin.write('\r') // Enter on 是 → true
   check('ui: confirm Enter resolves true', (await first) === true)
-  await sleep(300)
+  await settle(() => screen().includes('排队的选择'))
   check('ui: queued select now active',
     screen().includes('排队的选择'), screen().slice(-200))
   stdin.write('\x1b') // Esc cancels the select
@@ -733,7 +735,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // Input: placeholder shown when empty; typed text resolves.
 {
   const pending = plugin.tuiDialogs.input({ title: '说点什么', placeholder: '占位提示', initial: '' })
-  await sleep(300)
+  await settle(() => screen().includes('占位提示'))
   check('ui: input dialog renders placeholder', screen().includes('占位提示'), screen().slice(-200))
   for (const ch of '你好') { stdin.write(ch); await sleep(60) }
   stdin.write('\r')
@@ -743,7 +745,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // Input with initial: pre-filled, edited, submitted.
 {
   const pending = plugin.tuiDialogs.input({ title: '改改', initial: '原文' })
-  await sleep(300)
+  await settle(() => screen().includes('原文'))
   stdin.write('\x7f') // backspace removes 文
   await sleep(150)
   stdin.write('\r')
@@ -755,8 +757,10 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // survive it, on its default Yes focus.
 {
   const pending = plugin.tuiDialogs.confirm({ title: '粘贴确认' })
-  await sleep(300)
+  await settle(() => screen().includes('粘贴确认'))
   stdin.write('\x1b[200~\r\n\r\n\x1b[201~')
+  // 稳定性探针（对话框不得被粘贴确认掉）：条件在粘贴前就成立，轮询会
+  // 立即返回，测不到「没被误触」——保留固定窗口。
   await sleep(250)
   check('ui: pure-newline paste does NOT confirm the dialog',
     dialogStore.getSnapshot()?.kind === 'confirm')
@@ -770,6 +774,8 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // resolved answer keeps the documented ≤500-cell bound.
 {
   const pending = plugin.tuiDialogs.input({ title: '粘贴输入', initial: '' })
+  // 排序等待：增量渲染只重绘变化单元格（标题与上一面板共享 '粘贴' 两格），
+  // 帧窗里凑不出完整标题可供 settle——保留固定窗口。
   await sleep(300)
   const chunk = '多行\n粘贴\x07' + '长'.repeat(600)
   stdin.write(`\x1b[200~${chunk}\x1b[201~`)
@@ -788,8 +794,11 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 {
   const nearCap = '字'.repeat(250) // 500 cells exactly (wide chars)
   const pending = plugin.tuiDialogs.input({ title: '顶格输入', initial: nearCap })
+  // 排序等待：同上，增量重绘下标题片段化，无可靠的屏幕观察点——保留。
   await sleep(300)
   stdin.write('x')
+  // 稳定性探针（超上限按键必须被忽略）：值不得变化，轮询等于没测——
+  // 保留固定窗口让误收的 x 有时间落地。
   await sleep(150)
   stdin.write('\r')
   check('ui: typing past the cell cap is ignored',
@@ -808,7 +817,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
       { id: 'second', label: '第二项' },
     ],
   })
-  await sleep(300)
+  await settle(() => screen().includes('同批选择'))
   stdin.write('\x1b[B\r') // Down + Enter in one chunk
   check('ui: batched ↓+Enter settles the NEW focus, not the stale one',
     (await pending) === 'second')
@@ -816,7 +825,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 }
 {
   const pending = plugin.tuiDialogs.confirm({ title: '同批确认' })
-  await sleep(300)
+  await settle(() => screen().includes('同批确认'))
   stdin.write('\x1b[C\r') // Right + Enter in one chunk → focus 否 → false
   check('ui: batched →+Enter settles the moved focus', (await pending) === false)
   await sleep(200)
@@ -825,7 +834,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // result), not compute from the same stale base.
 {
   const pending = plugin.tuiDialogs.input({ title: '同批退格', initial: 'abcd' })
-  await sleep(300)
+  await settle(() => screen().includes('同批退格'))
   stdin.write('\x7f\x7f')
   await sleep(150)
   stdin.write('\r')
@@ -837,6 +846,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // inside a pair.
 {
   const pending = plugin.tuiDialogs.input({ title: '表情退格', initial: 'a😊b' })
+  // 排序等待：同上，增量重绘下标题片段化，无可靠的屏幕观察点——保留。
   await sleep(300)
   stdin.write('\x1b[D') // left: cursor between 😊 and b
   await sleep(120)
@@ -848,6 +858,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 }
 {
   const pending = plugin.tuiDialogs.input({ title: '表情清空', initial: '😊' })
+  // 排序等待：同上，增量重绘下标题片段化，无可靠的屏幕观察点——保留。
   await sleep(300)
   stdin.write('\x7f') // single backspace at end of the sole emoji
   await sleep(150)
@@ -856,6 +867,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 }
 {
   const pending = plugin.tuiDialogs.input({ title: '表情步进', initial: '😊x' })
+  // 排序等待：同上，增量重绘下标题片段化，无可靠的屏幕观察点——保留。
   await sleep(300)
   // Left ×2 from the end: code-point steps land BEFORE the emoji (a UTF-16
   // step would park the cursor mid-surrogate and split the pair on insert).
@@ -871,13 +883,15 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // Status line: appears on set, disappears on clear.
 {
   plugin.tuiStatus.set('demo-plugin', '构建中 42%')
-  await sleep(300)
+  await settle(() => screen().includes('构建中 42%'))
   check('ui: status line renders the contribution', screen().includes('构建中 42%'), screen().slice(-300))
   // The incremental renderer only writes diffs: after the clear, assert on
   // frames written FROM the clear on — earlier frames legitimately still
   // contain the set text.
   const mark = stdout.frames.length
   plugin.tuiStatus.set('demo-plugin', undefined)
+  // 稳定性探针（清除后的重绘不得再含该文案）：mark 之后暂无新帧时条件
+  // 空洞成立，轮询会立即返回——保留固定窗口等待重绘发生。
   await sleep(300)
   check('ui: status line clears', !plainText(stdout.frames.slice(mark)).includes('构建中'))
 }
@@ -890,7 +904,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   plugin.tuiShortcuts.register('alt+p', { description: 'ui fire', handler: () => { fired += 1 } })
   await sleep(100)
   stdin.write('\x1bp') // alt+p
-  await sleep(300)
+  await settle(() => fired >= 1)
   check('ui: plugin shortcut handler fired through Chat', fired >= 1, String(fired))
   check('ui: shortcut keypress never reached submit', channel.submitCalls.length === 0)
 }
@@ -902,8 +916,10 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   let fired = 0
   plugin.tuiShortcuts.register('alt+b', { description: 'blocked', handler: () => { fired += 1 } })
   const pending = plugin.tuiDialogs.confirm({ title: '占键盘中' })
-  await sleep(300)
+  await settle(() => screen().includes('占键盘中'))
   stdin.write('\x1bb') // alt+b — must not reach shortcuts while the dialog is open
+  // 稳定性探针（快捷键不得触发）：fired 本就为 0，轮询会立即返回，
+  // 测不到「没被触发」——保留固定窗口。
   await sleep(200)
   check('ui: open dialog gates plugin shortcuts', fired === 0)
   stdin.write('\x1b')

--- a/scripts/verify-help-scroll.tsx
+++ b/scripts/verify-help-scroll.tsx
@@ -18,6 +18,7 @@ const [
   { Chat },
   { QuestionStore },
   { createChannel },
+  { settle, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -28,6 +29,7 @@ const [
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/dsh-adapter/channel.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 80
@@ -122,12 +124,9 @@ const write = async (input: string): Promise<void> => {
 }
 
 function screenText(): string {
-  const buffer = term.buffer.active
-  const lines: string[] = []
-  for (let row = 0; row < term.rows; row++) {
-    lines.push(buffer.getLine(row)?.translateToString(true) ?? '')
-  }
-  return lines.join('\n')
+  // 视口读取（baseY 起）：inline 模式有 scrollback 时直扫 getLine(0..rows)
+  // 读的是缓冲区开头，会混入已滚出的旧行。
+  return viewportLines(term).join('\n')
 }
 
 let failures = 0
@@ -145,7 +144,11 @@ const app = await render(<Fixture />, {
 })
 
 try {
-  await sleep(400)
+  await settle(() => {
+    const text = screenText()
+    return text.includes('/new —') && !text.includes('/q —') && text.includes('/ for commands')
+      && text.includes('↑/↓') && !text.includes('PENDING_SENTINEL')
+  })
   let text = screenText()
   check(text.includes('/new —'), 'help opens at the first command')
   check(!text.includes('/q —'), 'tail commands start outside the viewport')
@@ -153,58 +156,92 @@ try {
   check(text.includes('↑/↓'), 'a persistent scroll hint is visible')
   check(!text.includes('PENDING_SENTINEL'), 'pending preview stays behind the help overlay')
 
-  await write('\x1b[6~')
+  stdin.write('\x1b[6~')
+  await settle(() => !screenText().includes('/new —'))
   text = screenText()
   check(!text.includes('/new —'), 'PageDown advances by a viewport')
-  await write('\x1b[5~')
+  stdin.write('\x1b[5~')
+  await settle(() => screenText().includes('/new —'))
   text = screenText()
   check(text.includes('/new —'), 'PageUp returns by a viewport')
 
   // More presses than the content requires also exercise end clamping.
-  await write('\x1b[B'.repeat(60))
+  stdin.write('\x1b[B'.repeat(60))
+  await settle(() => {
+    const t = screenText()
+    return t.includes('/q —') && !t.includes('/new —')
+  })
   text = screenText()
   check(text.includes('/q —'), 'Down reaches the final command')
   check(!text.includes('/new —'), 'the viewport actually moved away from the top')
 
-  await write('\x1b[H')
+  stdin.write('\x1b[H')
+  await settle(() => screenText().includes('/new —'))
   text = screenText()
   check(text.includes('/new —'), 'Home returns to the first command')
 
-  await write('\x1b[F')
+  stdin.write('\x1b[F')
+  await settle(() => {
+    const t = screenText()
+    return t.includes('/q —') && t.includes('/ for commands')
+  })
   text = screenText()
   check(text.includes('/q —'), 'End jumps to the final command')
   check(text.includes('/ for commands'), 'shortcut reference stays fixed at the tail')
 
   // SGR mouse wheel up. The fixture's Chat-like owner must not move the
   // transcript while Help owns the overlay, while Help itself must move.
+  // Stability probe (transcriptWheelEvents must stay 0): a settle on the
+  // already-true condition would return immediately — keep the fixed window
+  // so a leaked wheel event has time to surface.
   await write('\x1b[<64;10;10M'.repeat(20))
   check(transcriptWheelEvents === 0, 'help suppresses transcript wheel scrolling')
   check(!screenText().includes('/q —'), 'mouse wheel scrolls the help viewport')
 
-  await write('\x1b')
+  stdin.write('\x1b')
+  await settle(() => {
+    const t = screenText()
+    return !t.includes('commands:') && t.includes('PENDING_SENTINEL')
+  })
   check(!screenText().includes('commands:'), 'Escape closes help')
   check(screenText().includes('PENDING_SENTINEL'), 'pending preview returns after help closes')
-  await write('?')
+  stdin.write('?')
+  await settle(() => {
+    const t = screenText()
+    return t.includes('/new —') && !t.includes('PENDING_SENTINEL')
+  })
   text = screenText()
   check(text.includes('/new —'), 'reopening help resets the viewport to the top')
   check(!text.includes('PENDING_SENTINEL'), 'reopened help remains visually exclusive')
 
+  // Stability probe across a resize (the hint must REMAIN visible): the
+  // condition is already true before the repaint, so a settle would return
+  // immediately — keep the fixed window for a wrong reflow to surface.
   stdout.rows = 18
   term.resize(COLS, 18)
   stdout.emit('resize')
   await sleep(300)
   check(screenText().includes('↑/↓'), 'scroll hint remains visible after resize')
-  await write('\x1b[F')
+  stdin.write('\x1b[F')
+  await settle(() => screenText().includes('/q —'))
   check(screenText().includes('/q —'), 'resized help can still reach the tail')
 
+  // Ordering sleep kept: the narrow reflow has no single anchored condition
+  // to poll before the next keypress.
   stdout.columns = 60
   term.resize(60, 18)
   stdout.emit('resize')
   await sleep(300)
-  await write('\x1b[H')
+  stdin.write('\x1b[H')
+  await settle(() => screenText().includes('/ for commands'))
   check(screenText().includes('/ for commands'), 'narrow Help stacks shortcuts into the scroll viewport')
-  await write('\x1b[F')
-  await write('\x1b[B'.repeat(60))
+  stdin.write('\x1b[F')
+  await settle(() => screenText().includes('/q —'))
+  stdin.write('\x1b[B'.repeat(60))
+  await settle(() => {
+    const t = screenText()
+    return t.includes('/connect —') && t.includes('↑/↓')
+  })
   check(LOCAL_COMMANDS.at(-1)?.name === 'q' && screenText().includes('/connect —'), 'narrow Help keeps the command-list tail reachable after End and navigation')
   check(screenText().includes('↑/↓'), 'narrow Help keeps the navigation hint fixed')
 } finally {
@@ -282,37 +319,49 @@ const chat = await render(
 )
 
 try {
+  // Startup and per-key typing keep fixed sleeps: the prompt echo has no
+  // single stable anchor to poll while the completion menu reshuffles.
   await sleep(500)
   for (const key of '/help') await write(key)
-  await write('\r')
+  stdin.write('\r')
+  await settle(() => screenText().includes('↑/↓'))
   check(screenText().includes('↑/↓'), '/help opens Help through the real Chat command path')
 
-  await write('\x1b')
+  stdin.write('\x1b')
+  await settle(() => !screenText().includes('↑/↓'))
+  // Negative probe (transcript search must NOT open on `/`): a settle would
+  // return immediately on the already-true condition — keep a fixed window.
   await write('/')
   let routed = screenText()
   check(!routed.includes('no matches'), 'ordinary Esc then slash stays in command completion')
   check(routed.includes('help'), 'ordinary slash completion is visible after Help closes')
   for (const key of 'help') await write(key)
-  await write('\r')
+  stdin.write('\r')
+  await settle(() => screenText().includes('↑/↓'))
   check(screenText().includes('↑/↓'), '/help reopens through the real Chat command path')
 
   // Ctrl+O must be inert behind Help; Esc then returns to the ordinary
-  // prompt, where `/` belongs to slash-command completion.
+  // prompt, where `/` belongs to slash-command completion. (The Ctrl+O
+  // inertness is a must-not-change probe — fixed window kept.)
   await write('\x0f')
-  await write('\x1b')
+  stdin.write('\x1b')
+  await settle(() => !screenText().includes('↑/↓'))
   await write('/')
   routed = screenText()
   check(!routed.includes('no matches'), 'slash after Help does not open transcript search')
   check(routed.includes('help'), 'slash completion remains available after Help closes')
 
   for (const key of 'help') await write(key)
-  await write('\r')
+  stdin.write('\r')
+  await settle(() => screenText().includes('↑/↓'))
   routed = screenText()
   check(routed.includes('↑/↓'), '/help can be submitted again after closing Help')
 
   // Composer-local, Chat-global, and plugin bindings must not mutate hidden
   // state behind Help. The broad Chat yield guards future shortcuts too,
   // instead of relying on an incomplete list of per-binding conditions.
+  // These are all must-not-change probes: polling the already-true condition
+  // would return immediately, so each keeps its fixed observation window.
   await write('\x14')
   check(screenText().includes('↑/↓'), 'Ctrl+T does not open trajectory behind Help')
   await write('\x10')
@@ -324,13 +373,15 @@ try {
   await write('\x1b[Z')
   check(modeCycles === 0, 'Shift+Tab does not cycle session mode behind Help')
   await write('\x1b[1;2A')
-  await write('x')
+  stdin.write('x')
+  await settle(() => !screenText().includes('↑/↓'))
   check(!screenText().includes('↑/↓'), 'typing after Shift+Up dismisses Help instead of being trapped in selection mode')
   await write('\x03')
 
   // Help owns Esc even during a live turn. The Chat-level cancel branch must
   // yield, so one Esc closes the overlay without aborting the agent.
-  await write('?')
+  stdin.write('?')
+  await settle(() => screenText().includes('↑/↓'))
   const onSessionEvent = handlers.get('session/event') as
     | ((session: unknown, event: unknown) => void)
     | undefined
@@ -340,9 +391,10 @@ try {
     type: 'turn/start',
     data: { turn: 1 },
   })
-  await sleep(180)
+  await settle(() => chatChannel.working)
   check(chatChannel.working, 'full Chat fixture enters working state')
-  await write('\x1b')
+  stdin.write('\x1b')
+  await settle(() => !screenText().includes('↑/↓'))
   check(cancelCalls === 0, 'Escape closes Help without cancelling a working turn')
   check(!screenText().includes('↑/↓'), 'Escape still closes Help while a turn is working')
   onSessionEvent?.(agent.session, {
@@ -351,14 +403,16 @@ try {
     type: 'turn/end',
     data: { turn: 1, reason: { kind: 'completed' } },
   })
-  await sleep(180)
+  await settle(() => !chatChannel.working)
 
   // A deliberately enabled Ctrl+O transcript mode survives Help, but `/`
   // typed while Help is visible belongs to the prompt and dismisses Help;
   // it must not open the transcript search bar behind the overlay.
   await write('\x0f')
-  await write('?')
-  await write('/')
+  stdin.write('?')
+  await settle(() => screenText().includes('↑/↓'))
+  stdin.write('/')
+  await settle(() => !screenText().includes('↑/↓'))
   routed = screenText()
   check(!routed.includes('no matches'), 'slash typed in Help does not open transcript search')
   check(chatChannel.commandCompletions('/').some(command => command.name === 'help'), 'slash typed in Help returns to command completion')

--- a/scripts/verify-i18n-command-descriptions.tsx
+++ b/scripts/verify-i18n-command-descriptions.tsx
@@ -20,6 +20,7 @@ const [
   { setLang },
   { LOCAL_COMMANDS },
   { stringWidth },
+  { settle, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -30,6 +31,7 @@ const [
   import('../src/i18n.js'),
   import('../src/commands.js'),
   import('../src/ink/stringWidth.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
@@ -56,10 +58,7 @@ function makeTerm(cols: number, rows: number) {
 }
 
 function screenText(term: InstanceType<typeof XTerm>, rows: number): string {
-  const buf = term.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < rows; y++) lines.push(buf.getLine(y)?.translateToString(true) ?? '')
-  return lines.join('\n')
+  return viewportLines(term, rows).join('\n')
 }
 
 // 混合清单：内置命令 + 已收录外部命令（plan）+ 未收录外部命令。
@@ -81,11 +80,16 @@ console.log('CommandSuggestions 随 /lang 切换:')
     React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }),
     { stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(300)
+  // 初始渲染的语言取决于环境，命令名与语言无关——以其出现为首帧信号。
+  await settle(() => screenText(term, ROWS).includes('new'))
 
   setLang('zh')
   app.rerender(React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }))
-  await sleep(200)
+  await settle(() => {
+    const t = screenText(term, ROWS)
+    return t.includes('新开会话') && t.includes('压缩会话历史') && t.includes('切换计划模式')
+      && t.includes('Registry fallback text') && !t.includes('Toggle plan mode')
+  })
   let text = screenText(term, ROWS)
   assert(text.includes('新开会话'), 'zh：内置命令显示中文描述（新开会话）')
   assert(text.includes('压缩会话历史'), 'zh：compact 显示中文描述')
@@ -95,7 +99,10 @@ console.log('CommandSuggestions 随 /lang 切换:')
 
   setLang('en')
   app.rerender(React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }))
-  await sleep(200)
+  await settle(() => {
+    const t = screenText(term, ROWS)
+    return t.includes('Start a new conversation') && t.includes('Toggle plan mode') && !t.includes('新开会话')
+  })
   text = screenText(term, ROWS)
   assert(text.includes('Start a new conversation'), 'en：内置命令回退 LOCAL_COMMANDS 英文原文')
   assert(text.includes('Toggle plan mode'), 'en：外部命令 plan 回退注册表英文原文')
@@ -118,18 +125,22 @@ console.log('HelpMenu 随 /lang 切换:')
     React.createElement(HelpMenu, { commands }),
     { stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(300)
+  // 同上：以语言无关的命令名出现为首帧信号。
+  await settle(() => screenText(term, ROWS).includes('/new'))
 
   setLang('zh')
   app.rerender(React.createElement(HelpMenu, { commands }))
-  await sleep(200)
+  await settle(() => {
+    const t = screenText(term, ROWS)
+    return t.includes('/new — 新开会话') && t.includes('/rewind — 回退会话到历史消息')
+  })
   let text = screenText(term, ROWS)
   assert(text.includes('/new — 新开会话'), 'zh：帮助菜单显示 /new — 新开会话')
   assert(text.includes('/rewind — 回退会话到历史消息'), 'zh：帮助菜单显示 rewind 中文描述')
 
   setLang('en')
   app.rerender(React.createElement(HelpMenu, { commands }))
-  await sleep(200)
+  await settle(() => screenText(term, ROWS).includes('/new — Start a new conversation'))
   text = screenText(term, ROWS)
   assert(text.includes('/new — Start a new conversation'), 'en：帮助菜单显示英文原文')
 
@@ -151,14 +162,16 @@ console.log('窄终端中文描述截断:')
     React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }),
     { stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(300)
+  // 断言条件（截断省略号）出现即帧已画到位；unmount 后保留短暂固定等待，
+  // 让尚在途的 term.write 回调全部落盘再读缓冲。
+  await settle(() => viewportLines(term, ROWS).some(line => line.includes('…')))
   app.unmount()
   await sleep(100)
 
-  const buf = term.buffer.active
+  const screenLines = viewportLines(term, ROWS)
   let sawEllipsis = false
   for (let y = 0; y < ROWS; y++) {
-    const line = buf.getLine(y)?.translateToString(true) ?? ''
+    const line = screenLines[y] ?? ''
     if (line.trim() === '') continue
     const w = stringWidth(line)
     assert(w <= COLS, `第 ${y} 行宽 ${w} ≤ 终端宽 ${COLS}：'${line.trimEnd()}'`)

--- a/scripts/verify-keymap.mjs
+++ b/scripts/verify-keymap.mjs
@@ -43,6 +43,7 @@ import {
   resetKeymapOverrides,
   setKeymapOverrides,
 } from '../lib/types/utils/keymap.js'
+import { settle, viewportLines } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -217,16 +218,11 @@ const instance = await render(
   }),
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
 )
+// 启动等待保留固定 sleep：首帧内容（含随机 tip）没有稳定的轮询锚点。
 await sleep(700)
 setLang('en')
 
-const screen = () => {
-  const lines = []
-  for (let row = 0; row < term.rows; row += 1) {
-    lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '')
-  }
-  return lines.join('\n')
-}
+const screen = () => viewportLines(term).join('\n')
 
 const promptText = () => {
   // Anchored at line start: the input border rows and hint lines can carry
@@ -241,12 +237,12 @@ const clipboardNotice = () => notifications.some(n => /clipboard|剪贴板/i.tes
 
 // Baseline: a plain 'v' types normally.
 stdin.write('v')
-await sleep(250)
+await settle(() => promptText() === 'v')
 check('plain v types', promptText() === 'v', JSON.stringify(promptText()))
 
 // Ctrl+C clears the non-empty prompt (idle single press).
 stdin.write('\x03')
-await sleep(250)
+await settle(() => promptText() === '')
 check('ctrl+c clears the prompt', promptText() === '', JSON.stringify(promptText()))
 
 // Alt+V arrives as ESC v. Whatever the clipboard holds, the paste branch
@@ -255,7 +251,7 @@ check('ctrl+c clears the prompt', promptText() === '', JSON.stringify(promptText
 const beforeAltV = promptText()
 notifications.length = 0
 stdin.write('\x1bv')
-await sleep(800)
+await settle(() => promptText() !== beforeAltV || clipboardNotice())
 check(
   'alt+v reaches the clipboard paste branch',
   promptText() !== beforeAltV || clipboardNotice(),
@@ -265,11 +261,11 @@ check('alt+v does not type a bare v on an empty clipboard', clipboardNotice() ||
 
 // Ctrl+V (0x16) goes through the same branch.
 stdin.write('\x03')
-await sleep(250)
+await settle(() => promptText() === '')
 const beforeCtrlV = promptText()
 notifications.length = 0
 stdin.write('\x16')
-await sleep(800)
+await settle(() => promptText() !== beforeCtrlV || clipboardNotice())
 check(
   'ctrl+v reaches the clipboard paste branch',
   promptText() !== beforeCtrlV || clipboardNotice(),
@@ -280,11 +276,11 @@ check(
 // takes the key: with $VISUAL/$EDITOR unset the outcome is the
 // unavailable notification, and no 'g' is typed either way.
 stdin.write('\x03')
-await sleep(250)
+await settle(() => promptText() === '')
 setKeymapOverrides({ editor: 'alt+g' })
 notifications.length = 0
 stdin.write('\x1bg')
-await sleep(800)
+await settle(() => notifications.some(n => /editor|编辑器/i.test(String(n.text))))
 const editorNotice = notifications.some(n => /editor|编辑器/i.test(String(n.text)))
 check('remapped alt+g editor key does not type g', promptText() !== 'g', JSON.stringify(promptText()))
 check('remapped editor key reached the editor path (notify seen)', editorNotice, JSON.stringify(notifications.map(n => n.text)))

--- a/scripts/verify-loaded-context-width.tsx
+++ b/scripts/verify-loaded-context-width.tsx
@@ -6,13 +6,14 @@
 process.env.DSH_TUI_LANG = 'en'
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render, ThemeProvider }, { LoadedContextPanel }] =
+const [{ Writable }, React, { Terminal: XTerm }, { render, ThemeProvider }, { LoadedContextPanel }, { settle, viewportLines }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
     import('@xterm/headless'),
     import('../src/ui.js'),
     import('../src/components/LoadedContextPanel.js'),
+    import('./lib/term-test.mjs'),
   ])
 
 const COLS = 60
@@ -60,12 +61,10 @@ const app = await render(
   },
 )
 
-await new Promise(resolve => setTimeout(resolve, 300))
+await settle(() =>
+  viewportLines(term, ROWS).some(line => line.includes('Context loaded') && line.includes('Ctrl+P')))
 
-const lines = Array.from(
-  { length: ROWS },
-  (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '',
-)
+const lines = viewportLines(term, ROWS)
 const contentLines = lines.filter(line => line.trim() !== '')
 
 await app.unmount()

--- a/scripts/verify-login-credentials.tsx
+++ b/scripts/verify-login-credentials.tsx
@@ -14,6 +14,7 @@ const [
   { QuestionStore },
   { LOCAL_COMMANDS },
   { setLang },
+  { settle },
 ] = await Promise.all([
   import('node:assert'),
   import('node:stream'),
@@ -23,6 +24,7 @@ const [
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
   import('../src/i18n.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 class FakeStdout extends Writable {
@@ -149,9 +151,10 @@ async function runLogin(status: unknown) {
       patchConsole: false,
     },
   )
+  // 启动等待保留固定 delay：假 stdout 丢弃全部帧，没有可轮询的观察点。
   await delay(500)
   stdin.write('/login\r')
-  await delay(700)
+  await settle(() => channel.localCalls.length === 1)
   await instance.unmount()
   assert.equal(channel.localCalls.length, 1, '/login must produce one local report')
   assert.deepEqual(channel.credentialRefs, ['DEEPSEEK_API_KEY'], '/login must query the credentials service')

--- a/scripts/verify-picker-edge.tsx
+++ b/scripts/verify-picker-edge.tsx
@@ -28,9 +28,10 @@ const { join: joinPath } = await import('node:path')
 process.env.HOME = mkdtempSync(joinPath(tmpdir(), 'dshtui-edge-'))
 process.env.USERPROFILE = process.env.HOME
 
-const [{ Terminal: XTerm }, React] = await Promise.all([
+const [{ Terminal: XTerm }, React, { settle, viewportLines }] = await Promise.all([
   import('@xterm/headless'),
   import('react'),
+  import('./lib/term-test.mjs'),
 ])
 const { render } = await import('../src/ui.js')
 const { ModelPicker } = await import('../src/components/ModelPicker.js')
@@ -80,6 +81,9 @@ async function mountAt(cols: number) {
         models, focusIndex, currentModel: 'p/m12', onHover: noop,
       }) as never,
     )
+    // 翻页前后屏幕形态没有可区分的观察点（长名的尾部序号被省略号截掉，
+    // 行文本与翻页前一致），对已成立条件轮询会立即返回等于没测；
+    // 保留固定窗口等重绘落盘。
     await sleep(400)
     const buf = term.buffer.active
     const texts: string[] = []
@@ -119,7 +123,12 @@ async function mountAt(cols: number) {
       patchConsole: false,
     },
   )
-  await sleep(400)
+  // 首帧：标题、页脚、焦点指示与选中勾都画出来才算挂载完成。
+  await settle(() => {
+    const lines = viewportLines(term, ROWS)
+    return lines.some(line => line.includes('模型')) && lines.some(line => line.includes('Enter'))
+      && lines.some(line => line.includes('❯')) && lines.some(line => line.includes('✓'))
+  })
   return { instance, frame, term }
 }
 

--- a/scripts/verify-plain-enter-guard.mjs
+++ b/scripts/verify-plain-enter-guard.mjs
@@ -27,6 +27,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Writable, PassThrough } from 'node:stream'
 import React from 'react'
+import { settle } from './lib/term-test.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -82,6 +83,9 @@ await sleep(500)
 
 // Modifier Enters must be inert in the panel (they were inert text tokens
 // before #110; the guard restores that for decision paths).
+// Stability probes (nothing may be decided): a settle would return
+// immediately on the already-true condition — keep fixed windows so a
+// wrong decision has time to surface.
 stdin.write('\x1b\r') // Option+Enter (ESC CR) → meta+return
 await sleep(250)
 check('Option+Enter (ESC CR) does not decide', decisions.length === 0, JSON.stringify(decisions))
@@ -96,7 +100,7 @@ check('Shift+Enter (CSI 13;2u) does not decide', decisions.length === 0, JSON.st
 
 // Plain Enter still confirms the focused row (default 0 = allowed-once).
 stdin.write('\r')
-await sleep(250)
+await settle(() => decisions.length === 1 && decisions[0] === 'allowed-once')
 check('plain Enter decides the focused outcome', decisions.length === 1 && decisions[0] === 'allowed-once', JSON.stringify(decisions))
 
 instance.unmount()

--- a/scripts/verify-plugin-scene-boundary.tsx
+++ b/scripts/verify-plugin-scene-boundary.tsx
@@ -13,11 +13,12 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { render, Text }, { PluginSceneBoundary }] = await Promise.all([
+const [{ Writable }, React, { render, Text }, { PluginSceneBoundary }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('../src/ui.js'),
   import('../src/components/PluginSceneBoundary.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 let failed = 0
@@ -41,8 +42,6 @@ class FakeStderr extends Writable {
   override _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
 }
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-
 // --- 1. healthy scene renders through untouched ----------------------------
 const healthy = await render(
   <PluginSceneBoundary id="ok" onError={() => { check('healthy scene never reports', false) }}>
@@ -50,7 +49,7 @@ const healthy = await render(
   </PluginSceneBoundary>,
   { stdout: new FakeStdout() as never, stderr: new FakeStderr() as never, patchConsole: false, exitOnCtrlC: false },
 )
-await sleep(100)
+await settle(() => frames.join('').includes('scene-ok-content'))
 check('healthy scene content painted', frames.join('').includes('scene-ok-content'))
 await healthy.unmount()
 
@@ -69,7 +68,7 @@ const crashed = await render(
   </PluginSceneBoundary>,
   { stdout: new FakeStdout() as never, stderr: new FakeStderr() as never, patchConsole: false, exitOnCtrlC: false },
 )
-await sleep(150)
+await settle(() => reports.length === 1)
 check('boundary reports the crash exactly once', reports.length === 1, `reports=${reports.length}`)
 check('report carries scene id and error message',
   reports[0]?.id === 'demo' && reports[0]?.message.includes('boom-场景炸了'),

--- a/scripts/verify-prompt-history-draft.mjs
+++ b/scripts/verify-prompt-history-draft.mjs
@@ -13,6 +13,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Writable } from 'node:stream'
+import { settle } from './lib/term-test.mjs'
 
 const home = mkdtempSync(join(tmpdir(), 'dsh-tui-history-draft-'))
 process.env.HOME = home
@@ -78,18 +79,24 @@ const write = async (input) => {
 }
 
 try {
+  // Startup and typing/arrow ordering keep fixed waits: the fake stdout
+  // discards frames, so there is nothing observable to settle on for them.
+  // Each Enter's effect IS observable through `submitted`, so settle there.
   await wait(300)
   await write('first')
-  await write('\r')
+  stdin.write('\r')
+  await settle(() => submitted.length === 1)
   await write('second')
-  await write('\r')
+  stdin.write('\r')
+  await settle(() => submitted.length === 2)
   await write('unfinished draft')
 
   // Repeated Up clamps at the oldest entry; repeated Down returns to and
   // stays on the draft after passing the newest entry.
   for (let i = 0; i < 3; i += 1) await write('\x1b[A')
   for (let i = 0; i < 3; i += 1) await write('\x1b[B')
-  await write('\r')
+  stdin.write('\r')
+  await settle(() => submitted.length === 3)
 
   if (submitted.length !== 3 || submitted[2] !== 'unfinished draft') {
     console.error(`FAIL: unfinished draft was not restored: ${JSON.stringify(submitted)}`)

--- a/scripts/verify-scroll.mjs
+++ b/scripts/verify-scroll.mjs
@@ -25,14 +25,13 @@
 import { Writable, PassThrough } from 'node:stream'
 import React from 'react'
 import { render, Text, ScrollBox } from '../lib/types/ui.js'
+import { settle } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
-
-const sleep = ms => new Promise(r => setTimeout(r, ms))
 
 function makeStreams() {
   const stdout = new Writable({
@@ -86,7 +85,9 @@ async function run() {
       })
     },
   })
-  await sleep(400)
+  // The extra frame clause is ordering: scrollTo below needs the first
+  // full-height layout committed, which the fixed sleep used to cover.
+  await settle(() => scrollHandle !== null && frameLog.at(-1)?.scrollHeight === 60)
   if (!scrollHandle) {
     check('ScrollBox handle attached', false)
     process.exit(failed)
@@ -95,7 +96,7 @@ async function run() {
 
   // ---- bottom-scrolled: 60 rows, maxScroll 36, scroll to 36.
   scrollHandle.scrollTo(36)
-  await sleep(400)
+  await settle(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60)
   const bottomScrolled = frameLog.at(-1)
   check('bottom scroll landed at maxScroll', bottomScrolled.scrollTop === 36 && bottomScrolled.scrollHeight === 60, JSON.stringify(bottomScrolled))
 
@@ -105,23 +106,29 @@ async function run() {
   // sticky; a sticky shrink frame clamps to the collapsed maxScroll (#421:
   // freezing past the content paints blank — see the docstring exception).
   instance.rerender(makeScroller(20))
-  await sleep(400)
+  await settle(() => {
+    const f = frameLog.find(f => f.scrollHeight === 24)
+    return f !== undefined && f.scrollTop === 0
+  })
   const shrinkFrame = frameLog.find(f => f.scrollHeight === 24)
   check('shrink frame clamps the re-pinned sticky view to the collapsed bottom', shrinkFrame !== undefined && shrinkFrame.scrollTop === 0, JSON.stringify(shrinkFrame ?? frameLog.at(-1)))
 
   // ---- grow back: 60 rows. Position re-validated at the bottom.
   instance.rerender(makeScroller(60))
-  await sleep(400)
+  await settle(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60)
   const grownFrame = frameLog.at(-1)
   check('grow-back frame stays at the bottom', grownFrame.scrollTop === 36 && grownFrame.scrollHeight === 60, JSON.stringify(grownFrame))
 
   // ---- mid-scrolled: 60 rows, scroll to 10 (away from bottom), shrink, grow.
   instance.rerender(makeScroller(60))
-  await sleep(400)
+  await settle(() => frameLog.at(-1)?.scrollHeight === 60)
   scrollHandle.scrollTo(10)
-  await sleep(400)
+  await settle(() => frameLog.at(-1)?.scrollTop === 10)
   instance.rerender(makeScroller(20))
-  await sleep(400)
+  await settle(() => {
+    const f = frameLog.filter(f => f.scrollHeight === 24).at(-1)
+    return f !== undefined && f.scrollTop === 10
+  })
   const midShrink = frameLog.filter(f => f.scrollHeight === 24).at(-1)
   check('mid-scroll shrink frame keeps the position', midShrink !== undefined && midShrink.scrollTop === 10, JSON.stringify(midShrink ?? frameLog.at(-1)))
 
@@ -130,7 +137,7 @@ async function run() {
   // computed from the artifact frame (opentui #709: content-size changes
   // must not reset the manual-scroll state).
   instance.rerender(makeScroller(60))
-  await sleep(400)
+  await settle(() => frameLog.at(-1)?.scrollTop === 10 && frameLog.at(-1)?.scrollHeight === 60)
   const midGrown = frameLog.at(-1)
   check('post-shrink grow frame keeps the mid position', midGrown.scrollTop === 10 && midGrown.scrollHeight === 60, JSON.stringify(midGrown))
 

--- a/scripts/verify-scrollbar-gutter.tsx
+++ b/scripts/verify-scrollbar-gutter.tsx
@@ -17,7 +17,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -25,6 +25,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100, ROWS = 40
@@ -71,10 +72,10 @@ const channel: any = {
   commandCompletions: (input: string) => completeCommands(input),
 }
 const emitChannel = () => { channel.version++; for (const l of listeners) l() }
-const setGutter = async (mode: string) => {
+// 切换后由各调用点 settle 到断言条件出现（./lib/term-test.mjs）。
+const setGutter = (mode: string) => {
   channel.scrollGutter = mode
   emitChannel()
-  await sleep(400)
 }
 
 const inst = await render(
@@ -83,8 +84,6 @@ const inst = await render(
   </AlternateScreen>,
   { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(700)
-
 function screenLines(): string[] {
   const buf = term.buffer.active
   return Array.from({ length: ROWS }, (_, y) => buf.getLine(buf.baseY + y)?.translateToString(true) ?? '')
@@ -123,19 +122,24 @@ function gutterSnapshot(): { thumbs: number[]; ticks: number[]; chevrons: number
   }
   return { thumbs, ticks, chevrons }
 }
+// 逐事件 pacing sleep 保留：滚轮事件需要逐个进入 hover/scroll 路径，
+// 每步之间没有可区分新旧帧的屏幕条件可轮询。
 const wheel = async (up: boolean, times: number) => {
   for (let i = 0; i < times; i++) {
     stdin.write(`\x1b[<${up ? 64 : 65};90;30M`)
     await sleep(150)
   }
 }
-const clickAt = async (col: number, row: number) => {
+const clickAt = (col: number, row: number) => {
   stdin.write(`\x1b[<0;${col};${row}M`)
   stdin.write(`\x1b[<0;${col};${row}m`)
-  await sleep(400)
 }
 
 // ── 1. 默认 timeline ──
+await settle(() => {
+  const snap = gutterSnapshot()
+  return snap.ticks.length > 0 && snap.chevrons.length === 2 && snap.thumbs.length === 0
+})
 {
   const snap = gutterSnapshot()
   check('默认 timeline：rail tick + chevron 存在', snap.ticks.length > 0 && snap.chevrons.length === 2,
@@ -144,7 +148,13 @@ const clickAt = async (col: number, row: number) => {
 }
 
 // ── 2. 切 scrollbar：██ 贴底，无 chevron/tick ──
-await setGutter('scrollbar')
+setGutter('scrollbar')
+await settle(() => {
+  const snap = gutterSnapshot()
+  const [, bottom] = gutterRange()
+  return snap.thumbs.length >= 2 && snap.chevrons.length === 0 && snap.ticks.length === 0 &&
+    snap.thumbs[snap.thumbs.length - 1] === bottom - 1
+})
 {
   const snap = gutterSnapshot()
   check('scrollbar：██ 滑块出现', snap.thumbs.length >= 2, `thumbs=${snap.thumbs.length}`)
@@ -157,6 +167,13 @@ await setGutter('scrollbar')
 
 // ── 3. 上滚（whale 滚出视口）：滑块在轨道内且离开底端 ──
 await wheel(true, 16)
+await settle(() => {
+  const snap = gutterSnapshot()
+  const [top, bottom] = gutterRange()
+  if (snap.thumbs.length < 2) return false
+  const first = snap.thumbs[0]!, last = snap.thumbs[snap.thumbs.length - 1]!
+  return first >= top && last < bottom - 1
+})
 {
   const snap = gutterSnapshot()
   const [top, bottom] = gutterRange()
@@ -171,15 +188,15 @@ await wheel(true, 16)
 // ── 4. 点击轨道顶部：滚到顶（whale 回到视口，跳过滑块位置断言）──
 {
   const [top] = gutterRange()
-  await clickAt(COLS, top + 1)
+  clickAt(COLS, top + 1)
+  await settle(() => screenLines().slice(0, 24).some(l => l.includes('问题 1')))
   const lines = screenLines()
   check('点击轨道顶后滚到顶（问题 1 可见）', lines.slice(0, 24).some(l => l.includes('问题 1')),
     `top4=${JSON.stringify(lines.slice(0, 4).map(l => l.trimEnd().slice(0, 24)))}`)
 }
 
 // ── 5. 切 hidden：无 gutter（whale 的 █ 不算——只查 timeline/scrollbar glyph）──
-await setGutter('hidden')
-{
+const hasGutterGlyph = (): boolean => {
   const [top, bottom] = gutterRange()
   let anyGlyph = false
   for (let y = top; y < bottom; y++) {
@@ -194,12 +211,22 @@ await setGutter('hidden')
       if (!whale) anyGlyph = true
     }
   }
+  return anyGlyph
+}
+setGutter('hidden')
+await settle(() => !hasGutterGlyph())
+{
+  const anyGlyph = hasGutterGlyph()
   check('hidden：右缘无任何 gutter glyph', !anyGlyph)
 }
 
 // ── 6. 切回 timeline：rail 恢复 ──
 await wheel(false, 30)
-await setGutter('timeline')
+setGutter('timeline')
+await settle(() => {
+  const snap = gutterSnapshot()
+  return snap.ticks.length === 8 && snap.chevrons.length === 2
+})
 {
   const snap = gutterSnapshot()
   check('切回 timeline：rail 恢复', snap.ticks.length === 8 && snap.chevrons.length === 2,

--- a/scripts/verify-session-browser-layout.mjs
+++ b/scripts/verify-session-browser-layout.mjs
@@ -179,6 +179,12 @@ for (const lang of ['zh', 'en']) {
       )
     }
 
+    // Fixed sleeps kept on purpose (settle would not help here): every
+    // assertion is a layout INVARIANT — no wrapped line, hint row last —
+    // that already holds on the pre-keystroke screen, so polling for it
+    // returns immediately on the stale frame and the new frame goes
+    // untested. The window gives each repaint (and the async session list)
+    // time to land before the invariant is re-checked.
     inspect('initial')
     for (const [keys, label] of KEYS) {
       stdin.write(keys)

--- a/scripts/verify-session-browser.mjs
+++ b/scripts/verify-session-browser.mjs
@@ -31,6 +31,7 @@ import { render } from '../lib/types/ui.js'
 import { Chat } from '../lib/types/screens/Chat.js'
 import { setLang } from '../lib/types/i18n.js'
 import instances from '../lib/types/ink/instances.js'
+import { settle } from './lib/term-test.mjs'
 
 const { Terminal } = xtermPkg
 
@@ -238,30 +239,37 @@ const instance = await render(
 // does. Without this the browser would render with inline geometry and the
 // test would be measuring an artefact of its own rig.
 for (const value of instances.values()) instances.set(process.stdout, value)
-await sleep(700)
 
 const flat = (s) => s.replace(/\s+/g, ' ')
 
-/** The composed screen, as the user sees it. */
+/** The composed screen, as the user sees it. Reads from baseY: before the
+ *  browser enters the alternate screen the harness is in inline mode, where
+ *  scrollback would shift the viewport (baseY is 0 in the alt screen). */
 const screen = () => {
   const buf = stdout.term.buffer.active
   return Array.from({ length: stdout.term.rows }, (_, y) =>
-    (buf.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+    (buf.getLine(buf.baseY + y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
     .join('\n')
 }
 
-async function windowed(action, settle = 300) {
+async function windowed(action, settleMs = 300) {
   stdout.frames.length = 0
   action()
-  await sleep(settle)
+  await sleep(settleMs)
   return toPlain(stdout.frames.join(''))
 }
 
 setLang('en')
 
+// 启动落定：composer 提示符出现即可接收输入。
+await settle(() => screen().includes('❯'))
+
 // ── open the browser ────────────────────────────────────────────────────
-await windowed(() => stdin.write('/resume'), 250)
-await windowed(() => stdin.write('\r'), 600)
+stdin.write('/resume')
+await settle(() => flat(screen()).includes('/resume'))
+stdin.write('\r')
+await settle(() =>
+  /Resume session/.test(flat(screen())) && /gamma/.test(screen()) && /❯\s*gamma/.test(screen()))
 let s = screen()
 check('the browser opens as a screen', /Resume session/.test(flat(s)), flat(s).slice(0, 120))
 check('conversations are listed', /gamma/.test(s) && /beta/.test(s) && /alpha/.test(s))
@@ -279,55 +287,79 @@ check('focus starts on the MRU top row (gamma)', /❯\s*gamma/.test(s), s.split(
 // chunk, all handled before React re-renders. Every one of them must move
 // the cursor; a handler reading its start position from the render closure
 // would compute them all from the same row and keep only the last.
-await windowed(() => stdin.write('\x1b[B\x1b[B'), 450) // two ↓ in one chunk
+stdin.write('\x1b[B\x1b[B') // two ↓ in one chunk
+await settle(() => /❯\s*alpha/.test(screen()))
 s = screen()
 check('two arrows in one chunk move two rows, not one', /❯\s*alpha/.test(s), s.split('\n').filter(l => l.includes('❯')).join('|'))
-await windowed(() => stdin.write('\x1b[A\x1b[A'), 450) // two ↑ back to the top
+stdin.write('\x1b[A\x1b[A') // two ↑ back to the top
+await settle(() => /❯\s*gamma/.test(screen()))
 check('and back again', /❯\s*gamma/.test(screen()))
 // Control bytes this screen does not claim must never be typed into the
 // search box. A chord arriving as raw C0 (here two ctrl+s in one chunk, which
 // the parser hands over as literal control characters rather than as the
 // shortcut) used to land in the query and leave a filter matching nothing,
 // with nothing on screen to explain why the list went empty.
+// Stability probe (the query and list must NOT change; the expected final
+// screen equals the current one, so a settle would return immediately) —
+// keep the fixed window for a wrong repaint to show up.
 await windowed(() => stdin.write('\x13\x13'), 500)
 // An empty query still shows the placeholder; a polluted one would not.
 check('unclaimed control bytes never reach the search box', /Type to search/.test(flat(screen())), flat(screen()).slice(0, 200))
 check('and the list is untouched by them', /gamma/.test(screen()) && /alpha/.test(screen()) && /3 sessions/.test(flat(screen())))
 
 // ── search ──────────────────────────────────────────────────────────────
-await windowed(() => stdin.write('alph'), 400)
+stdin.write('alph')
+await settle(() => /alpha/.test(screen()) && !/gamma/.test(screen()) && /❯\s*alpha/.test(screen()))
 s = screen()
 check('typing filters the list', /alpha/.test(s) && !/gamma/.test(s), flat(s).slice(0, 200))
 check('the cursor lands on the surviving row', /❯\s*alpha/.test(s))
+// Fixed window kept: the assertion condition (/alpha/) already holds before
+// the backspace — the only change is one query character, which these
+// regexes cannot distinguish ('alpha' contains 'alph'), so a settle would
+// return on the stale screen.
 await windowed(() => stdin.write('\x7f'), 300) // backspace
 s = screen()
 check('backspace widens the query again', /alpha/.test(s))
-await windowed(() => stdin.write('\x1b'), 350) // Esc clears the query first
+stdin.write('\x1b') // Esc clears the query first
+await settle(() => /gamma/.test(screen()) && /Resume session/.test(flat(screen())))
 s = screen()
 check('Esc clears the query rather than leaving', /gamma/.test(s) && /Resume session/.test(flat(s)))
 
 // ── reveal the delegated runs ───────────────────────────────────────────
-await windowed(() => stdin.write('\x13'), 400) // ctrl+s
+stdin.write('\x13') // ctrl+s
+await settle(() => /audit run/.test(screen()))
 s = screen()
 check('ctrl+s reveals the delegated runs', /audit run/.test(s), flat(s).slice(0, 300))
 check('nothing is folded any more', /0 runs folded/.test(flat(s)) || !/runs folded/.test(flat(s)))
 const runLine = s.split('\n').find((l) => l.includes('audit run')) ?? ''
 check('a run is indented under its parent', /^\s{3,}/.test(runLine), JSON.stringify(runLine))
-await windowed(() => stdin.write('\x13'), 400) // fold them back
+stdin.write('\x13') // fold them back
+await settle(() => !/audit run/.test(screen()))
 check('ctrl+s folds them away again', !/audit run/.test(screen()))
 
 // ── rename, and the cursor that follows it ──────────────────────────────
-await windowed(() => stdin.write('\x1b[B'), 300) // ↓ → beta
-s = await windowed(() => stdin.write('\x12'), 350) // ctrl+r → rename
+stdin.write('\x1b[B') // ↓ → beta
+await settle(() => /❯\s*beta/.test(screen()))
+// The prefill assertion reads the PAINTED window (per-cell diff semantics),
+// so poll the accumulating frame bytes for the same condition.
+stdout.frames.length = 0
+stdin.write('\x12') // ctrl+r → rename
+await settle(() => /✎ beta/.test(flat(toPlain(stdout.frames.join('')))))
+s = toPlain(stdout.frames.join(''))
 check('rename prefills the editor with the focused title', /✎ beta/.test(flat(s)), flat(s).slice(-160))
-await windowed(() => stdin.write('renamed'), 250)
-await windowed(() => stdin.write('\r'), 700)
+stdin.write('renamed')
+await settle(() => /betarenamed/.test(screen()))
+stdin.write('\r')
+await settle(() => channel.calls.rename.length === 1)
 check(
   'the rename call hit the intended session',
   channel.calls.rename.length === 1 && channel.calls.rename[0][0] === 's-mid',
   JSON.stringify(channel.calls.rename),
 )
-await sleep(60)
+await settle(() => {
+  const row = screen().split('\n').find((l) => l.includes('betarenamed')) ?? ''
+  return /❯\s*betarenamed/.test(row)
+})
 s = screen()
 const renamedRow = s.split('\n').find((l) => l.includes('betarenamed')) ?? ''
 check(
@@ -340,14 +372,21 @@ check(
 // Composed screen, not the painted window: the notice row this replaces sat
 // on the same line, so the per-cell diff legitimately emits only the changed
 // characters and a regex over those bytes can never match.
-await windowed(() => stdin.write('\x04'), 400) // ctrl+d
+stdin.write('\x04') // ctrl+d
+await settle(() => /Delete "betarenamed"/.test(flat(screen())))
 check('the confirmation names the focused session', /Delete "betarenamed"/.test(flat(screen())), flat(screen()).slice(-220))
+// Negative probe (Ctrl+Enter must NOT confirm): nothing is supposed to
+// change, so a settle would return immediately — keep the fixed window.
 await windowed(() => stdin.write('\x1b[13;5u'), 400) // Ctrl+Enter must not confirm
 check('Ctrl+Enter does not confirm an irreversible delete', channel.calls.delete.length === 0, JSON.stringify(channel.calls.delete))
-await windowed(() => stdin.write('\x1b'), 350) // Esc cancels
+stdin.write('\x1b') // Esc cancels
+await settle(() => !/Delete "/.test(flat(screen())) && channel.calls.delete.length === 0)
 check('Esc cancels the confirmation', !/Delete "/.test(flat(screen())) && channel.calls.delete.length === 0)
-await windowed(() => stdin.write('\x04'), 400)
-await windowed(() => stdin.write('\x1b[13u\x1b[13u'), 700)
+stdin.write('\x04')
+await settle(() => /Delete "betarenamed"/.test(flat(screen())))
+stdin.write('\x1b[13u\x1b[13u')
+await settle(() =>
+  /Deleted session betarenamed/.test(flat(screen())) && /2 sessions/.test(flat(screen())))
 check(
   'repeated Enter commits one delete, on the session the confirmation named',
   channel.calls.delete.length === 1 && channel.calls.delete[0] === 's-mid',
@@ -360,7 +399,8 @@ check('the browser says what it did, on the screen the user is looking at', /Del
 check('the deleted row leaves the list', /2 sessions/.test(flat(s)) && !s.split('\n').some(l => /^[❯\s]*betarenamed/.test(l)), flat(s).slice(0, 200))
 
 // ── resume failure detail ──────────────────────────────────────────────────
-await windowed(() => stdin.write('\r'), 500)
+stdin.write('\r')
+await settle(() => /corrupt session log: seq gap in committed region/.test(flat(screen())))
 s = screen()
 check('a failed resume stays in the browser', /Resume session/.test(flat(s)), flat(s).slice(0, 180))
 check(
@@ -375,7 +415,8 @@ check(
 )
 
 // ── leaving ─────────────────────────────────────────────────────────────
-await windowed(() => stdin.write('\x1b'), 500)
+stdin.write('\x1b')
+await settle(() => !/Resume session/.test(flat(screen())))
 s = screen()
 check('Esc leaves the browser and restores the conversation', !/Resume session/.test(flat(s)), flat(s).slice(0, 160))
 

--- a/scripts/verify-shrink.mjs
+++ b/scripts/verify-shrink.mjs
@@ -32,6 +32,7 @@ const { Writable, PassThrough } = await import('node:stream')
 const React = await import('react')
 const m = await import('@xterm/headless'); const XTerm = m.default?.Terminal ?? m.Terminal
 const { render, Box, Text } = await import('../lib/types/ui.js')
+const { settle } = await import('./lib/term-test.mjs')
 
 const COLS = 100
 const ROWS = 28
@@ -63,8 +64,6 @@ function makeStreams(term) {
   return { stdout, stderr, stdin }
 }
 
-const sleep = ms => new Promise(r => setTimeout(r, ms))
-
 let failed = 0
 function check(name, ok, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -92,12 +91,32 @@ function check(name, ok, extra = '') {
     exitOnCtrlC: false,
     patchConsole: false,
   })
-  await sleep(500)
+  // 主屏收缩语义按「buffer 尾窗口」读（刻意非视口读取：scrollback 是断言
+  // 的一部分）。
+  const tailWindow = () => {
+    const buf = term.buffer.active
+    const start = Math.max(0, buf.length - ROWS)
+    const lines = []
+    for (let y = start; y < buf.length; y++) {
+      lines.push((buf.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
+    }
+    return lines
+  }
+  // 初始帧落定（marker 已解析）后再取 shrink 字节窗口的边界。
+  await settle(() => tailWindow().some(l => l.includes('BOTTOM_PINNED_MARKER')))
   const framesBefore = stdout.frames.length
 
   // Shrink: 60 -> 40 lines.
   instance.rerender(React.createElement(App, { lineCount: 40 }))
-  await sleep(500)
+  await settle(() => {
+    const lines = tailWindow()
+    const nums = lines
+      .map(l => /^line (\d+) padded content$/.exec(l.trim()))
+      .filter(Boolean)
+      .map(match => Number(match[1]))
+    return !lines.some(l => /line (4\d|5\d) padded/.test(l)) &&
+      nums.length > 0 && nums[nums.length - 1] === 39
+  })
   const shrinkBytes = stdout.frames.slice(framesBefore).join('')
 
   // 1. 无 scrollback 沉积、无 WT 跳顶序列。

--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -11,6 +11,7 @@
  */
 import { createChannel } from '../lib/types/dsh-adapter/channel.js'
 import { LOCAL_COMMANDS } from '../lib/types/commands.js'
+import { settle } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -100,7 +101,9 @@ check(
   !channel.commandList.some(command => command.name === 'i-h'),
 )
 
-await tick()
+await settle(() =>
+  channel.commandList.some(command => command.name === 'i-h') &&
+  channel.commandList.some(command => command.name === 'helper'))
 
 // ---- async phase: user-invocable skills merged, marked, deduped
 const names = channel.commandList.map(command => command.name)
@@ -136,7 +139,9 @@ if (skillsChange === undefined || skillsChange.length === 0) {
 } else {
   check('skills/change handler captured', true)
   fire('skills/change')
-  await tick()
+  await settle(() =>
+    channel.commandList.some(command => command.name === 'newskill') &&
+    !channel.commandList.some(command => command.name === 'helper'))
   const refreshed = channel.commandList.map(command => command.name)
   check('removed skill leaves the menu', !refreshed.includes('helper'))
   check('added skill enters the menu', refreshed.includes('newskill'))
@@ -152,7 +157,7 @@ ctx.get = (name) => {
 let warned = 0
 ctx.logger = { warn() { warned += 1 } }
 fire('skills/change')
-await tick()
+await settle(() => warned >= 1)
 {
   const after = channel.commandList.map(command => command.name)
   check(
@@ -178,7 +183,7 @@ ctx.get = (name) => {
 }
 warned = 0
 fire('skills/change')
-await tick()
+await settle(() => warned >= 1)
 {
   const after = channel.commandList.map(command => command.name)
   check(
@@ -201,7 +206,9 @@ ctx.get = (name) => {
   return undefined
 }
 fire('skills/change')
-await tick()
+await settle(() =>
+  !channel.commandList.some(command => command.name === 'i-h') &&
+  !channel.commandList.some(command => command.name === 'newskill'))
 {
   const after = channel.commandList.map(command => command.name)
   check(
@@ -229,9 +236,11 @@ await tick()
     skills: [{ name: 'live', description: 'Live skill', invocation: { modelInvocable: true, userInvocable: true } }],
     complete: true,
   })
-  await tick()
+  await settle(() => channel.commandList.some(command => command.name === 'live'))
   check('superseding read repopulates the menu', channel.commandList.some(command => command.name === 'live'))
   pending[0].reject(new Error('stale scan failed'))
+  // Stability probe (nothing may change, nothing may warn): a settle over an
+  // already-true condition returns immediately — keep the fixed window.
   await tick()
   check('stale read failure logs no warning', staleWarned === 0, `warned=${staleWarned}`)
   check(
@@ -268,8 +277,7 @@ await tick()
     { name: 'review', description: 'Shadow skill (review)', invocation: { modelInvocable: true, userInvocable: true } },
   )
   fire('skills/change')
-  await tick()
-  await tick()
+  await settle(() => typeof registered.get('i-h')?.handler === 'function')
 
   check(
     'user-invocable skill is registered as a real command',
@@ -309,7 +317,7 @@ await tick()
     agent.followups.length = 0
     const outcome = await descriptor.handler({ agent, rawInput: ' 做年终总结', signal: undefined })
     check('kernel path reports success', outcome?.kind === 'success', JSON.stringify(outcome))
-    await tick()
+    await settle(() => agent.followups.length === 1)
     const gesture = agent.followups[0]
     check('kernel path delivers exactly one message', agent.followups.length === 1)
     check(

--- a/scripts/verify-subagent-settle.tsx
+++ b/scripts/verify-subagent-settle.tsx
@@ -96,6 +96,9 @@ const channel: any = {
 }
 const bump = () => { channel.version++; for (const cb of listeners) (cb as () => void)() }
 
+/** 固定窗口刻意保留（不换 settle）：帧计数窗口本身就是被测对象——
+ *  「settled 后空闲帧数 = 0」是不得发生渲染的稳定性探针，对已成立
+ *  条件轮询会立即返回，等于没测。 */
 async function countIdleFrames(windowMs: number): Promise<number> {
   await sleep(300)
   const before = frameCount

--- a/scripts/verify-subagent-stream-batching.tsx
+++ b/scripts/verify-subagent-stream-batching.tsx
@@ -29,10 +29,11 @@ process.env.HOME = isolatedHome
 process.env.USERPROFILE = isolatedHome
 mkdirSync(joinPath(isolatedHome, '.dsh-tui'), { recursive: true })
 
-const [{ Context }, { createChannel }, { SubagentActivityStore }] = await Promise.all([
+const [{ Context }, { createChannel }, { SubagentActivityStore }, { settle }] = await Promise.all([
   import('@deepseek-ai/cordis'),
   import('../src/dsh-adapter/channel.js'),
   import('../src/dsh-adapter/subagents.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 let failed = 0
@@ -84,7 +85,7 @@ const chunk = (text: string) => ({ type: 'assistant/chunk', data: { chunk: { typ
 ;(ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit('subagent/start', {
   id: 'child-agent', runId: 'run-1', provider: 'fake-provider',
 })
-await sleep(50)
+await settle(() => channel.subagents.length === 1 && channel.subagents[0]?.agentId === 'child-agent')
 const linked = channel.subagents.length === 1 && channel.subagents[0]!.agentId === 'child-agent'
 check('subagent/start 建立 tracked subagent', linked, JSON.stringify(channel.subagents.map(s => s.agentId)))
 
@@ -100,6 +101,8 @@ for (let i = 0; i < BURST; i++) {
 // 同 tick 发完：此时投影应远少于 chunk 数（仅 start 路径与 store 内部，
 // channel 层的投影最多 0 次——全部延迟到 16ms flush）
 const syncProjections = snapshotCalls
+// 固定窗口保留：下方「flush 后投影次数受帧数约束」是不得超额的稳定性探针，
+// settle 会在首次 flush（内容齐了）就返回，错过窗口后段的多余投影。
 await sleep(120) // 等 16ms flush 落定
 const subRow = channel.rows.find(r => r.kind === 'subagent')
 const projected = (subRow?.subagent?.outputLines ?? []).join('')
@@ -123,7 +126,8 @@ const endedRow = channel.rows.find(r => r.kind === 'subagent')
 check('subagent/end 状态同步可见（completed）', endedRow?.subagent?.status === 'completed', 'status=' + String(endedRow?.subagent?.status))
 check('end 前最后一帧 chunk 已含在投影中', (endedRow?.subagent?.outputLines ?? []).join('') === expected, 'len=' + (endedRow?.subagent?.outputLines ?? []).length)
 check('final summary 不被延迟覆盖', endedRow?.subagent?.summary === '最终结论', 'summary=' + String(endedRow?.subagent?.summary))
-// 被取代的延迟 flush 不再重复投影
+// 被取代的延迟 flush 不再重复投影。固定窗口保留：这是「不得发生」的稳定
+// 性探针，对已成立条件轮询会立即返回，等于没测。
 const afterEnd = snapshotCalls
 await sleep(80)
 check('被取代的延迟 flush 无多余投影', snapshotCalls - afterEnd <= 1, `extra=${snapshotCalls - afterEnd}`)

--- a/scripts/verify-submit.mjs
+++ b/scripts/verify-submit.mjs
@@ -18,6 +18,7 @@
  * Run with plain node against the compiled lib: `node scripts/verify-submit.mjs`
  */
 import { createChannel } from '../lib/types/dsh-adapter/channel.js'
+import { settle } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -26,8 +27,8 @@ function check(name, ok, extra = '') {
 }
 
 const sleep = ms => new Promise(r => setTimeout(r, ms))
-/** 投递链（sendChain）落定：expandMentions + followup/steer 都是微任务级。 */
-const settle = () => sleep(10)
+// 投递链（sendChain）落定：expandMentions + followup/steer 都是微任务级，
+// settle 轮询到断言条件出现（./lib/term-test.mjs）。
 
 const handlers = new Map()
 const ctx = {
@@ -80,13 +81,13 @@ const channel = createChannel(ctx, agent, {
 
 // ---- followup (Tab queue) path
 channel.submit('  第一条消息  ')
-await settle()
+await settle(() => followupCalls.length === 1 && followupCalls[0]?.content?.[0]?.text === '第一条消息')
 check('submit → agent.followup', followupCalls.length === 1 && followupCalls[0]?.content?.[0]?.text === '第一条消息')
 check('submit tracked as pending followup', channel.pending.length === 1 && channel.pending[0]?.placement === 'followup', JSON.stringify(channel.pending))
 
 // ---- steer (Enter while working) path
 channel.steer('第二条消息')
-await settle()
+await settle(() => steerCalls.length === 1 && steerCalls[0]?.content?.[0]?.text === '第二条消息')
 check('steer → agent.steer', steerCalls.length === 1 && steerCalls[0]?.content?.[0]?.text === '第二条消息')
 check('steer tracked as pending steer', channel.pending.length === 2 && channel.pending[1]?.placement === 'steer', JSON.stringify(channel.pending))
 check('blank steer ignored', channel.steer('   ') === undefined && steerCalls.length === 1)
@@ -106,7 +107,7 @@ if (discardedHandler) {
 
 // ---- removePending pulls a message back out of the inbox
 channel.steer('撤回我')
-await settle()
+await settle(() => channel.pending.length === 1)
 check('steer for removal tracked', channel.pending.length === 1, JSON.stringify(channel.pending))
 const removed = channel.removePending(channel.pending[0]?.id ?? '')
 check('removePending → agent.inbox.remove', removed === true && inboxRemovals.length === 1)
@@ -115,7 +116,7 @@ check('removePending unknown id is false', channel.removePending('nope') === fal
 
 // ---- inbox.remove refuses (already claimed) → pending kept, no ghost send
 channel.steer('已被认领')
-await settle()
+await settle(() => channel.pending.length === 1)
 inboxRemoveResult = false
 check('refused pull-back keeps pending', channel.removePending(channel.pending[0]?.id ?? '') === false && channel.pending.length === 1, JSON.stringify(channel.pending))
 inboxRemoveResult = true
@@ -148,7 +149,7 @@ const interruptChannel = createChannel(ctx, interruptAgent, {
 })
 check('interruptAndDeliver trims and counts', interruptChannel.interruptAndDeliver(['插话一', '   ', '插话二']) === 2)
 check('interruptAndDeliver cancels without keepInbox', interruptCalls.length === 1 && interruptCalls[0].options === undefined, JSON.stringify(interruptCalls))
-await sleep(10)
+await settle(() => interruptFollowups.length === 2 && interruptChannel.pending.length === 2)
 check('re-queued without waiting for idle (all texts)', interruptFollowups.length === 2 && interruptChannel.pending.length === 2, JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
 check('re-queued as followup', interruptChannel.pending.every(p => p.placement === 'followup'))
 resolveIdle?.()
@@ -180,6 +181,8 @@ const interruptChannel2 = createChannel(ctx, interruptAgent2, {
 interruptChannel2.interruptAndDeliver(['x'])
 interruptChannel2.interruptAndDeliver(['y'])
 resolveIdle2()
+// Stability probe (must NOT double-deliver): a settle would return as soon
+// as 'y' lands and could miss a late wrongful 'x' — keep the fixed window.
 await sleep(10)
 check('double interrupt does not double-deliver', interruptFollowups.filter(m => m.content?.[0]?.text === 'x').length === 0 && interruptFollowups.filter(m => m.content?.[0]?.text === 'y').length === 1, JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
 
@@ -208,7 +211,7 @@ const convergenceChannel = createChannel(ctx, convergenceAgent, {
   activity: false,
 })
 convergenceChannel.interruptAndDeliver(['取消后立即恢复'])
-await sleep(10)
+await settle(() => convergenceFollowups.length === 1 && convergenceChannel.pending.length === 1)
 check('cancel convergence does not depend on whenIdle', convergenceFollowups.length === 1 && convergenceChannel.pending.length === 1, JSON.stringify(convergenceFollowups))
 
 // No whenIdle observer: delivery still uses the same convergence wake.
@@ -230,7 +233,7 @@ const fallbackChannel = createChannel(ctx, fallbackAgent, {
   activity: false,
 })
 fallbackChannel.interruptAndDeliver(['兜底投递'])
-await sleep(10)
+await settle(() => fallbackCalls.length === 1 && fallbackChannel.pending.length === 1)
 check('no-whenIdle agent still receives the wake', fallbackCalls.length === 1 && fallbackChannel.pending.length === 1, JSON.stringify(fallbackCalls))
 
 process.exit(failed)

--- a/scripts/verify-terminal-queries.tsx
+++ b/scripts/verify-terminal-queries.tsx
@@ -91,6 +91,9 @@ const instance = await render(<QueryProbe />, {
 })
 
 await waitFor(() => stdout.output.includes('\x1b]11;?') && stdout.output.includes('\x1b[>0q'))
+// Stability probe (must NOT change): raw mode is already true here and must
+// stay true while the replies are late — a settle on the already-true
+// condition would return immediately, so keep a fixed delay window.
 await sleep(450)
 assert.equal(stdin.isRaw, true, 'late terminal replies must remain protected by raw mode')
 

--- a/scripts/verify-text-background.tsx
+++ b/scripts/verify-text-background.tsx
@@ -2,11 +2,12 @@
 
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { render, ThemeProvider, Text }] =
+const [{ PassThrough, Writable }, React, { render, ThemeProvider, Text }, { settle }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
     import('../src/ui.js'),
+    import('./lib/term-test.mjs'),
   ])
 
 class FakeStdout extends Writable {
@@ -59,7 +60,7 @@ const instance = await render(
   },
 )
 
-await new Promise(resolve => setTimeout(resolve, 100))
+await settle(() => stdout.frames.join('').includes('\x1b[48;2;255;215;95m'))
 await instance.unmount()
 
 const output = stdout.frames.join('')

--- a/scripts/verify-thinking-display.tsx
+++ b/scripts/verify-thinking-display.tsx
@@ -17,6 +17,7 @@ const [
   { render },
   { Chat },
   { setLang },
+  { settle, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -24,6 +25,7 @@ const [
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/i18n.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -54,12 +56,7 @@ class FakeStdin extends PassThrough {
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 function screenText(): string {
-  const buffer = term.buffer.active
-  const lines: string[] = []
-  for (let y = 0; y < ROWS; y++) {
-    lines.push(buffer.getLine(y)?.translateToString(true) ?? '')
-  }
-  return lines.join('\n')
+  return viewportLines(term, ROWS).join('\n')
 }
 
 let failures = 0
@@ -189,14 +186,14 @@ const instance = await render(
     patchConsole: false,
   },
 )
-await sleep(500)
+await settle(() => screenText().includes('SECRET_REASONING_TRACE'))
 
 check('切换前流式思考行可见', screenText().includes('SECRET_REASONING_TRACE'))
 
 stdin.write('/thinking')
-await sleep(150)
+await settle(() => screenText().includes('/thinking'))
 stdin.write('\r')
-await sleep(300)
+await settle(() => screenText().includes('思考过程显示'))
 
 let screen = screenText()
 check('对话框明确这是思考过程显示设置', screen.includes('思考过程显示'))
@@ -204,9 +201,12 @@ check('对话框明确不改变模型思考行为', screen.includes('不改变�
 check('隐藏项说明模型仍会照常思考', screen.includes('模型仍会照常思考'))
 
 stdin.write('\x1b[B')
+// 排序 sleep 保留：选中项移动只改高亮色，不改可见文本，屏上无可 settle 的内容。
 await sleep(120)
 stdin.write('\r')
-await sleep(300)
+// 对话框盖住转录区时「思考行不可见」早已成立，settle 屏幕条件会提前返回；
+// 通知只在确认处理后才写入，才是确认已生效的信号（也是下方断言之一）。
+await settle(() => channel.notifications.includes('思考过程：隐藏'))
 
 screen = screenText()
 check('隐藏立即生效，不出现质量警告', !screen.includes('可能降低质量'))
@@ -217,9 +217,9 @@ check('通知准确说明思考过程已隐藏', channel.notifications.includes(
 
 setLang('en')
 stdin.write('/thinking')
-await sleep(150)
+await settle(() => screenText().includes('/thinking'))
 stdin.write('\r')
-await sleep(300)
+await settle(() => screenText().includes('Thinking display'))
 
 screen = screenText()
 check('English dialog describes thinking display', screen.includes('Thinking display'))
@@ -227,9 +227,10 @@ check('English dialog says model behavior is unchanged', screen.includes('does n
 check('English shown option describes conversation visibility', screen.includes("Show DeepSeek's reasoning"))
 
 stdin.write('\x1b[A')
+// 排序 sleep 保留：选中项移动只改高亮色，不改可见文本，屏上无可 settle 的内容。
 await sleep(120)
 stdin.write('\r')
-await sleep(300)
+await settle(() => screenText().includes('SECRET_REASONING_TRACE'))
 
 screen = screenText()
 check('showing reasoning again takes effect immediately', screen.includes('SECRET_REASONING_TRACE'))

--- a/scripts/verify-timeline-rail.tsx
+++ b/scripts/verify-timeline-rail.tsx
@@ -20,7 +20,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -28,6 +28,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100, ROWS = 40
@@ -116,7 +117,10 @@ const inst = await render(
   </AlternateScreen>,
   { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(700)
+await settle(() => {
+  const snap = railSnapshot()
+  return snap.ticks.length === 8 && snap.activeRow !== null && snap.upRow !== null && snap.downRow !== null
+})
 
 function screenLines(): string[] {
   const buf = term.buffer.active
@@ -253,6 +257,8 @@ await wheel(true, 40)
     `active=${snap.activeRow} first=${snap.ticks[0]}`)
   const before = screenLines()[0]
   if (snap.upRow !== null) {
+    // 稳定性探针：断言点击后「无操作」——clickAt 内置的固定窗口就是给
+    // 错误滚动留的现身时间，settle 对已成立条件会立即返回，等于没测。
     await clickAt(COLS, snap.upRow + 1)
     const after = screenLines()[0]
     check('顶部 ▲ 无操作（dim = no-op）', before === after, `before=${JSON.stringify(before)} after=${JSON.stringify(after)}`)
@@ -296,6 +302,8 @@ await wheel(false, 20)
     await sleep(8)
     if (screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮'))) anyCard = true
   }
+  // 稳定性探针保留固定窗口：断言「卡不得出现」——settle 对已成立的
+  // 否定条件会立即返回，等于没给错误弹卡留出现身时间。
   await sleep(60)
   if (screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮'))) anyCard = true
   check('快速划过 tick 全程无预览卡（dwell 门）', !anyCard)
@@ -303,7 +311,7 @@ await wheel(false, 20)
   const row = snap.ticks[2]
   if (row !== undefined) {
     stdin.write(`\x1b[<35;${COLS};${row + 1}M`)
-    await sleep(350)
+    await settle(() => screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')))
     check('停留 350ms 后预览卡出现', screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')))
     await hoverAt(30, 20)
   }
@@ -314,6 +322,8 @@ await wheel(false, 20)
   ;(stdout as any).columns = 59
   stdout.emit('resize')
   term.resize(59, ROWS)
+  // 固定窗口保留：断言是「rail 不存在」的否定条件，resize 回流的瞬态
+  // 屏幕可能提早满足它——settle 会在重绘完成前就返回。
   await sleep(500)
   const hidden = !screenLines().some((_, y) => {
     const two = cellAt(y, 57) + cellAt(y, 58)
@@ -323,7 +333,10 @@ await wheel(false, 20)
   ;(stdout as any).columns = COLS
   stdout.emit('resize')
   term.resize(COLS, ROWS)
-  await sleep(500)
+  await settle(() => {
+    const snap = railSnapshot()
+    return snap.ticks.length === 8 && snap.upRow !== null
+  })
   const snap = railSnapshot()
   check('恢复 100 列 rail 回来', snap.ticks.length === 8 && snap.upRow !== null,
     `ticks=${snap.ticks.length} up=${snap.upRow}`)
@@ -360,7 +373,10 @@ await inst.unmount()
     </AlternateScreen>,
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(900)
+  await settle(() => {
+    const snap = railSnapshot()
+    return snap.ticks.length === 12 && snap.activeRow !== null
+  })
   const snap = railSnapshot()
   check('工具重会话：rail 覆盖全部 12 轮', snap.ticks.length === 12,
     `ticks=${snap.ticks.length}（折叠窗口内仅 ~5 轮）`)
@@ -369,7 +385,12 @@ await inst.unmount()
   const firstTick = snap.ticks[0]
   if (firstTick !== undefined) {
     await clickAt(COLS, firstTick + 1)
-    await sleep(600)
+    // 揭示跳转先画转录区、━━ 后移：两条断言的条件都到位才算落定。
+    await settle(() => {
+      const snap = railSnapshot()
+      return screenLines().slice(0, 6).some(l => l.includes('问题 1'))
+        && snap.activeRow !== null && snap.ticks.indexOf(snap.activeRow) === 0
+    })
     const lines = screenLines()
     check('点击折叠 tick：问题 1 揭示并到顶', lines.slice(0, 6).some(l => l.includes('问题 1')),
       `top6=${JSON.stringify(lines.slice(0, 4).map(l => l.trimEnd().slice(0, 30)))}`)

--- a/scripts/verify-trace-scene.tsx
+++ b/scripts/verify-trace-scene.tsx
@@ -28,7 +28,7 @@ process.env.FORCE_COLOR = '3'
 // to agree with.
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { TrajectoryScene }, { Chat }, { QuestionStore }, { stringWidth }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { TrajectoryScene }, { Chat }, { QuestionStore }, { stringWidth }, { settle }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -38,6 +38,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Traj
     import('../src/screens/Chat.js'),
     import('../src/dsh-adapter/questions.js'),
     import('../src/ink/stringWidth.js'),
+    import('./lib/term-test.mjs'),
   ])
 const { miniWakeWidth } = await import('../src/components/trajectory/MiniWake.js')
 const traj = await import('../src/dsh-adapter/trajectory/index.js')
@@ -236,7 +237,15 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     }),
     { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(160)
+  // The ledger rows animate in (motion arrive): settle on the FULL asserted
+  // content — returning at the first painted rows would snapshot a frame that
+  // is still growing, and the stale mid-animation frames then poison every
+  // whole-buffer negative check later in this part.
+  await settle(() => {
+    const s = screen()
+    return s.includes('轨迹') && s.includes('read_file') && s.includes('grep_repo')
+      && /web_search\s*×4/.test(s) && (s.includes('RATE_LIMIT') || s.includes('RTY')) && s.includes('▸')
+  })
   const first = screen()
 
   check('scene shows its title and totals', first.includes('轨迹') && /\d+\s*轮/.test(first), first.split('\n')[0]?.trim())
@@ -260,10 +269,10 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   const before = hintRow(first)
   const rowAtStart = cursorRow(first)
   stdin.write('\x1b[A')
-  await sleep(240)
+  await settle(() => cursorRow(screen()) === rowAtStart - 1)
   const afterUp = screen()
   stdin.write('\x1b[A')
-  await sleep(240)
+  await settle(() => cursorRow(screen()) === rowAtStart - 2)
   const afterTwo = screen()
   check('cursor opens pinned to the newest row', rowAtStart >= 0, `row ${rowAtStart}`)
   check(
@@ -279,6 +288,12 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   )
 
   // Jump to the next failure, then confirm the inspector explains it.
+  // Fixed window kept: the assertion's condition ALREADY holds before the
+  // seek (the retry row prints RATE_LIMIT in the ledger), so a settle on it
+  // returns instantly — and the next `/` write then coalesces into the same
+  // stdin chunk as `]`, reaching useInput as one `']/'` string that matches
+  // neither key. The delay both lets the seek process and keeps the
+  // keystrokes in separate chunks.
   stdin.write(']')
   await sleep(140)
   const atFailure = screen()
@@ -288,12 +303,15 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   stdin.write('/')
   await sleep(80)
   stdin.write('tool:read_file')
-  await sleep(180)
+  await settle(() => {
+    const s = screen()
+    return s.includes('read_file') && !s.includes('grep_repo')
+  })
   const filtered = screen()
   check('query narrows the ledger', filtered.includes('read_file') && !filtered.includes('grep_repo'))
   check('query reports its match count', /\d+\/\d+/.test(filtered), /\d+\/\d+[^\n]*/.exec(filtered)?.[0])
   stdin.write('\x1b')
-  await sleep(140)
+  await settle(() => screen().includes('grep_repo'))
   check('esc clears the query', screen().includes('grep_repo'))
 
   // View switching. The hotspot rows animate in (motion arrive); a fixed
@@ -353,7 +371,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   // inline geometry — the alt-screen path, which is exactly what the two
   // safety assertions below exist to prove, would go untested.
   for (const value of instances.values()) instances.set(process.stdout, value)
-  await sleep(220)
+  await settle(() => screen().includes('conversation line'))
   const conversation = screen()
   const scrollbackBefore = rowsOf()
   check('conversation renders before the scene opens', conversation.includes('conversation line'))
@@ -380,6 +398,9 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     stdin.write('q')
     await sleep(round === 0 ? 200 : 70)
   }
+  // Fixed window kept: this is also the quiescence window for the scrollback
+  // accounting below — settling on the restored conversation would sample
+  // rowsOf() before the post-restore repaint lands and undercount per-trip.
   await sleep(200)
 
   const restored = screen()
@@ -472,10 +493,13 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   writes.length = 0
 
   stdin.write('\x14')
-  await sleep(250)
+  await settle(() => term.buffer.active.type === 'alternate')
   check('frame-restore probe enters the alternate screen', term.buffer.active.type === 'alternate')
   instances.get(process.stdout)?.resetPools()
   stdin.write('q')
+  // Fixed window kept (negative probe): the assertion below is that NOTHING
+  // repaints the marker after DEC 1049 restores the main screen — a wrong
+  // repaint needs this window to show up in the captured writes.
   await sleep(500)
 
   const roundTrip = writes.join('')
@@ -576,10 +600,10 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   )
 
   stdin.write('\x0f') // Ctrl+O
-  await sleep(400)
+  await settle(() => screen().includes('reasoning line 79'))
   check('Ctrl+O expands settled reasoning after the round trip', screen().includes('reasoning line 79'))
   stdin.write('\x0f')
-  await sleep(400)
+  await settle(() => !screen().includes('reasoning line 79'))
   check('a second Ctrl+O folds settled reasoning again', !screen().includes('reasoning line 79'))
 
   instance.unmount()
@@ -631,7 +655,10 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
   )
   for (const value of instances.values()) instances.set(process.stdout, value)
-  await sleep(600)
+  await settle(() => {
+    const s = screen()
+    return /ctrl\+t|⌘t/.test(s) && (s.match(/\? 查看快捷键/g) ?? []).length === 1
+  })
 
   const startup = screen()
   check('the startup tip teaches the trajectory key', /ctrl\+t|⌘t/.test(startup), '')

--- a/scripts/verify-unseen-report-once.tsx
+++ b/scripts/verify-unseen-report-once.tsx
@@ -74,6 +74,9 @@ const instance = await render(<MessageList rows={rows} {...props} />, {
 })
 
 // Let measurements settle (heights land, base corrects, count stabilizes).
+// Fixed window on purpose: the baseline below is "reports have STOPPED
+// arriving" — polling for the first positive report would capture settledLen
+// too early and misread later settling reports as no-op re-reports.
 await sleep(500)
 const settledLen = reports.length
 const settledValue = reports[settledLen - 1]
@@ -86,6 +89,8 @@ if (settledLen === 0 || settledValue === undefined || settledValue <= 0) {
 // count changes, so a correct report stays silent.
 for (let i = 0; i < 6; i++) {
   instance.rerender(<MessageList rows={rows} {...props} />)
+  // Stability probe (must NOT change): a wrong re-report needs a fixed window
+  // to show up — settle on the already-true "no new report" would be a no-op.
   await sleep(60)
 }
 const afterNoop = reports.length
@@ -101,6 +106,8 @@ if (afterNoop !== settledLen) {
 // A real change MUST still report exactly once: append a new row below the fold.
 rows.push({ id: 31, kind: 'assistant', text: 'fresh row\nwith two lines', streaming: false })
 instance.rerender(<MessageList rows={rows} {...props} />)
+// Fixed window on purpose: the assertion is "EXACTLY one new report" —
+// settling on the first report would return before a duplicate could land.
 await sleep(300)
 const finalLen = reports.length
 if (finalLen !== settledLen + 1 || reports[finalLen - 1] === settledValue) {

--- a/scripts/verify-whale-toggle.mjs
+++ b/scripts/verify-whale-toggle.mjs
@@ -14,6 +14,7 @@ const [
   { render, ThemeProvider },
   { LogoHeader },
   { createChannel },
+  { settle },
 ] = await Promise.all([
   import('node:assert'),
   import('node:stream'),
@@ -21,6 +22,7 @@ const [
   import('../src/ui.js'),
   import('../src/components/MessageList.js'),
   import('../src/dsh-adapter/channel.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 let checks = 0
@@ -85,7 +87,6 @@ class FakeOutput extends Writable {
   }
 }
 
-const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 const stripAnsi = text => text
   .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '')
   .replace(/\x1b\]9;[^\x07]*\x07/g, '')
@@ -110,7 +111,10 @@ async function renderHeader({ columns, whale }) {
       patchConsole: false,
     },
   )
-  await sleep(180)
+  await settle(() => {
+    const plain = stripAnsi(stdout.writes.join(''))
+    return plain.includes('dsh-TUI') && plain.includes('whale-model-probe')
+  })
   const raw = stdout.writes.join('')
   await instance.unmount()
   return { raw, plain: stripAnsi(raw) }

--- a/scripts/verify-word-jump.mjs
+++ b/scripts/verify-word-jump.mjs
@@ -37,6 +37,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Writable, PassThrough } from 'node:stream'
 import React from 'react'
+import { settle } from './lib/term-test.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -113,7 +114,8 @@ await feed('\x1b[D')    // bare Left  → caret 6 (single char; jump bug: 0)
 await feed('Z')
 await feed('\x1b[1;5C') // Ctrl+Right → caret 14 (end of "…world")
 await feed('Q')
-await feed('\r')
+stdin.write('\r')
+await settle(() => submitted.length === 1 && submitted[0] === 'hello ZYXworldQ')
 
 check(
   'caret moves + inserts compose to the expected submitted text',

--- a/scripts/verify-working-activity.mjs
+++ b/scripts/verify-working-activity.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { settle } from './lib/term-test.mjs'
 
 const testHome = mkdtempSync(join(tmpdir(), 'dsh-tui-activity-home-'))
 process.env.HOME = testHome
@@ -143,7 +144,7 @@ sessionEvent()(agent.session, {
 assert.equal(channel.workingActivity?.phase, 'tool')
 
 const elapsedBeforeTick = channel.workingActivity.turnElapsedMs
-await new Promise((resolve) => setTimeout(resolve, 550))
+await settle(() => channel.workingActivity.turnElapsedMs >= elapsedBeforeTick + 450)
 assert.ok(channel.workingActivity.turnElapsedMs >= elapsedBeforeTick + 450, '500 ms timer refreshes elapsed state')
 
 sessionEvent()(agent.session, {


### PR DESCRIPTION
# refactor(test): 回归脚本等待/读屏公共设施 + 52 个脚本去固定 sleep（#532）

关联 issue：#532。**基于 #529 的分支（含其两个提交），请先合 #529。** 不碰 `src/`，产品行为零变化。

## 内容

**`scripts/lib/term-test.mjs`**（新增）：`settle(pred)` 轮询等待（30ms × 上限 4s，超时静默返回、调用方断言照常失败）、`writeParsed(term, bytes)` promise 化 write 回调、`viewportLines(term)` baseY 视口读取，以及 screenHas/findText。纯 ESM JS，.mjs 与 .tsx 脚本都能 import。

**52 个脚本约 200 处转换**：「sleep 固定毫秒后断言」改为「settle(断言同条件) 后断言」；write+sleep 回放改 writeParsed；inline 模式 `getLine(0..ROWS)` 直扫改视口读取（断言 scrollback 的脚本刻意保留缓冲区读法并注释）。断言谓词、消息、顺序零改动（diff 里被删的 check/assert 行为 0）。

**三类 sleep 有意保留**，逐处注释：

1. 稳定性探针（断言动作后状态不得改变）——对已成立条件轮询立即返回，等于没测。
2. 时间窗口即被测对象（帧计数窗、采样节奏、动画时窗快照、双侧终态等价对比）。
3. 按键排序：settle 条件在按键前已成立会立即返回，两次按键并进同一 stdin chunk 导致丢键（verify-trace-scene 的 `]` 点实测复现后回退为固定窗口）。

**12 个脚本判定无需转换**（已有轮询、或整脚本属上述类别）：verify-resize-temporal、verify-shrink-anchored-pad、verify-message-measure-depth、verify-resize-reflow、verify-subagent-settle、verify-effort-ignition、verify-terminal-queries、verify-unseen-report-once、repro-effort、repro-diff-split、repro-idle-oscillation、repro-inline-scrollback。

## 验证

| 检查 | 结果 |
|---|---|
| 每个改动脚本逐个运行 | ✅ exit 0 |
| 5 个 CI 组本地全跑（render-scroll / input-terminal / channel-ui / session-workspace / flaky-observation） | ✅ 除 4 个与本改动无关的本机环境性失败外全绿（见下） |
| flaky-observation：verify-trace-scene + verify-resize-temporal | ✅ |
| 6 忙循环 CPU 负载抽样（转换点最多的 6 个脚本 × 2 轮） | ✅ 12/12 |
| `pnpm build` | ✅ |

本机环境性失败（转换前后失败输出逐字一致，已核对；CI 上这些测试此前均绿）：repro-askpanel、verify-askpanel-layout、verify-askpanel-hide-custom-input、verify-compact。疑与本机语言环境有关（断言中文文案、脚本未钉 `DSH_TUI_LANG`），与本 PR 无关。

## 依据

生态调研（gemini-cli / codex / opencode / crush / pi-tui / xterm.js 官方测试）：渲染测试的等待方式一律是回调或轮询，渲染层零 retry；固定 sleep 是各家 flaky 修复 commit 的删除对象。xterm.js 官方测试即 write-callback promise 化 + `pollFor` 轮询断言，本 PR 与其同构。
