### PR TITLE
fix(test): timeline-rail 开场 settle 条件补齐顶部锚定不变量——修 #532 起的 CI 惯性红

### DIFF
--- a/scripts/verify-timeline-rail.tsx
+++ b/scripts/verify-timeline-rail.tsx
@@ -119,7 +119,13 @@ const inst = await render(
 )
 await settle(() => {
   const snap = railSnapshot()
-  return snap.ticks.length === 8 && snap.activeRow !== null && snap.upRow !== null && snap.downRow !== null
+  if (snap.ticks.length !== 8 || snap.activeRow === null || snap.upRow === null || snap.downRow === null) return false
+  // 断言同条件：初始 sticky 滚动到底与 rail active 重算之间存在竞争，
+  // 只等「tick 出现」在快 runner 上会断到 active 尚未对齐的帧（块 1 的
+  // 顶部锚定断言随机红）。settle 必须包含块 1 断言的同一不变量——active
+  // 与视口顶行的轮次归属一致；真回归时此条件永不成立，超时后断言照常红。
+  const owner = topOwningTurn()
+  return owner !== null && snap.ticks.indexOf(snap.activeRow) === owner - 1
 })
 
 function screenLines(): string[] {


### PR DESCRIPTION
## 现象

#532 合并后，所有非文档 PR 的 `render-scroll` 组稳定红在 `verify-timeline-rail`（1/26）：

```
FAIL: active = 视口顶行所属轮次（顶部锚定，非最新轮）  (active#1 vs 顶行属于问题 5)
```

#558、#560 均为此挂；main 自身显绿是因为最近几次 push 是纯文档改动，分流跳过了该组。干净 main（8b58a4a）本地 3 连必挂，非 flaky。

## 根因（已二分定位）

`0e0078e`（#532）把该脚本开场的 `sleep(700)` 换成 settle 时，条件弱于随后的断言：只等「8 个 tick + 三个行号非空」，没等 rail active 与初始 sticky 滚到底后的视口顶行轮次对齐。两者之间存在竞争，快 runner 上 settle 提前返回，断到未同步的帧。`0e0078e~1` 绿、`0e0078e` 红。

## 修法

即 #532 自己声明的原则「settle(断言同条件) 后再断言」：把块 1 的顶部锚定不变量（`ticks.indexOf(activeRow) === topOwningTurn() - 1`）并进开场 settle。真回归时该条件永不成立，超时后断言照常红，不损失检测力。

## 验证

修后本地 3 连全绿（修前同机 3 连红）。仅测试脚本改动，无产品代码变化。合并后 #558 / #560 重跑 CI 即可转绿。