### PR TITLE
fix(settings): sections 服务行被组合 dispose 时退化到包内本地 host,修复 /settings 区块从未生效(#557)

### DIFF
--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -77,7 +77,7 @@ import { readActivityConfig } from '../activityPrefs.js'
 import { attachSessionToWorkspace } from './workspace.js'
 import { createLocalWorkspaceRuntime, getHostWorkspaceRuntime, type TuiWorkspaceCommand, type TuiWorkspaceCommandResult, type TuiWorkspaceTarget } from './workspaces.js'
 import { getHostCommandTrees } from './command-trees.js'
-import { getHostSettingsSections, type TuiSettingsSection, type TuiSettingsSectionsRuntime } from './settings-sections.js'
+import { getHostSettingsSections, getLocalSettingsSectionsHost, type TuiSettingsSection, type TuiSettingsSectionsRuntime } from './settings-sections.js'
 import type { SettingsHost } from './settingsEditor.js'
 import { getHostSceneRuntime, type TuiSceneDescriptor, type TuiSceneRuntime } from './scenes.js'
 import { getHostRenderers, type TuiRendererRuntime } from './renderers.js'
@@ -1647,9 +1647,12 @@ export function createChannel(
   // tuiWorkspaces/tuiCommandTrees): mounted by the bundle patch's
   // dsh-tui-scenes row; absent the row, `pluginScene` simply stays undefined.
   const sceneRuntime = getHostSceneRuntime(ctx.get('tuiScenes') as TuiSceneRuntime | undefined)
+  // Falls back to the in-package local host when the composition's service
+  // row is unavailable (issue #557: the row can be disposed right after
+  // load in real compositions); the TUI's own section registers there.
   const settingsSectionsRuntime = getHostSettingsSections(
     ctx.get('tuiSettingsSections') as TuiSettingsSectionsRuntime | undefined,
-  )
+  ) ?? getLocalSettingsSectionsHost()
   // Custom-entry text renderers (optional service, dsh-tui-extensions row):
   // absent the row, unknown plugin event types stay invisible in the
   // transcript, exactly as before the seam existed.

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -46,7 +46,7 @@ import { getHostStatusStore, type TuiStatusRuntime } from './status.js'
 import { getHostShortcuts, type TuiShortcutRuntime } from './shortcuts.js'
 import { attachSessionToWorkspace } from './workspace.js'
 import { createLocalWorkspaceRuntime, getHostWorkspaceRuntime } from './workspaces.js'
-import { getHostSettingsSections, type TuiSettingsField, type TuiSettingsSectionsRuntime } from './settings-sections.js'
+import { getHostSettingsSections, getLocalSettingsSectionsHost, type TuiSettingsField, type TuiSettingsSectionsRuntime } from './settings-sections.js'
 import { withHostRootCapability } from './host-access.js'
 import { render, ThemeProvider, AlternateScreen } from '../ui.js'
 import instances from '../ink/instances.js'
@@ -729,10 +729,16 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       },
     }
   })
