### PR TITLE
docs: 修正 0.9.0 更名残留与失效路径（themes 双旧名/版本归属/顶层 src 404）

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -190,7 +190,7 @@ terminal support for the extended keyboard protocol (iTerm2 / kitty / WezTerm /
 ghostty / tmux); macOS's built-in Terminal.app consumes `⌘` shortcuts itself,
 so keep using `Ctrl`.
 
-**Mouse** (fullscreen is the factory default since 0.8.8; set `fullscreen: false` to restore the inline main screen; updating from an older version clears a previously saved inline choice once — you can still pick inline again afterwards)
+**Mouse** (fullscreen is the factory default since 0.9.0; set `fullscreen: false` to restore the inline main screen; updating from an older version clears a previously saved inline choice once — you can still pick inline again afterwards)
 
 | Action | Function |
 |---|---|

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -7,9 +7,9 @@
 ```text
 Cordis profile
   -> src/index.ts (plugin contract and Schema)
-  -> src/plugin.ts (services, Agent, and React lifecycle)
+  -> src/dsh-adapter/plugin.ts (services, Agent, and React lifecycle)
   -> DSH Agent / session / tool services
-  -> src/channel.ts (session/event -> Channel)
+  -> src/dsh-adapter/channel.ts (session/event -> Channel)
   -> src/screens/Chat.tsx (keyboard and mode orchestration)
   -> src/components/* (views)
   -> src/ui.ts (themed renderer facade)
@@ -22,8 +22,8 @@ Cordis profile
 | Module | Owns |
 | --- | --- |
 | `src/index.ts` | Cordis plugin name, injection declaration, config interface, and Schema; keep the entry small and lazy |
-| `src/plugin.ts` | TTY guard, questionnaire/skill registration, Agent create/resume, React mount, and the single cleanup funnel |
-| `src/channel.ts` | DSH event projection plus submit, steer, resume, rewind, model, and preset actions |
+| `src/dsh-adapter/plugin.ts` | TTY guard, questionnaire/skill registration, Agent create/resume, React mount, and the single cleanup funnel |
+| `src/dsh-adapter/channel.ts` | DSH event projection plus submit, steer, resume, rewind, model, and preset actions |
 | `src/workspaces.ts` | Local-path fallback and generic workspace-provider registry; it must contain no provider protocol, copy, or dependency |
 | `src/screens/Chat.tsx` | Modal precedence, global keys, scroll/search/selection state, and slash dispatch |
 | `src/components/` | User views and design-system primitives; no Agent or session source of truth |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,9 +7,9 @@
 ```text
 Cordis profile
   -> src/index.ts（插件契约与 Schema）
-  -> src/plugin.ts（服务、Agent、React 生命周期）
+  -> src/dsh-adapter/plugin.ts（服务、Agent、React 生命周期）
   -> DSH Agent / session / tool services
-  -> src/channel.ts（session/event -> Channel）
+  -> src/dsh-adapter/channel.ts（session/event -> Channel）
   -> src/screens/Chat.tsx（键盘与模式编排）
   -> src/components/*（视图）
   -> src/ui.ts（主题化 renderer facade）
@@ -22,8 +22,8 @@ Cordis profile
 | 模块 | 所有权 |
 | --- | --- |
 | `src/index.ts` | Cordis 插件名称、注入声明、配置接口与 Schema；保持入口轻量并延迟加载 runtime |
-| `src/plugin.ts` | TTY 检查、问卷与 Skills 注册、Agent 创建/恢复、React 挂载、统一退出清理 |
-| `src/channel.ts` | 将 DSH 持久化事件投影为 transcript；提供 submit、steer、resume、rewind、model/preset 等动作 |
+| `src/dsh-adapter/plugin.ts` | TTY 检查、问卷与 Skills 注册、Agent 创建/恢复、React 挂载、统一退出清理 |
+| `src/dsh-adapter/channel.ts` | 将 DSH 持久化事件投影为 transcript；提供 submit、steer、resume、rewind、model/preset 等动作 |
 | `src/workspaces.ts` | 本地路径 fallback 与通用工作区 provider registry；不得包含任何 provider 的协议、文案或依赖 |
 | `src/screens/Chat.tsx` | modal 优先级、全局按键、滚动/搜索/选择状态、slash command 分发 |
 | `src/components/` | 用户界面和 design-system；不直接拥有 Agent 或 session 真相 |

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -50,9 +50,9 @@ boundaries and helpers over introducing parallel abstractions.
 
 - `src/index.ts`: public Cordis plugin entry point, configuration schema, and
   lazy handoff to the runtime plugin.
-- `src/plugin.ts`: TTY validation, service registration, agent creation/resume,
+- `src/dsh-adapter/plugin.ts`: TTY validation, service registration, agent creation/resume,
   React tree mounting, and terminal/process teardown.
-- `src/channel.ts`: event-to-view projection and the non-React action surface.
+- `src/dsh-adapter/channel.ts`: event-to-view projection and the non-React action surface.
   It translates DSH session events into transcript rows and implements submit,
   steering, rewind, resume, model/preset switching, local reports, and related
   state transitions.
@@ -75,7 +75,7 @@ boundaries and helpers over introducing parallel abstractions.
 - `src/*Prefs.ts`, `src/customTheme.ts`, and `src/sessionHistory.ts`: persisted
   user preferences and local session metadata under `~/.dsh-tui`.
 - `skills/*/SKILL.md`: skills shipped in the npm package and registered by
-  `src/packaged-skills.ts`.
+  `src/dsh-adapter/packaged-skills.ts`.
 - `cordis.patch.yml`: package bundle overlay used by profile installation.
   Ordering, row IDs, disabled host rows, and insert/override semantics matter.
 - `cordis.yml`: full bare-composition example for direct Cordis/DSH startup.
@@ -95,9 +95,9 @@ The central runtime path is:
 ```text
 Cordis config
   -> src/index.ts
