### PR TITLE
fix(utils): mouse 调试日志写入 DATA_DIR——新名开关却落盘旧目录

### DIFF
--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,5 +1,5 @@
 import { appendFileSync } from 'node:fs'
-import { homedir } from 'node:os'
+import { DATA_DIR } from './paths.js'
 import { join } from 'node:path'
 
 /**
@@ -15,7 +15,7 @@ export function logForDebugging(message: string, fields?: Record<string, unknown
 }
 
 /**
- * Mouse-chain diagnostics: appends to `~/.dsh-cc/mouse-debug.log` when
+ * Mouse-chain diagnostics: appends to `~/.dsh-tui/mouse-debug.log` when
  * `DSH_TUI_DEBUG_MOUSE` is set. Unlike logForDebugging (stderr), a file
  * keeps the fullscreen alt screen unpolluted and survives the session for
  * post-mortem reading. Every append is try/catch-guarded — diagnostics
@@ -28,7 +28,7 @@ export function logMouseDebug(message: string, fields?: Record<string, unknown>)
   const suffix = fields === undefined ? '' : ` ${JSON.stringify(fields)}`
   try {
     const line = `${new Date().toISOString()} ${message}${suffix}\n`
-    appendFileSync(join(homedir(), '.dsh-cc', 'mouse-debug.log'), line)
+    appendFileSync(join(DATA_DIR, 'mouse-debug.log'), line)
   } catch {
     // ignore — see doc comment
   }


### PR DESCRIPTION
## 问题

路径一致性审计（见 #534 的文档侧）发现的一处**代码级**行为错位：

`src/utils/debug.ts:31`：设置 `DSH_TUI_DEBUG_MOUSE=1` 开启 mouse 调试后，日志硬编码写入 `~/.dsh-cc/mouse-debug.log`（旧目录）——开关用新名（`DSH_TUI_` 前缀），落盘却在旧目录，排障者按新数据目录 `~/.dsh-tui/` 找日志必然扑空。

## 修复

改用 `DATA_DIR` 常量（与 `themePrefs`/`modelPrefs` 等全部 prefs 的 `PREFS_DIR = DATA_DIR` 一致），文件头注释同步。

## 验证

`tsc --noEmit` 通过。低频诊断路径，无行为面变化（仅日志落盘位置对齐重命名方向）。

## 顺带讨论（不在本 PR 改）

审计同时发现两处开发者面残留，供维护者定夺是否跟进：
- `scripts/run.ts:17-19` 开发启动器把 `DSH_HOME` 钉死 `~/.dsh-cc`（heap-watch 等开发产物落旧目录）
- `DSH_CC_HEAP_WATCH` / `DSH_CC_NODE_PTY` / `DSH_CC_REPRO_DUMP` 三个 scripts 私有变量沿用旧前缀（不在 RENAMED_ENV 映射内、不被 src/ 读取）