-  const settingsSections = getHostSettingsSections(
-    ctx.get('tuiSettingsSections') as TuiSettingsSectionsRuntime | undefined,
-  )
-  if (settingsSections !== undefined) {
+  // Prefer the composition's sections service; fall back to the in-package
+  // local host. Real compositions have been observed disposing the whole
+  // dsh-tui-* host-seam insert list right after load (issue #557), which
+  // left this registration silently skipped and /settings read-only.
+  // channel.ts reads through the same fallback, so both sides meet in the
+  // same registry either way.
+  {
+    const settingsSections = getHostSettingsSections(
+      ctx.get('tuiSettingsSections') as TuiSettingsSectionsRuntime | undefined,
+    ) ?? getLocalSettingsSectionsHost()
     const unregister = settingsSections.register({
       ns: 'dsh-tui',
       title: 'dsh-tui',

--- a/src/dsh-adapter/settings-sections.ts
+++ b/src/dsh-adapter/settings-sections.ts
@@ -199,8 +199,8 @@ function settingsSectionStateFor(runtime: TuiSettingsSectionsRuntime): SettingsS
   return state
 }
 
-function registerSection(runtime: TuiSettingsSectionsRuntime, section: TuiSettingsSection, owner?: object): () => void {
-  const state = settingsSectionStateFor(runtime)
+function registerSection(runtime: TuiSettingsSectionsRuntime | SettingsSectionState, section: TuiSettingsSection, owner?: object): () => void {
+  const state = isSectionState(runtime) ? runtime : settingsSectionStateFor(runtime)
   const ns = section.ns.trim()
   if (!/^[a-z][a-z0-9_-]*$/u.test(ns)) throw new TypeError(`invalid TUI settings-section namespace: ${section.ns}`)
   if (state.sections.has(ns)) throw new Error(`TUI settings section "${ns}" is already registered`)
@@ -254,8 +254,8 @@ function registerSection(runtime: TuiSettingsSectionsRuntime, section: TuiSettin
   }
 }
 
-function subscribeSections(runtime: TuiSettingsSectionsRuntime, listener: () => void, owner?: object): () => void {
-  const state = settingsSectionStateFor(runtime)
+function subscribeSections(runtime: TuiSettingsSectionsRuntime | SettingsSectionState, listener: () => void, owner?: object): () => void {
+  const state = isSectionState(runtime) ? runtime : settingsSectionStateFor(runtime)
   const entry = { owner, listener }
   state.listeners.add(entry)
   return () => {
@@ -277,6 +277,42 @@ export function getHostSettingsSections(runtime: TuiSettingsSectionsRuntime | un
   } catch {
     return undefined
   }
+}
+
+function isSectionState(value: object): value is SettingsSectionState {
+  return value instanceof Map === false && 'sections' in value && 'listeners' in value
+}
+
+/**
+ * In-package fallback registry: some real compositions dispose the
+ * `dsh-tui-settings-sections` service row right after it loads (the whole
+ * dsh-tui-* host-seam insert list is affected — see the issue-#183 skew
+ * family), leaving `ctx.get('tuiSettingsSections')` permanently undefined.
+ * The TUI's own section must not depend on that: plugin.ts registers into —
+ * and channel.ts reads from — this local host whenever the composition
+ * service is unavailable. Third-party sections still require the service
+ * row; the local host only carries the TUI's own section.
+ */
+const localSectionsState: SettingsSectionState = {
+  sections: new Map(),
+  owners: new Map(),
+  listeners: new Set(),
+  host: undefined,
+}
+
+export function getLocalSettingsSectionsHost(): TuiSettingsSectionsHost {
+  localSectionsState.host ??= Object.freeze({
+    register(section: TuiSettingsSection) {
+      return registerSection(localSectionsState, section)
+    },
+    list() {
+      return [...localSectionsState.sections.values()]
+    },
+    subscribe(listener: () => void) {
+      return subscribeSections(localSectionsState, listener)
+    },
+  })
+  return localSectionsState.host
 }
 
 export default TuiSettingsSectionsRuntime


### PR DESCRIPTION
关联:#557

## 问题

真实组合(`dsh --profile dsh-tui`)中,整批 dsh-tui-* host seam 插入行加载后随即被 dispose(证据链见 #557:服务构造完成 → fiber DISPOSED → store 条目被清)。`plugin.ts` 的设置区块注册因 `ctx.get('tuiSettingsSections') === undefined` 被静默跳过,`/settings` 自 #238 合并以来在真实运行中从未出现过插件设置区块,只有只读命名空间列表。CI 未覆盖:回归脚本用内存假 host,不经过真实组合。

## 修复(止血)

照 `tuiWorkspaces` 的本地降级先例(issue #183 备注的路径):

- `settings-sections.ts`:新增包内本地注册表 `getLocalSettingsSectionsHost()`;`registerSection` / `subscribeSections` 改为可直接作用于 state,供本地 host 复用同一套校验与通知逻辑;
- `plugin.ts`(注册端)与 `channel.ts`(读取端):组合服务缺席时落到**同一个**本地 host,健在时仍优先——第三方插件区块行为不变。

根因(loader/include 为何 dispose 这批行)不在本 PR 范围,见 #557。

## 验证

- `pnpm verify:build` 全绿(boundary/contract/patch-surface/plugin 系列/i18n);
- `repro-settings.tsx` 通过;
- 真实组合手测:修复后 `/settings` 正常渲染 dsh-tui 可编辑区块(语言/diff 布局/鲸鱼娘等),staged 编辑与保存写回 settings.yaml 均正常。
