### PR TITLE
fix: 退出后鼠标报告模式残留——dispose 窗口内自愈探针重写 ENABLE（#522）

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -115,6 +115,11 @@ const GROUPS = {
     ["verify-exit-resume-marker", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-resume-marker.tsx']],
 // 退出阶段 stderr/console 恢复回归（issue #42）：shutdown 解绑恢复物理流并注销监听器。
     ["verify-shutdown-stderr", ['node', '--import', 'tsx/esm', 'scripts/verify-shutdown-stderr.tsx']],
+// 退出鼠标残留回归（issue #522）：detach 闩锁后自愈探针不再重写
+// ENABLE_MOUSE_TRACKING；unmount 在末帧渲染抛错时仍同步写完整清理
+// （帧在 EXIT_ALT_SCREEN 前、DISABLE 后 SHOW_CURSOR），handle 暴露
+// detach 方法供 finishExit 兜底闩锁。
+    ["verify-exit-mouse-cleanup", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-cleanup.tsx']],
 // /update 纯函数回归：版本探测（双布局+外来 manifest 拒绝）、
 // registry 解析（env/npmrc/默认）、semver 比较、pnpm --latest。
     ["verify-update", ['node', 'scripts/verify-update.mjs']],

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -1,0 +1,215 @@
+/**
+ * Exit mouse-reporting cleanup regression (issue #522): after dsh-tui exits
+ * the shell keeps echoing SGR mouse sequences (ESC[<btn;col;rowM) because
+ * ENABLE_MOUSE_TRACKING was re-written AFTER the exit cleanup's
+ * DISABLE_MOUSE_TRACKING — the self-heal probe (and the DECRPM re-entry
+ * reply) fired inside the dispose window, and a throwing final render could
+ * skip the whole synchronous cleanup block.
+ *
+ * Guards:
+ * 1. The render() handle exposes detachForShutdown/detachStdinForHandoff,
+ *    so finishExit's instances-map fallback can latch the runtime even when
+ *    the map lookup misses (stdout identity drift).
+ * 2. detachForShutdown latches the self-heal paths: probeAltScreenHealth,
+ *    reassertTerminalModes and reenterAltScreen stop writing
+ *    ENABLE_MOUSE_TRACKING / ENTER_ALT_SCREEN afterwards.
+ * 3. unmount() survives a throwing final render and still writes the full
+ *    synchronous cleanup (EXIT_ALT_SCREEN → DISABLE_MOUSE_TRACKING →
+ *    SHOW_CURSOR) to the stdout stream's own fd, with the last frame (when
+ *    present) preceding EXIT_ALT_SCREEN.
+ */
+import React from 'react'
+import { closeSync, openSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { render, AlternateScreen, Text } from '../src/ui.js'
+import instances from '../src/ink/instances.js'
+import {
+  DISABLE_MOUSE_TRACKING,
+  ENABLE_MOUSE_TRACKING,
+  ENTER_ALT_SCREEN,
+  EXIT_ALT_SCREEN,
+  SHOW_CURSOR,
+} from '../src/ink/termio/dec.js'
+import { serializeDiff } from '../src/ink/terminal.js'
+
+let failures = 0
+const results: string[] = []
+const check = (name: string, ok: boolean) => {
+  results.push(`${ok ? 'PASS' : 'FAIL'}: ${name}`)
+  if (!ok) failures++
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  isRaw = false
+
+  setRawMode(value: boolean): this {
+    this.isRaw = value
+    return this
+  }
+
+  ref(): this {
+    return this
+  }
+
+  unref(): this {
+    return this
+  }
+}
+
+/** PassThrough masquerading as a TTY; optionally pinned to a real fd. */
+function fakeTTY(options: { fd?: number } = {}): NodeJS.WriteStream {
+  const stream = new PassThrough() as unknown as NodeJS.WriteStream & {
+    fd?: number | null
+  }
+  Object.assign(stream, { isTTY: true, columns: 80, rows: 24 })
+  if (options.fd !== undefined) {
+    Object.defineProperty(stream, 'fd', { value: options.fd, configurable: true })
+  }
+  return stream
+}
+
+const drain = (stream: NodeJS.WriteStream): string => {
+  let out = ''
+  let chunk: unknown
+  while ((chunk = (stream as PassThrough).read()) !== null) {
+    out += String(chunk)
+  }
+  return out
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+// ---------------------------------------------------------------------------
+// 1 + 2. Handle exposes the detach methods; detach latches the self-heal
+// paths so nothing re-writes ENABLE_MOUSE_TRACKING after shutdown begins.
+// ---------------------------------------------------------------------------
+{
+  const stdout = fakeTTY()
+  const stdin = new FakeStdin()
+  const instance = await render(
+    React.createElement(AlternateScreen, null, React.createElement(Text, null, 'exit mouse cleanup')),
+    {
+      stdout,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      exitOnCtrlC: false,
+      patchConsole: true,
+    },
+  )
+
+  check(
+    'render handle exposes detachForShutdown (finishExit fallback can latch)',
+    typeof instance.detachForShutdown === 'function',
+  )
+  check(
+    'render handle exposes detachStdinForHandoff',
+    typeof instance.detachStdinForHandoff === 'function',
+  )
+
+  const ink = instances.get(stdout)
+  check('live Ink instance found by stdout', ink !== undefined)
+
+  const mounted = drain(stdout)
+  check('AlternateScreen mount enables mouse tracking', mounted.includes(ENABLE_MOUSE_TRACKING))
+
+  // While active, the probe re-asserts mouse tracking (first call passes the
+  // 250ms throttle).
+  ink?.probeAltScreenHealth()
+  await new Promise(resolve => setImmediate(resolve))
+  const afterProbe = drain(stdout)
+  check('active probe re-asserts mouse tracking', afterProbe.includes(ENABLE_MOUSE_TRACKING))
+
+  // Latch, then let the probe throttle window pass: every self-heal path must
+  // stay silent afterwards.
+  instance.detachForShutdown()
+  await sleep(300)
+
+  ink?.probeAltScreenHealth()
+  await new Promise(resolve => setImmediate(resolve))
+  const afterLatchProbe = drain(stdout)
+  check('latched probe does not re-enable mouse tracking', !afterLatchProbe.includes(ENABLE_MOUSE_TRACKING))
+
+  ink?.reassertTerminalModes()
+  await new Promise(resolve => setImmediate(resolve))
+  const afterReassert = drain(stdout)
+  check('latched reassert does not re-enable mouse tracking', !afterReassert.includes(ENABLE_MOUSE_TRACKING))
+
+  ;(ink as unknown as { reenterAltScreen(): void }).reenterAltScreen()
+  await new Promise(resolve => setImmediate(resolve))
+  const afterReenter = drain(stdout)
+  check('latched reenter does not re-enter alt screen', !afterReenter.includes(ENTER_ALT_SCREEN))
+  check('latched reenter does not re-enable mouse tracking', !afterReenter.includes(ENABLE_MOUSE_TRACKING))
+
+  instance.detachStdinForHandoff()
+  check('handle detachStdinForHandoff removes stdin readers', stdin.listenerCount('readable') === 0)
+}
+
+// ---------------------------------------------------------------------------
+// 3. unmount() must survive a throwing final render and still write the full
+// synchronous cleanup to the stdout stream's own fd.
+// ---------------------------------------------------------------------------
+{
+  const tmpFile = join(tmpdir(), `dsh-tui-exit-mouse-cleanup-${process.pid}.out`)
+  const tmpFd = openSync(tmpFile, 'w')
+  const stdout = fakeTTY({ fd: tmpFd })
+  const stdin = new FakeStdin()
+  const instance = await render(
+    React.createElement(AlternateScreen, null, React.createElement(Text, null, 'cleanup survives render crash')),
+    {
+      stdout,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      exitOnCtrlC: false,
+      patchConsole: true,
+    },
+  )
+
+  const ink = instances.get(stdout) as unknown as { renderNow(): void }
+  ink.renderNow = () => {
+    throw new Error('final render boom')
+  }
+
+  let unmountThrew = false
+  try {
+    instance.unmount()
+  } catch {
+    unmountThrew = true
+  }
+  closeSync(tmpFd)
+
+  check('unmount survives a throwing final render', !unmountThrew)
+  const cleanup = readFileSync(tmpFile, 'utf8')
+  check('sync cleanup exits the alt screen', cleanup.includes(EXIT_ALT_SCREEN))
+  check('sync cleanup disables mouse tracking', cleanup.includes(DISABLE_MOUSE_TRACKING))
+  const disableAt = cleanup.indexOf(DISABLE_MOUSE_TRACKING)
+  check('EXIT_ALT_SCREEN precedes DISABLE_MOUSE_TRACKING',
+    cleanup.indexOf(EXIT_ALT_SCREEN) !== -1 &&
+    cleanup.indexOf(EXIT_ALT_SCREEN) < disableAt)
+  // The last frame itself carries a cursorShow patch, so search for the
+  // cleanup's SHOW_CURSOR only AFTER the disables.
+  check('sync cleanup shows the cursor after the disables',
+    cleanup.indexOf(SHOW_CURSOR, disableAt) !== -1)
+  check('sync cleanup contains no ENABLE_MOUSE_TRACKING', !cleanup.includes(ENABLE_MOUSE_TRACKING))
+
+  // The last frame (serialized with a BSU head) must land BEFORE the alt
+  // screen exits — an async frame write would arrive after ?1049l and paint
+  // misplaced residue on the main screen.
+  const frameAt = cleanup.indexOf('\x1b[?2026h')
+  if (frameAt !== -1) {
+    check('last frame lands before EXIT_ALT_SCREEN', frameAt < cleanup.indexOf(EXIT_ALT_SCREEN))
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. serializeDiff keeps the empty-diff contract after the extraction.
+// ---------------------------------------------------------------------------
+{
+  const sink = new PassThrough() as unknown as NodeJS.WriteStream
+  const empty = serializeDiff({ stdout: sink, stderr: sink }, [])
+  check('serializeDiff of an empty diff is empty', empty === '')
+}
+
+console.log(results.join('\n'))
+if (failures > 0) process.exit(1)

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1508,9 +1508,19 @@ async function finishExit(
   done: () => void,
 ): Promise<void> {
   try {
-    const runtime = readInkShutdownState(instances.get(process.stdout))
-    if (runtime === undefined && instance !== undefined) {
+    // Resolve the Ink runtime twice: the instances map is keyed by stdout
+    // identity, so a replaced/overridden stdout misses it; the render()
+    // handle is the caller's own instance and always matches (issue #522 —
+    // a missed lookup skipped detachForShutdown, leaving the stdin pump,
+    // TTY handlers and querier alive so the self-heal probe re-wrote
+    // ENABLE_MOUSE_TRACKING after DISABLE_MOUSE_TRACKING had been sent).
+    const fromMap = readInkShutdownState(instances.get(process.stdout))
+    const fromHandle = instance === undefined ? undefined : readInkShutdownState(instance)
+    const runtime = fromMap ?? fromHandle
+    if (runtime === undefined) {
       ctx.logger.debug('dsh-tui: Ink runtime unavailable during shutdown; using generic terminal cleanup')
+    } else if (fromMap === undefined) {
+      ctx.logger.debug('dsh-tui: Ink runtime resolved from the render handle (instances map missed); detaching')
     }
     const cursor = fullscreen ? '' : cursorMoveToFrameEnd(runtime)
 

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -36,7 +36,7 @@ import createRenderer, { type Renderer } from './renderer.js';
 import { CellWidth, CharPool, cellAt, createScreen, HyperlinkPool, isEmptyCellAt, migrateScreenPools, StylePool } from './screen.js';
 import { applySearchHighlight } from './searchHighlight.js';
 import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, pickFollowForSelection, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection.js';
-import { isDecstbmSafe, SYNC_OUTPUT_SUPPORTED, supportsExtendedKeys, supportsWin32InputMode, type Terminal, writeDiffToTerminal } from './terminal.js';
+import { isDecstbmSafe, SYNC_OUTPUT_SUPPORTED, serializeDiff, supportsExtendedKeys, supportsWin32InputMode, type Terminal, writeDiffToTerminal } from './terminal.js';
 import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ENABLE_WIN32_INPUT_MODE, ERASE_SCREEN, ERASE_SCROLLBACK, SGR_RESET } from './termio/csi.js';
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
 import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, setClipboard, supportsTabStatus, wrapForMultiplexer } from './termio/osc.js';
@@ -1173,6 +1173,10 @@ export default class Ink {
    */
   reassertTerminalModes = (includeAltScreen = false): void => {
     if (!this.options.stdout.isTTY) return;
+    // Shutdown latch: the >5s idle-gap trigger (or an event-loop stall
+    // detector firing during the dispose window) must not re-assert mouse
+    // tracking after the exit cleanup disabled it (issue #522).
+    if (this.isUnmounted) return;
     // Don't touch the terminal during an editor handoff — re-enabling kitty
     // keyboard here would undo enterAlternateScreen's disable and nano would
     // start seeing CSI-u sequences again.
@@ -1334,6 +1338,13 @@ export default class Ink {
    */
   private lastHealthProbeAt = 0;
   probeAltScreenHealth = (): void => {
+    // Shutdown latch: during the dispose window after detachForShutdown
+    // (up to the 5s fallback exit) stray input, focus, resize or a pending
+    // DECRPM reply would otherwise re-write ENABLE_MOUSE_TRACKING AFTER the
+    // exit cleanup's DISABLE_MOUSE_TRACKING — the mouse-reporting residue
+    // the shell then echoes as SGR garbage (issue #522). isUnmounted is set
+    // by detachForShutdown() before any cleanup sequence is written.
+    if (this.isUnmounted) return;
     const now = Date.now();
     if (now - this.lastHealthProbeAt < 250) return;
     this.lastHealthProbeAt = now;
@@ -1368,6 +1379,11 @@ export default class Ink {
    * stays true. ENTER_ALT_SCREEN is a terminal-side no-op if already in alt.
    */
   private reenterAltScreen(): void {
+    // Same shutdown latch as probeAltScreenHealth: a DECRPM reply resolving
+    // after detachForShutdown (or a SIGCONT racing unmount) must not re-enter
+    // the alt screen or re-enable mouse tracking past the exit cleanup
+    // (issue #522).
+    if (this.isUnmounted) return;
     this.options.stdout.write(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME + (this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : ''));
     this.resetFramesForAltScreen();
   }
@@ -1919,7 +1935,16 @@ export default class Ink {
     if (this.isUnmounted) {
       return;
     }
-    this.renderNow();
+    // The final frame render is best-effort: a mid-state React commit can
+    // throw (agent still working at the exact exit moment). It must NOT
+    // skip the synchronous cleanup block below — a skipped DISABLE_*
+    // leaves mouse reporting on past process exit, and the shell echoes
+    // SGR garbage for every click/drag/wheel (issue #522).
+    try {
+      this.renderNow();
+    } catch (renderError) {
+      logError(renderError instanceof Error ? renderError : new Error(String(renderError)));
+    }
     this.unsubscribeExit();
     if (typeof this.restoreConsole === 'function') {
       this.restoreConsole();
@@ -1930,43 +1955,57 @@ export default class Ink {
     // Non-TTY environments don't handle erasing ansi escapes well, so it's better to
     // only render last frame of non-static output
     const diff = this.log.renderPreviousOutput_DEPRECATED(this.frontFrame);
-    writeDiffToTerminal(this.terminal, optimize(diff));
+    const lastFrame = serializeDiff(this.terminal, optimize(diff));
 
     // Clean up terminal modes synchronously before process exit.
     // React's componentWillUnmount won't run in time when process.exit() is called,
     // so we must reset terminal modes here to prevent escape sequence leakage.
-    // Use writeSync to stdout (fd 1) to ensure writes complete before exit.
-    // We unconditionally send all disable sequences because terminal detection
-    // may not work correctly (e.g., in tmux, screen) and these are no-ops on
-    // terminals that don't support them.
+    // Use writeSync to the stdout stream's own fd (not a hard-coded 1 — a
+    // host that runs the TUI on a non-1 TTY would drop every sequence while
+    // the enable writes still reach the TTY, issue #522) to ensure writes
+    // complete before exit. We unconditionally send all disable sequences
+    // because terminal detection may not work correctly (e.g., in tmux,
+    // screen) and these are no-ops on terminals that don't support them.
     /* eslint-disable custom-rules/no-sync-fs -- process exiting; async writes would be dropped */
     if (this.options.stdout.isTTY) {
+      // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
+      // doesn't declare it, hence the local intersection cast.
+      const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
+      const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
+      // The last frame must land on the ALT screen while it is still up:
+      // writing it through the async stream would race the synchronous
+      // EXIT_ALT_SCREEN below and the frame bytes would arrive AFTER the
+      // switch to the main screen, painting misplaced residue over the
+      // shell (issue #522).
+      if (lastFrame !== '') {
+        writeSync(stdoutFd, lastFrame);
+      }
       if (this.altScreenActive) {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
         // Exit alt screen FIRST so other cleanup sequences go to the main screen.
-        writeSync(1, EXIT_ALT_SCREEN);
+        writeSync(stdoutFd, EXIT_ALT_SCREEN);
       }
       // Disable mouse tracking — unconditional because altScreenActive can be
       // stale if AlternateScreen's unmount (which flips the flag) raced a
       // blocked event loop + SIGINT. No-op if tracking was never enabled.
-      writeSync(1, DISABLE_MOUSE_TRACKING);
+      writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
       // Drain stdin so in-flight mouse events don't leak to the shell
       this.drainStdin();
       // Disable extended key reporting (both kitty and modifyOtherKeys)
-      writeSync(1, DISABLE_MODIFY_OTHER_KEYS);
-      writeSync(1, DISABLE_KITTY_KEYBOARD);
+      writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
+      writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
       // Disable win32-input-mode (no-op where never enabled)
-      writeSync(1, DISABLE_WIN32_INPUT_MODE);
+      writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
       // Disable focus events (DECSET 1004)
-      writeSync(1, DFE);
+      writeSync(stdoutFd, DFE);
       // Disable bracketed paste mode
-      writeSync(1, DBP);
+      writeSync(stdoutFd, DBP);
       // Show cursor
-      writeSync(1, SHOW_CURSOR);
+      writeSync(stdoutFd, SHOW_CURSOR);
       // Clear iTerm2 progress bar
-      writeSync(1, CLEAR_ITERM2_PROGRESS);
+      writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
       // Clear tab status (OSC 21337) so a stale dot doesn't linger
-      if (supportsTabStatus()) writeSync(1, wrapForMultiplexer(CLEAR_TAB_STATUS));
+      if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
     }
     /* eslint-enable custom-rules/no-sync-fs */
 

--- a/src/ink/root.ts
+++ b/src/ink/root.ts
@@ -60,6 +60,22 @@ export type Instance = {
    * Returns a promise, which resolves when app is unmounted.
    */
   waitUntilExit: Ink['waitUntilExit']
+  /**
+   * Detach the Ink runtime for process-level shutdown: latches isUnmounted
+   * (gating every mouse/alt-screen re-assert), cancels pending renders,
+   * releases TTY handlers and stdin raw mode, and disposes the querier.
+   * Exposed on the handle so shutdown code can latch the runtime even when
+   * the global instances map lookup misses (stdout identity drift, issue
+   * #522) — without it, the cleanup-vs-self-heal window re-enables mouse
+   * tracking after DISABLE_MOUSE_TRACKING has already been written.
+   */
+  detachForShutdown: Ink['detachForShutdown']
+  /**
+   * Fully detach stdin before handing the terminal to a child process that
+   * inherits it (the /update and /restart handoffs). See Ink's own method
+   * for the listener/pump semantics.
+   */
+  detachStdinForHandoff: Ink['detachStdinForHandoff']
   cleanup: () => void
 }
 
@@ -107,6 +123,8 @@ export const renderSync = (
       instance.unmount()
     },
     waitUntilExit: instance.waitUntilExit,
+    detachForShutdown: () => instance.detachForShutdown(),
+    detachStdinForHandoff: () => instance.detachStdinForHandoff(),
     cleanup: () => instances.delete(inkOptions.stdout),
   }
 }

--- a/src/ink/terminal.ts
+++ b/src/ink/terminal.ts
@@ -334,14 +334,22 @@ export type Terminal = {
  * @param diff - the frame diff patches to render.
  * @param skipSyncMarkers - when true, omit the BSU/ESU wrapping.
  */
-export function writeDiffToTerminal(
+/**
+ * Serialize a frame diff into a single ANSI string (BSU/ESU-wrapped unless
+ * skipSyncMarkers is set). Empty string when the diff has no patches.
+ * Extracted from writeDiffToTerminal so shutdown paths can write the last
+ * frame synchronously (issue #522: an async frame write racing the
+ * synchronous EXIT_ALT_SCREEN lands on the MAIN screen after the alt
+ * screen is gone, leaving misplaced residue).
+ */
+export function serializeDiff(
   terminal: Terminal,
   diff: Diff,
   skipSyncMarkers = false,
-): void {
+): string {
   // No output if there are no patches
   if (diff.length === 0) {
-    return
+    return ''
   }
 
   // BSU/ESU wrapping is opt-out to keep main-screen behavior unchanged.
@@ -425,5 +433,25 @@ export function writeDiffToTerminal(
   // Add synchronized update end and flush buffer
   if (useSync) buffer += ESU
   dumpFrame(buffer)
+  return buffer
+}
+
+/**
+ * Write a frame diff to the terminal as a single buffered write. Wraps
+ * the output in BSU/ESU synchronized-update markers unless skipSyncMarkers
+ * is set. No-op when the diff contains no patches.
+ * @param terminal - the terminal to write to.
+ * @param diff - the frame diff patches to render.
+ * @param skipSyncMarkers - when true, omit the BSU/ESU wrapping.
+ */
+export function writeDiffToTerminal(
+  terminal: Terminal,
+  diff: Diff,
+  skipSyncMarkers = false,
+): void {
+  const buffer = serializeDiff(terminal, diff, skipSyncMarkers)
+  if (buffer === '') {
+    return
+  }
   terminal.stdout.write(buffer)
 }


### PR DESCRIPTION
Closes #522

## 现象
\/exit\、\/q\ 或双击 Ctrl+C 退出 dsh-tui 后，shell 中点击/拖拽/滚轮会回显 \ESC[<0;12;5M\ 之类的 SGR 鼠标序列——鼠标报告模式残留开启。用户实测：纯 \/exit\ 优雅退出 100% 复现。

## 根因（三层竞态）
1. **自愈探针无 shutdown 闩锁**：\probeAltScreenHealth()\ 在每次按键/鼠标/焦点/resize/空闲恢复时无条件重写 \ENABLE_MOUSE_TRACKING\ 且不检查 \isUnmounted\；\eenterAltScreen\（DECRPM 回复回调）同理。退出清理 \DISABLE_MOUSE_TRACKING\ 之后到 \process.exit\ 之间最长 5s 的 dispose 窗口内，任何输入/挂起回复都会把 ENABLE 写在 DISABLE 之后。
2. **detach 可能被跳过**：\inishExit\ 只从 \instances.get(process.stdout)\ 解析 runtime，stdout 身份漂移时未命中 → \detachForShutdown\ 不执行 → stdin 泵、TTY 处理器、querier 全活着，窗口期持续触发 probe。
3. **unmount 清理段可能整体跳过**：\unmount()\ 开头 \enderNow()\ 在退出瞬间（agent 仍在工作）抛错 → 整个 writeSync 清理段（含 DISABLE）被跳过。
另外两处加固：\writeSync(1, …)\ 硬编码 fd1（stdout 非 fd1 时清理序列落空）；末帧异步流写与同步 \EXIT_ALT_SCREEN\ 竞态，帧字节迟到落主屏。

## 修复
- **ink.tsx**：\probeAltScreenHealth\ / \eenterAltScreen\ / \eassertTerminalModes\ 入口加 \isUnmounted\ 闩锁；\unmount()\ 的 \enderNow\ 包 try/catch（渲染失败不再跳过清理）；末帧改为 \serializeDiff\ 同步写、先于 \EXIT_ALT_SCREEN\；\writeSync\ 改用 \stdout.fd ?? 1\。
- **root.ts**：\Instance\ handle 透传 \detachForShutdown\ / \detachStdinForHandoff\，作为 finishExit 兜底闩锁来源。
- **plugin.ts**：\inishExit\ runtime 解析在 map 未命中时 fallback 到 render handle，并加 debug 日志区分命中来源。
- **terminal.ts**：拆分导出 \serializeDiff\（空 diff 契约不变，\writeDiffToTerminal\ 行为不变）。
- **verify-exit-mouse-cleanup**（新回归，18/18）：handle 暴露 detach 方法；detach 后 probe/reassert/reenter 不再写 ENABLE；unmount 在末帧渲染抛错时仍同步写完整清理（帧在 EXIT_ALT_SCREEN 前、DISABLE 后 SHOW_CURSOR）；serializeDiff 空 diff 契约。已登记 \input-terminal\ CI 组。

## 验证
- \pnpm build\ 全绿（含 verify:build 门禁）
- \input-terminal\ 组 18/18（含新回归）
- \ender-scroll\ 组 26 项：仅 \erify-timeline-rail\ 组内时序 flake（#542 已登记的 rail settle 竞态，单独跑即绿，与本改动路径零交集）