### PR TITLE
fix(ink): 退出查询泄漏两处补刀——querier dispose 后拒绝重发 + 清理后 re-drain（#507/#492）

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -120,6 +120,11 @@ const GROUPS = {
 // （帧在 EXIT_ALT_SCREEN 前、DISABLE 后 SHOW_CURSOR），handle 暴露
 // detach 方法供 finishExit 兜底闩锁。
     ["verify-exit-mouse-cleanup", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-cleanup.tsx']],
+// 退出查询泄漏回归（#507/#492）：退出清理（DISABLE）之后，健康探针/
+// 模式重断言/已 dispose 的 querier 都不得再写出任何 ENABLE 或查询
+// 字节、不得拉回 raw mode——在途回复与鼠标事件由清理后的 re-drain
+// 吞掉，不再落入 shell。
+    ["verify-exit-mouse-residue", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-residue.tsx']],
 // /update 纯函数回归：版本探测（双布局+外来 manifest 拒绝）、
 // registry 解析（env/npmrc/默认）、semver 比较、pnpm --latest。
     ["verify-update", ['node', 'scripts/verify-update.mjs']],

--- a/scripts/verify-exit-mouse-residue.tsx
+++ b/scripts/verify-exit-mouse-residue.tsx
@@ -1,0 +1,142 @@
+/**
+ * 退出清理之后鼠标追踪不得再被重新打开（#522 / #507 / #492 的确定性蒸馏）。
+ *
+ * 症状：/exit 回到 shell 后，点击/移动鼠标冒出 `ESC[<0;12;5M` 之类 SGR 序列
+ * 被 shell 原样回显——SGR 鼠标模式是终端会话状态，进程退出不会自动重置；
+ * 残留 = 退出清理（DISABLE_MOUSE_TRACKING）之后仍有任何代码写出 ENABLE。
+ *
+ * 场景蒸馏（无需时序竞态）：
+ *   1. 挂载 AlternateScreen（altScreenActive=true，mouseTracking=true——
+ *      probe 的全部前置条件就位）；
+ *   2. 模拟退出漏斗 finishExit 的同序两步：detachForShutdown()（置
+ *      isUnmounted）→ 写出 DISABLE_MOUSE_TRACKING；
+ *   3. 过 250ms 节流窗后调 probeAltScreenHealth()——对应退出前窗口期
+ *      （writeStream 1s + disposeRootAndThen 5s 兜底）内任何按键/鼠标
+ *      输入触发的健康探针；
+ *   4. 断言：清理序列之后不得再出现任何鼠标 ENABLE（?1000h/1002h/1003h/
+ *      1006h）。未修复的 probe 不检查 isUnmounted，每次必红。
+ *
+ * Run: node --import tsx/esm scripts/verify-exit-mouse-residue.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen, Text }, { default: instances }, { TerminalQuerier, decrqm }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/ink/instances.js'),
+    import('../src/ink/terminal-querier.js'),
+  ])
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const COLS = 40
+const ROWS = 10
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 100, allowProposedApi: true })
+
+// 捕获写给终端的全部字节——断言的对象就是这条字节流的顺序。
+const bytes: string[] = []
+let lastFlushed: Promise<void> = Promise.resolve()
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    const text = String(chunk)
+    bytes.push(text)
+    lastFlushed = new Promise<void>(res => term.write(text, () => { cb(); res() }))
+  }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+const stdout = new FakeStdout() as unknown as NodeJS.WriteStream
+const stdin = new FakeStdin() as unknown as NodeJS.ReadStream
+const flush = (): Promise<void> => lastFlushed
+
+const MOUSE_ENABLE = /\x1b\[\?100[0236]h/
+const MOUSE_DISABLE = /\x1b\[\?100[0236]l/
+
+await render(
+  <AlternateScreen>
+    <Text>exit-residue probe</Text>
+  </AlternateScreen>,
+  { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
+)
+
+/** 三条防线的最小驱动面（避免 as any，按仓库 unknown 收窄惯例）。 */
+type InkDriver = {
+  detachForShutdown(): void
+  probeAltScreenHealth(): void
+  reassertTerminalModes(includeAltScreen?: boolean): void
+  app?: { querier?: TerminalQuerier }
+}
+const ink = instances.get(stdout) as unknown as InkDriver | undefined
+check('Ink 实例存在（挂载成功）', ink !== undefined)
+if (!ink) process.exit(1)
+await flush()
+await sleep(50)
+
+// ── 模拟退出漏斗 finishExit（src/dsh-adapter/plugin.ts）：先 detach（置
+// isUnmounted），cleanup 序列随后写出——与真实退出同序。detach 置位后，
+// 窗口期一切终端写入都不应再发生。
+ink.detachForShutdown()
+stdout.write('\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l')
+await flush()
+
+const cut = bytes.length
+const cleanupTail = bytes.slice(0, cut).join('')
+check('退出清理序列已写出（DISABLE 到达终端）', MOUSE_DISABLE.test(cleanupTail))
+
+// ── 250ms 节流窗过去，退出前窗口期的输入派发触发健康探针。
+await sleep(300)
+ink.probeAltScreenHealth()
+await flush()
+await sleep(50)
+
+const tail = bytes.slice(cut).join('')
+check('清理之后无任何鼠标 ENABLE 残留（probe 尊重 isUnmounted）', !MOUSE_ENABLE.test(tail),
+  tail.match(MOUSE_ENABLE) ? `残留序列: ${JSON.stringify(tail.match(MOUSE_ENABLE))}` : '')
+
+// ── 第二刀防线：stdin-resume 路径的重断言同样不得在退出后碰终端
+// （kitty keyboard / focus reporting 重开 = #492 的 extended-key 残留）。
+const cut2 = bytes.length
+ink.reassertTerminalModes(true)
+await flush()
+await sleep(50)
+const tail2 = bytes.slice(cut2).join('')
+check('退出后 reassertTerminalModes 零字节写出（kitty keyboard 不重开）', tail2 === '',
+  tail2 ? `写出了 ${JSON.stringify(tail2.slice(0, 40))}` : '')
+
+// ── 第三刀防线：dispose 之后的 querier 不得再发查询、不得再拉回 raw mode
+// （#507 的 DECRPM/DA1 回复泄漏 shell + ?2004h raw mode 重开）。
+// detach 链（ink → App.detachForShutdown）已 dispose querier；绕过 probe
+// 直接打 querier，模拟退出窗口期任何残余调用方。
+const cut3 = bytes.length
+const querier: TerminalQuerier | undefined = ink.app?.querier
+check('querier 存在且已被 detach 链持有', querier !== undefined)
+if (querier) {
+  void querier.send(decrqm(1049))
+  void querier.flush()
+  await flush()
+  await sleep(50)
+  const tail3 = bytes.slice(cut3).join('')
+  const QUERY_BYTES = /\x1b\[\?1049\$p|\x1b\[c|\x1b\[\?2004h/
+  check('dispose 后 querier 零查询字节 / 不拉回 raw mode', !QUERY_BYTES.test(tail3),
+    tail3 ? `写出了 ${JSON.stringify(tail3.slice(0, 40))}` : '')
+}
+
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILURES`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1500,6 +1500,8 @@ type InkShutdownState = {
    * lingering parent stops racing the restarted TUI for keypresses.
    */
   detachStdinForHandoff?: () => void
+  /** Drain pending stdin bytes; the exit funnel re-drains after cleanup. */
+  drainStdin?: () => void
   frontFrame?: { cursor?: { x: number; y: number } }
   displayCursor?: { x: number; y: number } | null
 }
@@ -1555,6 +1557,16 @@ async function finishExit(
     ].join('')
     const suffix = notice === undefined ? '' : `${notice}\n`
     await writeStream(process.stdout, `${cleanup}\r\n${suffix}`)
+    // Re-drain AFTER the cleanup sequences have landed (#507): terminal
+    // replies and mouse packets already in flight when the exit started
+    // keep arriving while cleanup is being written — the detach-time drain
+    // cannot see them. Unconsumed at process exit they land in the shell's
+    // input queue (DECRPM/DA1/XTVERSION garbage pasted into the prompt).
+    // 150ms settle covers reply RTT on slow links (ssh/ghostty is #522's
+    // environment; 50ms proved too tight there) while staying well inside
+    // the exit window the user already waits through.
+    await new Promise<void>(resolve => setTimeout(resolve, 150))
+    runtime?.drainStdin?.()
     if (stderrNotice !== undefined) {
       await writeStream(process.stderr, `\n${stderrNotice}\n`)
     }
@@ -1569,6 +1581,7 @@ function readInkShutdownState(value: unknown): InkShutdownState | undefined {
   const candidate = value as Record<string, unknown>
   if (candidate.detachForShutdown !== undefined && typeof candidate.detachForShutdown !== 'function') return undefined
   if (candidate.detachStdinForHandoff !== undefined && typeof candidate.detachStdinForHandoff !== 'function') return undefined
+  if (candidate.drainStdin !== undefined && typeof candidate.drainStdin !== 'function') return undefined
   if (candidate.frontFrame !== undefined && !isFrameState(candidate.frontFrame)) return undefined
   if (candidate.displayCursor !== undefined && candidate.displayCursor !== null && !isCursorState(candidate.displayCursor)) return undefined
   return value as InkShutdownState

--- a/src/ink/terminal-querier.ts
+++ b/src/ink/terminal-querier.ts
@@ -161,6 +161,15 @@ export class TerminalQuerier {
    */
   private queue: Pending[] = []
 
+  /**
+   * Set by dispose(). Post-dispose send()/flush() must not touch the
+   * terminal: they would re-enable raw mode (holdRawMode) and emit query
+   * bytes after the exit funnel's cleanup has already restored cooked
+   * mode — the replies then leak into the shell (#507). Resolving as
+   * "no answer" keeps callers' .then() chains inert instead of pending.
+   */
+  private disposed = false
+
   constructor(
     private stdout: NodeJS.WriteStream,
     private setRawMode?: (enabled: boolean) => void,
@@ -187,6 +196,7 @@ export class TerminalQuerier {
   send<T extends TerminalResponse>(
     query: TerminalQuery<T>,
   ): Promise<T | undefined> {
+    if (this.disposed) return Promise.resolve(undefined)
     return new Promise(resolve => {
       this.queue.push({
         kind: 'query',
@@ -208,6 +218,7 @@ export class TerminalQuerier {
    * Safe to call with no pending queries — still waits for a round-trip.
    */
   flush(): Promise<void> {
+    if (this.disposed) return Promise.resolve()
     return new Promise(resolve => {
       this.queue.push({
         kind: 'sentinel',
@@ -220,6 +231,7 @@ export class TerminalQuerier {
 
   /** Resolve and release all pending queries when their owning app unmounts. */
   dispose(): void {
+    this.disposed = true
     for (const pending of this.queue.splice(0)) {
       if (pending.kind === 'query') pending.resolve(undefined)
       else pending.resolve()


### PR DESCRIPTION
## 定位：#548 的补充

#548（已合并）落地了 probe/reassert/reenterAltScreen 的 isUnmounted 闩锁、runtime 双路解析与 unmount 抛错容错。本 PR 在其之上补两条 **#548 未覆盖** 的泄漏路径——都来自 #507 的 PTY 字节级实证：

### 补刀 1：TerminalQuerier disposed 标志（#507 查询泄漏根因）

`TerminalQuerier.dispose()` 原先只排空队列，无 disposed 标志——dispose 后 `send()`/`flush()` 仍会：
- `holdRawMode()` 把 raw mode 拉回来（`?2004h ?1004h >1u >4;2m`）
- 写出查询字节（`?1049$:p` + DA1 sentinel）

进程随即退出，终端的回复（`1049;2$y`、DA1、XTVERSION）无人消费、落入 shell 输入队列——#507 实测这些乱码会粘进用户下一条命令被整行执行（在家目录生成了 0 字节文件）。

修复：加 `disposed` 标志，dispose 后 `send`/`flush` 入口拒绝并 resolve `undefined`（调用方 `.then()` 链保持 inert 而非悬挂）。`holdRawMode` 仅被这两个入口调用，raw mode 拉回与查询字节的主链就此断根。

### 补刀 2：finishExit 清理序列落地后 re-drain（在途回复兜底）

detach 时点的 `drainStdin` 发生在清理序列写出**之前**——清理落地后才到达的在途回复与鼠标事件逃过 drain，进程退出后落入 shell。

修复：`finishExit` 在 `writeStream(cleanup)` 完成之后 settle **150ms** 再 `runtime?.drainStdin()`。150ms 的依据：覆盖 ssh 慢链路的回复 RTT（#522 正是 ssh + ghostty 环境，50ms 在该场景偏紧），且远小于退出窗口用户本就要等待的时长。`InkShutdownState` 接口相应扩展 `drainStdin`（含形状校验）。

## 回归验证

新增 `scripts/verify-exit-mouse-residue.tsx`（挂 `input-terminal` CI 组，与 #548 的 `verify-exit-mouse-cleanup` 互补）：

挂载 alt screen → `detachForShutdown()` + 写 DISABLE（与退出漏斗同序）→ 过 250ms 节流窗 → 依次触发 **probe / reassert / querier** 三条防线 → 断言：清理后零鼠标 ENABLE、reassert 零字节写出、querier 零查询字节且不拉回 raw mode。

- rebase 于 #548（e9f2e03）之上：本脚本与 #548 的 `verify-exit-mouse-cleanup` **双双全绿**
- 类型检查通过；`input-terminal` 组此前 18/18（含两脚本）
- 本地 dsh-auth 子模块构建问题导致的 1 条环境性 tsc 错误除外（未触碰该文件）

## 与 #548 的关系

| 修复点 | #548 | 本 PR |
|---|---|---|
| probe/reassert/reenterAltScreen 闩锁 | ✅ | 已剔除重复，仅回归脚本继续覆盖 |
| runtime 双路解析 + unmount 抛错容错 | ✅ | — |
| querier dispose 后拒绝重发 | — | ✅ 补刀 1 |
| 清理后 settle re-drain | — | ✅ 补刀 2 |

Fixes #507
Fixes #492
Refs #522（主症状已由 #548 修复，本 PR 补齐其查询泄漏面）