-  -> src/plugin.ts
+  -> src/dsh-adapter/plugin.ts
   -> DSH agent/session services
-  -> src/channel.ts (session events -> Channel snapshot)
+  -> src/dsh-adapter/channel.ts (session events -> Channel snapshot)
   -> src/screens/Chat.tsx
   -> src/components/*
   -> src/ui.ts
@@ -283,7 +283,7 @@ the required credentials.
 
 ### Cordis Lifecycle And Configuration
 
-- Keep `src/index.ts` as the small public plugin contract and `src/plugin.ts`
+- Keep `src/index.ts` as the small public plugin contract and `src/dsh-adapter/plugin.ts`
   as the runtime implementation. Preserve the lazy handoff unless the task
   intentionally changes the plugin-loading contract.
 - Register resources through Cordis and clean them up through `ctx.effect` or
@@ -379,9 +379,9 @@ the required credentials.
 | Plugin config or environment behavior | `src/index.ts`, runtime consumer, `cordis.patch.yml`, `cordis.yml`, `README.md`, `README_EN.md` |
 | Slash commands or shortcuts | `src/commands.ts`, `src/screens/Chat.tsx`, help/input components, both READMEs, relevant skill mapping/tests |
 | Theme contract or persisted theme behavior | `src/theme.ts`, all palettes, theme provider/picker, custom-theme parser, theme verification, both READMEs |
-| Session/channel behavior | `src/channel.ts`, affected UI projections, compiled output, focused channel/replay regression |
+| Session/channel behavior | `src/dsh-adapter/channel.ts`, affected UI projections, compiled output, focused channel/replay regression |
 | Renderer/layout behavior | `src/ink/` or Yoga source, compiled output, CI regressions, focused scroll/resize/PTY probe |
-| Packaged skill | `skills/<name>/SKILL.md`, `src/packaged-skills.ts` assumptions, command prompt/mapping if exposed as a slash command |
+| Packaged skill | `skills/<name>/SKILL.md`, `src/dsh-adapter/packaged-skills.ts` assumptions, command prompt/mapping if exposed as a slash command |
 | User-facing documented behavior | Chinese and English READMEs, plus config comments/help text where applicable |
 | Package version or dependency | `package.json`, `pnpm-lock.yaml`, generated/published artifacts as applicable; do not churn the legacy npm lock incidentally |
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,9 +40,9 @@ DeepSeek Harness 拥有，TUI 只消费它们。
 ## 仓库地图（Repository Map）
 
 - `src/index.ts`：公共 Cordis 插件入口、配置 Schema，与对运行时插件的惰性移交。
-- `src/plugin.ts`：TTY 校验、服务注册、Agent 创建/恢复、React 树挂载，以及
+- `src/dsh-adapter/plugin.ts`：TTY 校验、服务注册、Agent 创建/恢复、React 树挂载，以及
   终端/进程的收尾清理。
-- `src/channel.ts`：事件到视图的投影 + 非 React 的动作面。把 DSH 会话事件
+- `src/dsh-adapter/channel.ts`：事件到视图的投影 + 非 React 的动作面。把 DSH 会话事件
   翻译成 transcript 行，实现 submit、steer、rewind、resume、模型/preset 切换、
   本地报告及相关状态迁移。
 - `src/screens/Chat.tsx`：顶层交互协调器。负责模态优先级、全局键盘、滚动/
@@ -60,7 +60,7 @@ DeepSeek Harness 拥有，TUI 只消费它们。
 - `src/cc/`：为 Claude Code 风格 UI 适配的终端格式化与呈现辅助。
 - `src/*Prefs.ts`、`src/customTheme.ts`、`src/sessionHistory.ts`：持久化的
   用户偏好与 `~/.dsh-tui` 下的本地会话元数据。
-- `skills/*/SKILL.md`：随 npm 包分发的技能，由 `src/packaged-skills.ts` 注册。
+- `skills/*/SKILL.md`：随 npm 包分发的技能，由 `src/dsh-adapter/packaged-skills.ts` 注册。
 - `cordis.patch.yml`：profile 安装时使用的包级 bundle 覆盖层。行的顺序、行 ID、
   被禁用的 host 行、insert/override 语义都很关键。
 - `cordis.yml`：直接 Cordis/DSH 启动的完整裸组合示例。
@@ -77,9 +77,9 @@ DeepSeek Harness 拥有，TUI 只消费它们。
 ```text
 Cordis config
   -> src/index.ts
-  -> src/plugin.ts
+  -> src/dsh-adapter/plugin.ts
   -> DSH agent/session services
-  -> src/channel.ts (session events -> Channel snapshot)
+  -> src/dsh-adapter/channel.ts (session events -> Channel snapshot)
   -> src/screens/Chat.tsx
   -> src/components/*
   -> src/ui.ts
@@ -218,7 +218,7 @@ TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式�
 
 ### Cordis 生命周期与配置
 
-- 保持 `src/index.ts` 是小的公共插件契约、`src/plugin.ts` 是运行时实现。
+- 保持 `src/index.ts` 是小的公共插件契约、`src/dsh-adapter/plugin.ts` 是运行时实现。
   除非任务有意改插件加载契约，否则保留惰性移交。
 - 资源通过 Cordis 注册，用 `ctx.effect` 或既有单一退出漏斗清理。渲染失败必须
   响亮且非零退出；正常退出必须在进程退出前恢复终端状态。
@@ -296,9 +296,9 @@ TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式�
 | 插件配置或环境行为 | `src/index.ts`、运行时消费、`cordis.patch.yml`、`cordis.yml`、`README.md`、`README_EN.md` |
 | Slash 命令或快捷键 | `src/commands.ts`、`src/screens/Chat.tsx`、帮助/输入组件、双 README、相关技能映射/测试 |
 | 主题契约或持久化主题行为 | `src/theme.ts`、所有色板、主题 provider/picker、自定义主题解析器、主题验证、双 README |
-| 会话/channel 行为 | `src/channel.ts`、受影响的 UI 投影、编译产物、聚焦 channel/回放回归 |
+| 会话/channel 行为 | `src/dsh-adapter/channel.ts`、受影响的 UI 投影、编译产物、聚焦 channel/回放回归 |
 | 渲染器/布局行为 | `src/ink/` 或 Yoga 源、编译产物、CI 回归、聚焦滚动/resize/PTY 探针 |
-| 打包技能 | `skills/<name>/SKILL.md`、`src/packaged-skills.ts` 假设、暴露为 slash 命令时的提示/映射 |
+| 打包技能 | `skills/<name>/SKILL.md`、`src/dsh-adapter/packaged-skills.ts` 假设、暴露为 slash 命令时的提示/映射 |
 | 用户可见的文档化行为 | 中英文 README，外加适用的配置注释/帮助文本 |
 | 包版本或依赖 | `package.json`、`pnpm-lock.yaml`、适用时的生成/发布产物；不要顺手搅动旧 npm 锁文件 |
 

--- a/docs/plugins.en.md
+++ b/docs/plugins.en.md
@@ -377,7 +377,7 @@ declare module '@deepseek-ai/dsh-session/types' {
 ```
 
 > dsh-TUI's profile carries its own compatibility repair
-> (`src/compat/sessionLog.ts`) that patches third-party event types, so resume
+> (`src/dsh-adapter/compat/sessionLog.ts`) that patches third-party event types, so resume
 > works in the dsh-tui profile regardless; bare compositions, Web, and other
 > headless consumers have no such repair — registration is still mandatory.
 
@@ -398,7 +398,7 @@ slot, the plugin silently has no effect.
 
 Note: **dsh-TUI itself does not provide the `tuiPrompt` service** — it consumes
 `activity/status` events directly to render the working line (see
-`src/channel.ts` and `src/components/ActivityLine.tsx`). If your plugin targets
+`src/dsh-adapter/channel.ts` and `src/components/ActivityLine.tsx`). If your plugin targets
 both the official TUI and dsh-TUI, adopt `dsh-working-activity`'s **dual-outlet**
 pattern: the prompt slot for the official TUI, log-only events for dsh-TUI and
 other consumers.
@@ -421,7 +421,7 @@ registry?.register({
 })
 ```
 
-See the core package's `src/packaged-skills.ts`: single-line scalar frontmatter
+See the core package's `src/dsh-adapter/packaged-skills.ts`: single-line scalar frontmatter
 (`name`, `description`); duplicate or invalid entries are skipped — **a skill
 registration failure must never take down TUI boot**. Once registered, the skill
 is usable through DSH's `/skill` surface.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -314,7 +314,7 @@ declare module '@deepseek-ai/dsh-session/types' {
 }
 ```
 
-> dsh-TUI 的 profile 自身带兼容修复（`src/compat/sessionLog.ts`），会修补第三方
+> dsh-TUI 的 profile 自身带兼容修复（`src/dsh-adapter/compat/sessionLog.ts`），会修补第三方
 > 事件类型，所以在 dsh-tui profile 里 resume 依然可用；但裸组合、Web 或其他
 > headless 消费者没有这层修复——注册仍然必须做。
 
@@ -332,7 +332,7 @@ handle?.set('实时内容')  // 模板里 ${my-slot} 的值
 `'${cwd}${git/worktree}${activity}${model}…'`）；模板没有该槽位时插件静默无效果。
 
 注意：**dsh-TUI 本身不提供 `tuiPrompt` 服务**——它直接消费 `activity/status`
-事件渲染工作状态行（见 `src/channel.ts` 与 `src/components/ActivityLine.tsx`）。
+事件渲染工作状态行（见 `src/dsh-adapter/channel.ts` 与 `src/components/ActivityLine.tsx`）。
 如果你的插件同时面向官方 TUI 和 dsh-TUI，就采用 `dsh-working-activity` 的
 **双出口**模式：槽位给官方 TUI，log-only 事件给 dsh-TUI 与其他消费者。
 
@@ -353,7 +353,7 @@ registry?.register({
 })
 ```
 
-参考主包 `src/packaged-skills.ts`：单行标量 frontmatter（`name`、`description`），
+参考主包 `src/dsh-adapter/packaged-skills.ts`：单行标量 frontmatter（`name`、`description`），
 重复或无效条目跳过，**绝不让技能注册失败拖垮 TUI 启动**。注册成功后技能即可
 通过 DSH 的 `/skill` 面使用。
 

--- a/docs/project-documentation/README.md
+++ b/docs/project-documentation/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+> **基线过时提示（v0.9.0+ 读者）**：本目录文档基于 2026-08-15 审计基线 `b2f4087`
+> （目录重命名之前）。其中 `~/.dsh-cc/*` 现为 `~/.dsh-tui/*`（theme/model/preset/lang
+> 等 prefs 均随 `DATA_DIR` 迁移），顶层 `src/plugin.ts` / `src/channel.ts` 等现为
+> `src/dsh-adapter/` 下。引用时以活文档与源码为准。
+
 # dsh-cc-tui 架构文档
 
 本目录是 dsh-cc-tui（`@deepseek-ai/dsh-cc-tui`）的架构文档集，与 `docs/` 下

--- a/docs/themes.en.md
+++ b/docs/themes.en.md
@@ -18,7 +18,7 @@ Without an explicit choice, the TUI queries the terminal background with OSC
 not answer.
 
 `auto` turns that one-shot startup detection into a standing choice: it is a
-valid value for `/theme`, `CC_TUI_THEME`, and `~/.dsh-cc/theme.json`. Selecting
+valid value for `/theme`, `DSH_TUI_THEME`, and `~/.dsh-tui/theme.json`. Selecting
 `auto` applies the last detected base immediately and re-queries OSC 11 in the
 background — on terminals that follow the system theme, picking `auto` again
 (or restarting) catches up after a system light/dark switch. `/theme status`

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -16,8 +16,8 @@ dsh-TUI 提供三套 Gentle Mist Blue 色板，外加一个 `auto` 伪主题：
 未明确指定主题时，TUI 会通过 OSC 11 查询终端背景并在 `light` 与 `dark` 之间
 选择；终端不响应时回退到 `dark`。
 
-`auto` 把这次性启动检测变成常驻选择：它在 `/theme`、`CC_TUI_THEME`、
-`~/.dsh-cc/theme.json` 中都是合法值。选中 `auto` 时立即应用上次检测结果，并
+`auto` 把这次性启动检测变成常驻选择：它在 `/theme`、`DSH_TUI_THEME`、
+`~/.dsh-tui/theme.json` 中都是合法值。选中 `auto` 时立即应用上次检测结果，并
 在后台重新查询 OSC 11——跟随系统主题的终端切换深浅色后，再次选择 `auto`（或
 重启）即可跟上。`/theme status` 会显示 `auto` 当前解析到的色板。解析结果通过
 `getTheme('auto')` 对所有消费方生效。注意：用户自定义主题若命名为 `auto` 会被

--- a/docs/vscode.en.md
+++ b/docs/vscode.en.md
@@ -18,7 +18,7 @@ integrated terminal** (xterm.js). This page covers two ways to use it:
    start; for when you do not want the extension.
 
 > Version note: `dsh-tui` on this page refers to this repository (the TUI
-> plugin, currently **0.8.3**; 0.7.0+ recommended); `dsh-tui-vscode` refers
+> plugin, currently **0.9.0**; 0.7.0+ recommended); `dsh-tui-vscode` refers
 > to the companion extension (currently **0.5.1**). The two version and
 > release independently. See the
 > [baobaolaodie/dsh-tui-vscode](https://github.com/baobaolaodie/dsh-tui-vscode)

--- a/docs/vscode.md
+++ b/docs/vscode.md
@@ -12,7 +12,7 @@ dsh-TUI 是终端程序：它把 ANSI 写进 PTY、从 PTY 读按键，因此任
    实现，扩展已上架 VS Code Marketplace。
 2. **内置集成终端直接运行** —— 零安装，秒级可用，适合不想装扩展的场景。
 
-> 版本说明：本页中的 `dsh-tui` 指本仓库（TUI 插件，当前 **0.8.3**，建议
+> 版本说明：本页中的 `dsh-tui` 指本仓库（TUI 插件，当前 **0.9.0**，建议
 > 0.7.0+）；`dsh-tui-vscode` 指 companion 扩展（当前 **0.5.1**）。两者版本
 > 独立、各自发布。扩展的完整说明见其仓库
 > [baobaolaodie/dsh-tui-vscode](https://github.com/baobaolaodie/dsh-tui-vscode)


### PR DESCRIPTION
## 动机

对 main（v0.9.0，7383612）做了一次「路径与引用一致性」全量审计（文档引用 vs `src/utils/paths.ts` 常量与实际行为交叉验证 + 全仓 631 文件 glob 对照），发现四类用户可见问题，本 PR 修复文档侧：

| 项 | 位置 | 问题 | 证据 |
|---|---|---|---|
| 笔误家族 | docs/themes.md:19 + themes.en.md:21 | `CC_TUI_THEME` + `~/.dsh-cc/theme.json` 双旧名——同文档几行后的优先级列表写的是正确新名（自相矛盾） | themePrefs.ts `PREFS_DIR = DATA_DIR`；i18n.ts:172 UI 提示亦为 ~/.dsh-tui；paths.ts:48 CC_TUI_THEME→DSH_TUI_THEME 映射 |
| 版本归属 | README_EN.md:177 | "fullscreen 默认 since 0.8.8"——v0.8.8 实为 `default(false)`，**0.9.0 才翻 true** | git grep v0.8.8 vs main 的 index.ts |
| 版本停更 | docs/vscode.md:15 + .en.md | "当前 0.8.3"——实际 0.9.0 | package.json |
| **顶层路径 404** | architecture/contributing/plugins 中英六文件 | 引用 `src/plugin.ts`、`src/channel.ts`、`src/packaged-skills.ts` 等——**这些顶层路径在 main 全历史从未存在**（`git log -- src/plugin.ts` 为 0），实为 `src/dsh-adapter/` 下；文档长期未跟目录重组，贡献者按图索骥即 404 | ls-tree 全量对照 |
| 快照过时 | project-documentation/README | 目录为旧基线（b2f4087，重命名前）审计快照 | 顶部加过时横幅，不逐行刷新 |

## 刻意不动的正确引用（防误修清单）

resume.txt 双写 `~/.dsh-cc`（sessionHistory.ts 真双写）、首启目录迁移描述（migrateLegacyDataDir 真复制）、launcher 的 `DSH_CC_RESUME_SESSION` 双设、verify-legacy-rename 的测试断言——均为真实迁移语义，审计已逐一源码实证。

## 验证

纯文档改动（13 文件，含横幅）；无代码影响。另有代码侧一处同族问题（debug.ts 的 mouse 日志写旧目录）将单独开小 PR。