### PR TITLE
test: 等待原语重写 settled——统一等待与断言条件，迁移全部 CI 回归脚本

### DIFF
--- a/scripts/lib/term-test.mjs
+++ b/scripts/lib/term-test.mjs
@@ -5,9 +5,14 @@
  * stdin 解析 → React 状态 → 节流渲染 → xterm 异步解析。它没有固定上界，
  * 所以「固定 sleep 后断言」在慢 runner 上会断言到旧屏幕。
  *
- * - settle(pred)      取代「sleep 后断言」：轮询到预期状态出现再让调用方
- *                     断言。超时不抛错——紧随其后的断言用同一条件失败，
- *                     并打印脚本自己的诊断；真回归仍然会红。
+ * - settled(pred)     取代「sleep 后断言」与「settle 后断言」：轮询到谓词
+ *                     为真（或超时）后返回谓词终值，调用方把返回值直接交给
+ *                     自己的 check/assert——等待条件与断言条件是同一个表达式，
+ *                     「settle 等到 A、断言却要 B」这类分叉（#561）在写法上
+ *                     不可能出现。
+ * - settle(pred)      仅用于「等到某状态再继续操作」且后面没有紧随断言的
+ *                     场景（如等界面就绪再发按键）。等待后要断言的一律用
+ *                     settled。超时静默返回。
  * - writeParsed(term) 取代「write + sleep」：xterm 的 write 异步分块解析，
  *                     buffer 只在回调触发后才反映写入（官方文档语义）。
  * - viewportLines()   取代「getLine(0..ROWS) 直扫」：inline 模式有
@@ -23,19 +28,35 @@
 /** @param {number} ms */
 export const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
 
+// CI 共享 runner 有负载抖动，条件成立即返回，加大上限只影响真失败的耗时。
+const DEFAULT_TIMEOUT_MS = process.env.CI ? 8000 : 4000
+
 /**
- * 轮询到 pred() 为真（30ms 间隔，默认上限 4s）。超时静默返回，由调用方
- * 紧随其后的断言以同一条件失败。
+ * 轮询到 pred() 为真（30ms 间隔，默认上限本地 4s / CI 8s）。超时静默返回。
+ * 只用于「等到某状态再继续操作」；等待后要断言的用 settled。
  * @param {() => boolean} pred
  * @param {{ timeoutMs?: number, stepMs?: number }} [opts]
  */
 export async function settle(pred, opts = {}) {
   const stepMs = opts.stepMs ?? 30
-  const deadline = Date.now() + (opts.timeoutMs ?? 4000)
+  const deadline = Date.now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
   while (Date.now() < deadline) {
     if (pred()) return
     await sleep(stepMs)
   }
+}
+
+/**
+ * 轮询到 pred() 为真后返回其终值（超时返回最后一次求值结果）。
+ * 用法：`check('label', await settled(() => cond))`——等待与断言共用
+ * 同一个谓词，条件只写一遍。
+ * @param {() => boolean} pred
+ * @param {{ timeoutMs?: number, stepMs?: number }} [opts]
+ * @returns {Promise<boolean>}
+ */
+export async function settled(pred, opts = {}) {
+  await settle(pred, opts)
+  return Boolean(pred())
 }
 
 /**

--- a/scripts/repro-askpanel.tsx
+++ b/scripts/repro-askpanel.tsx
@@ -8,7 +8,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }, { settle, viewportLines }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }, { settle, settled, sleep, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -34,7 +34,6 @@ class FakeStdin extends PassThrough {
 }
 const stdout = new FakeStdout()
 const stdin = new FakeStdin()
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 /** The real terminal screen, line by line. */
 function screen(): string {
   return viewportLines(term, ROWS).join('\n')
@@ -59,7 +58,6 @@ const app = await render(
   }),
   { stdout, stdin, stderr: new FakeStdout(), debug: true, exitOnCtrlC: false },
 )
-await settle(() => screen().includes('自定义回答') && screen().includes('输入文字附带回答'))
 
 let failures = 0
 const results: string[] = []
@@ -69,24 +67,22 @@ const check = (name: string, ok: boolean) => {
 }
 
 // 1. Initial render: the input row is visible INSIDE the option list.
-const s1 = screen()
-check('选项列表里直接可见「自定义回答」输入行', s1.includes('自定义回答'))
-check('提示行说明可直接输入', s1.includes('输入文字附带回答'))
+check('选项列表里直接可见「自定义回答」输入行', await settled(() => screen().includes('自定义回答')))
+check('提示行说明可直接输入', await settled(() => screen().includes('输入文字附带回答')))
 
 // 2. Type on the focused "我有" option: text lands in the input row, the
 //    option list stays (no jump), and the label is attached.
 stdin.write('sk-test123')
-await settle(() => screen().includes('sk-test123') && screen().includes('（附加：我有）'))
-const s2 = screen()
-check('输入内容出现在输入行', s2.includes('sk-test123'))
-check('视图不跳转（选项列表仍在）', s2.includes('我没有'))
-check('输入行标注附加标签「我有」', s2.includes('（附加：我有）'))
+check('输入内容出现在输入行', await settled(() => screen().includes('sk-test123')))
+check('视图不跳转（选项列表仍在）', await settled(() => screen().includes('我没有')))
+check('输入行标注附加标签「我有」', await settled(() => screen().includes('（附加：我有）')))
 
 // 3. Enter right there → the answer carries BOTH the label and the text.
 stdin.write('\r')
-await settle(() => answer !== undefined)
-const a1 = answer as { selected?: string[]; custom?: string } | undefined
-check('提交同时携带 selected + custom', a1?.selected?.join() === '我有' && a1?.custom === 'sk-test123')
+check('提交同时携带 selected + custom', await settled(() => {
+  const a1 = answer as { selected?: string[]; custom?: string } | undefined
+  return a1?.selected?.join() === '我有' && a1?.custom === 'sk-test123'
+}))
 
 // 4. Pure custom: focus the input row itself (↓↓) and type → no label.
 answer = undefined
@@ -100,15 +96,15 @@ app.rerender(
 await settle(() => screen().includes('还有别的要说吗？'))
 stdin.write('[B') // ↓
 stdin.write('[B') // ↓ → input row
+// 焦点移动无可观测的纯文本条件（高亮为颜色，已被裁剪），保留固定 pacing。
 await sleep(200)
 stdin.write('随便说说')
-await settle(() => screen().includes('随便说说'))
-const s4 = screen()
-check('输入行内联编辑（视图仍不跳转）', s4.includes('随便说说') && s4.includes('没有'))
+check('输入行内联编辑（视图仍不跳转）', await settled(() => screen().includes('随便说说') && screen().includes('没有')))
 stdin.write('\r')
-await settle(() => answer !== undefined)
-const a2 = answer as { selected?: string[]; custom?: string } | undefined
-check('输入行直接提交为纯自定义（无标签）', a2?.selected?.length === 0 && a2?.custom === '随便说说')
+check('输入行直接提交为纯自定义（无标签）', await settled(() => {
+  const a2 = answer as { selected?: string[]; custom?: string } | undefined
+  return a2?.selected?.length === 0 && a2?.custom === '随便说说'
+}))
 
 // 5. Multi-select: Space checks an option, typing appends, Enter on the
 //    option row carries checked labels + text.
@@ -126,15 +122,18 @@ app.rerender(
 )
 await settle(() => screen().includes('要哪些口味？'))
 stdin.write(' ') // check 甜
+// 勾选状态无可观测的纯文本条件（勾选标记依赖样式渲染），保留固定 pacing。
 await sleep(150)
 stdin.write('少放糖')
 await settle(() => screen().includes('少放糖'))
 stdin.write('\r')
-await settle(() => answer !== undefined)
-const a3 = answer as { selected?: string[]; custom?: string } | undefined
-check('多选：勾选 + 文本一起提交', a3?.selected?.join() === '甜' && a3?.custom === '少放糖')
+check('多选：勾选 + 文本一起提交', await settled(() => {
+  const a3 = answer as { selected?: string[]; custom?: string } | undefined
+  return a3?.selected?.join() === '甜' && a3?.custom === '少放糖'
+}))
 
 app.unmount()
+// unmount 后输出 flush 无可观测条件，保留固定 pacing。
 await sleep(100)
 console.log(results.join('\n'))
 console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURES`)

--- a/scripts/repro-clipboard.tsx
+++ b/scripts/repro-clipboard.tsx
@@ -70,10 +70,10 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
-// sleep 在慢 runner 上会断言到旧屏幕。alt-screen 下 baseY 恒 0，视口读取
-// 与旧的 getLine(0..ROWS) 直扫等价。
-const { sleep, settle } = termTest
+// 等待/读屏走公共辅助（issue #532）：settled 轮询到谓词为真后返回终值，
+// 等待与断言共用同一条件——固定 sleep 在慢 runner 上会断言到旧屏幕。
+// alt-screen 下 baseY 恒 0，视口读取与旧的 getLine(0..ROWS) 直扫等价。
+const { sleep, settled } = termTest
 const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 
 const listeners = new Set<() => void>()
@@ -114,6 +114,7 @@ const instance = await render(
   </AlternateScreen>,
   { stdout: new FakeStdout(), stdin: stdinObj, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
 await sleep(600)
 
 let failed = 0
@@ -125,20 +126,16 @@ const check = (name: string, ok: boolean, extra = '') => {
 try {
   // 1. '?' opens the help overlay; Ctrl+V must close it up front.
   stdinObj.write('?')
-  await settle(() => screenHas('? for this help'))
-  check('? opens the help overlay', screenHas('? for this help'))
+  check('? opens the help overlay', await settled(() => screenHas('? for this help')))
   stdinObj.write('\x16')
-  await settle(() => !screenHas('? for this help'))
-  check('Ctrl+V closes the help overlay before the read resolves', !screenHas('? for this help'))
+  check('Ctrl+V closes the help overlay before the read resolves', await settled(() => !screenHas('? for this help')))
 
   // 2. The stub clipboard text lands in the prompt.
-  await settle(() => screenHas('UI粘贴内容'))
-  check('clipboard text lands in the prompt', screenHas('UI粘贴内容'))
+  check('clipboard text lands in the prompt', await settled(() => screenHas('UI粘贴内容')))
 
   // 3. Busy latch released: a second Ctrl+V pastes again (doubled text).
   stdinObj.write('\x16')
-  await settle(() => screenHas('UI粘贴内容UI粘贴内容'))
-  check('second Ctrl+V pastes again (busy latch released)', screenHas('UI粘贴内容UI粘贴内容'))
+  check('second Ctrl+V pastes again (busy latch released)', await settled(() => screenHas('UI粘贴内容UI粘贴内容')))
 } finally {
   await instance.unmount()
   rmSync(stubDir, { recursive: true, force: true })

--- a/scripts/repro-collapse-shrink.tsx
+++ b/scripts/repro-collapse-shrink.tsx
@@ -21,7 +21,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }, { sleep, settle }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }, { sleep, settled }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -110,15 +110,17 @@ async function run(): Promise<void> {
     exitOnCtrlC: false,
     patchConsole: false,
   })
-  await settle(() => live.screen().length >= ROWS - 1)
-  check('the expanded frame is taller than the viewport', live.screen().length >= ROWS - 1,
+  check('the expanded frame is taller than the viewport', await settled(() => live.screen().length >= ROWS - 1),
     `${live.screen().length} rows visible of ${ROWS}`)
 
   const mark = live.writes.length
   setOpen?.(false)
-  await settle(() =>
-    !live.screen().some(line => line.includes('body line'))
-    && live.screen().filter(line => line.includes('panel header')).length === 1)
+  check('the collapsed screen has no leftover body lines',
+    await settled(() => !live.screen().some(line => line.includes('body line'))),
+    live.screen().filter(line => line.includes('body line')).length + ' leftover')
+  check('the header appears exactly once',
+    await settled(() => live.screen().filter(line => line.includes('panel header')).length === 1),
+    `${live.screen().filter(line => line.includes('panel header')).length} copies`)
   if (process.env.DBG_SHRINK === '1') {
     live.writes.slice(mark).forEach((w, i) => {
       console.log(`[w${i}] ${JSON.stringify(w.slice(0, 160))}`)
@@ -127,6 +129,7 @@ async function run(): Promise<void> {
   const collapsed = live.screen()
   liveInstance.unmount()
   live.term.dispose()
+  // 卸载/dispose 的收尾 pacing：无可观测完成条件，保留固定小窗口。
   await sleep(40)
 
   // ── the same short state, built fresh ────────────────────────────────────
@@ -138,20 +141,14 @@ async function run(): Promise<void> {
     exitOnCtrlC: false,
     patchConsole: false,
   })
-  await settle(() => cold.screen().join('\n') === collapsed.join('\n'))
+  const matches = await settled(() => cold.screen().join('\n') === collapsed.join('\n'))
   const fresh = cold.screen()
   coldInstance.unmount()
   cold.term.dispose()
 
-  check('the collapsed screen has no leftover body lines',
-    !collapsed.some(line => line.includes('body line')),
-    collapsed.filter(line => line.includes('body line')).length + ' leftover')
-  check('the header appears exactly once',
-    collapsed.filter(line => line.includes('panel header')).length === 1,
-    `${collapsed.filter(line => line.includes('panel header')).length} copies`)
   check('the collapsed screen matches a fresh render',
-    collapsed.join('\n') === fresh.join('\n'),
-    collapsed.join('\n') === fresh.join('\n')
+    matches,
+    matches
       ? ''
       : `after=${JSON.stringify(collapsed.slice(0, 4))} fresh=${JSON.stringify(fresh.slice(0, 4))}`)
 }

--- a/scripts/repro-ctrlc.tsx
+++ b/scripts/repro-ctrlc.tsx
@@ -42,7 +42,7 @@ class FakeStdin extends PassThrough {
 // 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
 // sleep 在慢 runner 上会断言到旧屏幕。alt-screen 下 baseY 恒 0，视口读取
 // 与旧的 getLine(0..ROWS) 直扫等价。
-const { sleep, settle } = termTest
+const { settle, settled } = termTest
 const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 
 const listeners = new Set<() => void>()
@@ -84,7 +84,7 @@ const instance = await render(
   </AlternateScreen>,
   { stdout: new FakeStdout(), stdin: stdinObj, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(600)
+await settle(() => termTest.viewportLines(term).some(l => l.trim().length > 0))
 
 let failed = 0
 const check = (name: string, ok: boolean, extra = '') => {
@@ -94,24 +94,20 @@ const check = (name: string, ok: boolean, extra = '') => {
 
 // 1. type text, ctrl+c → cleared, no exit, no exit-arm notification
 stdinObj.write('hello world')
-await settle(() => screenHas('hello world'))
-check('typed text visible in prompt', screenHas('hello world'))
+check('typed text visible in prompt', await settled(() => screenHas('hello world')))
 stdinObj.write('\x03')
-await settle(() => !screenHas('hello world'))
-check('ctrl+c clears non-empty input', !screenHas('hello world'))
+check('ctrl+c clears non-empty input', await settled(() => !screenHas('hello world')))
 check('ctrl+c with text does not exit', !exited)
 check('ctrl+c with text does not arm exit', !screenHas('Press Ctrl+C again'), JSON.stringify(channel.notifications))
 
 // 2. ctrl+c on empty input → arms exit
 stdinObj.write('\x03')
-await settle(() => screenHas('Press Ctrl+C again') || channel.notifications.length > 0)
-check('ctrl+c on empty input arms exit', screenHas('Press Ctrl+C again') || channel.notifications.length > 0, JSON.stringify(channel.notifications))
+check('ctrl+c on empty input arms exit', await settled(() => screenHas('Press Ctrl+C again') || channel.notifications.length > 0), JSON.stringify(channel.notifications))
 check('first press does not exit', !exited)
 
 // 3. second press exits
 stdinObj.write('\x03')
-await settle(() => exited)
-check('second ctrl+c exits', exited)
+check('second ctrl+c exits', await settled(() => exited))
 
 await instance.unmount()
 process.exit(failed)

--- a/scripts/repro-diff-split.tsx
+++ b/scripts/repro-diff-split.tsx
@@ -16,7 +16,7 @@ process.env.FORCE_COLOR = '3'
 // module import resolves the startup lang (env > persisted > locale).
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }, { getCliHighlightPromise }, { parseAnsiRuns, chalkFromToken, highlightLines }] = await Promise.all([
+const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }, { getCliHighlightPromise }, { parseAnsiRuns, chalkFromToken, highlightLines }, { sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -24,9 +24,9 @@ const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseM
   import('../src/components/messages/AssistantToolUseMessage.js'),
   import('../src/cc/cliHighlight.js'),
   import('../src/components/SplitDiffView.js'),
+  import('./lib/term-test.mjs'),
 ])
 
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failures = 0
 const check = (name: string, ok: boolean, extra = '') => {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${ok || extra === '' ? '' : `  (${extra})`}`)
@@ -66,7 +66,8 @@ async function renderAt(cols, tool, diffLayout = 'auto', toolBackground = 'none'
     { stdout: new FakeStdout(), debug: true, exitOnCtrlC: false },
   )
   // cli-highlight loads lazily on first use; give it room to land so the
-  // syntax-color assertions see the settled frame.
+  // syntax-color assertions see the settled frame.（懒加载后的补色重绘无
+  // 调用方无关的可观测条件，保留固定窗口。）
   await sleep(900)
   const buf = term.buffer.active
   const lines = []

--- a/scripts/repro-drag-select-streaming.tsx
+++ b/scripts/repro-drag-select-streaming.tsx
@@ -37,10 +37,10 @@ const { default: instances } = await import('../src/ink/instances.js')
 const { stringWidth } = await import('../src/ink/stringWidth.js')
 
 const COLS = 100, ROWS = 40
-// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
-// sleep 在慢 runner 上会断言到旧屏幕。alt-screen 下 baseY 恒 0，视口读取
-// 与直扫等价。
-const { sleep, settle } = termTest
+// 等待/读屏走公共辅助（issue #532）：settled 轮询到谓词为真后返回终值，
+// 等待与断言共用同一条件——固定 sleep 在慢 runner 上会断言到旧屏幕。
+// alt-screen 下 baseY 恒 0，视口读取与直扫等价。
+const { sleep, settled } = termTest
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -111,6 +111,8 @@ const inst = await render(tree, {
 instances.set(process.stdout, instances.get(stdout)!)
 inst.rerender(tree)
 
+// 首帧挂载 pacing：等 React 树完成首次渲染与鼠标/选取 hook 挂接，
+// 无单一可观测条件。
 await sleep(900)
 
 function screenLines(): string[] {
@@ -145,10 +147,8 @@ writes.length = 0
 await dragOver(TMARK, 2, 10)
 {
   const expect = TMARK.slice(2, 10 + 1)
-  await settle(() => osc52Payloads().includes(expect))
-  const payloads = osc52Payloads()
-  check('静息拖选 → OSC 52 携带完整选中文本', payloads.includes(expect),
-    `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
+  check('静息拖选 → OSC 52 携带完整选中文本', await settled(() => osc52Payloads().includes(expect)),
+    `payloads=${JSON.stringify(osc52Payloads())} expect="${expect}"`)
 }
 
 // ── 回归组：上滚阅读到中部历史 + 尾部流式并发 ──
@@ -180,6 +180,8 @@ const streamLoop = (async () => {
   }
 })()
 
+// 真实墙钟语义：拖选必须落在 2.6s 流式窗口的中段——streamed>0 一到就返回
+// 的轮询表达不了"流式进行中"这个并发时点，保留固定等待。
 await sleep(400)  // 流式已在跑
 try {
   await dragOver(HMARK, 3, 11)
@@ -188,26 +190,24 @@ try {
 }
 await streamLoop
 streamRow.streaming = undefined
+// 流式收尾后的重绘 pacing：无单一可观测条件（下面的 settled 只等 OSC 52）。
 await sleep(400)
 
 {
   const expect = HMARK.slice(3, 11 + 1)
-  await settle(() => osc52Payloads().includes(expect))
-  const payloads = osc52Payloads()
-  check('流式并发时拖选 → OSC 52 携带完整选中文本', payloads.includes(expect),
-    `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
+  check('流式并发时拖选 → OSC 52 携带完整选中文本', await settled(() => osc52Payloads().includes(expect)),
+    `payloads=${JSON.stringify(osc52Payloads())} expect="${expect}"`)
 }
 
 // ── 附加：流式结束后（静息）再拖一次，看是否恢复 ──
 writes.length = 0
+// 静息 pacing：给上一次选区/复制状态一个收尾窗口，无单一可观测条件。
 await sleep(200)
 try {
   await dragOver(HMARK, 3, 11)
   const expect = HMARK.slice(3, 11 + 1)
-  await settle(() => osc52Payloads().includes(expect))
-  const payloads = osc52Payloads()
-  check('流式结束后拖选 → 恢复完整', payloads.includes(expect),
-    `payloads=${JSON.stringify(payloads)} expect="${expect}"`)
+  check('流式结束后拖选 → 恢复完整', await settled(() => osc52Payloads().includes(expect)),
+    `payloads=${JSON.stringify(osc52Payloads())} expect="${expect}"`)
 } catch (e) {
   check('流式结束后标记行仍可见', false, String(e))
 }

--- a/scripts/repro-effort.tsx
+++ b/scripts/repro-effort.tsx
@@ -22,14 +22,13 @@
 import { Context } from '@deepseek-ai/cordis'
 import { LlmRuntime } from '@deepseek-ai/dsh-llm'
 import { createChannel } from '../src/dsh-adapter/channel.js'
+import { settle, sleep } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
-
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 const root = new Context()
 const llm = new LlmRuntime(root)
@@ -85,8 +84,10 @@ const channel = createChannel(root as never, agent, {
 })
 check('startup status line seeds the configured effort', channel.reasoningEffort === 'high', channel.reasoningEffort)
 
-// applyPreferredEffort is async (route metadata resolution) — let it settle.
-await sleep(50)
+// applyPreferredEffort is async (route metadata resolution) — let it settle:
+// it writes state.effortLevels and installs selection.current in the same
+// synchronous continuation, so effortLevels appearing implies the install ran.
+await settle(() => channel.effortLevels !== undefined)
 
 // ── dsh-agent-loop buildRequest simulation (fresh session, first request) ──
 // 1. prompt assembly: installModelSelection snapshots selection.current here.
@@ -144,6 +145,8 @@ createChannel(root2 as never, agent2, {
   provider: 'deepseek-official',
   activity: false,
 })
+// 稳定性探针（状态不得改变）：断言的是「无配置 effort 时不安装选择」，
+// 无可轮询的完成条件（no-op 路径不留痕）——保留固定窗口让错误安装显形。
 await sleep(50)
 const seed2 = { provider: 'deepseek-official', model: 'deepseek-v4-flash' }
 const proposed2 = (await (agentCtx2 as Context).waterfall(

--- a/scripts/repro-external-editor.tsx
+++ b/scripts/repro-external-editor.tsx
@@ -66,10 +66,10 @@ class FakeStdin extends PassThrough {
   unref() { return this }
 }
 const stdinObj = new FakeStdin()
-// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——固定
-// sleep 在慢 runner 上会断言到旧屏幕；inline 模式有 scrollback 时视口从
-// baseY 起，getLine(0..ROWS) 直扫会混入已滚出的行。
-const { sleep, settle, writeParsed } = termTest
+// 等待/读屏走公共辅助（issue #532）：异步状态断言用 settled——等待与断言
+// 共用同一谓词；固定 sleep 在慢 runner 上会断言到旧屏幕；inline 模式有
+// scrollback 时视口从 baseY 起，getLine(0..ROWS) 直扫会混入已滚出的行。
+const { sleep, settled, writeParsed } = termTest
 const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 
 const listeners = new Set<() => void>()
@@ -122,6 +122,7 @@ const instance = await render(
   <Chat channel={channel} questionStore={new QuestionStore()} onExit={() => {}} />,
   { stdout: new FakeStdout(), stdin: stdinObj, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
+// 启动固定窗保留：FakeStdout 丢弃全部帧，无可轮询观察点（后续断言各有兜底）。
 await sleep(600)
 
 let failed = 0
@@ -134,31 +135,27 @@ const check = (name: string, ok: boolean, extra = '') => {
 // 输入框打上草稿。
 channel.rows.push({ id: rowId++, kind: 'user', text: 'transcript-anchor-历史消息' })
 bump()
-await settle(() => screenHas('transcript-anchor'))
-check('预备: transcript 历史消息可见', screenHas('transcript-anchor'))
+check('预备: transcript 历史消息可见', await settled(() => screenHas('transcript-anchor')))
 
 stdinObj.write('什么是cordis')
-await settle(() => screenHas('什么是cordis'))
-check('预备: 草稿已入输入框', screenHas('什么是cordis'))
+check('预备: 草稿已入输入框', await settled(() => screenHas('什么是cordis')))
 
 // Ctrl+G → 假编辑器（600ms 后写盘退出）
 stdinObj.write('\x07')
+// sleep 保留：编辑器会话期间界面无变化（终端已交接），注入必须落在
+// 600ms 会话窗口内——真实墙钟 pacing，无可轮询的完成条件。
 await sleep(250)
 // 交接会话期间的残留字节：若无 drain/抑制，恢复后双击 Esc = 清输入 +
 // 空输入再 Esc = 打开 rewind 选择器。
 stdinObj.write('\x1b\x1b')
+// sleep 保留：同上，会话窗口内的 pacing，无可观测条件。
 await sleep(100)
 // 模拟 nvim 的 rmcup：终端被弹回主屏，随后我们的 2J 将落在主屏上。
 // write 回调在 xterm 解析完毕后触发，保证与后续 2J 的先后顺序。
 await writeParsed(term, '\x1b[?1049l')
 
 // 等回填完成（编辑器 600ms 写盘 + 往返）
-let roundTripped = false
-for (let i = 0; i < 100; i++) {
-  await sleep(50)
-  if (screenHas('什么是cordis EDITED')) { roundTripped = true; break }
-}
-check('往返: 编辑结果回填输入框', roundTripped)
+check('往返: 编辑结果回填输入框', await settled(() => screenHas('什么是cordis EDITED'), { timeoutMs: 5000 }))
 // 让晚到乱码（FakeStdout 注入）与任何延迟副作用落定。
 // 稳定性探针（不得改变）：下面的 bug1-3 断言的是"东西仍在/没被触发"，
 // 对已成立条件轮询会立即返回等于没测——保留固定窗口。
@@ -171,8 +168,7 @@ check('bug3: 终端应答残片未落入界面', !screenHas('48;93') && !screenH
 
 // 活性：抑制窗口已过的正常输入必须可用
 stdinObj.write('X')
-await settle(() => screenHas('什么是cordis EDITEDX'))
-check('活性: 抑制窗口结束后输入正常', screenHas('什么是cordis EDITEDX'))
+check('活性: 抑制窗口结束后输入正常', await settled(() => screenHas('什么是cordis EDITEDX')))
 
 if (savedEditor === undefined) delete process.env.EDITOR
 else process.env.EDITOR = savedEditor

--- a/scripts/repro-idle-oscillation.tsx
+++ b/scripts/repro-idle-oscillation.tsx
@@ -21,7 +21,7 @@ const TRACE_PATH = join(tmpdir(), 'dsh-geometry-trace.jsonl')
 rmSync(TRACE_PATH, { force: true })
 process.env.DSH_TUI_GEOMETRY_TRACE = TRACE_PATH
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }, { sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -29,11 +29,11 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/ink/instances.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 108
 const ROWS = 34
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
@@ -116,6 +116,8 @@ await render(
 const ink: any = instances.get(stdout)
 if (!ink) { console.log('FAIL 未找到 Ink 实例'); process.exit(1) }
 ink.setAltScreenActive(true, true)
+// 基线必须取自不再重绘的稳态帧：「内容非空」不等于「已定格」，无可轮询的
+// 完成条件——保留固定稳定窗。
 await sleep(1500)
 await lastFlushed
 
@@ -127,6 +129,7 @@ check('落定后画面非空', baseline.trim().length > 200, 'bytes=' + baseline
 const baselineTraceLines = readFileSync(TRACE_PATH, 'utf8').trim().split('\n').length
 let screenDriftFrames = 0
 const seenScreens = new Set<string>()
+// 30ms 间隔本身是被测驱动源（#433 的均匀 30ms 帧源），墙钟语义保留。
 for (let i = 0; i < 100; i++) {
   bump()
   await sleep(30)
@@ -135,6 +138,7 @@ for (let i = 0; i < 100; i++) {
   seenScreens.add(shot)
   if (shot !== baseline) screenDriftFrames++
 }
+// 风暴收尾稳定窗：断言「画面回到基线且不再漂移」是稳定性探针，保留固定窗口。
 await sleep(200)
 await lastFlushed
 

--- a/scripts/repro-inline-scrollback.tsx
+++ b/scripts/repro-inline-scrollback.tsx
@@ -17,13 +17,14 @@ process.env.TERM_PROGRAM = 'WezTerm'  // DEC-2026 同步输出路径（与真机
 process.env.DSH_TUI_THEME = 'dark'    // 跳过 OSC 11 探测，保持确定性
 process.env.DSH_TUI_LANG = 'zh'       // 固定中文 UI（splash 标语断言）
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
@@ -75,7 +76,9 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+// 本脚本的全部 sleep 都是模拟流式时间线的固定节奏（chunk 节拍、tick 窗口、
+// 收尾稳定窗）：断言是「scrollback 恰好一份拷贝 / 不得重复」的稳定性探针，
+// 换成对已成立条件的轮询会立即返回、错过晚到的污染帧——保留墙钟语义。
 
 /** 整个 buffer（scrollback + 视口）逐行取纯文本。 */
 function fullBufferLines(): string[] {

--- a/scripts/repro-inline-thirdparty.tsx
+++ b/scripts/repro-inline-thirdparty.tsx
@@ -17,7 +17,7 @@ process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'WezTerm'
 process.env.DSH_TUI_THEME = 'dark'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep, settle, writeParsed }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep, settle, settled, writeParsed }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -91,6 +91,7 @@ const instance = await render(
 await sleep(3500)
 
 // 流式短回复并定格（保持帧高 < 视口，隔离"第三方输出"变量）。
+// 80ms 为模拟流式的 chunk 节拍（时间线本身是场景），保留固定 pacing。
 const msg = { id: id++, kind: 'assistant', text: '', streaming: true }
 channel.rows.push(msg); bump()
 for (let i = 0; i < 12; i++) {
@@ -100,6 +101,8 @@ for (let i = 0; i < 12; i++) {
 msg.streaming = false
 channel.working = false
 bump()
+// 定格稳定窗：golden 必须取自不再重绘的稳态帧，「内容可见」不等于「不再
+// 重绘」，无可轮询的完成条件——保留固定窗口。
 await sleep(600)
 
 // 对照基准：定格后的干净视口。
@@ -110,6 +113,7 @@ const golden = viewportLines()
 await writeParsed(term, '\r\n[5764] Error: Non-HTTPS URLs are only allowed for localhost\r\n[35540] Usage: npx tsx proxy.ts <https://server-url>\r\n')
 
 // 之后只有轻微 UI 活动（通知/指标 tick 级别的小 diff）——真实空闲场景。
+// 固定窗口是场景语义：断言污染在轻微活动后仍存留（稳定性探针），不可轮询。
 channel.responseChars += 7; bump()
 await sleep(300)
 channel.responseChars += 7; bump()
@@ -127,13 +131,13 @@ const { default: instances } = await import('../src/ink/instances.js')
 const ink: any = instances.get(stdoutObj as any)
 check('前置：取到 ink 实例', !!ink)
 ink?.reassertTerminalModes?.()
-await settle(() => {
-  const lines = viewportLines()
-  return !lines.some(l => l.includes('[5764] Error') || l.includes('[35540] Usage'))
-    && Array.from({ length: 12 }, (_, i) => `概览要点第 ${i + 1} 条`).every(t => lines.some(l => l.includes(t)))
+// 等待与断言共用同一快照 healed：settle 谓词即后续两条 check 的条件，无分叉。
+let healed: string[] = []
+await settled(() => {
+  healed = viewportLines()
+  return !healed.some(l => l.includes('[5764] Error') || l.includes('[35540] Usage'))
+    && Array.from({ length: 12 }, (_, i) => `概览要点第 ${i + 1} 条`).every(t => healed.some(l => l.includes(t)))
 })
-
-const healed = viewportLines()
 console.log('=== 自愈后对照（G=干净基准 H=重锚后） ===')
 let diffRows = 0
 for (let y = 0; y < ROWS; y++) {

--- a/scripts/repro-model-switch-scrollback.tsx
+++ b/scripts/repro-model-switch-scrollback.tsx
@@ -28,7 +28,7 @@ const reproHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-repro-home-'))
 process.env.HOME = reproHome
 process.env.USERPROFILE = reproHome
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { createChannel }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { createChannel }, { settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -65,8 +65,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-
 function fullBufferLines(): string[] {
   const buf = term.buffer.active
   const out: string[] = []
@@ -179,18 +177,19 @@ const SPLASH = '探索未至之境'
 const HIST0 = '历史问题 0：检查一下构建配置'
 const HIST1 = '历史回答 1：'
 // boot 落定：轮询到 splash 与历史行都上屏再断言（原固定 1200ms 在慢
-// runner 上会断言到未画完的缓冲区）。
-await settle(() => countMarker(SPLASH) === 1 && countMarker(HIST0) === 1 && countMarker(HIST1) === 1)
-
-console.log(`boot: buffer=${term.buffer.active.length} 行 (视口 ${ROWS})`)
-check('boot 后 splash 恰好一份', countMarker(SPLASH) === 1, `实际 ${countMarker(SPLASH)}`)
-check('boot 后历史行恰好一份', countMarker(HIST0) === 1 && countMarker(HIST1) === 1,
+// runner 上会断言到未画完的缓冲区）——等待与断言共用同一谓词（settled）。
+check('boot 后 splash 恰好一份', await settled(() => countMarker(SPLASH) === 1), `实际 ${countMarker(SPLASH)}`)
+check('boot 后历史行恰好一份', await settled(() => countMarker(HIST0) === 1 && countMarker(HIST1) === 1),
   `问题=${countMarker(HIST0)} 回答=${countMarker(HIST1)}`)
+console.log(`boot: buffer=${term.buffer.active.length} 行 (视口 ${ROWS})`)
 
 // ---- 走真实 UI 路径：输入 /model → 回车开 picker → ↓ → 回车切换 ----------------
 // 与真机操作逐键一致：补全面板、picker、notify、fork+replay 全部经过。
 const bufLen = (tag: string) =>
   console.log(`  [${tag}] buffer=${term.buffer.active.length} scrollback=${term.buffer.active.baseY}`)
+// 逐键 40ms 与各步 200/600ms 均为按键序列的 ordering pacing：补全浮层/
+// picker 的 key-ready 状态无法用纯文本屏幕内容观测（同 repro-settings），
+// 保留固定窗口。
 const typeKeys = async (keys: string) => {
   for (const ch of keys) {
     stdin.write(ch)
@@ -212,7 +211,7 @@ stdin.write('\r')            // 确认 → fork + replay
 await sleep(1500)
 bufLen('switched')
 
-check('切换后模型名生效', channel.model === 'deepseek-v4-pro', `实际 ${channel.model}`)
+check('切换后模型名生效', await settled(() => channel.model === 'deepseek-v4-pro'), `实际 ${channel.model}`)
 check('切换后 splash 恰好一份', countMarker(SPLASH) === 1, `实际 ${countMarker(SPLASH)}`)
 check('切换后历史行恰好一份', countMarker(HIST0) === 1 && countMarker(HIST1) === 1,
   `问题=${countMarker(HIST0)} 回答=${countMarker(HIST1)}`)

--- a/scripts/repro-paste-fold.tsx
+++ b/scripts/repro-paste-fold.tsx
@@ -58,12 +58,13 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-// 等待/读屏走公共辅助（issue #532）：settle 轮询到预期状态再断言——
-// 固定 sleep 在慢 runner 上会断言到旧屏幕（旧 300ms 版本挂过 CI，而
-// 后续 submit 断言通过，证明状态早已正确）；真回归仍会红（条件永不
-// 满足则超时后断言照常失败）。alt-screen 下 baseY 恒 0，视口读取与
-// 旧的 getLine(0..ROWS) 直扫等价。
-const { sleep, settle } = termTest
+// 等待/读屏走公共辅助（issue #532）：settled 轮询到谓词为真后返回终值，
+// 等待与断言共用同一条件——固定 sleep 在慢 runner 上会断言到旧屏幕（旧
+// 300ms 版本挂过 CI，而后续 submit 断言通过，证明状态早已正确）；真回归
+// 仍会红（条件永不满足则超时后返回 false，断言照常失败）。settle 只用于
+// 等到某状态再继续操作、后面没有紧随断言的地方。alt-screen 下 baseY 恒
+// 0，视口读取与旧的 getLine(0..ROWS) 直扫等价。
+const { sleep, settle, settled } = termTest
 const screenHas = (s: string): boolean => termTest.screenHas(term, s)
 const findText = (s: string): { col: number; row: number } | null => termTest.findText(term, s)
 
@@ -107,6 +108,7 @@ const instance = await render(
   </AlternateScreen>,
   { stdout: new FakeStdout(), stdin: stdinObj, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
 await sleep(600)
 
 let failed = 0
@@ -134,9 +136,8 @@ const click = (col: number, row: number) => {
 try {
   // 1. A big bracketed paste folds into an atomic block chip.
   stdinObj.write(`\x1b[200~${pasted}\x1b[201~`)
-  await settle(() => screenHas('▸ 12 lines') && screenHas('fold-line-0'))
-  check('big paste folds into block chip', screenHas('▸ 12 lines'), screenHas('▸ 12 lines') ? '' : 'no chip stats on screen')
-  check('chip shows the first-line preview', screenHas('fold-line-0'))
+  check('big paste folds into block chip', await settled(() => screenHas('▸ 12 lines')), screenHas('▸ 12 lines') ? '' : 'no chip stats on screen')
+  check('chip shows the first-line preview', await settled(() => screenHas('fold-line-0')))
   check('block text hides the later lines', !screenHas('FOURTH_MARKER'))
 
   // 2. Hover pops the bordered peek CARD over the chip — the input box
@@ -144,14 +145,12 @@ try {
   //    Clicking a card row expands the block into the editable input.
   let pos = findText('fold-line-0')
   if (pos) hover(pos.col + 1, pos.row + 1)
-  await settle(() => screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
   check('hover pops the peek card with block head',
-    screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
+    await settled(() => screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines')))
   check('peek card caps the tail rows', !screenHas('EIGHTH_MARKER'))
   const cardPos = findText('FOURTH_MARKER')
   if (cardPos) click(cardPos.col + 1, cardPos.row + 1)
-  await settle(() => screenHas('EIGHTH_MARKER'))
-  check('card click expands the block for editing', screenHas('EIGHTH_MARKER'))
+  check('card click expands the block for editing', await settled(() => screenHas('EIGHTH_MARKER')))
   // Stability probe (must NOT change): a settle would return immediately,
   // so give any wrong repaint a fixed window to show up instead.
   hover(1, 1)
@@ -162,20 +161,19 @@ try {
   //    caret to line 0, the window returns to the head and row 0 shows the
   //    prefix); then the chip click expands the block again.
   stdinObj.write('\x1b[A'.repeat(11))
-  await settle(() => findText('▾ 12 lines') !== null)
+  check('expanded input shows the ▾ fold prefix', await settled(() => findText('▾ 12 lines') !== null))
   let prefix = findText('▾ 12 lines')
-  check('expanded input shows the ▾ fold prefix', prefix !== null)
   if (prefix) {
     click(prefix.col + 1, prefix.row + 1)
-    await settle(() => !screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
-    check('▾ prefix folds the input into a block', !screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines'))
+    check('▾ prefix folds the input into a block', await settled(() => !screenHas('FOURTH_MARKER') && screenHas('▸ 12 lines')))
   }
   pos = findText('fold-line-0')
   if (pos) click(pos.col + 1, pos.row + 1)
-  await settle(() => screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
   // The caret was dragged to the block's end when folding, so the expanded
   // input shows the TAIL window (EIGHTH_MARKER) — and no chip.
-  check('chip click expands the block', screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
+  check('chip click expands the block', await settled(() => screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines')))
+  // Stability probe (must NOT change): a settle would return immediately —
+  // keep a fixed window for a wrong repaint to surface.
   hover(1, 1)
   await sleep(300)
   check('chip-expanded stays after the mouse leaves', screenHas('EIGHTH_MARKER'))
@@ -186,8 +184,7 @@ try {
   prefix = findText('▾ 12 lines')
   if (prefix) {
     click(prefix.col + 1, prefix.row + 1)
-    await settle(() => screenHas('▸ 12 lines'))
-    check('▾ prefix folds again', screenHas('▸ 12 lines'))
+    check('▾ prefix folds again', await settled(() => screenHas('▸ 12 lines')))
   }
 
   // 4. Typing NEVER expands the block (CC behavior): the char lands after
@@ -199,55 +196,44 @@ try {
   stdinObj.write('zzctrl')
   await settle(() => screenHas('zzctrl'))
   stdinObj.write('\x7f'.repeat(3))
-  await settle(() => screenHas('zzc') && !screenHas('zzctrl'))
   check('control: batch Backspace deletes 3 chars, block stays',
-    screenHas('zzc') && !screenHas('zzctrl') && screenHas('▸ 12 lines'))
+    await settled(() => screenHas('zzc') && !screenHas('zzctrl') && screenHas('▸ 12 lines')))
   stdinObj.write('\x7f'.repeat(3))
   await settle(() => !screenHas('zzc'))
   stdinObj.write('tail')
-  await settle(() => screenHas('tail'))
-  check('typing keeps the block folded', screenHas('▸ 12 lines') && screenHas('tail'))
+  check('typing keeps the block folded', await settled(() => screenHas('▸ 12 lines') && screenHas('tail')))
   stdinObj.write('\x7f'.repeat(4))
-  await settle(() => !screenHas('tail'))
   check('Backspace removes the typed char, block stays folded',
-    screenHas('▸ 12 lines') && !screenHas('tail'))
+    await settled(() => screenHas('▸ 12 lines') && !screenHas('tail')))
   stdinObj.write('\x1b')
-  await settle(() => screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
-  check('Esc expands the block (does not clear)', screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines'))
+  check('Esc expands the block (does not clear)', await settled(() => screenHas('EIGHTH_MARKER') && !screenHas('▸ 12 lines')))
   // Esc on the EXPANDED big input folds it back into a block — the toggle
   // is lossless; clearing a big draft goes through Backspace/Ctrl+C.
   stdinObj.write('\x1b')
-  await settle(() => screenHas('▸ 12 lines'))
-  check('Esc on expanded big input folds it back', screenHas('▸ 12 lines'))
+  check('Esc on expanded big input folds it back', await settled(() => screenHas('▸ 12 lines')))
   stdinObj.write('\x1b')
-  await settle(() => !screenHas('▸ 12 lines') && screenHas('EIGHTH_MARKER'))
-  check('Esc on the block expands again', !screenHas('▸ 12 lines') && screenHas('EIGHTH_MARKER'))
+  check('Esc on the block expands again', await settled(() => !screenHas('▸ 12 lines') && screenHas('EIGHTH_MARKER')))
   stdinObj.write('\r')
-  await settle(() => submitted !== '')
-  check('Enter submits the full text', submitted === pasted, `got ${submitted.length} chars`)
+  check('Enter submits the full text', await settled(() => submitted === pasted), `got ${submitted.length} chars`)
 
   // 5. Text typed BEFORE the block stays visible and is submitted with it.
   submitted = ''
   stdinObj.write('pre:')
   await settle(() => screenHas('pre:'))
   stdinObj.write(`\x1b[200~${pasted}\x1b[201~`)
-  await settle(() => screenHas('▸ 12 lines') && screenHas('pre:'))
   check('paste after text folds; head text stays visible',
-    screenHas('▸ 12 lines') && screenHas('pre:'))
+    await settled(() => screenHas('▸ 12 lines') && screenHas('pre:')))
   stdinObj.write('\r')
-  await settle(() => submitted !== '')
-  check('submit includes the head text', submitted === 'pre:' + pasted)
+  check('submit includes the head text', await settled(() => submitted === 'pre:' + pasted))
 
   // 6. Backspace at the block's tail deletes the WHOLE block in one key;
   //    Enter on the now-empty prompt submits nothing.
   submitted = 'sentinel'
   stdinObj.write(`\x1b[200~${pasted}\x1b[201~`)
-  await settle(() => screenHas('▸ 12 lines'))
-  check('paste folds again', screenHas('▸ 12 lines'))
+  check('paste folds again', await settled(() => screenHas('▸ 12 lines')))
   stdinObj.write('\x7f')
-  await settle(() => !screenHas('▸ 12 lines') && !screenHas('fold-line-0'))
   check('Backspace deletes the whole block',
-    !screenHas('▸ 12 lines') && !screenHas('fold-line-0'))
+    await settled(() => !screenHas('▸ 12 lines') && !screenHas('fold-line-0')))
   // Negative probe (nothing may be submitted): a settle has no state change
   // to wait for — keep a fixed window for a wrong submit to surface.
   stdinObj.write('\r')
@@ -258,8 +244,7 @@ try {
   stdinObj.write('tiny')
   await settle(() => screenHas('tiny'))
   stdinObj.write('\x1b')
-  await settle(() => !screenHas('tiny'))
-  check('Esc clears a small (non-foldable) input', !screenHas('tiny'))
+  check('Esc clears a small (non-foldable) input', await settled(() => !screenHas('tiny')))
 } finally {
   await instance.unmount()
   rmSync(dataDir, { recursive: true, force: true })

--- a/scripts/repro-picker-windowing.tsx
+++ b/scripts/repro-picker-windowing.tsx
@@ -66,7 +66,7 @@ const [
   { createChannel },
   { listWindow },
   { ListItem },
-  { settle, viewportLines },
+  { settle, settled, sleep, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -101,8 +101,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
-
 // console.error 收集（四/五次审查）：生产默认 patchConsole，React key
 // warning 会被写进错误日志而非终端；这里拦截 console.error 并在结尾做
 // **严格零断言**——只筛 React 警告会静默吞掉其他错误让 CI 误绿（五次审查
@@ -243,12 +241,13 @@ for (const c of winCases) {
     </Box>,
     { stdout: new FakeStdout2(), stdin: new FakeStdin(), stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
   )
-  // 落定：等全部标记行（M0..M4）上屏再取快照断言（原固定 300ms）。
+  // 落定：等全部标记行（M0..M4）上屏（原固定 300ms）——断言在 settle 捕获
+  // 的同一快照 lines2 上求值，无重读分叉。
+  let lines2: string[] = []
   await settle(() => {
-    const ls = viewportLines(term2, ROWS)
-    return ['M0', 'M1', 'M2', 'M3', 'M4'].every(m => ls.some(l => l.includes(m)))
+    lines2 = viewportLines(term2, ROWS)
+    return ['M0', 'M1', 'M2', 'M3', 'M4'].every(m => lines2.some(l => l.includes(m)))
   })
-  const lines2 = viewportLines(term2, ROWS)
   const rowOf2 = (needle: string) => lines2.findIndex(l => l.includes(needle))
   check('契约：顶层字符串换行压平（恰 1 行）',
     rowOf2('M1') === rowOf2('M0') + 2 && (lines2[rowOf2('M0') + 1] ?? '').includes('Foo Bar'),
@@ -324,8 +323,11 @@ const instance = await render(
   <Chat channel={channel as never} questionStore={new QuestionStore()} onExit={() => {}} />,
   { stdout: new FakeStdout(), stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await sleep(1200)
+// boot 落定：转录尾行上屏即可开始逐键交互（原固定 1200ms）。
+await settle(() => screenLines().some(l => l.includes('rewind 消息 29')))
 
+// 逐键 stepMs 与各步 100–400ms 固定窗口为按键序列的 ordering pacing：
+// 浮层 key-ready / 关闭过渡无法用纯文本屏幕内容观测（同 repro-settings）。
 const typeKeys = async (s: string, stepMs = 40) => {
   for (const ch of s) { stdin.write(ch); await sleep(stepMs) }
 }
@@ -336,15 +338,13 @@ const typeKeys = async (s: string, stepMs = 40) => {
   await typeKeys('/model')
   await sleep(200)
   stdin.write('\r')
-  await settle(() => focusLineVisible('Model 00'))
   // 焦点初始落在当前模型 model-00（索引 0）：每项 2 行也必须留在屏内。
-  check('/model 焦点 0 在屏（带描述，每项 2 行）', focusLineVisible('Model 00'))
+  check('/model 焦点 0 在屏（带描述，每项 2 行）', await settled(() => focusLineVisible('Model 00')))
   check('/model 打开缓冲区零增长', term.buffer.active.length === bufBefore,
     `${bufBefore} → ${term.buffer.active.length}`)
   dump('model focus 0')
   for (let i = 0; i < 20; i++) { stdin.write('\x1b[B'); await sleep(25) }
-  await settle(() => focusLineVisible('Model 20'))
-  check('/model ↓×20 焦点 20 在屏', focusLineVisible('Model 20'))
+  check('/model ↓×20 焦点 20 在屏', await settled(() => focusLineVisible('Model 20')))
   dump('model focus 20')
   stdin.write('\x1b')
   await sleep(400)
@@ -354,22 +354,19 @@ const typeKeys = async (s: string, stepMs = 40) => {
 {
   const bufBefore = term.buffer.active.length
   stdin.write('\x12') // ctrl+r
-  await settle(() => focusLineVisible('/model'))
   // 历史新→旧：最新一条是上一阶段真实键入的 '/model'（appendHistory 落盘），
   // 之后才是预置的 histcmd-29…00。焦点 0 = '/model'。
-  check('ctrl+r 焦点 0 在屏（2 行项 + gap）', focusLineVisible('/model'))
+  check('ctrl+r 焦点 0 在屏（2 行项 + gap）', await settled(() => focusLineVisible('/model')))
   check('ctrl+r 打开缓冲区零增长', term.buffer.active.length === bufBefore,
     `${bufBefore} → ${term.buffer.active.length}`)
   dump('history focus 0')
   stdin.write('\x1b[A') // ↑ 从 0 回绕到末项
-  await settle(() => focusLineVisible('histcmd-00'))
-  check('ctrl+r ↑ 回绕末项焦点在屏', focusLineVisible('histcmd-00'))
+  check('ctrl+r ↑ 回绕末项焦点在屏', await settled(() => focusLineVisible('histcmd-00')))
   stdin.write('\x1b[B') // ↓ 回绕回 0
   await sleep(200)
   for (let i = 0; i < 15; i++) { stdin.write('\x1b[B'); await sleep(25) }
-  await settle(() => focusLineVisible('histcmd-15'))
   // 索引 15 = histcmd-15（索引 0 是 '/model'，索引 1 才是 histcmd-29）。
-  check('ctrl+r ↓×15 焦点 15 在屏', focusLineVisible('histcmd-15'))
+  check('ctrl+r ↓×15 焦点 15 在屏', await settled(() => focusLineVisible('histcmd-15')))
   dump('history focus 15')
   stdin.write('\x1b')
   await sleep(400)
@@ -383,12 +380,13 @@ const typeKeys = async (s: string, stepMs = 40) => {
   await typeKeys('/theme')
   await sleep(200)
   stdin.write('\r')
+  // 断言在 settle 捕获的同一快照 lines 上求值，无重读分叉。
+  let lines: string[] = []
   await settle(() => {
-    const ls = screenLines()
-    const row = ls.findIndex(l => l.includes('Foo Bar NL'))
-    return row !== -1 && (ls[row] ?? '').includes('██')
+    lines = screenLines()
+    const row = lines.findIndex(l => l.includes('Foo Bar NL'))
+    return row !== -1 && (lines[row] ?? '').includes('██')
   })
-  const lines = screenLines()
   const nameRow = lines.findIndex(l => l.includes('Foo Bar NL'))
   check('/theme 换行 displayName 单行渲染且色块同行',
     nameRow !== -1 && (lines[nameRow] ?? '').includes('██'),
@@ -403,25 +401,22 @@ const typeKeys = async (s: string, stepMs = 40) => {
 // ------------------------------------------------------------ RewindPicker
 {
   const bufBefore = term.buffer.active.length
-  stdin.write('\x1b') // 双击 Esc（空输入）打开 rewind
+  stdin.write('\x1b') // 双击 Esc（空输入）打开 rewind——双击判定窗口是墙钟语义
   await sleep(100)
   stdin.write('\x1b')
-  await settle(() => focusLineVisible('rewind 消息 29'))
   // 焦点 0 = 最新用户消息；首项带 'last message' 描述（2 行）。
-  check('rewind 焦点 0 在屏（首项 2 行）', focusLineVisible('rewind 消息 29'))
-  check('rewind 首项描述行在屏', screenLines().some(l => l.includes('最近一条消息')))
+  check('rewind 焦点 0 在屏（首项 2 行）', await settled(() => focusLineVisible('rewind 消息 29')))
+  check('rewind 首项描述行在屏', await settled(() => screenLines().some(l => l.includes('最近一条消息'))))
   check('rewind 打开缓冲区零增长', term.buffer.active.length === bufBefore,
     `${bufBefore} → ${term.buffer.active.length}`)
   dump('rewind focus 0')
   stdin.write('\x1b[A') // ↑ 回绕到末项 = 最老一条
-  await settle(() => focusLineVisible('rewind 消息 00'))
-  check('rewind ↑ 回绕末项焦点在屏', focusLineVisible('rewind 消息 00'))
+  check('rewind ↑ 回绕末项焦点在屏', await settled(() => focusLineVisible('rewind 消息 00')))
   stdin.write('\x1b[B') // ↓ 回绕回 0
   await sleep(200)
   for (let i = 0; i < 15; i++) { stdin.write('\x1b[B'); await sleep(25) }
-  await settle(() => focusLineVisible('rewind 消息 14'))
   // 索引 15 = rewind 消息 14（索引 0 是最新的 29）。
-  check('rewind ↓×15 焦点 15 在屏', focusLineVisible('rewind 消息 14'))
+  check('rewind ↓×15 焦点 15 在屏', await settled(() => focusLineVisible('rewind 消息 14')))
   dump('rewind focus 15')
   stdin.write('\x1b')
   await sleep(400)

--- a/scripts/repro-pill.tsx
+++ b/scripts/repro-pill.tsx
@@ -10,7 +10,7 @@ process.env.FORCE_COLOR = '3'
 // module import resolves the startup lang (env > persisted > locale).
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { settle, settled, sleep, screenHas }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -40,7 +40,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 function pillText(): string {
   const buf = term.buffer.active
   for (let y = 0; y < ROWS; y++) {
@@ -116,11 +115,10 @@ check('at bottom: no pill initially', pillText() === '', JSON.stringify(pillText
 
 // scroll well up, then 8 new rows arrive
 wheel('up', 6)
-await sleep(500)
+// 滚离底部的可观测条件：最后一条消息移出视口。
+await settle(() => !screenHas(term, '消息 30:'))
 addRows(8)
-await settle(() => /8 new messages/.test(pillText()))
-const pill0 = pillText()
-check('pill appears with the new-message count', /8 new messages/.test(pill0), pill0)
+check('pill appears with the new-message count', await settled(() => /8 new messages/.test(pillText())), pillText())
 
 // wheel down in small steps: the count must DECREASE monotonically.
 // The per-step sleeps stay fixed: this loop SAMPLES the pill after each step
@@ -140,7 +138,7 @@ for (let step = 0; step < 12; step++) {
 }
 check('count decrements while scrolling down (not pinned at max)', seen.some(v => v !== 'gone' && v !== '8') , seen.join(' → '))
 check('count never increases while scrolling down', monotonic, seen.join(' → '))
-check('pill gone at the bottom', pillText() === '', JSON.stringify(pillText()))
+check('pill gone at the bottom', await settled(() => pillText() === ''), JSON.stringify(pillText()))
 
 await instance.unmount()
 process.exit(failed)

--- a/scripts/repro-resize-blank.tsx
+++ b/scripts/repro-resize-blank.tsx
@@ -9,7 +9,7 @@ process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'Orca'
 process.env.DSH_TUI_THEME = 'dark'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }, { settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -22,7 +22,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
 
 let COLS = 232
 const ROWS = 71
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
@@ -110,11 +109,12 @@ await render(
 const ink: any = instances.get(stdout)
 if (!ink) { console.log('FAIL 未找到 Ink 实例'); process.exit(1) }
 ink.setAltScreenActive(true, true)
-// boot 是唯一的 false→true 等待（消息区从空到有内容）；后面全部 resize
-// 断言是「不得空白」稳定性探针，保留固定窗口。
-await settle(() => density() >= 3)
+// boot 是唯一的 false→true 等待（消息区从空到有内容）——settled 终值直接
+// 交给断言；后面全部 resize 断言是「不得空白」稳定性探针，保留固定窗口。
+const booted = await settled(() => density() >= 3)
 check('alt-screen 已激活', ink.isAltScreenActive === true)
-assertVisible('启动落定 400 行')
+check('[启动落定 400 行] 消息区非空', booted, 'density=' + density())
+if (!booted) dump('启动落定 400 行')
 
 function doResize(w: number, h: number) {
   stdout.columns = w

--- a/scripts/repro-resume-position.tsx
+++ b/scripts/repro-resume-position.tsx
@@ -26,7 +26,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle, settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -38,7 +38,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
 ])
 
 const COLS = 100, ROWS = 40
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -145,8 +144,8 @@ function makeChannel(initialRows: any[]) {
   return channel
 }
 
-function assertLanded(tag: string, ms: number): void {
-  const lines = screenLines()
+function assertLanded(tag: string, ms: number, snapshot?: string[]): void {
+  const lines = snapshot ?? screenLines()
   const screen = lines.join('\n')
   const tailVisible = screen.includes('TAILMARK_Q7X')
   const midVisible = screen.includes('MIDMARK_Z9')
@@ -170,8 +169,10 @@ function assertLanded(tag: string, ms: number): void {
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
   const t0 = performance.now()
-  await settle(() => screenLines().join('\n').includes('TAILMARK_Q7X'))
-  assertLanded('S1 boot--resume', performance.now() - t0)
+  // 等待与断言共用同一快照：assertLanded 在 settle 捕获的 lines 上求值。
+  let lines: string[] = []
+  await settle(() => { lines = screenLines(); return lines.join('\n').includes('TAILMARK_Q7X') })
+  assertLanded('S1 boot--resume', performance.now() - t0, lines)
   await inst.unmount()
 }
 
@@ -184,9 +185,9 @@ for (const [tag, scrollFirst] of [['S2 resume(at-bottom)', false], ['S3 resume(s
   )
   await settle(() => screenLines().join('\n').includes('问题 15'))
   if (scrollFirst) {
+    // 逐事件 pacing：滚轮事件逐个进入 scroll 路径。
     for (let i = 0; i < 12; i++) { stdin.write('\x1b[<64;50;20M'); await sleep(16) }
-    await settle(() => !screenLines().join('\n').includes('问题 15'))
-    check(`${tag}: 前置——上滚后视口离开底部`, !screenLines().join('\n').includes('问题 15'))
+    check(`${tag}: 前置——上滚后视口离开底部`, await settled(() => !screenLines().join('\n').includes('问题 15')))
   }
   // /resume → 浏览器 → Enter 恢复聚焦会话
   // 两处保留固定 sleep（排序用途）：紧随的 Enter 依赖补全浮层/浏览器的按键
@@ -196,7 +197,7 @@ for (const [tag, scrollFirst] of [['S2 resume(at-bottom)', false], ['S3 resume(s
   await sleep(300)
   stdin.write('\r')
   await sleep(500)
-  check(`${tag}: 浏览器打开`, screenLines().some(l => l.includes('历史会话')), '')
+  check(`${tag}: 浏览器打开`, await settled(() => screenLines().some(l => l.includes('历史会话'))), '')
   stdin.write('\r') // Enter → resumeTo → onClose
   // 保留固定 sleep：紧随的「滚 1 上 2 下」自愈探针依赖行高测量已静息——
   // settle 到 TAILMARK 首次上屏就开滚，滚回底部的格数会因高度仍在估算而
@@ -211,8 +212,7 @@ for (const [tag, scrollFirst] of [['S2 resume(at-bottom)', false], ['S3 resume(s
   stdin.write('\x1b[<65;50;20M')
   await sleep(120)
   stdin.write('\x1b[<65;50;20M')
-  await settle(() => screenLines().join('\n').includes('TAILMARK_Q7X'))
-  const healed = screenLines().join('\n').includes('TAILMARK_Q7X')
+  const healed = await settled(() => screenLines().join('\n').includes('TAILMARK_Q7X'))
   check(`${tag}: 滚离后滚回底部，最新消息可见`, healed)
   if (!healed) {
     console.log('  ──── 自愈探针后视口 ────')

--- a/scripts/repro-settings.tsx
+++ b/scripts/repro-settings.tsx
@@ -20,7 +20,7 @@ process.env.FORCE_COLOR = '3'
 // module import resolves the startup lang (env > persisted > locale).
 process.env.DSH_TUI_LANG = 'en'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { ApprovalStore }, commandModule, { settle, viewportLines }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { ApprovalStore }, commandModule, { settle, settled, sleep, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -52,7 +52,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 function screenText(): string {
   // 刻意读缓冲区开头而非视口：本 inline harness 下 /settings 屏的标题行会被
   // 滚进 scrollback（baseY 上方），断言以完整首帧内容为目标——换成 baseY 视口
@@ -192,28 +191,28 @@ await settle(() => screenText().includes('Explore the uncharted'))
 stdin.write('/settings')
 await sleep(200)
 stdin.write('\r')
-await settle(() => screenText().includes('Plugin settings'))
-assert(screenText().includes('Plugin settings'), 'screen opens with the title')
-assert(screenText().includes('Demo settings') && screenText().includes('(demo-plugin)'), 'section header renders')
-assert(screenText().includes('Enabled') && screenText().includes('true'), 'boolean field shows its value')
-assert(screenText().includes('overridden'), 'user-layer presence marks the override')
+assert(await settled(() => screenText().includes('Plugin settings')), 'screen opens with the title')
+assert(await settled(() => screenText().includes('Demo settings') && screenText().includes('(demo-plugin)')), 'section header renders')
+assert(await settled(() => screenText().includes('Enabled') && screenText().includes('true')), 'boolean field shows its value')
+assert(await settled(() => screenText().includes('overridden')), 'user-layer presence marks the override')
 
 // 2. Enter stages a boolean toggle; `s` saves it as a fenced set op.
 stdin.write('\r')
-await settle(() => screenText().includes('unsaved'))
-assert(screenText().includes('unsaved'), 'staged toggle marks the section dirty')
+assert(await settled(() => screenText().includes('unsaved')), 'staged toggle marks the section dirty')
 stdin.write('s')
-await settle(() => mutations.length === 1)
-assert(mutations.length === 1, 'save wrote exactly one mutation')
+// 写入落地后 mutations[0] 即终态，后续为同步派生断言。
+assert(await settled(() => mutations.length === 1), 'save wrote exactly one mutation')
 const first = mutations[0]
 assert(first?.ns === 'demo-plugin' && first.expected === 3, 'write fenced by the seeded revision')
 const firstOps = first?.ops as { op: string; path: readonly string[]; value?: unknown }[]
 assert(firstOps?.[0]?.op === 'set' && firstOps[0].path.join('.') === 'enabled' && firstOps[0].value === false, 'boolean toggle became a set op')
-assert(screenText().includes('Saved demo-plugin'), 'save notice renders')
+assert(await settled(() => screenText().includes('Saved demo-plugin')), 'save notice renders')
 assert(docs['demo-plugin']?.value.enabled === false, 'host document reflects the write')
 
 // 3. Number field: ↓ focus, Enter edit (the draft seeds from the current
 // value), backspace the old digit away, type, Enter stage, s save.
+// 下面的逐键 200ms 均为编辑器模式切换的 pacing：焦点/编辑态只体现为颜色与
+// 光标，无可观测的纯文本条件，保留固定窗口。
 stdin.write('\x1b[B') // ↓
 await sleep(200)
 stdin.write('\r')
@@ -229,8 +228,7 @@ stdin.write('\r')
 await sleep(200)
 assert(screenText().includes('10'), 'staged number draft renders')
 stdin.write('s')
-await settle(() => mutations.length === 2)
-assert(mutations.length === 2, 'second save wrote')
+assert(await settled(() => mutations.length === 2), 'second save wrote')
 const secondOps = mutations[1]?.ops as { op: string; path: readonly string[]; value?: unknown }[]
 assert(secondOps?.[0]?.op === 'set' && secondOps[0].path.join('.') === 'limit' && secondOps[0].value === 10, 'number draft became a numeric set op')
 
@@ -239,6 +237,7 @@ assert(secondOps?.[0]?.op === 'set' && secondOps[0].path.join('.') === 'limit' &
 // section's form — clean here — and closed, silently dropping the staged
 // toggle. The fixed behavior: Esc discards EVERY section's staged drafts
 // first (notice), and only a second Esc leaves.
+// 逐键固定 pacing：焦点移动只体现为颜色高亮，无可观测的纯文本条件。
 stdin.write('\x1b[A') // ↑ back to Enabled
 await sleep(200)
 stdin.write('\r') // stage a toggle in demo-plugin (dirty)
@@ -248,9 +247,8 @@ await sleep(150)
 stdin.write('\x1b[B') // ↓ into other-plugin's Mode field
 await sleep(300)
 stdin.write('\x1b') // Esc: focused section is clean, demo-plugin is dirty
-await settle(() => screenText().includes('Discarded all unsaved edits'))
-assert(screenText().includes('Discarded all unsaved edits'), 'Esc discards staged edits across ALL sections')
-assert(screenText().includes('Other settings'), 'screen stays open after the discard')
+assert(await settled(() => screenText().includes('Discarded all unsaved edits')), 'Esc discards staged edits across ALL sections')
+assert(await settled(() => screenText().includes('Other settings')), 'screen stays open after the discard')
 assert(mutations.length === 2, 'discard wrote nothing')
 
 // 5. Quiescence (P1-1): with the screen open and idle, settingsHost() calls
@@ -270,8 +268,7 @@ assert(settingsHostCalls - quietCalls < 50, 'idle screen settles (no render loop
 // (SessionBrowser shows the same artifact; pre-existing renderer behavior,
 // not this screen's doing).
 stdin.write('\x1b')
-await settle(() => screenText().includes('Explore the uncharted'))
-assert(screenText().includes('Explore the uncharted'), 'second Esc returns to the conversation')
+assert(await settled(() => screenText().includes('Explore the uncharted')), 'second Esc returns to the conversation')
 
 await instance.unmount()
 
@@ -311,17 +308,17 @@ const groupInstance = await render(
   <Settings channel={groupChannel} onClose={() => { groupClosed = true }} />,
   { stdout: new GroupStdout(), stdin: groupStdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await settle(() => groupScreenText().includes('Name') && groupScreenText().includes('Advanced'))
-assert(groupScreenText().includes('Name') && groupScreenText().includes('Advanced'), 'group root renders ungrouped fields and group entry', groupScreenText())
+assert(await settled(() => groupScreenText().includes('Name') && groupScreenText().includes('Advanced')), 'group root renders ungrouped fields and group entry', groupScreenText())
 assert(!groupScreenText().includes('Endpoint'), 'group root hides grouped fields', groupScreenText())
+// 焦点移动只体现为颜色高亮，无可观测的纯文本条件，保留固定 pacing。
 groupStdin.write('\x1b[B') // ↓ from Name to Advanced
 await sleep(200)
 groupStdin.write('\r')
-await settle(() => groupScreenText().includes('Endpoint') && groupScreenText().includes('Esc back'))
 // The headless renderer leaves the first row stale across in-place screen
 // transitions, so assert navigation through group-only content and its hint.
-assert(groupScreenText().includes('Endpoint') && groupScreenText().includes('Esc back'), 'Enter opens the group page', groupScreenText())
+assert(await settled(() => groupScreenText().includes('Endpoint') && groupScreenText().includes('Esc back')), 'Enter opens the group page', groupScreenText())
 assert(!groupScreenText().includes('Name'), 'group page shows only its fields', groupScreenText())
+// 编辑器模式切换与逐键退格的 pacing：编辑态无可观测的纯文本条件，保留固定窗口。
 groupStdin.write('\r')
 await sleep(150)
 for (let i = 0; i < 3; i++) {
@@ -337,25 +334,25 @@ groupStdin.write('\r')
 await sleep(300)
 assert(groupScreenText().includes('new'), 'group field draft is staged', groupScreenText())
 groupStdin.write('\x1b')
-await settle(() => groupScreenText().includes('unsaved') && !groupScreenText().includes('Endpoint'))
-assert(groupScreenText().includes('unsaved') && !groupScreenText().includes('Endpoint'), 'Esc returns to root without dropping the staged edit', groupScreenText())
+assert(await settled(() => groupScreenText().includes('unsaved') && !groupScreenText().includes('Endpoint')), 'Esc returns to root without dropping the staged edit', groupScreenText())
+// 焦点移动只体现为颜色高亮，无可观测的纯文本条件，保留固定 pacing。
 groupStdin.write('\x1b[B')
 await sleep(200)
 groupStdin.write('\r')
-await settle(() => groupScreenText().includes('new'))
-assert(groupScreenText().includes('new'), 're-entering the group restores the staged draft', groupScreenText())
+assert(await settled(() => groupScreenText().includes('new')), 're-entering the group restores the staged draft', groupScreenText())
 groupStdin.write('s')
-await settle(() => mutations.length === 3)
+// 写入落地后 mutations[2] 即终态，后续为同步派生断言。
+const groupSaved = await settled(() => mutations.length === 3)
 const groupMutation = mutations[2]
 const groupOps = groupMutation?.ops as { op: string; path: readonly string[]; value?: unknown }[]
-assert(groupMutation?.ns === 'group-plugin' && groupMutation.expected === 5, 'group save is revision-fenced')
+assert(groupSaved && groupMutation?.ns === 'group-plugin' && groupMutation.expected === 5, 'group save is revision-fenced')
 assert(groupOps?.[0]?.op === 'set' && groupOps[0].path.join('.') === 'advanced.endpoint' && groupOps[0].value === 'new', 'group save keeps the nested field path')
 assert((docs['group-plugin']?.value.advanced as Record<string, unknown> | undefined)?.endpoint === 'new', 'nested group value reaches the host document')
+// 两次 Esc 之间的处理顺序无可观测中间条件（第一次 Esc 不改变可断言的纯文本），保留固定 pacing。
 groupStdin.write('\x1b')
 await sleep(200)
 groupStdin.write('\x1b')
-await settle(() => groupClosed)
-assert(groupClosed, 'clean group screen exits from the root page')
+assert(await settled(() => groupClosed), 'clean group screen exits from the root page')
 await groupInstance.unmount()
 
 // 8. Focus-follow scrolling (P2-3): a terminal shorter than the entry list
@@ -394,18 +391,17 @@ const smallInstance = await render(
   <Settings channel={smallChannel} onClose={() => { smallClosed = true }} />,
   { stdout: new SmallStdout(), stdin: smallStdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await settle(() => smallScreenText().includes('Long settings'))
-assert(smallScreenText().includes('Long settings'), 'small terminal opens the screen', smallScreenText())
-assert(smallScreenText().includes('Field 0') && !smallScreenText().includes('Field 15'), 'top of the list renders first', smallScreenText())
+assert(await settled(() => smallScreenText().includes('Long settings')), 'small terminal opens the screen', smallScreenText())
+assert(await settled(() => smallScreenText().includes('Field 0') && !smallScreenText().includes('Field 15')), 'top of the list renders first', smallScreenText())
+// 逐键 ↓ 的 pacing：中间焦点位置只体现为颜色，无可观测的纯文本条件。
 for (let i = 0; i < 15; i++) {
   smallStdin.write('\x1b[B')
   await sleep(120)
 }
-assert(smallScreenText().includes('Field 15'), 'focus on the last field scrolls it into view', smallScreenText())
-assert(!smallScreenText().includes('Field 0'), 'scrolled-out fields leave the viewport', smallScreenText())
+assert(await settled(() => smallScreenText().includes('Field 15')), 'focus on the last field scrolls it into view', smallScreenText())
+assert(await settled(() => !smallScreenText().includes('Field 0')), 'scrolled-out fields leave the viewport', smallScreenText())
 smallStdin.write('\x1b')
-await settle(() => smallClosed)
-assert(smallClosed, 'Esc on a clean screen closes it')
+assert(await settled(() => smallClosed), 'Esc on a clean screen closes it')
 await smallInstance.unmount()
 
 // 9. The same focus-follow guarantee applies inside a group subpage.
@@ -436,17 +432,16 @@ const groupedSmallInstance = await render(
   <Settings channel={groupedSmallChannel} onClose={() => {}} />,
   { stdout: new GroupedSmallStdout(), stdin: groupedSmallStdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
-await settle(() => groupedSmallScreenText().includes('Advanced fields') && !groupedSmallScreenText().includes('Grouped field 0'))
-assert(groupedSmallScreenText().includes('Advanced fields') && !groupedSmallScreenText().includes('Grouped field 0'), 'short group root hides grouped fields', groupedSmallScreenText())
+assert(await settled(() => groupedSmallScreenText().includes('Advanced fields') && !groupedSmallScreenText().includes('Grouped field 0')), 'short group root hides grouped fields', groupedSmallScreenText())
 groupedSmallStdin.write('\r')
-await settle(() => groupedSmallScreenText().includes('Grouped field 0') && !groupedSmallScreenText().includes('Grouped field 15'))
-assert(groupedSmallScreenText().includes('Grouped field 0') && !groupedSmallScreenText().includes('Grouped field 15'), 'short group page starts at its first field', groupedSmallScreenText())
+assert(await settled(() => groupedSmallScreenText().includes('Grouped field 0') && !groupedSmallScreenText().includes('Grouped field 15')), 'short group page starts at its first field', groupedSmallScreenText())
+// 逐键 ↓ 的 pacing：中间焦点位置只体现为颜色，无可观测的纯文本条件。
 for (let i = 0; i < 15; i++) {
   groupedSmallStdin.write('\x1b[B')
   await sleep(120)
 }
-assert(groupedSmallScreenText().includes('Grouped field 15'), 'short group page follows focus to its last field', groupedSmallScreenText())
-assert(!groupedSmallScreenText().includes('Grouped field 0'), 'short group page windows scrolled-out fields', groupedSmallScreenText())
+assert(await settled(() => groupedSmallScreenText().includes('Grouped field 15')), 'short group page follows focus to its last field', groupedSmallScreenText())
+assert(await settled(() => !groupedSmallScreenText().includes('Grouped field 0')), 'short group page windows scrolled-out fields', groupedSmallScreenText())
 await groupedSmallInstance.unmount()
 
 console.log('repro-settings: all assertions passed')

--- a/scripts/repro-thinking.tsx
+++ b/scripts/repro-thinking.tsx
@@ -20,7 +20,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { render }, { Chat }, { QuestionStore }, { Terminal: XTerm }, fs, { writeParsed, viewportLines }] =
+const [{ PassThrough, Writable }, React, { render }, { Chat }, { QuestionStore }, { Terminal: XTerm }, fs, { writeParsed, viewportLines, sleep }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -124,8 +124,9 @@ const instance = await render(
   },
 )
 
-// 启动稳定
-await new Promise(r => setTimeout(r, 500))
+// 启动稳定：让 spinner 先空转若干 50ms 动画帧——动画重绘本身是被测对象，
+// 固定墙钟 pacing 是场景的一部分，无可轮询的完成条件。
+await sleep(500)
 
 // 流式灌文本 ~6 秒（thinking 状态保持）。内容刻意全为中文、不含 'thinking'
 // 与孤立 ASCII 't'，让残影断言无歧义。
@@ -139,11 +140,13 @@ const CHUNKS = [
 ]
 for (const chunk of CHUNKS) {
   pushChunk(chunk)
-  await new Promise(r => setTimeout(r, 120))
+  // 120ms 是场景 pacing：流式增长与 50ms 动画帧交错才能诱发残影，
+  // 不是在等某个可观测状态。
+  await sleep(120)
 }
 
-// 再让 spinner 空转几帧
-await new Promise(r => setTimeout(r, 800))
+// 再让 spinner 空转几帧（墙钟 pacing：残影需要多帧重绘才会显形）
+await sleep(800)
 
 const byteStream = stdout.frames.join('')
 try { instance.unmount() } catch {}

--- a/scripts/repro-toolcards.tsx
+++ b/scripts/repro-toolcards.tsx
@@ -8,7 +8,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }, { settle }] = await Promise.all([
+const [{ Writable }, React, { Terminal: XTerm }, { render }, { AssistantToolUseMessage }, { settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -27,7 +27,6 @@ class FakeStdout extends Writable {
   _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
 }
 const stdout = new FakeStdout()
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 /** The real terminal screen, line by line (colors stripped). */
 function lines(): string[] {
   const buf = term.buffer.active
@@ -93,71 +92,57 @@ const editTool = {
 }
 
 const app = await render(card('edit', editTool), { stdout, debug: true, exitOnCtrlC: false })
-await settle(() => rowOf('- const a = 1') >= 0 && rowOf('+ const a = 2') >= 0)
 
 /**
- * Swap the rendered card; key forces a clean remount per scenario. `ready`
- * is polled until the new card's distinctive content is parsed (the old
- * fixed 250ms could sample a half-parsed screen on slow runners).
+ * Swap the rendered card; key forces a clean remount per scenario. Each
+ * scenario's checks poll their own full condition via settled（等待与断言
+ * 共用同一谓词），so no separate ready predicate is needed here.
  */
-async function show(key: string, tool: Record<string, unknown>, ready: () => boolean, verbose = false): Promise<void> {
+function show(key: string, tool: Record<string, unknown>, verbose = false): void {
   app.rerender(card(key, tool, verbose))
-  await settle(ready)
 }
 
 // 1. Settled Edit: diff body, red `- ` / green `+ ` lines under the ⎿ gutter.
-{
-  const s = screen()
-  check('编辑卡片标题为「Edit /tmp/a.ts」（非 JSON args）', s.includes('Edit /tmp/a.ts') && !s.includes('{"file_path"'))
-  const delRow = rowOf('- const a = 1')
-  const addRow = rowOf('+ const a = 2')
-  check('删除行带 ⎿ 缩进', delRow >= 0 && lines()[delRow]!.startsWith(' ⎿ - const a = 1'))
-  check('新增行延续缩进', addRow >= 0 && lines()[addRow]!.startsWith('   + const a = 2'))
-  check('删除行为红色系', delRow >= 0 && fgAt(7, delRow) === 0xb26671)
-  check('新增行为绿色系', addRow >= 0 && fgAt(7, addRow) === 0x57956b)
-}
+check('编辑卡片标题为「Edit /tmp/a.ts」（非 JSON args）', await settled(() => screen().includes('Edit /tmp/a.ts') && !screen().includes('{"file_path"')))
+check('删除行带 ⎿ 缩进', await settled(() => { const r = rowOf('- const a = 1'); return r >= 0 && lines()[r]!.startsWith(' ⎿ - const a = 1') }))
+check('新增行延续缩进', await settled(() => { const r = rowOf('+ const a = 2'); return r >= 0 && lines()[r]!.startsWith('   + const a = 2') }))
+check('删除行为红色系', await settled(() => { const r = rowOf('- const a = 1'); return r >= 0 && fgAt(7, r) === 0xb26671 }))
+check('新增行为绿色系', await settled(() => { const r = rowOf('+ const a = 2'); return r >= 0 && fgAt(7, r) === 0x57956b }))
 
 // 2. Write 新建（oldText null）只有 + 行。
-await show('write', {
+show('write', {
   name: 'write',
   callView: {
     card: 'diff',
     title: 'Write /tmp/new.ts',
     diffs: [{ path: '/tmp/new.ts', oldText: null, newText: 'hello\nworld' }],
   },
-}, () => screen().includes('+ hello') && screen().includes('+ world'))
-{
-  const s = screen()
-  check('新建文件标题为「Write /tmp/new.ts」', s.includes('Write /tmp/new.ts'))
-  check('新建只有新增行', s.includes('+ hello') && s.includes('+ world') && !s.includes('- hello'))
-}
+})
+check('新建文件标题为「Write /tmp/new.ts」', await settled(() => screen().includes('Write /tmp/new.ts')))
+check('新建只有新增行', await settled(() => screen().includes('+ hello') && screen().includes('+ world') && !screen().includes('- hello')))
 
 // 3. Bash 终端卡：命令作标题，输出缩进。
-await show('bash', {
+show('bash', {
   name: 'bash',
   argsText: '{"command":"ls -la"}',
   callView: { card: 'terminal', title: 'ls -la' },
   resultView: { card: 'terminal', output: 'total 8\nfile1\nfile2', exitCode: 0 },
   resultFull: 'total 8\nfile1\nfile2',
-}, () => screen().includes('Bash(ls -la)') && rowOf('total 8') >= 0)
-{
-  const s = screen()
-  check('终端卡标题为「Bash(ls -la)」', s.includes('Bash(ls -la)'))
-  const outRow = rowOf('total 8')
-  check('终端输出带 ⎿ 缩进', outRow >= 0 && lines()[outRow]!.startsWith(' ⎿ total 8'))
-}
+})
+check('终端卡标题为「Bash(ls -la)」', await settled(() => screen().includes('Bash(ls -la)')))
+check('终端输出带 ⎿ 缩进', await settled(() => { const r = rowOf('total 8'); return r >= 0 && lines()[r]!.startsWith(' ⎿ total 8') }))
 
 // 4. Bash 非零退出：追加 Exit code 行。
-await show('bash-err', {
+show('bash-err', {
   name: 'bash',
   callView: { card: 'terminal', title: 'false' },
   resultView: { card: 'terminal', output: '', exitCode: 1 },
   resultFull: '',
-}, () => rowOf('Exit code 1') >= 0)
-check('非零退出显示 Exit code 行', rowOf('Exit code 1') >= 0)
+})
+check('非零退出显示 Exit code 行', await settled(() => rowOf('Exit code 1') >= 0))
 
 // 5. Read 卡：正文剥离 <path>/<content> 信封。
-await show('read', {
+show('read', {
   name: 'read',
   callView: { card: 'generic', title: 'Read /tmp/x.ts' },
   resultView: {
@@ -166,59 +151,45 @@ await show('read', {
     content: [{ type: 'text', text: 'line one\nline two' }],
   },
   resultFull: '<path>/tmp/x.ts</path>\n<content>\nline one\nline two\n</content>',
-}, () => rowOf('line one') >= 0)
-{
-  const s = screen()
-  check('Read 正文无信封标签', s.includes('line one') && !s.includes('<content>') && !s.includes('<path>'))
-  const row = rowOf('line one')
-  check('Read 正文带 ⎿ 缩进', row >= 0 && lines()[row]!.startsWith(' ⎿ line one'))
-}
+})
+check('Read 正文无信封标签', await settled(() => screen().includes('line one') && !screen().includes('<content>') && !screen().includes('<path>')))
+check('Read 正文带 ⎿ 缩进', await settled(() => { const r = rowOf('line one'); return r >= 0 && lines()[r]!.startsWith(' ⎿ line one') }))
 
 // 6. 无 presenter 的工具：回退到 Name(args) + 原始结果（仍然缩进）。
-await show('fallback', {
+show('fallback', {
   name: 'read',
   resultFull: 'raw output here',
-}, () => rowOf('raw output here') >= 0)
-{
-  const s = screen()
-  check('无视图时回退 Name(args) 标题', s.includes('Read({"file_path":"/tmp/a.ts"})'))
-  const row = rowOf('raw output here')
-  check('无视图时结果仍缩进', row >= 0 && lines()[row]!.startsWith(' ⎿ raw output here'))
-}
+})
+check('无视图时回退 Name(args) 标题', await settled(() => screen().includes('Read({"file_path":"/tmp/a.ts"})')))
+check('无视图时结果仍缩进', await settled(() => { const r = rowOf('raw output here'); return r >= 0 && lines()[r]!.startsWith(' ⎿ raw output here') }))
 
 // 7. 折叠上限：文本正文超过 3 行折叠 + 提示；Ctrl+O 展开。
-await show('cap', {
+show('cap', {
   name: 'bash',
   callView: { card: 'terminal', title: 'seq 6' },
   resultView: { card: 'terminal', output: '1\n2\n3\n4\n5\n6', exitCode: 0 },
   resultFull: '1\n2\n3\n4\n5\n6',
-}, () => screen().includes('… +3 lines (ctrl+o to expand)'))
-{
-  const s = screen()
-  check('文本正文折叠为 3 行 + 提示', s.includes('… +3 lines (ctrl+o to expand)') && rowOf('4') === -1)
-}
-await show('cap-open', {
+})
+check('文本正文折叠为 3 行 + 提示', await settled(() => screen().includes('… +3 lines (ctrl+o to expand)') && rowOf('4') === -1))
+show('cap-open', {
   name: 'bash',
   callView: { card: 'terminal', title: 'seq 6' },
   resultView: { card: 'terminal', output: '1\n2\n3\n4\n5\n6', exitCode: 0 },
   resultFull: '1\n2\n3\n4\n5\n6',
-}, () => rowOf('6') >= 0 && !screen().includes('ctrl+o to expand'), true)
-check('verbose 不折叠', rowOf('6') >= 0 && !screen().includes('ctrl+o to expand'))
+}, true)
+check('verbose 不折叠', await settled(() => rowOf('6') >= 0 && !screen().includes('ctrl+o to expand')))
 
 // 8. 错误卡：errorText 红色缩进。
-await show('error', {
+show('error', {
   name: 'read',
   status: 'error',
   errorText: 'Error: ENOENT',
-}, () => rowOf('Error: ENOENT') >= 0)
-{
-  const row = rowOf('Error: ENOENT')
-  check('错误行带 ⎿ 缩进', row >= 0 && lines()[row]!.startsWith(' ⎿ Error: ENOENT'))
-  check('错误行有颜色', row >= 0 && fgAt(7, row) !== 0)
-}
+})
+check('错误行带 ⎿ 缩进', await settled(() => { const r = rowOf('Error: ENOENT'); return r >= 0 && lines()[r]!.startsWith(' ⎿ Error: ENOENT') }))
+check('错误行有颜色', await settled(() => { const r = rowOf('Error: ENOENT'); return r >= 0 && fgAt(7, r) !== 0 }))
 
 // 9. 运行中的 Edit：挂起期间就展示待定 diff。
-await show('running-diff', {
+show('running-diff', {
   name: 'edit',
   status: 'running',
   callView: {
@@ -226,37 +197,21 @@ await show('running-diff', {
     title: 'Edit /tmp/a.ts',
     diffs: [{ path: '/tmp/a.ts', oldText: 'old', newText: 'new' }],
   },
-}, () => rowOf('- old') >= 0 && rowOf('+ new') >= 0)
-check('运行中展示待定 diff', rowOf('- old') >= 0 && rowOf('+ new') >= 0)
+})
+check('运行中展示待定 diff', await settled(() => rowOf('- old') >= 0 && rowOf('+ new') >= 0))
 
 // 10. 状态点：分类定色、失败红 ✗。
-await show('dot-bash', { name: 'bash', argsText: '{"command":"ls"}' },
-  () => rowOf('Bash') >= 0 && (lines()[rowOf('Bash')] ?? '').includes('•'))
-{
-  const row = rowOf('Bash')
-  check('bash 点为鼠尾草绿小点', row >= 0 && lines()[row]!.includes('•') && fgAt(lines()[row]!.indexOf('•'), row) === 0x7fae99)
-}
-await show('dot-read', { name: 'read' },
-  () => rowOf('Read') >= 0 && (lines()[rowOf('Read')] ?? '').includes('•'))
-{
-  const row = rowOf('Read')
-  check('read 点为青蓝小点', row >= 0 && fgAt(lines()[row]!.indexOf('•'), row) === 0x82b8c7)
-}
-await show('dot-edit', { name: 'edit' },
-  () => rowOf('Edit') >= 0 && (lines()[rowOf('Edit')] ?? '').includes('•'))
-{
-  const row = rowOf('Edit')
-  check('edit 点为雾紫小点', row >= 0 && fgAt(lines()[row]!.indexOf('•'), row) === 0xb3a0d4)
-}
-await show('dot-error', { name: 'bash', status: 'error', errorText: 'boom' },
-  () => rowOf('Bash') >= 0 && (lines()[rowOf('Bash')] ?? '').includes('✗'))
-{
-  const row = rowOf('Bash')
-  check('失败点变红 ✗', row >= 0 && lines()[row]!.includes('✗') && fgAt(lines()[row]!.indexOf('✗'), row) === 0xda8a93)
-}
+show('dot-bash', { name: 'bash', argsText: '{"command":"ls"}' })
+check('bash 点为鼠尾草绿小点', await settled(() => { const r = rowOf('Bash'); return r >= 0 && lines()[r]!.includes('•') && fgAt(lines()[r]!.indexOf('•'), r) === 0x7fae99 }))
+show('dot-read', { name: 'read' })
+check('read 点为青蓝小点', await settled(() => { const r = rowOf('Read'); return r >= 0 && lines()[r]!.includes('•') && fgAt(lines()[r]!.indexOf('•'), r) === 0x82b8c7 }))
+show('dot-edit', { name: 'edit' })
+check('edit 点为雾紫小点', await settled(() => { const r = rowOf('Edit'); return r >= 0 && lines()[r]!.includes('•') && fgAt(lines()[r]!.indexOf('•'), r) === 0xb3a0d4 }))
+show('dot-error', { name: 'bash', status: 'error', errorText: 'boom' })
+check('失败点变红 ✗', await settled(() => { const r = rowOf('Bash'); return r >= 0 && lines()[r]!.includes('✗') && fgAt(lines()[r]!.indexOf('✗'), r) === 0xda8a93 }))
 
 // 10. 多 hunk 编辑（settled contextual diff）：同文件相邻 hunk 用 ⋯ 分隔。
-await show('multi-hunk', {
+show('multi-hunk', {
   name: 'edit',
   callView: {
     card: 'diff',
@@ -271,11 +226,11 @@ await show('multi-hunk', {
       { path: '/tmp/a.ts', oldText: 'l9', newText: 'l9c' },
     ],
   },
-}, () => rowOf('⋯') >= 0 && rowOf('- l1') >= 0 && rowOf('+ l9c') >= 0)
-check('多 hunk 用 ⋯ 分隔', rowOf('⋯') >= 0 && rowOf('- l1') >= 0 && rowOf('+ l9c') >= 0)
+})
+check('多 hunk 用 ⋯ 分隔', await settled(() => rowOf('⋯') >= 0 && rowOf('- l1') >= 0 && rowOf('+ l9c') >= 0))
 
 // 11. Grep 搜索卡：按文件分组的 matches。
-await show('grep', {
+show('grep', {
   name: 'grep',
   callView: { card: 'generic', title: 'Grep TODO in src' },
   resultView: {
@@ -286,15 +241,12 @@ await show('grep', {
     total: 7,
   },
   resultFull: 'src/a.ts:12: // TODO fix',
-}, () => rowOf('12: // TODO fix') >= 0 && rowOf('(7 total)') >= 0)
-{
-  const s = screen()
-  check('搜索卡标题回退到 call 标题', s.includes('Grep TODO in src'))
-  check('搜索卡按文件分组 + 截断计数', rowOf('src/a.ts') >= 0 && rowOf('12: // TODO fix') >= 0 && rowOf('(7 total)') >= 0)
-}
+})
+check('搜索卡标题回退到 call 标题', await settled(() => screen().includes('Grep TODO in src')))
+check('搜索卡按文件分组 + 截断计数', await settled(() => rowOf('src/a.ts') >= 0 && rowOf('12: // TODO fix') >= 0 && rowOf('(7 total)') >= 0))
 
 // 12. Glob 搜索卡：paths 形状。
-await show('glob', {
+show('glob', {
   name: 'glob',
   callView: { card: 'generic', title: 'Glob **/*.ts' },
   resultView: {
@@ -305,10 +257,11 @@ await show('glob', {
     total: 2,
   },
   resultFull: 'src/a.ts\nsrc/b.ts',
-}, () => rowOf('src/b.ts') >= 0)
-check('Glob paths 逐行列出', rowOf('src/a.ts') >= 0 && rowOf('src/b.ts') >= 0)
+})
+check('Glob paths 逐行列出', await settled(() => rowOf('src/a.ts') >= 0 && rowOf('src/b.ts') >= 0))
 
 app.unmount()
+// unmount 后输出 flush 无可观测条件，保留固定 pacing。
 await sleep(100)
 console.log(results.join('\n'))
 console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURES`)

--- a/scripts/verify-askpanel-hide-custom-input.tsx
+++ b/scripts/verify-askpanel-hide-custom-input.tsx
@@ -11,7 +11,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }, { settle, viewportLines }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { AskUserQuestionPanel }, { settle, settled, sleep, viewportLines }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -37,7 +37,6 @@ class FakeStdin extends PassThrough {
 }
 const stdout = new FakeStdout()
 const stdin = new FakeStdin()
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 function screen(): string {
   return viewportLines(term, ROWS).join('\n')
 }
@@ -87,9 +86,9 @@ await mount({
   options: [{ label: '内置 provider' }, { label: '自定义 API 端点' }],
   hideCustomInput: true,
 }, () => screen().includes('内置 provider') && !screen().includes('自定义回答'))
-check('1 hide: 无「自定义回答」输入行', !screen().includes('自定义回答'))
-check('1 hide: hint 无输入提示', !screen().includes('输入回答') && !screen().includes('输入文字附带回答'))
-check('1 hide: 选项照常渲染', screen().includes('内置 provider') && screen().includes('自定义 API 端点'))
+check('1 hide: 无「自定义回答」输入行', await settled(() => !screen().includes('自定义回答')))
+check('1 hide: hint 无输入提示', await settled(() => !screen().includes('输入回答') && !screen().includes('输入文字附带回答')))
+check('1 hide: 选项照常渲染', await settled(() => screen().includes('内置 provider') && screen().includes('自定义 API 端点')))
 
 // Tab/可打印字符「应被忽略」是状态不得改变的稳定性探针：轮询已成立条件会
 // 立即返回等于没测，键间保留固定窗口。
@@ -100,9 +99,8 @@ await sleep(100)
 stdin.write('x')     // 可打印字符应被忽略
 await sleep(100)
 stdin.write('\r')    // Enter 提交焦点项
-await settle(() => eq(answer, { selected: ['自定义 API 端点'] }))
 check('1 hide: Enter 只提交 selected，无 custom',
-  eq(answer, { selected: ['自定义 API 端点'] }), JSON.stringify(answer))
+  await settled(() => eq(answer, { selected: ['自定义 API 端点'] })), JSON.stringify(answer))
 
 // ── 2. 无选项纯文本题 + hideCustomInput（hide 必须被忽略）─────────────
 await mount({
@@ -111,13 +109,12 @@ await mount({
   // patchConsole 会把前面 check 消息（含「自定义回答」字样）渲染进终端，
   // 只盯它会立即返回——用新题独有的问题文本当挂载完成信号。
 }, () => screen().includes('输入 API key'))
-check('2 text-only: hide 被忽略，输入行仍在', screen().includes('自定义回答'))
+check('2 text-only: hide 被忽略，输入行仍在', await settled(() => screen().includes('自定义回答')))
 stdin.write('sk-secret')
 await settle(() => screen().includes('sk-secret'))
 stdin.write('\r')
-await settle(() => eq(answer, { selected: [], custom: 'sk-secret' }))
 check('2 text-only: 文本照常提交',
-  eq(answer, { selected: [], custom: 'sk-secret' }), JSON.stringify(answer))
+  await settled(() => eq(answer, { selected: [], custom: 'sk-secret' })), JSON.stringify(answer))
 
 // ── 3. 多选题不带 hide（模型选择题形态）：默认行为不回退 ──────────────
 await mount({
@@ -127,15 +124,16 @@ await mount({
   // 上一屏已含「自定义回答」，settle 只盯它会立即返回——加新题独有的选项
   // 文本当挂载完成信号。
 }, () => screen().includes('deepseek-chat') && screen().includes('自定义回答'))
-check('3 multi: 输入行保留', screen().includes('自定义回答'))
+check('3 multi: 输入行保留', await settled(() => screen().includes('自定义回答')))
 stdin.write(' ')      // 勾选第一项
+// 键间固定 pacing：空格勾选没有独有的可观测文本（提交结果由下方 settled
+// 断言兜底），保留小窗口保证勾选先于后续输入被处理。
 await sleep(100)
 stdin.write('extra-model') // 输入行补充
 await settle(() => screen().includes('extra-model'))
 stdin.write('\r')
-await settle(() => eq(answer, { selected: ['deepseek-chat'], custom: 'extra-model' }))
 check('3 multi: 勾选 + 自定义补充同时生效',
-  eq(answer, { selected: ['deepseek-chat'], custom: 'extra-model' }), JSON.stringify(answer))
+  await settled(() => eq(answer, { selected: ['deepseek-chat'], custom: 'extra-model' })), JSON.stringify(answer))
 
 app.unmount()
 console.log(failures === 0 ? '\nAll hide-custom-input checks passed' : `\n${failures} check(s) FAILED`)

--- a/scripts/verify-askpanel-layout.tsx
+++ b/scripts/verify-askpanel-layout.tsx
@@ -12,7 +12,7 @@ export {} // 模块边界：避免顶层 await/全局名与其他 verify 脚本�
 
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settle, settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -21,8 +21,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
   import('../src/dsh-adapter/questions.js'),
   import('./lib/term-test.mjs'),
 ])
-
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 /** 用户真实会话日志里的 payload（issue 现场）：4 个选项全带描述。 */
 const EXACT_QUESTION = {
@@ -151,11 +149,14 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
     React.createElement(Chat, { channel: makeChannel(rows as unknown[]), questionStore: store as never, onExit: () => {} }),
     { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(600)
+  await settle(() => screen().trim().length > 0)
   void store.ask({ questions: [EXACT_QUESTION] } as never)
-  await settle(() => REQUIRED.every(t => screen().includes(t)))
-  check(`静态渲染（${name}）`, screen())
+  // 断言在 settle 捕获的同一快照上求值——等待条件与 check 的缺行计算共用 shot，无分叉。
+  let shot = ''
+  await settled(() => { shot = screen(); return REQUIRED.every(t => shot.includes(t)) })
+  check(`静态渲染（${name}）`, shot)
   app.unmount()
+  // unmount 后输出 flush 无可观测条件，保留固定 pacing。
   await sleep(100)
 }
 
@@ -171,9 +172,9 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
     React.createElement(Chat, { channel, questionStore: store as never, onExit: () => {} }),
     { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(600)
+  await settle(() => screen().trim().length > 0)
   void store.ask({ questions: [EXACT_QUESTION] } as never)
-  await sleep(400)
+  await settle(() => REQUIRED.every(t => screen().includes(t)))
   let worst = ''
   let worstMissing = -1
   for (let tick = 0; tick < 20; tick++) {
@@ -181,6 +182,7 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
     channel.responseChars += 1
     channel.version += 1
     for (const l of [...listeners]) l()
+    // 差分重绘的帧采样 pacing（取最坏帧），无可轮询的完成条件——保留固定间隔。
     await sleep(120)
     const s = screen()
     const missing = REQUIRED.filter(t => !s.includes(t)).length
@@ -191,6 +193,7 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
   }
   check('activity tick 差分重绘（20 次取最坏帧）', worst)
   app.unmount()
+  // unmount 后输出 flush 无可观测条件，保留固定 pacing。
   await sleep(100)
 }
 
@@ -202,19 +205,23 @@ for (const [name, rows] of [['短会话', shortRows], ['长高录', tallRows]] a
     React.createElement(Chat, { channel: makeChannel(tallRows), questionStore: store as never, onExit: () => {} }),
     { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(600)
+  await settle(() => screen().trim().length > 0)
   void store.ask({ questions: [EXACT_QUESTION] } as never)
-  await sleep(400)
+  await settle(() => REQUIRED.every(t => screen().includes(t)))
   for (const [c, r] of [[200, 60], [190, 58], [160, 50], [135, 44], [130, 42]] as const) {
     stdout.columns = c
     stdout.rows = r
     term.resize(c, r)
     stdout.emit('resize')
+    // resize 风暴的抖动节奏本身是被测对象（快速连续 resize），保留固定 pacing。
     await sleep(90)
   }
-  await settle(() => REQUIRED.every(t => screen().includes(t)))
-  check('resize 风暴后（130x42）', screen())
+  // 断言在 settle 捕获的同一快照上求值——等待条件与 check 的缺行计算共用 shot，无分叉。
+  let shot = ''
+  await settled(() => { shot = screen(); return REQUIRED.every(t => shot.includes(t)) })
+  check('resize 风暴后（130x42）', shot)
   app.unmount()
+  // unmount 后输出 flush 无可观测条件，保留固定 pacing。
   await sleep(100)
 }
 

--- a/scripts/verify-askpanel-long-list.tsx
+++ b/scripts/verify-askpanel-long-list.tsx
@@ -8,7 +8,7 @@
 process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal }, { render }, { AskUserQuestionPanel }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal }, { render }, { AskUserQuestionPanel }, { settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -24,7 +24,6 @@ class FakeStdin extends PassThrough {
   unref() { return this }
 }
 
-const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 const terminal = new Terminal({ cols: 90, rows: 24, scrollback: 1000, allowProposedApi: true })
 const stdout = new Writable({
   write(chunk, _encoding, callback) { terminal.write(String(chunk), callback) },
@@ -55,25 +54,6 @@ function viewport(): string {
     buffer.getLine(buffer.viewportY + y)?.translateToString(true) ?? '').join('\n')
 }
 
-// 每个快照 settle 到「焦点标签在屏且恰一个 ●」——断言的同一条件；只盯焦点
-// 标签会在旧焦点行尚未擦除的半解析帧上提前返回。
-const settled = (label: string): boolean =>
-  viewport().includes(label) && viewport().split('\n').filter(line => line.includes('●')).length === 1
-await settle(() => settled('● provider-00'))
-const initial = viewport()
-for (let index = 0; index < 25; index += 1) {
-  stdin.write('\x1b[B')
-  await delay(20)
-}
-await settle(() => settled('● provider-25'))
-const moved = viewport()
-
-terminal.resize(90, 18)
-stdout.rows = 18
-stdout.emit('resize')
-await settle(() => settled('● provider-25'))
-const resized = viewport()
-
 let failures = 0
 function check(name: string, ok: boolean): void {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}`)
@@ -81,10 +61,28 @@ function check(name: string, ok: boolean): void {
 }
 const selectedRows = (screen: string): number => screen.split('\n').filter(line => line.includes('●')).length
 
+// 每阶段的两个条件（焦点标签在屏 + 恰一个 ●）必须在**同一快照**上同时成立：
+// 拆成两个独立 settled 会被半解析帧分别骗过（第一帧双 ● 但含目标标签、
+// 下一帧单 ● 却是错误行）。settled 谓词内捕获快照，两条 check 读同一快照。
+let initial = ''
+await settled(() => { initial = viewport(); return initial.includes('● provider-00') && selectedRows(initial) === 1 })
 check('initial focus label is visible', initial.includes('● provider-00'))
 check('initial viewport has exactly one selected/focused row', selectedRows(initial) === 1)
+for (let index = 0; index < 25; index += 1) {
+  stdin.write('\x1b[B')
+  // 键间固定 pacing：逐项下移无需逐帧断言，保留小窗口保证按键不粘连。
+  await sleep(20)
+}
+let moved = ''
+await settled(() => { moved = viewport(); return moved.includes('● provider-25') && selectedRows(moved) === 1 })
 check('focus 25 label is visible after navigation', moved.includes('● provider-25'))
 check('moved viewport has exactly one selected/focused row', selectedRows(moved) === 1)
+
+terminal.resize(90, 18)
+stdout.rows = 18
+stdout.emit('resize')
+let resized = ''
+await settled(() => { resized = viewport(); return resized.includes('● provider-25') && selectedRows(resized) === 1 })
 check('focus 25 stays visible after shrinking to 18 rows', resized.includes('● provider-25'))
 check('resized viewport has exactly one selected/focused row', selectedRows(resized) === 1)
 

--- a/scripts/verify-back-to-bottom.tsx
+++ b/scripts/verify-back-to-bottom.tsx
@@ -16,7 +16,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle, settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -28,7 +28,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
 ])
 
 const COLS = 100, ROWS = 40
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -94,24 +93,22 @@ function pillText(): string | null {
   return null
 }
 const lastTurnVisible = () => screenLines().some(l => l.includes('问题 8'))
+// 逐事件 pacing sleep 保留：滚轮事件需要逐个进入 hover/scroll 路径，
+// 每步之间没有可区分新旧帧的屏幕条件可轮询。
 const wheel = async (up: boolean, times: number) => {
   for (let i = 0; i < times; i++) {
     stdin.write(`\x1b[<${up ? 64 : 65};90;30M`)
     await sleep(150)
   }
 }
-/**
- * 按键后等待：给 until 则 settle 到该条件（断言的同一条件）；不给则保留
- * 固定 400ms——「钉底按 End 无操作」这类稳定性探针必须要固定窗口。
- */
-const pressKey = async (name: string, until?: () => boolean) => {
+/** 按键：等待由调用点的 settled 断言承担（「无操作」稳定性探针除外，
+ *  那里保留固定窗口）。 */
+const pressKey = (name: string) => {
   const seqs: Record<string, string> = {
     end: '\x1b[F',
     enter: '\r',
   }
   stdin.write(seqs[name]!)
-  if (until) await settle(until)
-  else await sleep(400)
 }
 
 // ── 1. 钉底：无 pill ──
@@ -119,67 +116,61 @@ check('钉底无 pill', pillText() === null, `pill=${JSON.stringify(pillText())}
 
 // ── 2. 上滚：常驻 pill；流入新消息后切计数 ──
 await wheel(true, 6)
-{
+check('上滚后 pill 出现（回到底部）', await settled(() => {
   const p = pillText()
-  check('上滚后 pill 出现（回到底部）', p !== null && p.includes('回到底部'), `pill=${JSON.stringify(p)}`)
-}
+  return p !== null && p.includes('回到底部')
+}), `pill=${JSON.stringify(pillText())}`)
 // 追加一轮新消息（模拟流式落定）
 rows.push({ id: 17, kind: 'user', text: '问题 9' })
 rows.push({ id: 18, kind: 'assistant', text: '回复 9 第 1 行\n回复 9 第 2 行' })
 emitChannel()
-await settle(() => {
+check('新消息后 pill 切计数', await settled(() => {
   const p = pillText()
   return p !== null && /2 条新消息/.test(p)
-})
-{
-  const p = pillText()
-  check('新消息后 pill 切计数', p !== null && /2 条新消息/.test(p), `pill=${JSON.stringify(p)}`)
-}
+}), `pill=${JSON.stringify(pillText())}`)
 
 // ── 3. End 键回底 ──
-await pressKey('end', () => lastTurnVisible() && pillText() === null)
-{
-  check('End 后回到底部（末轮可见）', lastTurnVisible())
-  check('End 后 pill 消失', pillText() === null, `pill=${JSON.stringify(pillText())}`)
-}
+pressKey('end')
+check('End 后回到底部（末轮可见）', await settled(() => lastTurnVisible()))
+check('End 后 pill 消失', await settled(() => pillText() === null), `pill=${JSON.stringify(pillText())}`)
 
 // ── 4. 上滚后 Enter 回底 ──
 await wheel(true, 8)
-{
-  check('再次上滚 pill 重现', pillText() !== null, `pill=${JSON.stringify(pillText())}`)
-}
-await pressKey('enter', () => lastTurnVisible() && pillText() === null)
-{
-  check('Enter 后回到底部', lastTurnVisible() && pillText() === null,
-    `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
-}
+check('再次上滚 pill 重现', await settled(() => pillText() !== null), `pill=${JSON.stringify(pillText())}`)
+pressKey('enter')
+check('Enter 后回到底部', await settled(() => lastTurnVisible() && pillText() === null),
+  `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
 
 // ── 5. 点击 pill 回底 ──
 await wheel(true, 8)
 {
-  const lines = screenLines()
   let pillRow = -1, pillCol = -1
-  for (let y = 0; y < ROWS && pillRow === -1; y++) {
-    const l = lines[y]!
-    const x = l.indexOf('↓')
-    if (x >= 0) { pillRow = y; pillCol = x }
-  }
+  await settle(() => {
+    const lines = screenLines()
+    pillRow = -1
+    pillCol = -1
+    for (let y = 0; y < ROWS && pillRow === -1; y++) {
+      const l = lines[y]!
+      const x = l.indexOf('↓')
+      if (x >= 0) { pillRow = y; pillCol = x }
+    }
+    return pillRow !== -1
+  })
   check('点击前 pill 可见', pillRow !== -1, `row=${pillRow}`)
   if (pillRow !== -1) {
     stdin.write(`\x1b[<0;${pillCol + 2};${pillRow + 1}M`)
     stdin.write(`\x1b[<0;${pillCol + 2};${pillRow + 1}m`)
-    await settle(() => lastTurnVisible() && pillText() === null)
-    check('点击 pill 后回到底部', lastTurnVisible() && pillText() === null,
+    check('点击 pill 后回到底部', await settled(() => lastTurnVisible() && pillText() === null),
       `last=${lastTurnVisible()} pill=${JSON.stringify(pillText())}`)
   }
 }
 
 // ── 6. 钉底按 End：无操作不崩 ──
-// 稳定性探针：期望状态不变（已在底部），不传 until、保留固定窗口。
-await pressKey('end')
-{
-  check('钉底按 End 无操作', lastTurnVisible() && pillText() === null)
-}
+// 稳定性探针：期望状态不变（已在底部），保留固定窗口——轮询已成立条件
+// 会立即返回等于没测。
+pressKey('end')
+await sleep(400)
+check('钉底按 End 无操作', lastTurnVisible() && pillText() === null)
 
 await inst.unmount()
 
@@ -200,11 +191,12 @@ await inst.unmount()
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
   await settle(() => screenLines().some(l => l.includes('问题 20')))
-  // 上滚 30 格 → 中部（跳底距离 ≈ 150 行 ≫ 视口）
+  // 上滚 30 格 → 中部（跳底距离 ≈ 150 行 ≫ 视口）；逐事件 pacing 保留。
   for (let i = 0; i < 30; i++) {
     stdin.write('\x1b[<64;90;30M')
     await sleep(60)
   }
+  // 中部位置稳定窗：随后的回底延迟采样以此为起点，无可轮询条件。
   await sleep(300)
   // End 回底 + 采样
   stdin.write('\x1b[F')
@@ -214,6 +206,7 @@ await inst.unmount()
     if (screenLines().some(l => l.includes('问题 20'))) { settledAt = (s + 1) * 50; break }
   }
   check('远距 End 回底：末轮可见（≤600ms）', settledAt > 0, `settledAt=${settledAt}ms`)
+  // 回底后的空白带/pill 断言是稳定性探针，取样前保留固定稳定窗。
   await sleep(300)
   const lines = screenLines()
   // 空白行统计：转译区（跳过置顶头）连续全空行数 ≤ 6（轮间分隔正常 2-3 行）

--- a/scripts/verify-batched-prompt-input.mjs
+++ b/scripts/verify-batched-prompt-input.mjs
@@ -14,7 +14,7 @@ import { PassThrough, Writable } from 'node:stream'
 import React from 'react'
 import { render } from '../lib/types/ui.js'
 import { PromptInput } from '../lib/types/components/PromptInput.js'
-import { settle } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -70,15 +70,17 @@ const instance = await render(
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
 )
 
-await new Promise(resolve => setTimeout(resolve, 500))
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
+await sleep(500)
 stdin.write('a\x1b[Db')
-await new Promise(resolve => setTimeout(resolve, 200))
+// 批与 Enter 之间的 pacing：编辑态对外不可观测（stdout 被丢弃），只有
+// submit 可断言——保留固定窗口（本文件后续同类 sleep 同理）。
+await sleep(200)
 stdin.write('\r')
-await settle(() => submitted.length === 1 && submitted[0] === 'ba')
 
 check(
   'batched text, cursor movement, text, and Enter submit the composed value',
-  submitted.length === 1 && submitted[0] === 'ba',
+  await settled(() => submitted.length === 1 && submitted[0] === 'ba'),
   JSON.stringify(submitted),
 )
 
@@ -86,13 +88,12 @@ check(
 // Two IME commits in one read must compose instead of both reading the empty
 // render closure and leaving only the final character (issue #215).
 stdin.write('\x1b[65;30;20320;1;0;1_\x1b[65;30;22909;1;0;1_')
-await new Promise(resolve => setTimeout(resolve, 200))
+await sleep(200)
 stdin.write('\r')
-await settle(() => submitted.length === 2 && submitted[1] === '你好')
 
 check(
   'batched Termy win32 IME records preserve every committed character',
-  submitted.length === 2 && submitted[1] === '你好',
+  await settled(() => submitted.length === 2 && submitted[1] === '你好'),
   JSON.stringify(submitted),
 )
 
@@ -101,13 +102,12 @@ check(
 // records; each edit must compose before Enter steers the text (issue #219).
 channel.working = true
 stdin.write('\x1b[78;49;110;1;0;1_\x1b[80;25;112;1;0;1_\x1b[77;50;109;1;0;1_')
-await new Promise(resolve => setTimeout(resolve, 200))
+await sleep(200)
 stdin.write('\r')
-await settle(() => steered.length === 1 && steered[0] === 'npm')
 
 check(
   'batched Windows input while streaming preserves npm before steer',
-  steered.length === 1 && steered[0] === 'npm',
+  await settled(() => steered.length === 1 && steered[0] === 'npm'),
   JSON.stringify(steered),
 )
 
@@ -121,20 +121,19 @@ const multilineCases = [
   ['Shift+Enter', '\x1b[13;2u', 'shift'],
 ]
 for (const [index, [label, newlineKey, prefix]] of multilineCases.entries()) {
+  // 按键间 pacing（同上）：各段必须作为独立 chunk 依次落入编辑态。
   stdin.write(`${prefix} first`)
-  await new Promise(resolve => setTimeout(resolve, 100))
+  await sleep(100)
   stdin.write(newlineKey)
-  await new Promise(resolve => setTimeout(resolve, 100))
+  await sleep(100)
   stdin.write(`${prefix} second`)
-  await new Promise(resolve => setTimeout(resolve, 100))
+  await sleep(100)
   stdin.write('\r')
-  await settle(() => submitted.length === index + 3
-    && submitted[index + 2] === `${prefix} first\n${prefix} second`)
 
   check(
     `${label} inserts a newline before Enter submits the multiline draft`,
-    submitted.length === index + 3
-      && submitted[index + 2] === `${prefix} first\n${prefix} second`,
+    await settled(() => submitted.length === index + 3
+      && submitted[index + 2] === `${prefix} first\n${prefix} second`),
     JSON.stringify(submitted),
   )
 }

--- a/scripts/verify-child-stderr.tsx
+++ b/scripts/verify-child-stderr.tsx
@@ -19,10 +19,9 @@ process.env.DSH_TUI_LANG = 'zh'
 
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
-import { settle } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 const SELF = fileURLToPath(import.meta.url)
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 let failures = 0
 const results: string[] = []
@@ -106,23 +105,17 @@ async function runDriver(): Promise<void> {
   // 纯排序等待：冷却窗口是墙钟时间，没有可观察的状态翻转——保留。
   await sleep(400)
   reporter.push(failing)
-  await settle(() => notices.length === 2)
-  check('冷却结束：同一行可再次通知', notices.length === 2)
+  check('冷却结束：同一行可再次通知', await settled(() => notices.length === 2))
 
   reporter.push('Usage: tsx proxy.ts <url>')
-  await settle(() => notices.length === 3 && (notices[2]?.includes('Usage:') ?? false))
-  check('不同的行各自成条通知', notices.length === 3 && (notices[2]?.includes('Usage:') ?? false))
+  check('不同的行各自成条通知', await settled(() => notices.length === 3 && (notices[2]?.includes('Usage:') ?? false)))
 
   reporter.push('\x1b[31mred-line\x1b[39m')
-  await settle(() => (notices.at(-1) ?? '').includes('red-line') && !(notices.at(-1) ?? '').includes('\x1b'))
-  const ansiNotice = notices.at(-1) ?? ''
-  check('ANSI 转义被剥离', ansiNotice.includes('red-line') && !ansiNotice.includes('\x1b'))
+  check('ANSI 转义被剥离', await settled(() => (notices.at(-1) ?? '').includes('red-line') && !(notices.at(-1) ?? '').includes('\x1b')))
 
   const longLine = 'x'.repeat(100)
   reporter.push(longLine)
-  await settle(() => (notices.at(-1) ?? '').includes('…') && !(notices.at(-1) ?? '').includes(longLine))
-  const longNotice = notices.at(-1) ?? ''
-  check('超长行被截断（带省略号）', longNotice.includes('…') && !longNotice.includes(longLine))
+  check('超长行被截断（带省略号）', await settled(() => (notices.at(-1) ?? '').includes('…') && !(notices.at(-1) ?? '').includes(longLine)))
 
   const countBefore = notices.length
   reporter.push('   ')

--- a/scripts/verify-cjk-truncate.tsx
+++ b/scripts/verify-cjk-truncate.tsx
@@ -8,7 +8,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render }, { FileSuggestions }, { stringWidth }, { truncateToWidth }, { settle, viewportLines }] = await Promise.all([
+const [{ Writable }, React, { Terminal: XTerm }, { render }, { FileSuggestions }, { stringWidth }, { truncateToWidth }, { settle, viewportLines, writeParsed }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -18,8 +18,6 @@ const [{ Writable }, React, { Terminal: XTerm }, { render }, { FileSuggestions }
   import('../src/ink/truncateToWidth.js'),
   import('./lib/term-test.mjs'),
 ])
-
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 let failures = 0
 function assert(cond: boolean, msg: string) {
@@ -84,7 +82,9 @@ const app = await render(
 )
 await settle(() => viewportLines(term, ROWS).some(line => line.includes('…')))
 app.unmount()
-await sleep(100)
+// 空写屏障：xterm write 队列 FIFO，回调在此前所有块解析完后触发——
+// 取代「unmount 后 sleep 等解析」。
+await writeParsed(term, '')
 
 const lines = viewportLines(term, ROWS)
 let sawEllipsis = false

--- a/scripts/verify-compact.mjs
+++ b/scripts/verify-compact.mjs
@@ -17,6 +17,7 @@ import React from 'react'
 import { render } from '../lib/types/ui.js'
 import { MessageList } from '../lib/types/components/MessageList.js'
 import { Writable, PassThrough } from 'node:stream'
+import { settled, sleep } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -29,8 +30,6 @@ const toPlain = s =>
     .replace(/\x1b\[(\d+)C/g, (_, n) => ' '.repeat(Number(n)))
     .replace(/\x1b\[[0-9;?>:]*[a-zA-Z]/g, '')
     .replace(/\x1b\]9;[^\x07]*\x07/g, '')
-
-const sleep = ms => new Promise(r => setTimeout(r, ms))
 
 const est = text => Math.ceil(text.length / 4)
 
@@ -195,13 +194,16 @@ const listProps = (expanded) => ({
     React.createElement(MessageList, listProps(false)),
     { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(200)
-  const frame = toPlain(stdout.frames.at(-1) ?? '')
+  const frame = () => toPlain(stdout.frames.at(-1) ?? '')
   // 空帧守卫：渲染崩溃时两条 hides 断言会空洞通过（本文件曾因 MessageList
   // 新增必需 prop 而空帧,只有 shows 报警）。先证明画面存在。
-  check('compact scenario renders at all', frame.includes('Conversation compacted'), '')
-  check('folded summary shows the fold line', frame.includes('摘要已折叠'), '')
-  check('folded summary hides the full text', !frame.includes(LONG_SUMMARY), '')
+  await settled(() => frame().includes('Conversation compacted') && frame().includes('摘要已折叠'))
+  // 负向断言观察窗保留：完整摘要若在正向落定之后迟到出现，落定瞬间检查会漏掉。
+  await sleep(200)
+  const shot = frame()
+  check('compact scenario renders at all', shot.includes('Conversation compacted'), '')
+  check('folded summary shows the fold line', shot.includes('摘要已折叠'), '')
+  check('folded summary hides the full text', !shot.includes(LONG_SUMMARY), '')
   instance.unmount()
 }
 
@@ -211,11 +213,14 @@ const listProps = (expanded) => ({
     React.createElement(MessageList, listProps(true)),
     { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(200)
   // Terminal wrap inserts newlines mid-string, so flatten before matching.
-  const frame = toPlain(stdout.frames.at(-1) ?? '').replace(/\n/g, '')
-  check('expanded summary shows the full text', frame.includes('压缩摘要'), '')
-  check('expanded summary hides the fold line', !frame.includes('摘要已折叠'), '')
+  const frame = () => toPlain(stdout.frames.at(-1) ?? '').replace(/\n/g, '')
+  await settled(() => frame().includes('压缩摘要'))
+  // 负向断言观察窗保留：折叠行若迟到泄漏，落定瞬间检查会漏掉。
+  await sleep(200)
+  const shot = frame()
+  check('expanded summary shows the full text', shot.includes('压缩摘要'), '')
+  check('expanded summary hides the fold line', !shot.includes('摘要已折叠'), '')
   instance.unmount()
 }
 

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -18,7 +18,7 @@ process.env.FORCE_COLOR = '3'
 // locale, none of which a runner is obliged to agree with.
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settle }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settled, sleep }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -29,8 +29,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
     import('./lib/term-test.mjs'),
   ])
 const instances = (await import('../src/ink/instances.js')).default
-
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 let failed = 0
 function check(name: string, ok: boolean, extra = ''): void {
@@ -202,44 +200,36 @@ const panelHeader = (text: string): string =>
     rows: [],
     pushLocal: (title: string, lines: readonly string[]) => { localReports.push({ title, lines }) },
   }))
-  await settle(() => /已加载上下文/.test(harness.screen()))
-
-  const summary = harness.screen()
-  check('the startup context panel is on screen', /已加载上下文/.test(summary))
-  check('the collapsed panel claims Ctrl+P', panelHeader(summary).includes('Ctrl+P'), panelHeader(summary).trim())
+  check('the startup context panel is on screen', await settled(() => /已加载上下文/.test(harness.screen())))
+  check('the collapsed panel claims Ctrl+P', await settled(() => panelHeader(harness.screen()).includes('Ctrl+P')), panelHeader(harness.screen()).trim())
 
   harness.stdin.write(CTRL_P)
-  await settle(() => harness.screen().includes('你是 dsh'))
-  const expanded = harness.screen()
-  check('Ctrl+P expands the panel before the first message', expanded.includes('你是 dsh'),
-    expanded.split('\n')[0]?.trim() ?? '')
-  check('the expanded details still point to /context', expanded.includes('/context'),
-    expanded.split('\n').filter(line => line.includes('/context')).join(' | '))
+  check('Ctrl+P expands the panel before the first message', await settled(() => harness.screen().includes('你是 dsh')),
+    harness.screen().split('\n')[0]?.trim() ?? '')
+  check('the expanded details still point to /context', await settled(() => harness.screen().includes('/context')),
+    harness.screen().split('\n').filter(line => line.includes('/context')).join(' | '))
 
   harness.stdin.write(CTRL_P)
-  await settle(() => !harness.screen().includes('你是 dsh'))
-  check('Ctrl+P collapses the panel again', !harness.screen().includes('你是 dsh'),
+  check('Ctrl+P collapses the panel again', await settled(() => !harness.screen().includes('你是 dsh')),
     panelHeader(harness.screen()).trim())
 
   harness.stdin.write(CTRL_T)
-  await settle(() => isScene(harness.screen()))
-  check('Ctrl+T opens the trajectory even before the first message', isScene(harness.screen()),
+  check('Ctrl+T opens the trajectory even before the first message', await settled(() => isScene(harness.screen())),
     harness.screen().split('\n')[0]?.trim())
 
   harness.stdin.write('q')
-  await settle(() => /已加载上下文/.test(harness.screen()))
-  check('q returns to the context summary', /已加载上下文/.test(harness.screen()))
+  check('q returns to the context summary', await settled(() => /已加载上下文/.test(harness.screen())))
 
   harness.stdin.write('/context\r')
-  await settle(() => localReports.at(-1)?.title === '/context')
+  check('/context emits one local report', await settled(() => localReports.at(-1)?.title === '/context'))
   const report = localReports.at(-1)
-  check('/context emits one local report', report?.title === '/context')
   check('the report contains loaded-context details',
     report?.lines.some(line => line.includes('harness:identity')) === true)
 
   instance.unmount()
   instances.delete(process.stdout)
   harness.term.dispose()
+  // 卸载/dispose 的收尾 pacing：无可观测完成条件，保留固定小窗口。
   await sleep(40)
 }
 
@@ -258,12 +248,10 @@ const panelHeader = (text: string): string =>
   check('the startup panel is gone once a row exists', !/已加载上下文/.test(before))
 
   harness.stdin.write(CTRL_T)
-  await settle(() => isScene(harness.screen()))
-  check('Ctrl+T opens the trajectory scene', isScene(harness.screen()), harness.screen().split('\n')[0]?.trim())
+  check('Ctrl+T opens the trajectory scene', await settled(() => isScene(harness.screen())), harness.screen().split('\n')[0]?.trim())
 
   harness.stdin.write('q')
-  await settle(() => !isScene(harness.screen()))
-  check('q returns to the conversation', !isScene(harness.screen()))
+  check('q returns to the conversation', await settled(() => !isScene(harness.screen())))
 
   instance.unmount()
   instances.delete(process.stdout)

--- a/scripts/verify-effort-accent.tsx
+++ b/scripts/verify-effort-accent.tsx
@@ -21,7 +21,7 @@ const [
   { render },
   { EffortChargeGlyph },
   { ClockProvider },
-  { settle },
+  { settled, sleep },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -32,7 +32,6 @@ const [
   import('./lib/term-test.mjs'),
 ])
 
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 let failures = 0
 function check(name: string, ok: boolean, detail = ''): void {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail === '' ? '' : ` (${detail})`}`)
@@ -134,8 +133,7 @@ check('charge ramps dark→full (sampled, monotone)',
 // 测不到「保持」——保留固定窗口。
 await sleep(300)
 check('past the charge window: accent stays solid', prefixFgTruecolor() && prefixBold())
-await settle(() => !prefixFgTruecolor() && !prefixBold())
-check('off the top tier again: accent gone', !prefixFgTruecolor() && !prefixBold())
+check('off the top tier again: accent gone', await settled(() => !prefixFgTruecolor() && !prefixBold()))
 
 if (failures > 0) {
   console.error(`${failures} check(s) failed`)

--- a/scripts/verify-effort-ignition.tsx
+++ b/scripts/verify-effort-ignition.tsx
@@ -32,6 +32,7 @@ const [
   { EffortTierBadge },
   { ClockProvider },
   math,
+  { sleep },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -41,9 +42,11 @@ const [
   import('../src/components/EffortTierBadge.js'),
   import('../src/ink/components/ClockContext.js'),
   import('../src/trajectory/effortIgnition.js'),
+  import('./lib/term-test.mjs'),
 ])
 
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+// sleep 全部保留：本文件按固定墙钟时间采样动画时间轴的各幕（时间轴本身
+// 是被测对象），改成轮询会移动采样点、破坏后续幕的相对时序。
 let failures = 0
 function check(name: string, ok: boolean, detail = ''): void {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${detail === '' ? '' : ` (${detail})`}`)
@@ -152,6 +155,7 @@ function SweepDriver(): React.ReactNode {
 {
   const harness = await makeHarness(6, React.createElement(SweepDriver))
   try {
+    // elapsed 前 150ms：t=300 切档之前采样静止态（时窗探针）。
     await sleep(150)
     const restText = harness.rowText(0)
     check('rest: plain theme border, no letters, one colour',
@@ -205,6 +209,8 @@ function SweepDriver(): React.ReactNode {
 async function runDarkScenario(name: string, node: React.ReactNode) {
   const harness = await makeHarness(6, node)
   try {
+    // 稳定性探针（不得播放任何动画）：覆盖整条时间轴的固定窗口——轮询
+    // 对「什么都没发生」立即返回，等于没测。
     await sleep(300)
     harness.writes.length = 0
     await sleep(1800)

--- a/scripts/verify-effort-slider-ui.mjs
+++ b/scripts/verify-effort-slider-ui.mjs
@@ -24,7 +24,7 @@ const { Terminal: XTerm } = xtermHeadless
 import { render } from '../lib/types/ui.js'
 import { Chat } from '../lib/types/screens/Chat.js'
 import { setLang } from '../lib/types/i18n.js'
-import { settle, viewportLines } from './lib/term-test.mjs'
+import { settle, settled, sleep, viewportLines } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -32,8 +32,6 @@ function check(name, ok, extra = '') {
   if (!ok) failed += 1
 }
 process.exitCode = 0
-
-const sleep = ms => new Promise(r => setTimeout(r, ms))
 
 const term = new XTerm({ cols: 110, rows: 34, scrollback: 100, allowProposedApi: true })
 
@@ -201,6 +199,7 @@ const instance = await render(
   }),
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
 )
+// 启动固定窗保留：等 Chat 首帧与快捷键安装完成，无单一可轮询锚点。
 await sleep(700)
 
 // inline 模式下有 scrollback 时 getLine(0..rows) 直扫读的是缓冲区开头；
@@ -214,80 +213,64 @@ setLang('en')
 // Help owns Esc while it is visible; Chat's modal guard must not let the key
 // reach working cancellation or any hidden global shortcut.
 stdin.write('/help')
-await sleep(250)
+// 输入已落屏（补全菜单描述可见）再回车——等待后只操作不断言，用 settle。
+await settle(() => screen().includes('Show shortcuts and commands'))
 stdin.write('\r')
-await settle(() => /scroll|commands:/.test(screen()))
-check('en: Help opens before slider', /scroll|commands:/.test(screen()), '')
+check('en: Help opens before slider', await settled(() => /scroll|commands:/.test(screen())), '')
 stdin.write('\x1b')
-await settle(() => !/commands:/.test(screen()))
-check('en: Esc closes Help only', !/commands:/.test(screen()), '')
+check('en: Esc closes Help only', await settled(() => !/commands:/.test(screen())), '')
 
 // 1. /effort bare → slider opens with the current level (High) checked.
 stdin.write('/effort')
-await sleep(250)
+await settle(() => screen().includes('Adjust the reasoning effort'))
 stdin.write('\r')
-await settle(() => /Reasoning effort/.test(screen()))
-let s = screen()
-check('slider opens with Reasoning effort title', /Reasoning effort/.test(s), '')
-check('slider lists all three levels', /Off/.test(s) && /High/.test(s) && /Max/.test(s), '')
-check('current level marked', /High\s*✓/.test(s) || /✓/.test(s), '')
+check('slider opens with Reasoning effort title', await settled(() => /Reasoning effort/.test(screen())), '')
+check('slider lists all three levels', await settled(() => /Off/.test(screen()) && /High/.test(screen()) && /Max/.test(screen())), '')
+check('current level marked', await settled(() => /High\s*✓/.test(screen()) || /✓/.test(screen())), '')
 
 // 2. → moves focus and applies immediately.
 stdin.write('\x1b[C')
-await settle(() => channel.setEffortCalls.length === 1 && channel.setEffortCalls[0] === 'max')
-check('right arrow applied setEffort(max)', channel.setEffortCalls.length === 1 && channel.setEffortCalls[0] === 'max', JSON.stringify(channel.setEffortCalls))
-await settle(() => /max/.test(screen()))
-s = screen()
-check('statusline effort shows max', /max/.test(s), '')
+check('right arrow applied setEffort(max)', await settled(() => channel.setEffortCalls.length === 1 && channel.setEffortCalls[0] === 'max'), JSON.stringify(channel.setEffortCalls))
+check('statusline effort shows max', await settled(() => /max/.test(screen())), '')
 
 // 3. Esc closes.
 stdin.write('\x1b')
-await settle(() => !/Reasoning effort/.test(screen().slice(-4000)))
-s = screen()
-check('Esc closed the slider', !/Reasoning effort/.test(s.slice(-4000)), '')
+check('Esc closed the slider', await settled(() => !/Reasoning effort/.test(screen().slice(-4000))), '')
 
 // 4. /effort off → direct set + notify.
 stdin.write('/effort off')
-await sleep(200)
+// 输入已落屏再回车（此串无补全项，等输入框本身）。
+await settle(() => screen().includes('/effort off'))
 stdin.write('\r')
-await settle(() => channel.setEffortCalls.includes('off'))
-check('/effort off applied', channel.setEffortCalls.includes('off'), JSON.stringify(channel.setEffortCalls))
+check('/effort off applied', await settled(() => channel.setEffortCalls.includes('off')), JSON.stringify(channel.setEffortCalls))
 
 // 5. Shift+Tab cycles the mode; StatusLine shows the label.
 stdin.write('\x1b[Z')
-await settle(() => screen().includes('计划模式') || /plan mode/.test(screen()))
-s = screen()
-check('statusline shows mode label', s.includes('计划模式') || /plan mode/.test(s), s.slice(-300))
+check('statusline shows mode label', await settled(() => screen().includes('计划模式') || /plan mode/.test(screen())), screen().slice(-300))
 stdin.write('\x1b[Z')
-await settle(() => channel.mode.id === 'full')
-check('second backtab → full', channel.mode.id === 'full', channel.mode.id)
+check('second backtab → full', await settled(() => channel.mode.id === 'full'), channel.mode.id)
 stdin.write('\x1b[Z')
-await settle(() => channel.modeIndex === 0)
-check('third backtab → default (no segment)', channel.modeIndex === 0, String(channel.modeIndex))
+check('third backtab → default (no segment)', await settled(() => channel.modeIndex === 0), String(channel.modeIndex))
 
 // 6. zh locale: the slider chrome hot-swaps to the localized strings
 //    (picker i18n branch: picker-title-effort / hint-adjust-done).
 setLang('zh')
 stdin.write('/help')
-await sleep(250)
+// zh 下 /help 的补全描述是本地化文案（i18n cmd-desc-help），等英文永远不成立。
+await settle(() => screen().includes('查看快捷键与命令'))
 stdin.write('\r')
-await settle(() => /命令：/.test(screen()))
-check('zh: Help opens before slider', /命令：/.test(screen()), '')
+check('zh: Help opens before slider', await settled(() => /命令：/.test(screen())), '')
 stdin.write('\x1b')
-await settle(() => !/命令：/.test(screen()))
-check('zh: Esc closes Help only', !/命令：/.test(screen()), '')
+check('zh: Esc closes Help only', await settled(() => !/命令：/.test(screen())), '')
 stdin.write('/effort')
-await sleep(250)
+// /effort 暂无 cmd-desc-effort 键，zh 下补全描述回退英文；若日后补键需同步改这里。
+await settle(() => screen().includes('Adjust the reasoning effort'))
 stdin.write('\r')
-await settle(() => screen().includes('推理强度'))
-s = screen()
-check('zh: slider title 推理强度', s.includes('推理强度'), '')
-check('zh: hint line localized', s.includes('调整') && s.includes('完成'), '')
+check('zh: slider title 推理强度', await settled(() => screen().includes('推理强度')), '')
+check('zh: hint line localized', await settled(() => screen().includes('调整') && screen().includes('完成')), '')
 // Read the xterm visible screen after the repaint, not the raw output backlog.
 stdin.write('\x1b')
-await settle(() => !screen().includes('推理强度'))
-s = screen()
-check('zh: Esc closed the slider', !s.includes('推理强度'), '')
+check('zh: Esc closed the slider', await settled(() => !screen().includes('推理强度')), '')
 setLang('en')
 
 instance.unmount()

--- a/scripts/verify-empty-assistant.tsx
+++ b/scripts/verify-empty-assistant.tsx
@@ -16,7 +16,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -28,7 +28,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
 ])
 
 const COLS = 100, ROWS = 40
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -96,12 +95,17 @@ const inst = await render(
   <AlternateScreen><Chat channel={channel} questionStore={new QuestionStore()} fullscreen /></AlternateScreen>,
   { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
 )
-await settle(() => {
-  const screen = screenLines().join('\n')
-  return screen.includes('Bash') && screen.includes('REALBODY-END') && screen.includes('REALBODY2-END')
-})
-
 {
+  // 正向条件各自 settled；负向（孤立 ●/⏵ 不出现）在正向全部落定后的
+  // 同帧同步判定——对空帧轮询「不存在」会立即真、等于没测。
+  check('工具卡正常渲染', await settled(() => screenLines().some(l => l.includes('Bash'))), '')
+  check('真实正文正常渲染', await settled(() => screenLines().join('\n').includes('REALBODY-END')), '')
+  check('⏵ 行 + 正文混合行保留正文', await settled(() => screenLines().join('\n').includes('REALBODY2-END')), '')
+  check('空文本 streaming 行保留（live dot）', await settled(() => {
+    const ls = screenLines()
+    const t = ls.findIndex(l => l.includes('Bash'))
+    return t >= 0 && ls.slice(t).some(l => l.includes('●'))
+  }), '')
   const lines = screenLines()
   const screen = lines.join('\n')
   // bug 形状：工具卡【上方】的孤立 ●（空 settled assistant）。streaming
@@ -110,12 +114,7 @@ await settle(() => {
   const dotAboveTool = toolRow >= 0 && lines.slice(0, toolRow).some(l => /^●\s*$/.test(l))
   check('空 settled assistant 行被过滤（工具卡上方无孤立 ●）', !dotAboveTool,
     `toolRow=${toolRow}`)
-  check('空文本 streaming 行保留（live dot）', lines.slice(toolRow).some(l => l.includes('●')),
-    '')
-  check('工具卡正常渲染', screen.includes('Bash'), '')
-  check('真实正文正常渲染', screen.includes('REALBODY-END'), '')
   check('叙述-only settled 行被过滤（⏵ 行不渲染、上方无孤立 ●）', !screen.includes('⏵') && !dotAboveTool, '')
-  check('⏵ 行 + 正文混合行保留正文', screen.includes('REALBODY2-END'), '')
 }
 
 // 落定翻转：streaming true → false 原地写（rows 身份/长度不变）。
@@ -123,12 +122,10 @@ await settle(() => {
 const streamRow = rows.find(r => r.id === 4)!
 streamRow.streaming = false
 channel.emit()
-await settle(() => loneDotLines(screenLines()).length === 0)
 {
-  const lines = screenLines()
-  check('落定翻转后空 assistant 行被过滤（缓存流位指纹生效）', loneDotLines(lines).length === 0,
-    `lone dots=${loneDotLines(lines).length}`)
-  check('翻转后真实正文仍在', lines.join('\n').includes('REALBODY-END'), '')
+  check('落定翻转后空 assistant 行被过滤（缓存流位指纹生效）', await settled(() => loneDotLines(screenLines()).length === 0),
+    `lone dots=${loneDotLines(screenLines()).length}`)
+  check('翻转后真实正文仍在', screenLines().join('\n').includes('REALBODY-END'), '')
 }
 // 用户空文本行不受影响（kind 限定）：一个空 user 行仍渲染其气泡形状
 rows.push({ id: 5, kind: 'user', text: '' })

--- a/scripts/verify-extension-events.tsx
+++ b/scripts/verify-extension-events.tsx
@@ -85,7 +85,7 @@ const [
   { Chat },
   { QuestionStore },
   { createChannel },
-  { settle },
+  { settle, settled, sleep },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -130,8 +130,6 @@ const plainText = (frames: string[]) => frames
   .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '')
   .replace(/\x1b\]9;[^\x07]*\x07/g, '')
   .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 /** Toasts are a LIST — the screen shows only the newest, so toast
  *  assertions read the channel's notification queue, not the frames. */
@@ -232,7 +230,7 @@ for (const [key, value] of Object.entries(services)) {
 // Mount the host row before the channel so the admitted test Component gets
 // the same verified identity and live grant store as a production plugin.
 ctx.plugin({ name: pluginHostRow.name, apply: pluginHostRow.apply })
-await sleep(60)
+await settle(() => ctx.get('tuiPluginHost') !== undefined)
 
 const liveAgent = makeAgent('a1', makeEvents(), captured)
 const channel = createChannel(ctx as never, liveAgent as never, {
@@ -296,6 +294,7 @@ const instance = await render(
   <Chat channel={channel as never} questionStore={new QuestionStore()} onExit={() => {}} />,
   { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
 await sleep(800)
 
 // ── 0. D-7 backstop: NO extensions row is mounted in this battery, yet an
@@ -308,11 +307,12 @@ await sleep(800)
       c.on('tui/input', () => ({ cancel: true }))
     },
   })
+  // 等未授权插件的订阅尝试注册完成：拒绝是静默的，没有可轮询的外部状态，
+  // 不给这段时间订阅根本没发生、探针会空过——保留固定窗口。
   await sleep(150)
   channel.submit('穿透检查')
-  await settle(() => captured.followupTexts.some(text => text.includes('穿透检查')))
   check('decision guard (no extensions row): ungranted plugin subscription denied',
-    captured.followupTexts.some(text => text.includes('穿透检查')),
+    await settled(() => captured.followupTexts.some(text => text.includes('穿透检查'))),
     JSON.stringify(captured.followupTexts))
 }
 
@@ -323,9 +323,8 @@ await sleep(800)
     return undefined
   })
   channel.submit('原始输入')
-  await settle(() => captured.followupTexts.some(text => text.includes('改写后的输入')))
   check('tui/input transform: delivered text is the plugin substitute',
-    captured.followupTexts.some(text => text.includes('改写后的输入')),
+    await settled(() => captured.followupTexts.some(text => text.includes('改写后的输入'))),
     JSON.stringify(captured.followupTexts))
   check('tui/input transform: the typed text never reached the agent',
     !captured.followupTexts.some(text => text.includes('原始输入')))
@@ -338,10 +337,9 @@ await sleep(800)
   const dispose = decisionCtx.on('tui/input', event =>
     event.text === '别发这个' ? { cancel: true, reason: '插件拦截了这条输入' } : undefined)
   channel.submit('别发这个')
-  await settle(() => plainText(stdout.frames).includes('插件拦截了这条输入'))
+  const cancelToasted = await settled(() => plainText(stdout.frames).includes('插件拦截了这条输入'))
   check('tui/input cancel: nothing delivered', captured.followupTexts.length === before)
-  check('tui/input cancel: reason toasted',
-    plainText(stdout.frames).includes('插件拦截了这条输入'))
+  check('tui/input cancel: reason toasted', cancelToasted)
   dispose()
 }
 
@@ -352,13 +350,10 @@ await sleep(800)
   const dispose = decisionCtx.on('tui/input', event =>
     event.text === '消毒检查' ? { cancel: true, reason: '拦截\x1b[31m\x07原因' } : undefined)
   channel.submit('消毒检查')
-  await settle(() => notified('拦截 [31m 原因')
-    && !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
-      .some(item => item.text.includes('\x1b')))
   check('tui/input cancel: reason sanitized before toasting',
-    notified('拦截 [31m 原因')
-    && !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
-      .some(item => item.text.includes('\x1b')))
+    await settled(() => notified('拦截 [31m 原因')
+      && !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
+        .some(item => item.text.includes('\x1b'))))
   dispose()
 
   // D-8: a decision still pending past 400ms surfaces a parked indicator.
@@ -369,12 +364,10 @@ await sleep(800)
     return { cancel: true, reason: '慢否决落地' } as const
   })
   channel.submit('慢决定')
-  await settle(() => notified('正在等待插件决定（tui/input）'))
   check('pending decision: parked indicator toasted past 400ms',
-    notified('正在等待插件决定（tui/input）'))
-  await settle(() => notified('慢否决落地') && !captured.followupTexts.some(text => text.includes('慢决定')))
+    await settled(() => notified('正在等待插件决定（tui/input）')))
   check('pending decision: the slow veto still lands',
-    notified('慢否决落地') && !captured.followupTexts.some(text => text.includes('慢决定')))
+    await settled(() => notified('慢否决落地') && !captured.followupTexts.some(text => text.includes('慢决定'))))
   // …and the indicator is dismissed the moment the decision lands — it must
   // not linger for its 4s timeout after the flow already continued.
   check('pending decision: the parked indicator is dismissed on resolution',
@@ -388,21 +381,17 @@ await sleep(800)
   const disposeCancel = decisionCtx.on('tui/input', event =>
     event.text === '无声拦截' ? { cancel: true } : undefined)
   channel.submit('无声拦截')
-  await settle(() => notified('操作已被插件取消')
-    && !captured.followupTexts.some(text => text.includes('无声拦截')))
   check('tui/input cancel without reason: host fallback toasted',
-    notified('操作已被插件取消')
-    && !captured.followupTexts.some(text => text.includes('无声拦截')))
+    await settled(() => notified('操作已被插件取消')
+      && !captured.followupTexts.some(text => text.includes('无声拦截'))))
   disposeCancel()
 
   const disposeHandled = decisionCtx.on('tui/input', event =>
     event.text === '无声接管' ? { handled: true } : undefined)
   channel.submit('无声接管')
-  await settle(() => notified('输入已由插件处理')
-    && !captured.followupTexts.some(text => text.includes('无声接管')))
   check('tui/input handled without notice: host fallback toasted',
-    notified('输入已由插件处理')
-    && !captured.followupTexts.some(text => text.includes('无声接管')))
+    await settled(() => notified('输入已由插件处理')
+      && !captured.followupTexts.some(text => text.includes('无声接管'))))
   disposeHandled()
 }
 
@@ -414,15 +403,12 @@ await sleep(800)
   })
   channel.submit('慢条甲')
   channel.submit('快条乙')
-  await settle(() => {
-    const indexA = captured.followupTexts.findIndex(text => text.includes('慢条甲'))
-    const indexB = captured.followupTexts.findIndex(text => text.includes('快条乙'))
-    return indexA !== -1 && indexB !== -1 && indexA < indexB
-  })
-  const indexA = captured.followupTexts.findIndex(text => text.includes('慢条甲'))
-  const indexB = captured.followupTexts.findIndex(text => text.includes('快条乙'))
   check('fifo: a slow decision on A does not let B overtake',
-    indexA !== -1 && indexB !== -1 && indexA < indexB, JSON.stringify(captured.followupTexts))
+    await settled(() => {
+      const indexA = captured.followupTexts.findIndex(text => text.includes('慢条甲'))
+      const indexB = captured.followupTexts.findIndex(text => text.includes('快条乙'))
+      return indexA !== -1 && indexB !== -1 && indexA < indexB
+    }), JSON.stringify(captured.followupTexts))
   dispose()
 }
 
@@ -434,15 +420,13 @@ await sleep(800)
   const cancelBefore = captured.cancelCalls
   channel.interruptAndDeliver(['插队文本'])
   // the fake has no whenIdle → 200ms fallback timer + decision
-  await settle(() => captured.followupTexts.length === before && notified('插队被拦截'))
   check('interruptAndDeliver: the tui/input veto applies to the Ctrl+Enter path',
-    captured.followupTexts.length === before && notified('插队被拦截'))
+    await settled(() => captured.followupTexts.length === before && notified('插队被拦截')))
   dispose()
 
   channel.interruptAndDeliver(['插队放行'])
-  await settle(() => captured.followupTexts.some(text => text.includes('插队放行')))
   check('interruptAndDeliver: the re-queue delivers without a veto',
-    captured.followupTexts.some(text => text.includes('插队放行')))
+    await settled(() => captured.followupTexts.some(text => text.includes('插队放行'))))
   check('interruptAndDeliver: a vetoed retry remains deliverable and cancel runs once',
     captured.cancelCalls === cancelBefore + 1, String(captured.cancelCalls))
 
@@ -454,10 +438,9 @@ await sleep(800)
     { type: 'turn/end', data: { turn: 99, reason: { kind: 'completed' } } },
   )
   channel.interruptAndDeliver(['终止后新插队'])
-  await settle(() => captured.cancelCalls === cancelBefore + 2
-    && captured.followupTexts.some(text => text.includes('终止后新插队')))
   check('interruptAndDeliver: turn/end permits a fresh cancel',
-    captured.cancelCalls === cancelBefore + 2 && captured.followupTexts.some(text => text.includes('终止后新插队')),
+    await settled(() => captured.cancelCalls === cancelBefore + 2
+      && captured.followupTexts.some(text => text.includes('终止后新插队'))),
     JSON.stringify({ cancelCalls: captured.cancelCalls, followups: captured.followupTexts }))
 }
 
@@ -467,9 +450,8 @@ await sleep(800)
     throw new Error('plugin exploded')
   })
   channel.submit('照常发送')
-  await settle(() => captured.followupTexts.some(text => text.includes('照常发送')))
   check('tui/input crash: a throwing listener degrades to no-opinion',
-    captured.followupTexts.some(text => text.includes('照常发送')))
+    await settled(() => captured.followupTexts.some(text => text.includes('照常发送'))))
   dispose()
 }
 
@@ -485,9 +467,8 @@ await sleep(800)
     event.text === '空白改写' ? { cancel: true, reason: '安全否决生效' } : undefined)
   const before = captured.followupTexts.length
   channel.submit('空白改写')
-  await settle(() => captured.followupTexts.length === before && notified('安全否决生效'))
   check('serial chain: blank rewrite does NOT bail the chain (veto still runs)',
-    captured.followupTexts.length === before && notified('安全否决生效'))
+    await settled(() => captured.followupTexts.length === before && notified('安全否决生效')))
   disposeBlank()
   disposeVeto()
 
@@ -500,9 +481,8 @@ await sleep(800)
   const disposeVeto2 = decisionCtx.on('tui/input', event =>
     event.text === '崩溃在前' ? { cancel: true, reason: '崩溃后的否决生效' } : undefined)
   channel.submit('崩溃在前')
-  await settle(() => !captured.followupTexts.some(text => text.includes('崩溃在前')) && notified('崩溃后的否决生效'))
   check('serial chain: a throwing listener does NOT skip the later veto',
-    !captured.followupTexts.some(text => text.includes('崩溃在前')) && notified('崩溃后的否决生效'))
+    await settled(() => !captured.followupTexts.some(text => text.includes('崩溃在前')) && notified('崩溃后的否决生效')))
   disposeThrow()
   disposeVeto2()
 
@@ -512,9 +492,8 @@ await sleep(800)
   const disposeTransform = decisionCtx.on('tui/input', event =>
     event.text === '垃圾返回' ? { text: '垃圾已被改写' } : undefined)
   channel.submit('垃圾返回')
-  await settle(() => captured.followupTexts.some(text => text.includes('垃圾已被改写')))
   check('serial chain: junk primitive return is skipped, later transform wins',
-    captured.followupTexts.some(text => text.includes('垃圾已被改写')))
+    await settled(() => captured.followupTexts.some(text => text.includes('垃圾已被改写'))))
   disposeJunk()
   disposeTransform()
 
@@ -533,9 +512,8 @@ await sleep(800)
   const disposeVeto3 = decisionCtx.on('tui/input', event =>
     event.text === '敌意返回' ? { cancel: true, reason: '敌意后的否决生效' } : undefined)
   channel.submit('敌意返回')
-  await settle(() => !captured.followupTexts.some(text => text.includes('敌意返回')) && notified('敌意后的否决生效'))
   check('serial chain: a throwing-getter return is skipped, later veto still runs',
-    !captured.followupTexts.some(text => text.includes('敌意返回')) && notified('敌意后的否决生效'))
+    await settled(() => !captured.followupTexts.some(text => text.includes('敌意返回')) && notified('敌意后的否决生效')))
   disposeHostile()
   disposeVeto3()
 }
@@ -568,34 +546,35 @@ await sleep(800)
 
   // Double-Esc on the empty input opens the picker (3s arming window).
   stdin.write('\x1b')
+  // 两次 Esc 之间的按键 pacing：连写会被终端输入解析吞成转义序列前缀，
+  // 无可观测条件——保留固定窗口。
   await sleep(120)
   stdin.write('\x1b')
-  await settle(() => plainText(stdout.frames.slice(-30)).includes('消息 09'))
-  const listShown = plainText(stdout.frames.slice(-30)).includes('消息 09')
+  const listShown = await settled(() => plainText(stdout.frames.slice(-30)).includes('消息 09'))
   check('rewind picker opens on double-Esc', listShown)
 
   // Enter on the newest message → the plugin decision resolves → mode list.
   stdin.write('\r')
-  await settle(() => {
+  const modesShown = await settled(() => {
     const tail = plainText(stdout.frames.slice(-40))
     return tail.includes('回退会话 + 恢复文件') && tail.includes('仅回退会话')
   })
   const afterEnter = plainText(stdout.frames.slice(-40))
-  check('rewind confirm renders plugin modes',
-    afterEnter.includes('回退会话 + 恢复文件') && afterEnter.includes('仅回退会话'),
-    afterEnter.slice(-200))
+  check('rewind confirm renders plugin modes', modesShown, afterEnter.slice(-200))
   check('rewind confirm: malformed description stripped, entry kept (no render crash)',
     afterEnter.includes('坏描述模式'))
   check('tui/rewind-prompt received the picked message seq', seen.promptSeq !== undefined)
 
   // ↓ once moves to the first plugin mode; Enter rewinds with it.
   stdin.write('\x1b[B')
+  // 选中态是颜色高亮，ANSI 洗净后不可观测——按键间保留固定 pacing。
   await sleep(150)
   stdin.write('\r')
-  await settle(() => seen.doneMode === 'files' && notified('已恢复 2 个文件') && seen.switchedKind === 'rewind')
-  check('picked mode id threaded to tui/rewind-done', seen.doneMode === 'files', String(seen.doneMode))
-  check('tui/rewind-done summary toasted', notified('已恢复 2 个文件'))
-  check("tui/session-switched fired with kind 'rewind'", seen.switchedKind === 'rewind')
+  check('picked mode id threaded to tui/rewind-done',
+    await settled(() => seen.doneMode === 'files'), String(seen.doneMode))
+  check('tui/rewind-done summary toasted', await settled(() => notified('已恢复 2 个文件')))
+  check("tui/session-switched fired with kind 'rewind'",
+    await settled(() => seen.switchedKind === 'rewind'))
   disposePrompt()
   disposeDone()
   disposeSwitched()
@@ -608,6 +587,9 @@ await sleep(800)
   // The section-4 rewind restored the picked message into the input for
   // re-editing: the first Esc clears it, then the double-Esc opens the
   // picker on the now-empty input.
+  // 连续 Esc 间的按键 pacing（清输入 → 武装 → 开列表）：连写会被吞成转义
+  // 序列前缀；第三次 Esc 后开列表的可观测文本「消息 09」也在恢复的输入行里，
+  // 无法区分——保留固定窗口。
   stdin.write('\x1b')
   await sleep(150)
   stdin.write('\x1b')
@@ -615,12 +597,13 @@ await sleep(800)
   stdin.write('\x1b')
   await sleep(400)
   stdin.write('\r') // Enter on the newest message → veto
-  await settle(() => notified('该消息不可回退'))
+  check('tui/rewind-prompt cancel: reason toasted', await settled(() => notified('该消息不可回退')))
   const tail = plainText(stdout.frames.slice(-40))
-  check('tui/rewind-prompt cancel: reason toasted', notified('该消息不可回退'))
   check('tui/rewind-prompt cancel: picker still open (list visible)', tail.includes('消息 09'))
   check('tui/rewind-prompt cancel: no delivery side effects', captured.followupTexts.length === forkCountBefore)
   stdin.write('\x1b') // close the picker
+  // 等收起重绘：帧是增量 diff，「列表已不可见」没有稳定的负向可观测条件
+  // ——保留固定窗口。
   await sleep(200)
   disposePrompt()
 }
@@ -642,8 +625,8 @@ await sleep(800)
   })
   const switched = await channel.newSession()
   check('/new succeeds without the veto', switched === true)
-  await settle(() => seen.includes('switched:new'))
-  check("tui/session-switched fired with kind 'new'", seen.includes('switched:new'), seen.join(','))
+  check("tui/session-switched fired with kind 'new'",
+    await settled(() => seen.includes('switched:new')), seen.join(','))
   disposeSwitched()
 }
 
@@ -651,31 +634,31 @@ await sleep(800)
 {
   const dispose = decisionCtx.on('tui/compact', () => ({ cancel: true, reason: '禁止压缩' }))
   channel.compact()
-  await settle(() => notified('禁止压缩'))
+  const compactVetoToasted = await settled(() => notified('禁止压缩'))
   check('tui/compact veto: compaction never ran', captured.compactCalls.length === 0)
-  check('tui/compact veto: reason toasted', notified('禁止压缩'))
+  check('tui/compact veto: reason toasted', compactVetoToasted)
   dispose()
 
   channel.compact()
-  await settle(() => captured.compactCalls.length === 1)
   check('tui/compact without the veto: compaction runs on the live agent',
-    captured.compactCalls.length === 1, JSON.stringify(captured.compactCalls))
+    await settled(() => captured.compactCalls.length === 1), JSON.stringify(captured.compactCalls))
 }
 
 // ── 8. compact stale-drop: a slow listener + /new during the await ───────
 {
   let release: (value: undefined) => void = () => {}
   const gate = new Promise<undefined>(resolve => { release = resolve })
-  const dispose = decisionCtx.on('tui/compact', () => gate)
+  let parked = false
+  const dispose = decisionCtx.on('tui/compact', () => { parked = true; return gate })
   channel.compact()
-  await sleep(200)
+  await settle(() => parked) // the compact decision is parked on the gate
   const switched = await channel.newSession()
   check('compact stale-drop setup: /new succeeded mid-await', switched === true)
   release(undefined)
-  await settle(() => notified('压缩已取消'))
+  const staleToasted = await settled(() => notified('压缩已取消'))
   check('compact stale-drop: the old session’s compaction never ran',
     captured.compactCalls.length === 1, JSON.stringify(captured.compactCalls))
-  check('compact stale-drop: stale notice toasted', notified('压缩已取消'))
+  check('compact stale-drop: stale notice toasted', staleToasted)
   dispose()
 }
 
@@ -688,9 +671,10 @@ await sleep(800)
 {
   let release: (value: undefined) => void = () => {}
   const gate = new Promise<undefined>(resolve => { release = resolve })
-  const dispose = decisionCtx.on('tui/compact', () => gate)
+  let parked = false
+  const dispose = decisionCtx.on('tui/compact', () => { parked = true; return gate })
   channel.compact()
-  await sleep(200)
+  await settle(() => parked) // the compact decision is parked on the gate
   const switched = await channel.newSession()
   check('compact ABA setup: /new succeeded mid-await', switched === true)
   const resumed = await channel.resumeTo('s-a1')
@@ -712,10 +696,14 @@ await sleep(800)
   check('switch stale setup: /new off the origin succeeded', moved === true)
   let release: (value: undefined) => void = () => {}
   const gate = new Promise<undefined>(resolve => { release = resolve })
-  const dispose = decisionCtx.on('tui/session-switch', event =>
-    event.kind === 'resume' ? gate : undefined)
+  let parked = false
+  const dispose = decisionCtx.on('tui/session-switch', event => {
+    if (event.kind !== 'resume') return undefined
+    parked = true
+    return gate
+  })
   const resumePromise = channel.resumeTo('s-a1')
-  await sleep(200)
+  await settle(() => parked) // the /resume decision is parked on the gate
   const switched = await channel.newSession()
   check('switch stale setup: a second /new completed mid-await', switched === true)
   release(undefined)
@@ -731,14 +719,18 @@ await sleep(800)
 {
   let release: (value: undefined) => void = () => {}
   const gate = new Promise<undefined>(resolve => { release = resolve })
+  let parked = false
   const dispose = decisionCtx.on('tui/input', async event => {
-    if (event.text === '旧会话首条') await gate
+    if (event.text === '旧会话首条') {
+      parked = true
+      await gate
+    }
     return undefined
   })
   const before = captured.followupTexts.length
   channel.submit('旧会话首条')
   channel.submit('旧会话次条')
-  await sleep(300) // the predecessor's decision is parked on the gate
+  await settle(() => parked) // the predecessor's decision is parked on the gate
   const switched = await channel.newSession()
   check('enqueue origin setup: /new succeeded while the predecessor parked', switched === true)
   release(undefined)
@@ -758,9 +750,10 @@ await sleep(800)
 {
   let release: (value: undefined) => void = () => {}
   const gate = new Promise<undefined>(resolve => { release = resolve })
-  const dispose = decisionCtx.on('tui/rewind-prompt', () => gate)
+  let parked = false
+  const dispose = decisionCtx.on('tui/rewind-prompt', () => { parked = true; return gate })
   const promptPromise = channel.promptRewind({ seq: 1, text: '消息 00' } as never)
-  await sleep(300)
+  await settle(() => parked) // the rewind decision is parked on the gate
   const switched = await channel.newSession()
   check('rewind stale setup: /new succeeded while the rewind decision parked', switched === true)
   release(undefined)
@@ -787,6 +780,7 @@ await sleep(800)
     switchedKinds.push(event.kind)
   })
   const rewindPromise = channel.rewindTo({ seq: 4, text: '回退恢复文本' } as never, null)
+  // sleep 是超时兜底（挂死检测的墙钟上界），不是等待条件——保留。
   const text = await Promise.race([rewindPromise, sleep(900).then(() => 'TIMEOUT' as const)])
   check('rewind-done decoupled: rewindTo returns the picked text without waiting for the listener',
     text === '回退恢复文本', String(text))
@@ -794,8 +788,7 @@ await sleep(800)
   check('rewind-done decoupled: session-switched did not wait for the listener',
     switchedKinds.includes('rewind'), switchedKinds.join(','))
   release('迟到摘要')
-  await settle(() => notified('迟到摘要'))
-  check('rewind-done decoupled: the late summary still toasts', notified('迟到摘要'))
+  check('rewind-done decoupled: the late summary still toasts', await settled(() => notified('迟到摘要')))
   disposeDone()
   disposeSwitched()
 }
@@ -808,8 +801,8 @@ await sleep(800)
   const dispose = decisionCtx.on('tui/input', event => (event.text === '超长等待' ? gate : undefined))
   channel.submit('超长等待')
   // past the 400ms threshold: the indicator is up
-  await settle(() => notified('正在等待插件决定（tui/input）'))
-  check('pending indicator: raised past the threshold', notified('正在等待插件决定（tui/input）'))
+  check('pending indicator: raised past the threshold',
+    await settled(() => notified('正在等待插件决定（tui/input）')))
   // The standard single-handler deadline is 1s. The indicator must remain
   // visible until that deadline resolves the never-settling callback; it is
   // not allowed to disappear on the ordinary 4s notification timer first.
@@ -819,12 +812,11 @@ await sleep(800)
   check('pending indicator: still up while the bounded decision is parked',
     notified('正在等待插件决定（tui/input）'))
   release(undefined)
-  await settle(() => captured.followupTexts.some(text => text.includes('超长等待')))
+  const delivered = await settled(() => captured.followupTexts.some(text => text.includes('超长等待')))
   check('pending indicator: dismissed when the deadline settles the decision',
     !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
       .some(item => item.text.includes('正在等待插件决定')))
-  check('pending indicator: the settled input is delivered',
-    captured.followupTexts.some(text => text.includes('超长等待')))
+  check('pending indicator: the settled input is delivered', delivered)
   dispose()
 }
 

--- a/scripts/verify-extension-ui.tsx
+++ b/scripts/verify-extension-ui.tsx
@@ -43,7 +43,7 @@ const [
   { dispatchTuiDecision, normalizeCancelDecision },
   { stringWidth },
   { KNOWN_SESSION_EVENT_TYPES },
-  { settle },
+  { settle, settled, sleep },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -96,8 +96,6 @@ const plainText = (frames: string[]) => frames
   .replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, '')
   .replace(/\x1b\]9;[^\x07]*\x07/g, '')
   .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 let failures = 0
 const check = (name: string, ok: boolean, detail = '') => {
@@ -224,7 +222,8 @@ ctx.plugin(TuiDialogRuntime)
 ctx.plugin(TuiStatusRuntime)
 ctx.plugin(TuiShortcutRuntime)
 ctx.plugin(TuiRendererRuntime)
-await sleep(100)
+await settle(() => ctx.get('tuiDialogs') !== undefined && ctx.get('tuiStatus') !== undefined
+  && ctx.get('tuiShortcuts') !== undefined && ctx.get('tuiRenderers') !== undefined)
 
 // Plugin-facing extension calls must originate from a live child activation.
 // Calling these services through the composition root would bind effects to
@@ -237,7 +236,7 @@ const pluginFiber = ctx.plugin({
     pluginCtx = candidate
   },
 })
-await sleep(50)
+await settle(() => pluginCtx !== undefined)
 if (pluginCtx === undefined) {
   await Promise.resolve(pluginFiber.dispose())
   throw new Error('UI extension probe did not start')
@@ -478,8 +477,7 @@ const plugin = pluginCtx
   let fired = 0
   plugin.tuiShortcuts.register('alt+z', { description: 'fire', handler: () => { fired += 1 } })
   check('tuiShortcuts.dispatch: matching key consumed', shortcutHost.dispatch('z', { meta: true }) === true)
-  await settle(() => fired === 1)
-  check('tuiShortcuts.dispatch: handler ran', fired === 1)
+  check('tuiShortcuts.dispatch: handler ran', await settled(() => fired === 1))
   check('tuiShortcuts.dispatch: non-matching key passes through', shortcutHost.dispatch('q', { ctrl: true }) === false)
 
   // Throwing handler → onError, never propagated.
@@ -490,8 +488,7 @@ const plugin = pluginCtx
     handler: () => { throw new Error('handler exploded') },
   })
   shortcutHost.dispatch('y', { meta: true })
-  await settle(() => errored === 'alt+y')
-  check('tuiShortcuts.dispatch: handler error routed to onError', errored === 'alt+y')
+  check('tuiShortcuts.dispatch: handler error routed to onError', await settled(() => errored === 'alt+y'))
   removeErrorHandler()
 
   // dispose unregisters
@@ -577,7 +574,7 @@ const plugin = pluginCtx
     },
   }))
   guardCtx.plugin({ name: pluginHostRow.name, apply: pluginHostRow.apply })
-  await sleep(50)
+  await settle(() => guardCtx.get('tuiPluginHost') !== undefined)
   const admitted = await mountAdmitted(guardCtx, 'my-guard-export', testManifest({
     id: 'my-guard',
     requires: [DECISION_COORDINATE],
@@ -608,7 +605,9 @@ const plugin = pluginCtx
       c.on('tui/compact', () => ({ cancel: true }))
     },
   })
-  await sleep(100)
+  // 拒绝在订阅时即发出 warn：等两条 denial 警告落地即代表插件 apply 已跑完。
+  await settle(() => guardWarnings.some(line => line.includes('"evil-plugin"') && line.includes('session.input.intercept'))
+    && guardWarnings.some(line => line.includes('session.compact.intercept')))
   check('decision guard: ungranted subscription never enters the chain',
     (await dispatchTuiDecision(guardCtx, 'tui/input', { text: '别的', sessionId: 'ui-session' }, passThrough)) === undefined
     && (await dispatchTuiDecision(guardCtx, 'tui/compact', { sessionId: 'ui-session' }, normalizeCancelDecision)) === undefined)
@@ -626,9 +625,8 @@ const plugin = pluginCtx
     { order: 'ui-observe' },
   )
   await dispatchTuiDecision(guardCtx, 'tui/session-switched', { sessionId: 'ui-session' }, () => undefined)
-  await settle(() => observed && !guardWarnings.some(line => line.includes('tui/session-switched')))
   check('decision guard: observe-class events stay ungated',
-    observed && !guardWarnings.some(line => line.includes('tui/session-switched')))
+    await settled(() => observed && !guardWarnings.some(line => line.includes('tui/session-switched'))))
   observeRelease()
   release()
 
@@ -692,6 +690,7 @@ const instance = await render(
   />,
   { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
 )
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
 await sleep(600)
 const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 
@@ -704,30 +703,28 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
       { id: 'second', label: '第二项', description: '带描述' },
     ],
   })
-  await settle(() => screen().includes('挑一个') && screen().includes('第二项'))
   check('ui: select dialog renders title + options',
-    screen().includes('挑一个') && screen().includes('第二项'), screen().slice(-200))
+    await settled(() => screen().includes('挑一个') && screen().includes('第二项')), screen().slice(-200))
   stdin.write('\x1b[B')
+  // 按键间 pacing：等上一键的编辑/选中态落地再发下一键，选中高亮是颜色，
+  // ANSI 洗净后无可观测条件（本文件后续同类 sleep 同理）。
   await sleep(150)
   stdin.write('\r')
   check('ui: select ↓+Enter resolves the second id', (await pending) === 'second')
-  await settle(() => dialogStore.getSnapshot() === null)
-  check('ui: dialog closed after settle', dialogStore.getSnapshot() === null)
+  check('ui: dialog closed after settle', await settled(() => dialogStore.getSnapshot() === null))
 }
 
 // FIFO: the second dialog waits for the first to settle. Confirm: Enter = yes.
 {
   const first = plugin.tuiDialogs.confirm({ title: '确认一下', message: '要做吗' })
   const second = plugin.tuiDialogs.select({ title: '排队的选择', options: [{ id: 'only', label: '唯一' }] })
-  await settle(() => screen().includes('确认一下') && screen().includes('要做吗'))
   check('ui: confirm renders with message + localized defaults',
-    screen().includes('确认一下') && screen().includes('要做吗'), screen().slice(-200))
+    await settled(() => screen().includes('确认一下') && screen().includes('要做吗')), screen().slice(-200))
   check('ui: FIFO — second dialog still queued', dialogStore.getSnapshot()?.kind === 'confirm')
   stdin.write('\r') // Enter on 是 → true
   check('ui: confirm Enter resolves true', (await first) === true)
-  await settle(() => screen().includes('排队的选择'))
   check('ui: queued select now active',
-    screen().includes('排队的选择'), screen().slice(-200))
+    await settled(() => screen().includes('排队的选择')), screen().slice(-200))
   stdin.write('\x1b') // Esc cancels the select
   check('ui: Esc cancels → undefined', (await second) === undefined)
 }
@@ -735,8 +732,8 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // Input: placeholder shown when empty; typed text resolves.
 {
   const pending = plugin.tuiDialogs.input({ title: '说点什么', placeholder: '占位提示', initial: '' })
-  await settle(() => screen().includes('占位提示'))
-  check('ui: input dialog renders placeholder', screen().includes('占位提示'), screen().slice(-200))
+  check('ui: input dialog renders placeholder', await settled(() => screen().includes('占位提示')), screen().slice(-200))
+  // 逐字符按键间 pacing（同上，无可观测条件）。
   for (const ch of '你好') { stdin.write(ch); await sleep(60) }
   stdin.write('\r')
   check('ui: input Enter resolves the typed text', (await pending) === '你好')
@@ -747,6 +744,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   const pending = plugin.tuiDialogs.input({ title: '改改', initial: '原文' })
   await settle(() => screen().includes('原文'))
   stdin.write('\x7f') // backspace removes 文
+  // 按键间 pacing（同上）。
   await sleep(150)
   stdin.write('\r')
   check('ui: input initial pre-fills and edits', (await pending) === '原')
@@ -779,6 +777,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   await sleep(300)
   const chunk = '多行\n粘贴\x07' + '长'.repeat(600)
   stdin.write(`\x1b[200~${chunk}\x1b[201~`)
+  // 粘贴解析 pacing：等整段粘贴落入输入值再发 Enter（同上，无可观测条件）。
   await sleep(250)
   stdin.write('\r')
   const resolved = await pending
@@ -821,6 +820,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   stdin.write('\x1b[B\r') // Down + Enter in one chunk
   check('ui: batched ↓+Enter settles the NEW focus, not the stale one',
     (await pending) === 'second')
+  // 面板收起重绘 pacing：下一面板标题在增量重绘下会片段化，无可靠观察点。
   await sleep(200)
 }
 {
@@ -828,6 +828,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   await settle(() => screen().includes('同批确认'))
   stdin.write('\x1b[C\r') // Right + Enter in one chunk → focus 否 → false
   check('ui: batched →+Enter settles the moved focus', (await pending) === false)
+  // 面板收起重绘 pacing（同上）。
   await sleep(200)
 }
 // Two Backspaces in one chunk must BOTH delete (each seeing the other's
@@ -836,6 +837,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   const pending = plugin.tuiDialogs.input({ title: '同批退格', initial: 'abcd' })
   await settle(() => screen().includes('同批退格'))
   stdin.write('\x7f\x7f')
+  // 按键间 pacing（同上）。
   await sleep(150)
   stdin.write('\r')
   check('ui: batched Backspace×2 deletes both characters', (await pending) === 'ab')
@@ -849,9 +851,9 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   // 排序等待：同上，增量重绘下标题片段化，无可靠的屏幕观察点——保留。
   await sleep(300)
   stdin.write('\x1b[D') // left: cursor between 😊 and b
-  await sleep(120)
+  await sleep(120) // 按键间 pacing（同上）
   stdin.write('\x7f') // backspace deletes the whole emoji
-  await sleep(120)
+  await sleep(120) // 按键间 pacing（同上）
   stdin.write('\r')
   check('ui: Backspace deletes a whole emoji (no lone surrogate)',
     (await pending) === 'ab')
@@ -861,7 +863,7 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   // 排序等待：同上，增量重绘下标题片段化，无可靠的屏幕观察点——保留。
   await sleep(300)
   stdin.write('\x7f') // single backspace at end of the sole emoji
-  await sleep(150)
+  await sleep(150) // 按键间 pacing（同上）
   stdin.write('\r')
   check('ui: Backspace on the sole emoji empties the value', (await pending) === '')
 }
@@ -872,9 +874,9 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
   // Left ×2 from the end: code-point steps land BEFORE the emoji (a UTF-16
   // step would park the cursor mid-surrogate and split the pair on insert).
   stdin.write('\x1b[D\x1b[D')
-  await sleep(120)
+  await sleep(120) // 按键间 pacing（同上）
   stdin.write('z')
-  await sleep(120)
+  await sleep(120) // 按键间 pacing（同上）
   stdin.write('\r')
   check('ui: arrow keys step by code point (insert never splits a pair)',
     (await pending) === 'z😊x')
@@ -883,8 +885,8 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 // Status line: appears on set, disappears on clear.
 {
   plugin.tuiStatus.set('demo-plugin', '构建中 42%')
-  await settle(() => screen().includes('构建中 42%'))
-  check('ui: status line renders the contribution', screen().includes('构建中 42%'), screen().slice(-300))
+  check('ui: status line renders the contribution',
+    await settled(() => screen().includes('构建中 42%')), screen().slice(-300))
   // The incremental renderer only writes diffs: after the clear, assert on
   // frames written FROM the clear on — earlier frames legitimately still
   // contain the set text.
@@ -902,10 +904,9 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 {
   let fired = 0
   plugin.tuiShortcuts.register('alt+p', { description: 'ui fire', handler: () => { fired += 1 } })
-  await sleep(100)
+  await settle(() => plugin.tuiShortcuts.list().some(entry => entry.combo === 'alt+p'))
   stdin.write('\x1bp') // alt+p
-  await settle(() => fired >= 1)
-  check('ui: plugin shortcut handler fired through Chat', fired >= 1, String(fired))
+  check('ui: plugin shortcut handler fired through Chat', await settled(() => fired >= 1), String(fired))
   check('ui: shortcut keypress never reached submit', channel.submitCalls.length === 0)
 }
 

--- a/scripts/verify-help-scroll.tsx
+++ b/scripts/verify-help-scroll.tsx
@@ -18,7 +18,7 @@ const [
   { Chat },
   { QuestionStore },
   { createChannel },
-  { settle, viewportLines },
+  { settle, settled, sleep, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -117,7 +117,6 @@ function Fixture(): React.ReactNode {
   )
 }
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 const write = async (input: string): Promise<void> => {
   stdin.write(input)
   await sleep(180)
@@ -144,50 +143,30 @@ const app = await render(<Fixture />, {
 })
 
 try {
-  await settle(() => {
-    const text = screenText()
-    return text.includes('/new —') && !text.includes('/q —') && text.includes('/ for commands')
-      && text.includes('↑/↓') && !text.includes('PENDING_SENTINEL')
-  })
-  let text = screenText()
-  check(text.includes('/new —'), 'help opens at the first command')
-  check(!text.includes('/q —'), 'tail commands start outside the viewport')
-  check(text.includes('/ for commands'), 'shortcut reference is visible at the top')
-  check(text.includes('↑/↓'), 'a persistent scroll hint is visible')
-  check(!text.includes('PENDING_SENTINEL'), 'pending preview stays behind the help overlay')
+  // 正向条件各自 settled；负向（尚未滚到的尾部/被遮住的 pending）在正向
+  // 落定后的同帧同步判定——空帧上轮询「不存在」会立即真。
+  check(await settled(() => screenText().includes('/new —')), 'help opens at the first command')
+  check(await settled(() => screenText().includes('/ for commands')), 'shortcut reference is visible at the top')
+  check(await settled(() => screenText().includes('↑/↓')), 'a persistent scroll hint is visible')
+  check(!screenText().includes('/q —'), 'tail commands start outside the viewport')
+  check(!screenText().includes('PENDING_SENTINEL'), 'pending preview stays behind the help overlay')
 
   stdin.write('\x1b[6~')
-  await settle(() => !screenText().includes('/new —'))
-  text = screenText()
-  check(!text.includes('/new —'), 'PageDown advances by a viewport')
+  check(await settled(() => !screenText().includes('/new —')), 'PageDown advances by a viewport')
   stdin.write('\x1b[5~')
-  await settle(() => screenText().includes('/new —'))
-  text = screenText()
-  check(text.includes('/new —'), 'PageUp returns by a viewport')
+  check(await settled(() => screenText().includes('/new —')), 'PageUp returns by a viewport')
 
   // More presses than the content requires also exercise end clamping.
   stdin.write('\x1b[B'.repeat(60))
-  await settle(() => {
-    const t = screenText()
-    return t.includes('/q —') && !t.includes('/new —')
-  })
-  text = screenText()
-  check(text.includes('/q —'), 'Down reaches the final command')
-  check(!text.includes('/new —'), 'the viewport actually moved away from the top')
+  check(await settled(() => screenText().includes('/q —')), 'Down reaches the final command')
+  check(await settled(() => !screenText().includes('/new —')), 'the viewport actually moved away from the top')
 
   stdin.write('\x1b[H')
-  await settle(() => screenText().includes('/new —'))
-  text = screenText()
-  check(text.includes('/new —'), 'Home returns to the first command')
+  check(await settled(() => screenText().includes('/new —')), 'Home returns to the first command')
 
   stdin.write('\x1b[F')
-  await settle(() => {
-    const t = screenText()
-    return t.includes('/q —') && t.includes('/ for commands')
-  })
-  text = screenText()
-  check(text.includes('/q —'), 'End jumps to the final command')
-  check(text.includes('/ for commands'), 'shortcut reference stays fixed at the tail')
+  check(await settled(() => screenText().includes('/q —')), 'End jumps to the final command')
+  check(await settled(() => screenText().includes('/ for commands')), 'shortcut reference stays fixed at the tail')
 
   // SGR mouse wheel up. The fixture's Chat-like owner must not move the
   // transcript while Help owns the overlay, while Help itself must move.
@@ -196,23 +175,14 @@ try {
   // so a leaked wheel event has time to surface.
   await write('\x1b[<64;10;10M'.repeat(20))
   check(transcriptWheelEvents === 0, 'help suppresses transcript wheel scrolling')
-  check(!screenText().includes('/q —'), 'mouse wheel scrolls the help viewport')
+  check(await settled(() => !screenText().includes('/q —')), 'mouse wheel scrolls the help viewport')
 
   stdin.write('\x1b')
-  await settle(() => {
-    const t = screenText()
-    return !t.includes('commands:') && t.includes('PENDING_SENTINEL')
-  })
-  check(!screenText().includes('commands:'), 'Escape closes help')
-  check(screenText().includes('PENDING_SENTINEL'), 'pending preview returns after help closes')
+  check(await settled(() => !screenText().includes('commands:')), 'Escape closes help')
+  check(await settled(() => screenText().includes('PENDING_SENTINEL')), 'pending preview returns after help closes')
   stdin.write('?')
-  await settle(() => {
-    const t = screenText()
-    return t.includes('/new —') && !t.includes('PENDING_SENTINEL')
-  })
-  text = screenText()
-  check(text.includes('/new —'), 'reopening help resets the viewport to the top')
-  check(!text.includes('PENDING_SENTINEL'), 'reopened help remains visually exclusive')
+  check(await settled(() => screenText().includes('/new —')), 'reopening help resets the viewport to the top')
+  check(await settled(() => !screenText().includes('PENDING_SENTINEL')), 'reopened help remains visually exclusive')
 
   // Stability probe across a resize (the hint must REMAIN visible): the
   // condition is already true before the repaint, so a settle would return
@@ -223,8 +193,7 @@ try {
   await sleep(300)
   check(screenText().includes('↑/↓'), 'scroll hint remains visible after resize')
   stdin.write('\x1b[F')
-  await settle(() => screenText().includes('/q —'))
-  check(screenText().includes('/q —'), 'resized help can still reach the tail')
+  check(await settled(() => screenText().includes('/q —')), 'resized help can still reach the tail')
 
   // Ordering sleep kept: the narrow reflow has no single anchored condition
   // to poll before the next keypress.
@@ -233,17 +202,12 @@ try {
   stdout.emit('resize')
   await sleep(300)
   stdin.write('\x1b[H')
-  await settle(() => screenText().includes('/ for commands'))
-  check(screenText().includes('/ for commands'), 'narrow Help stacks shortcuts into the scroll viewport')
+  check(await settled(() => screenText().includes('/ for commands')), 'narrow Help stacks shortcuts into the scroll viewport')
   stdin.write('\x1b[F')
   await settle(() => screenText().includes('/q —'))
   stdin.write('\x1b[B'.repeat(60))
-  await settle(() => {
-    const t = screenText()
-    return t.includes('/connect —') && t.includes('↑/↓')
-  })
-  check(LOCAL_COMMANDS.at(-1)?.name === 'q' && screenText().includes('/connect —'), 'narrow Help keeps the command-list tail reachable after End and navigation')
-  check(screenText().includes('↑/↓'), 'narrow Help keeps the navigation hint fixed')
+  check(LOCAL_COMMANDS.at(-1)?.name === 'q' && await settled(() => screenText().includes('/connect —')), 'narrow Help keeps the command-list tail reachable after End and navigation')
+  check(await settled(() => screenText().includes('↑/↓')), 'narrow Help keeps the navigation hint fixed')
 } finally {
   app.unmount()
 }
@@ -324,21 +288,18 @@ try {
   await sleep(500)
   for (const key of '/help') await write(key)
   stdin.write('\r')
-  await settle(() => screenText().includes('↑/↓'))
-  check(screenText().includes('↑/↓'), '/help opens Help through the real Chat command path')
+  check(await settled(() => screenText().includes('↑/↓')), '/help opens Help through the real Chat command path')
 
   stdin.write('\x1b')
   await settle(() => !screenText().includes('↑/↓'))
   // Negative probe (transcript search must NOT open on `/`): a settle would
   // return immediately on the already-true condition — keep a fixed window.
   await write('/')
-  let routed = screenText()
-  check(!routed.includes('no matches'), 'ordinary Esc then slash stays in command completion')
-  check(routed.includes('help'), 'ordinary slash completion is visible after Help closes')
+  check(!screenText().includes('no matches'), 'ordinary Esc then slash stays in command completion')
+  check(await settled(() => screenText().includes('help')), 'ordinary slash completion is visible after Help closes')
   for (const key of 'help') await write(key)
   stdin.write('\r')
-  await settle(() => screenText().includes('↑/↓'))
-  check(screenText().includes('↑/↓'), '/help reopens through the real Chat command path')
+  check(await settled(() => screenText().includes('↑/↓')), '/help reopens through the real Chat command path')
 
   // Ctrl+O must be inert behind Help; Esc then returns to the ordinary
   // prompt, where `/` belongs to slash-command completion. (The Ctrl+O
@@ -347,15 +308,12 @@ try {
   stdin.write('\x1b')
   await settle(() => !screenText().includes('↑/↓'))
   await write('/')
-  routed = screenText()
-  check(!routed.includes('no matches'), 'slash after Help does not open transcript search')
-  check(routed.includes('help'), 'slash completion remains available after Help closes')
+  check(!screenText().includes('no matches'), 'slash after Help does not open transcript search')
+  check(await settled(() => screenText().includes('help')), 'slash completion remains available after Help closes')
 
   for (const key of 'help') await write(key)
   stdin.write('\r')
-  await settle(() => screenText().includes('↑/↓'))
-  routed = screenText()
-  check(routed.includes('↑/↓'), '/help can be submitted again after closing Help')
+  check(await settled(() => screenText().includes('↑/↓')), '/help can be submitted again after closing Help')
 
   // Composer-local, Chat-global, and plugin bindings must not mutate hidden
   // state behind Help. The broad Chat yield guards future shortcuts too,
@@ -374,8 +332,7 @@ try {
   check(modeCycles === 0, 'Shift+Tab does not cycle session mode behind Help')
   await write('\x1b[1;2A')
   stdin.write('x')
-  await settle(() => !screenText().includes('↑/↓'))
-  check(!screenText().includes('↑/↓'), 'typing after Shift+Up dismisses Help instead of being trapped in selection mode')
+  check(await settled(() => !screenText().includes('↑/↓')), 'typing after Shift+Up dismisses Help instead of being trapped in selection mode')
   await write('\x03')
 
   // Help owns Esc even during a live turn. The Chat-level cancel branch must
@@ -391,12 +348,10 @@ try {
     type: 'turn/start',
     data: { turn: 1 },
   })
-  await settle(() => chatChannel.working)
-  check(chatChannel.working, 'full Chat fixture enters working state')
+  check(await settled(() => chatChannel.working), 'full Chat fixture enters working state')
   stdin.write('\x1b')
-  await settle(() => !screenText().includes('↑/↓'))
+  check(await settled(() => !screenText().includes('↑/↓')), 'Escape still closes Help while a turn is working')
   check(cancelCalls === 0, 'Escape closes Help without cancelling a working turn')
-  check(!screenText().includes('↑/↓'), 'Escape still closes Help while a turn is working')
   onSessionEvent?.(agent.session, {
     seq: 2,
     time: Date.now(),
@@ -413,8 +368,7 @@ try {
   await settle(() => screenText().includes('↑/↓'))
   stdin.write('/')
   await settle(() => !screenText().includes('↑/↓'))
-  routed = screenText()
-  check(!routed.includes('no matches'), 'slash typed in Help does not open transcript search')
+  check(!screenText().includes('no matches'), 'slash typed in Help does not open transcript search')
   check(chatChannel.commandCompletions('/').some(command => command.name === 'help'), 'slash typed in Help returns to command completion')
   await write('\x03')
   await write('\x0f')

--- a/scripts/verify-i18n-command-descriptions.tsx
+++ b/scripts/verify-i18n-command-descriptions.tsx
@@ -20,7 +20,7 @@ const [
   { setLang },
   { LOCAL_COMMANDS },
   { stringWidth },
-  { settle, viewportLines },
+  { settle, settled, viewportLines, writeParsed },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -33,8 +33,6 @@ const [
   import('../src/ink/stringWidth.js'),
   import('./lib/term-test.mjs'),
 ])
-
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 let failures = 0
 function assert(cond: boolean, msg: string) {
@@ -85,32 +83,22 @@ console.log('CommandSuggestions 随 /lang 切换:')
 
   setLang('zh')
   app.rerender(React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }))
-  await settle(() => {
-    const t = screenText(term, ROWS)
-    return t.includes('新开会话') && t.includes('压缩会话历史') && t.includes('切换计划模式')
-      && t.includes('Registry fallback text') && !t.includes('Toggle plan mode')
-  })
-  let text = screenText(term, ROWS)
-  assert(text.includes('新开会话'), 'zh：内置命令显示中文描述（新开会话）')
-  assert(text.includes('压缩会话历史'), 'zh：compact 显示中文描述')
-  assert(text.includes('切换计划模式'), 'zh：外部命令 plan 走 cmd-desc 中文映射')
-  assert(text.includes('Registry fallback text'), 'zh：未收录外部命令回退注册表原文')
-  assert(!text.includes('Toggle plan mode'), 'zh：已收录外部命令不再显示英文原文')
+  assert(await settled(() => screenText(term, ROWS).includes('新开会话')), 'zh：内置命令显示中文描述（新开会话）')
+  assert(await settled(() => screenText(term, ROWS).includes('压缩会话历史')), 'zh：compact 显示中文描述')
+  assert(await settled(() => screenText(term, ROWS).includes('切换计划模式')), 'zh：外部命令 plan 走 cmd-desc 中文映射')
+  assert(await settled(() => screenText(term, ROWS).includes('Registry fallback text')), 'zh：未收录外部命令回退注册表原文')
+  assert(await settled(() => !screenText(term, ROWS).includes('Toggle plan mode')), 'zh：已收录外部命令不再显示英文原文')
 
   setLang('en')
   app.rerender(React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }))
-  await settle(() => {
-    const t = screenText(term, ROWS)
-    return t.includes('Start a new conversation') && t.includes('Toggle plan mode') && !t.includes('新开会话')
-  })
-  text = screenText(term, ROWS)
-  assert(text.includes('Start a new conversation'), 'en：内置命令回退 LOCAL_COMMANDS 英文原文')
-  assert(text.includes('Toggle plan mode'), 'en：外部命令 plan 回退注册表英文原文')
-  assert(!text.includes('新开会话'), 'en：不再残留中文描述')
+  assert(await settled(() => screenText(term, ROWS).includes('Start a new conversation')), 'en：内置命令回退 LOCAL_COMMANDS 英文原文')
+  assert(await settled(() => screenText(term, ROWS).includes('Toggle plan mode')), 'en：外部命令 plan 回退注册表英文原文')
+  assert(await settled(() => !screenText(term, ROWS).includes('新开会话')), 'en：不再残留中文描述')
 
   setLang('zh')
   app.unmount()
-  await sleep(100)
+  // 空写屏障：等在途的 term.write 解析完（取代 unmount 后固定 sleep）。
+  await writeParsed(term, '')
 }
 
 // --- 2. ? 帮助菜单随语言切换 --------------------------------------------------
@@ -130,23 +118,17 @@ console.log('HelpMenu 随 /lang 切换:')
 
   setLang('zh')
   app.rerender(React.createElement(HelpMenu, { commands }))
-  await settle(() => {
-    const t = screenText(term, ROWS)
-    return t.includes('/new — 新开会话') && t.includes('/rewind — 回退会话到历史消息')
-  })
-  let text = screenText(term, ROWS)
-  assert(text.includes('/new — 新开会话'), 'zh：帮助菜单显示 /new — 新开会话')
-  assert(text.includes('/rewind — 回退会话到历史消息'), 'zh：帮助菜单显示 rewind 中文描述')
+  assert(await settled(() => screenText(term, ROWS).includes('/new — 新开会话')), 'zh：帮助菜单显示 /new — 新开会话')
+  assert(await settled(() => screenText(term, ROWS).includes('/rewind — 回退会话到历史消息')), 'zh：帮助菜单显示 rewind 中文描述')
 
   setLang('en')
   app.rerender(React.createElement(HelpMenu, { commands }))
-  await settle(() => screenText(term, ROWS).includes('/new — Start a new conversation'))
-  text = screenText(term, ROWS)
-  assert(text.includes('/new — Start a new conversation'), 'en：帮助菜单显示英文原文')
+  assert(await settled(() => screenText(term, ROWS).includes('/new — Start a new conversation')), 'en：帮助菜单显示英文原文')
 
   setLang('zh')
   app.unmount()
-  await sleep(100)
+  // 空写屏障：等在途的 term.write 解析完（取代 unmount 后固定 sleep）。
+  await writeParsed(term, '')
 }
 
 // --- 3. 窄终端中文截断不劈字 --------------------------------------------------
@@ -162,11 +144,11 @@ console.log('窄终端中文描述截断:')
     React.createElement(CommandSuggestions, { commands, selectedIndex: 0, columns: COLS }),
     { stdout, exitOnCtrlC: false, patchConsole: false },
   )
-  // 断言条件（截断省略号）出现即帧已画到位；unmount 后保留短暂固定等待，
-  // 让尚在途的 term.write 回调全部落盘再读缓冲。
+  // 断言条件（截断省略号）出现即帧已画到位；unmount 后用空写屏障等尚在
+  // 途的 term.write 回调全部落盘再读缓冲（xterm write 队列 FIFO）。
   await settle(() => viewportLines(term, ROWS).some(line => line.includes('…')))
   app.unmount()
-  await sleep(100)
+  await writeParsed(term, '')
 
   const screenLines = viewportLines(term, ROWS)
   let sawEllipsis = false

--- a/scripts/verify-keymap.mjs
+++ b/scripts/verify-keymap.mjs
@@ -43,7 +43,7 @@ import {
   resetKeymapOverrides,
   setKeymapOverrides,
 } from '../lib/types/utils/keymap.js'
-import { settle, viewportLines } from './lib/term-test.mjs'
+import { settle, settled, sleep, viewportLines } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -120,7 +120,6 @@ resetKeymapOverrides()
 // spawning a real editor that would hold the output pipes open.
 delete process.env.VISUAL
 delete process.env.EDITOR
-const sleep = ms => new Promise(r => setTimeout(r, ms))
 const term = new XTerm({ cols: 110, rows: 34, scrollback: 100, allowProposedApi: true })
 
 function makeStreams() {
@@ -237,13 +236,11 @@ const clipboardNotice = () => notifications.some(n => /clipboard|剪贴板/i.tes
 
 // Baseline: a plain 'v' types normally.
 stdin.write('v')
-await settle(() => promptText() === 'v')
-check('plain v types', promptText() === 'v', JSON.stringify(promptText()))
+check('plain v types', await settled(() => promptText() === 'v'), JSON.stringify(promptText()))
 
 // Ctrl+C clears the non-empty prompt (idle single press).
 stdin.write('\x03')
-await settle(() => promptText() === '')
-check('ctrl+c clears the prompt', promptText() === '', JSON.stringify(promptText()))
+check('ctrl+c clears the prompt', await settled(() => promptText() === ''), JSON.stringify(promptText()))
 
 // Alt+V arrives as ESC v. Whatever the clipboard holds, the paste branch
 // must consume the key: a prompt change or a clipboard notification are
@@ -251,10 +248,9 @@ check('ctrl+c clears the prompt', promptText() === '', JSON.stringify(promptText
 const beforeAltV = promptText()
 notifications.length = 0
 stdin.write('\x1bv')
-await settle(() => promptText() !== beforeAltV || clipboardNotice())
 check(
   'alt+v reaches the clipboard paste branch',
-  promptText() !== beforeAltV || clipboardNotice(),
+  await settled(() => promptText() !== beforeAltV || clipboardNotice()),
   JSON.stringify({ before: beforeAltV, after: promptText(), notices: notifications.map(n => n.text) }),
 )
 check('alt+v does not type a bare v on an empty clipboard', clipboardNotice() || promptText() !== 'v')
@@ -265,10 +261,9 @@ await settle(() => promptText() === '')
 const beforeCtrlV = promptText()
 notifications.length = 0
 stdin.write('\x16')
-await settle(() => promptText() !== beforeCtrlV || clipboardNotice())
 check(
   'ctrl+v reaches the clipboard paste branch',
-  promptText() !== beforeCtrlV || clipboardNotice(),
+  await settled(() => promptText() !== beforeCtrlV || clipboardNotice()),
   JSON.stringify({ before: beforeCtrlV, after: promptText(), notices: notifications.map(n => n.text) }),
 )
 
@@ -280,8 +275,7 @@ await settle(() => promptText() === '')
 setKeymapOverrides({ editor: 'alt+g' })
 notifications.length = 0
 stdin.write('\x1bg')
-await settle(() => notifications.some(n => /editor|编辑器/i.test(String(n.text))))
-const editorNotice = notifications.some(n => /editor|编辑器/i.test(String(n.text)))
+const editorNotice = await settled(() => notifications.some(n => /editor|编辑器/i.test(String(n.text))))
 check('remapped alt+g editor key does not type g', promptText() !== 'g', JSON.stringify(promptText()))
 check('remapped editor key reached the editor path (notify seen)', editorNotice, JSON.stringify(notifications.map(n => n.text)))
 check('default ctrl+g no longer matches after remap', !actionMatches('editor', 'g', { ctrl: true }))

--- a/scripts/verify-loaded-context-width.tsx
+++ b/scripts/verify-loaded-context-width.tsx
@@ -6,7 +6,7 @@
 process.env.DSH_TUI_LANG = 'en'
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { Terminal: XTerm }, { render, ThemeProvider }, { LoadedContextPanel }, { settle, viewportLines }] =
+const [{ Writable }, React, { Terminal: XTerm }, { render, ThemeProvider }, { LoadedContextPanel }, { settled, viewportLines }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -61,7 +61,8 @@ const app = await render(
   },
 )
 
-await settle(() =>
+// 等待与断言共用同一谓词；单行上界与行内容在同一快照上同步派生。
+const summaryRendered = await settled(() =>
   viewportLines(term, ROWS).some(line => line.includes('Context loaded') && line.includes('Ctrl+P')))
 
 const lines = viewportLines(term, ROWS)
@@ -69,6 +70,9 @@ const contentLines = lines.filter(line => line.trim() !== '')
 
 await app.unmount()
 
+if (!summaryRendered) {
+  throw new Error(`Collapsed context summary never rendered title + hint:\n${contentLines.join('\n')}`)
+}
 if (contentLines.length !== 1) {
   throw new Error(
     `Collapsed context summary occupied ${contentLines.length} rows at ${COLS} columns:\n${contentLines.join('\n')}`,

--- a/scripts/verify-login-credentials.tsx
+++ b/scripts/verify-login-credentials.tsx
@@ -14,7 +14,7 @@ const [
   { QuestionStore },
   { LOCAL_COMMANDS },
   { setLang },
-  { settle },
+  { settled, sleep },
 ] = await Promise.all([
   import('node:assert'),
   import('node:stream'),
@@ -50,7 +50,6 @@ class FakeStdin extends PassThrough {
   unref() { return this }
 }
 
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 const SECRET_SENTINEL = 'test-secret-must-not-appear'
 
 function makeChannel(status: unknown) {
@@ -154,12 +153,14 @@ async function runLogin(status: unknown) {
       patchConsole: false,
     },
   )
-  // 启动等待保留固定 delay：假 stdout 丢弃全部帧，没有可轮询的观察点。
-  await delay(500)
+  // 启动等待保留固定 sleep：假 stdout 丢弃全部帧，没有可轮询的观察点。
+  await sleep(500)
   stdin.write('/login\r')
-  await settle(() => channel.localCalls.length === 1)
+  const reported = await settled(() => channel.localCalls.length === 1)
   await instance.unmount()
-  assert.equal(channel.localCalls.length, 1, '/login must produce one local report')
+  assert.ok(reported, '/login must produce one local report')
+  // 卸载后再精确计数：迟到的第二条 report 只有在这里才会被发现。
+  assert.equal(channel.localCalls.length, 1, '/login must produce exactly one local report (post-unmount)')
   assert.deepEqual(channel.credentialRefs, ['DEEPSEEK_API_KEY'], '/login must query the credentials service')
   return channel.localCalls[0].lines
 }

--- a/scripts/verify-message-measure-depth.tsx
+++ b/scripts/verify-message-measure-depth.tsx
@@ -2,8 +2,7 @@ import { PassThrough, Writable } from 'node:stream'
 import React from 'react'
 import { render } from '../src/ui.js'
 import { MessageList } from '../src/components/MessageList.js'
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+import { settled } from './lib/term-test.mjs'
 
 class Output extends Writable {
   columns = 120
@@ -56,8 +55,8 @@ const instance = await render(<MessageList
   patchConsole: false,
 })
 
-const deadline = Date.now() + 2000
-while (textRevision < 60 && Date.now() < deadline) await sleep(25)
+// 等待与断言共用同一谓词：settled 终值直接决定下方的失败分支。
+const measured = await settled(() => textRevision === 60)
 
 await instance.unmount()
 const output = stdout.text + stderr.text
@@ -65,7 +64,7 @@ if (/Maximum update depth|Minified React error #185/.test(output)) {
   console.error('FAIL: MessageList entered a nested measurement update loop')
   process.exit(1)
 }
-if (textRevision !== 60) {
+if (!measured) {
   console.error(`FAIL: MessageList measurement stopped at revision ${textRevision}`)
   process.exit(1)
 }

--- a/scripts/verify-picker-edge.tsx
+++ b/scripts/verify-picker-edge.tsx
@@ -28,7 +28,7 @@ const { join: joinPath } = await import('node:path')
 process.env.HOME = mkdtempSync(joinPath(tmpdir(), 'dshtui-edge-'))
 process.env.USERPROFILE = process.env.HOME
 
-const [{ Terminal: XTerm }, React, { settle, viewportLines }] = await Promise.all([
+const [{ Terminal: XTerm }, React, { settle, sleep, viewportLines }] = await Promise.all([
   import('@xterm/headless'),
   import('react'),
   import('./lib/term-test.mjs'),
@@ -43,7 +43,6 @@ function check(name: string, ok: boolean, detail = ''): void {
 }
 
 const ROWS = 30
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 async function mountAt(cols: number) {
   // Name length lands the truncation ellipsis — and the focused+selected

--- a/scripts/verify-plain-enter-guard.mjs
+++ b/scripts/verify-plain-enter-guard.mjs
@@ -27,7 +27,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Writable, PassThrough } from 'node:stream'
 import React from 'react'
-import { settle } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -68,8 +68,6 @@ function makeStreams() {
   return { stdout, stderr, stdin }
 }
 
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-
 const decisions = []
 const { stdout, stderr, stdin } = makeStreams()
 const instance = await render(
@@ -79,6 +77,7 @@ const instance = await render(
   }),
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
 )
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
 await sleep(500)
 
 // Modifier Enters must be inert in the panel (they were inert text tokens
@@ -100,8 +99,7 @@ check('Shift+Enter (CSI 13;2u) does not decide', decisions.length === 0, JSON.st
 
 // Plain Enter still confirms the focused row (default 0 = allowed-once).
 stdin.write('\r')
-await settle(() => decisions.length === 1 && decisions[0] === 'allowed-once')
-check('plain Enter decides the focused outcome', decisions.length === 1 && decisions[0] === 'allowed-once', JSON.stringify(decisions))
+check('plain Enter decides the focused outcome', await settled(() => decisions.length === 1 && decisions[0] === 'allowed-once'), JSON.stringify(decisions))
 
 instance.unmount()
 

--- a/scripts/verify-plugin-scene-boundary.tsx
+++ b/scripts/verify-plugin-scene-boundary.tsx
@@ -13,7 +13,7 @@
  */
 process.env.FORCE_COLOR = '3'
 
-const [{ Writable }, React, { render, Text }, { PluginSceneBoundary }, { settle }] = await Promise.all([
+const [{ Writable }, React, { render, Text }, { PluginSceneBoundary }, { settled }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('../src/ui.js'),
@@ -49,8 +49,7 @@ const healthy = await render(
   </PluginSceneBoundary>,
   { stdout: new FakeStdout() as never, stderr: new FakeStderr() as never, patchConsole: false, exitOnCtrlC: false },
 )
-await settle(() => frames.join('').includes('scene-ok-content'))
-check('healthy scene content painted', frames.join('').includes('scene-ok-content'))
+check('healthy scene content painted', await settled(() => frames.join('').includes('scene-ok-content')))
 await healthy.unmount()
 
 // --- 2. throwing scene is caught, reported once, and stops painting --------
@@ -68,8 +67,7 @@ const crashed = await render(
   </PluginSceneBoundary>,
   { stdout: new FakeStdout() as never, stderr: new FakeStderr() as never, patchConsole: false, exitOnCtrlC: false },
 )
-await settle(() => reports.length === 1)
-check('boundary reports the crash exactly once', reports.length === 1, `reports=${reports.length}`)
+check('boundary reports the crash exactly once', await settled(() => reports.length === 1), `reports=${reports.length}`)
 check('report carries scene id and error message',
   reports[0]?.id === 'demo' && reports[0]?.message.includes('boom-场景炸了'),
   JSON.stringify(reports[0]))

--- a/scripts/verify-prompt-history-draft.mjs
+++ b/scripts/verify-prompt-history-draft.mjs
@@ -13,7 +13,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough, Writable } from 'node:stream'
-import { settle } from './lib/term-test.mjs'
+import { settle, settled, sleep } from './lib/term-test.mjs'
 
 const home = mkdtempSync(join(tmpdir(), 'dsh-tui-history-draft-'))
 process.env.HOME = home
@@ -72,17 +72,16 @@ const instance = await render(
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
 )
 
-const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms))
 const write = async (input) => {
   stdin.write(input)
-  await wait(120)
+  await sleep(120)
 }
 
 try {
   // Startup and typing/arrow ordering keep fixed waits: the fake stdout
   // discards frames, so there is nothing observable to settle on for them.
   // Each Enter's effect IS observable through `submitted`, so settle there.
-  await wait(300)
+  await sleep(300)
   await write('first')
   stdin.write('\r')
   await settle(() => submitted.length === 1)
@@ -96,9 +95,9 @@ try {
   for (let i = 0; i < 3; i += 1) await write('\x1b[A')
   for (let i = 0; i < 3; i += 1) await write('\x1b[B')
   stdin.write('\r')
-  await settle(() => submitted.length === 3)
+  const draftRestored = await settled(() => submitted.length === 3 && submitted[2] === 'unfinished draft')
 
-  if (submitted.length !== 3 || submitted[2] !== 'unfinished draft') {
+  if (!draftRestored) {
     console.error(`FAIL: unfinished draft was not restored: ${JSON.stringify(submitted)}`)
     process.exitCode = 1
   } else {

--- a/scripts/verify-question-backtrack.tsx
+++ b/scripts/verify-question-backtrack.tsx
@@ -21,6 +21,7 @@ const [
   { render },
   { AskUserQuestionPanel },
   { QuestionStore },
+  { settle, settled },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -28,9 +29,8 @@ const [
   import('../src/ui.js'),
   import('../src/components/questions/AskUserQuestionPanel.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 // ── Store state machine ────────────────────────────────────────────────
 const store = new QuestionStore()
@@ -106,12 +106,12 @@ const app = await render(React.createElement(AskUserQuestionPanel, {
   onBack: (draft: unknown) => { backDraft = draft },
   onCancel: () => { cancelled = true },
 }), { stdout, stdin, stderr: new FakeStdout(), exitOnCtrlC: false, patchConsole: false })
-await sleep(300)
-assert.ok(screen().includes('draft text'))
-assert.ok(screen().includes('● Beta'))
+assert.ok(await settled(() => screen().includes('draft text')))
+assert.ok(await settled(() => screen().includes('● Beta')))
 
 stdin.write('\x1b')
-await sleep(200)
+// onBack 回调同步整体赋值 backDraft；等回调触发后值即终态，深比较为同步派生断言。
+assert.ok(await settled(() => backDraft !== undefined))
 assert.deepEqual(backDraft, { selected: ['Beta'], custom: 'draft text' })
 assert.equal(cancelled, false)
 
@@ -123,10 +123,9 @@ app.rerender(React.createElement(AskUserQuestionPanel, {
   onAnswer() {},
   onCancel: () => { cancelled = true },
 }))
-await sleep(200)
+await settle(() => screen().includes('第一题'))
 stdin.write('\x1b')
-await sleep(200)
-assert.equal(cancelled, true)
+assert.equal(await settled(() => cancelled), true)
 
 await app.unmount()
 terminal.dispose()

--- a/scripts/verify-resize-reflow.tsx
+++ b/scripts/verify-resize-reflow.tsx
@@ -50,7 +50,7 @@ process.env.FORCE_COLOR = '3'
 // to agree with.
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -58,10 +58,12 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
     import('../src/ui.js'),
     import('../src/screens/Chat.js'),
     import('../src/dsh-adapter/questions.js'),
+    import('./lib/term-test.mjs'),
   ])
 const instances = (await import('../src/ink/instances.js')).default
 
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+// sleep 全部保留：本文件的 oracle 是「两次渲染的最终屏等价」——期望内容
+// 本身来自另一次渲染，没有可轮询的谓词，只能等固定窗口让渲染落定。
 
 let failed = 0
 function check(name: string, ok: boolean, extra = ''): void {
@@ -276,6 +278,7 @@ async function equivalence(from: [number, number], to: [number, number]): Promis
 
   const live = makeHarness(fromCols, fromRows)
   const liveInstance = await mount(live)
+  // 挂载后固定静置窗保留：等价 oracle 的期望内容来自另一次渲染，本侧无可轮询谓词。
   await sleep(420)
 
   // The emulator reflows exactly as a real terminal does; the app learns about

--- a/scripts/verify-resize-temporal.tsx
+++ b/scripts/verify-resize-temporal.tsx
@@ -17,7 +17,7 @@ process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'kitty'
 process.env.DSH_TUI_THEME = 'dark'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { default: instances }, { settle, settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -25,11 +25,11 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('../src/ink/instances.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const BASE_COLS = 108
 const ROWS = 34
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
@@ -113,16 +113,23 @@ function doResize(app: { stdout: any; term: typeof XTerm.prototype }, w: number,
 
 // ================= 1+2. 时间稳定性 & 往返循环 =================
 const app = await mountChat(makeRows())
-await sleep(1500)
-await app.flush()
-
-const baseline = screenLines(app.term)
 const composerY = (lines: string[]) => lines.findIndex(l => l.includes('╭'))
 const sentinelY = (lines: string[]) => lines.findIndex(l => l.includes('SENTINEL-TAIL'))
-check('基线含 composer 与 sentinel', composerY(baseline) >= 0 && sentinelY(baseline) >= 0, `composer=${composerY(baseline)} sentinel=${sentinelY(baseline)}`)
+// 基线就绪 = composer 与 transcript 最后一行（sentinel）都已上屏，且右缘
+// 滚动条（▴）已画上——滚动条在首个内容帧之后的一帧才出现，只等内容会把
+// 无滚动条的早帧当基线，导致回基线比对必挂。
+const baselineReady = await settled(() => {
+  const lines = screenLines(app.term)
+  return composerY(lines) >= 0 && sentinelY(lines) >= 0 && lines.some(l => l.endsWith('▴'))
+})
+await app.flush()
+const baseline = screenLines(app.term)
+check('基线含 composer 与 sentinel', baselineReady, `composer=${composerY(baseline)} sentinel=${sentinelY(baseline)}`)
 
 // ---- 1. resize 落定后不得继续漂 ----
 doResize(app, 90, ROWS)
+// 固定墙钟采样点保留：250ms 与 1000ms 的对比本身是被测语义（「状态不得
+// 再改变」探针），轮询会在首个成立帧立即返回，等于没测。
 await sleep(250); await app.flush()
 const at250 = screenLines(app.term)
 await sleep(750); await app.flush()
@@ -132,29 +139,34 @@ check('resize 落定后 250ms 与 1000ms 画面一致（时间不变量）', at2
 // ---- 2. 90↔150 循环 20 次后回基线 ----
 for (let i = 0; i < 20; i++) {
   doResize(app, i % 2 === 0 ? 150 : 90, ROWS)
-  await sleep(12)
+  await sleep(12) // 固定 pacing 保留：制造快速连环 resize 竞争，本身无可轮询条件
   await app.flush()
 }
 doResize(app, BASE_COLS, ROWS)
-await sleep(400); await app.flush()
+const roundTripSettled = await settled(() => screenLines(app.term).join('\n') === baseline.join('\n'))
+// 收敛后保留固定稳定窗：迟到的 resize repaint 可能在首个相等帧之后才漂移，
+// 轮询在首帧相等即返回，盖不住「之后不得再漂」的时间语义——终态再比对一次。
+await sleep(250); await app.flush()
 const roundTrip = screenLines(app.term)
-check('20 次宽度循环后画面回到基线（无累计漂移）', roundTrip.join('\n') === baseline.join('\n'), `composer ${composerY(baseline)}→${composerY(roundTrip)}, sentinel ${sentinelY(baseline)}→${sentinelY(roundTrip)}`)
+check('20 次宽度循环后画面回到基线（无累计漂移）', roundTripSettled && roundTrip.join('\n') === baseline.join('\n'), `composer ${composerY(baseline)}→${composerY(roundTrip)}, sentinel ${sentinelY(baseline)}→${sentinelY(roundTrip)}`)
 app.unmount()
-await sleep(150)
+await sleep(150) // 固定小窗保留：unmount 收尾写出无完成回调可等
 
 // ================= 3. 流中 resize：终态 == 冷渲染 =================
 const liveRows = makeRows()
 const streamRow: any = { id: 9999, kind: 'assistant', text: '', streaming: true }
 liveRows.push(streamRow)
 const app2 = await mountChat(liveRows)
-await sleep(1500); await app2.flush()
+// 等首帧就绪（sentinel 上屏）再开始流式：等待后只操作不断言 → settle
+await settle(() => sentinelY(screenLines(app2.term)) >= 0)
+await app2.flush()
 
 const STREAM_TEXT = '流式内容：第一段论述比较长，用来触发宽度变化下的重排。'.repeat(8) + '\n\n- 要点甲\n- 要点乙\n- 结论 TAILMARK-终'
 // 逐段流入，期间反复 resize（resize + live mutation 竞争）
 for (let i = 0; i < 10; i++) {
   streamRow.text = STREAM_TEXT.slice(0, Math.floor((STREAM_TEXT.length * (i + 1)) / 10))
   app2.bump()
-  await sleep(40)
+  await sleep(40) // 固定 pacing 保留：模拟流式节奏，与 resize 的竞争时序本身是被测对象
   if (i % 3 === 0) { doResize(app2, i % 2 === 0 ? 88 : 132, ROWS) }
   await app2.flush()
 }
@@ -162,21 +174,25 @@ streamRow.text = STREAM_TEXT
 streamRow.streaming = false
 doResize(app2, BASE_COLS, ROWS)
 app2.bump()
+// 固定窗口保留：尾标记在 finalize 前的流式帧里已上屏（末次切片即全文），
+// 轮询 tail 计数会对已成立条件立即返回、抓到旧宽度的中间帧；这里等的是
+// 回到 BASE_COLS 的终帧落定，无独立可轮询条件（终帧对错由冷渲染比对把关）。
 await sleep(600); await app2.flush()
 const warm = screenLines(app2.term)
 // 计数用全文唯一的尾标记（正文字符串内部有 repeat，不能当标记）
 const streamedOnce = warm.join('\n').split('TAILMARK-终').length - 1
 check('finalize 后流式文本恰好出现一次（无重复）', streamedOnce === 1, 'occurrences=' + streamedOnce)
 app2.unmount()
-await sleep(150)
+await sleep(150) // 固定小窗保留：unmount 收尾写出无完成回调可等
 
 // 冷渲染：同最终内容、同尺寸、从零渲染
 const coldRows = makeRows()
 coldRows.push({ id: 9999, kind: 'assistant', text: STREAM_TEXT, streaming: false })
 const app3 = await mountChat(coldRows)
-await sleep(1500); await app3.flush()
-const cold = screenLines(app3.term)
-check('流中 resize 终态 == 冷渲染（live mutation 竞争无残留几何）', warm.join('\n') === cold.join('\n'))
+const coldConverged = await settled(() => screenLines(app3.term).join('\n') === warm.join('\n'))
+// 同上：首个相等帧之后仍可能有迟到 repaint，固定稳定窗后取终态再比对。
+await sleep(250); await app3.flush()
+check('流中 resize 终态 == 冷渲染（live mutation 竞争无残留几何）', coldConverged && screenLines(app3.term).join('\n') === warm.join('\n'))
 app3.unmount()
 
 console.log(failed === 0 ? '\nALL PASS' : '\n' + failed + ' 项失败')

--- a/scripts/verify-scroll.mjs
+++ b/scripts/verify-scroll.mjs
@@ -25,7 +25,7 @@
 import { Writable, PassThrough } from 'node:stream'
 import React from 'react'
 import { render, Text, ScrollBox } from '../lib/types/ui.js'
-import { settle } from './lib/term-test.mjs'
+import { settle, settled } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -87,18 +87,12 @@ async function run() {
   })
   // The extra frame clause is ordering: scrollTo below needs the first
   // full-height layout committed, which the fixed sleep used to cover.
-  await settle(() => scrollHandle !== null && frameLog.at(-1)?.scrollHeight === 60)
-  if (!scrollHandle) {
-    check('ScrollBox handle attached', false)
-    process.exit(failed)
-  }
-  check('ScrollBox handle attached', true)
+  check('ScrollBox handle attached', await settled(() => scrollHandle !== null && frameLog.at(-1)?.scrollHeight === 60))
+  if (!scrollHandle) process.exit(failed)
 
   // ---- bottom-scrolled: 60 rows, maxScroll 36, scroll to 36.
   scrollHandle.scrollTo(36)
-  await settle(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60)
-  const bottomScrolled = frameLog.at(-1)
-  check('bottom scroll landed at maxScroll', bottomScrolled.scrollTop === 36 && bottomScrolled.scrollHeight === 60, JSON.stringify(bottomScrolled))
+  check('bottom scroll landed at maxScroll', await settled(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60), JSON.stringify(frameLog.at(-1)))
 
   // ---- shrink frame: 20 rows → content collapses to the viewport height
   // (24; the content wrapper flexGrows to at least the viewport), so
@@ -106,18 +100,14 @@ async function run() {
   // sticky; a sticky shrink frame clamps to the collapsed maxScroll (#421:
   // freezing past the content paints blank — see the docstring exception).
   instance.rerender(makeScroller(20))
-  await settle(() => {
+  check('shrink frame clamps the re-pinned sticky view to the collapsed bottom', await settled(() => {
     const f = frameLog.find(f => f.scrollHeight === 24)
     return f !== undefined && f.scrollTop === 0
-  })
-  const shrinkFrame = frameLog.find(f => f.scrollHeight === 24)
-  check('shrink frame clamps the re-pinned sticky view to the collapsed bottom', shrinkFrame !== undefined && shrinkFrame.scrollTop === 0, JSON.stringify(shrinkFrame ?? frameLog.at(-1)))
+  }), JSON.stringify(frameLog.find(f => f.scrollHeight === 24) ?? frameLog.at(-1)))
 
   // ---- grow back: 60 rows. Position re-validated at the bottom.
   instance.rerender(makeScroller(60))
-  await settle(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60)
-  const grownFrame = frameLog.at(-1)
-  check('grow-back frame stays at the bottom', grownFrame.scrollTop === 36 && grownFrame.scrollHeight === 60, JSON.stringify(grownFrame))
+  check('grow-back frame stays at the bottom', await settled(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60), JSON.stringify(frameLog.at(-1)))
 
   // ---- mid-scrolled: 60 rows, scroll to 10 (away from bottom), shrink, grow.
   instance.rerender(makeScroller(60))
@@ -125,21 +115,17 @@ async function run() {
   scrollHandle.scrollTo(10)
   await settle(() => frameLog.at(-1)?.scrollTop === 10)
   instance.rerender(makeScroller(20))
-  await settle(() => {
+  check('mid-scroll shrink frame keeps the position', await settled(() => {
     const f = frameLog.filter(f => f.scrollHeight === 24).at(-1)
     return f !== undefined && f.scrollTop === 10
-  })
-  const midShrink = frameLog.filter(f => f.scrollHeight === 24).at(-1)
-  check('mid-scroll shrink frame keeps the position', midShrink !== undefined && midShrink.scrollTop === 10, JSON.stringify(midShrink ?? frameLog.at(-1)))
+  }), JSON.stringify(frameLog.filter(f => f.scrollHeight === 24).at(-1) ?? frameLog.at(-1)))
 
   // ---- the frame AFTER the shrink artifact must not pull the mid position
   // to the bottom: the positional at-bottom check must not trust a maxScroll
   // computed from the artifact frame (opentui #709: content-size changes
   // must not reset the manual-scroll state).
   instance.rerender(makeScroller(60))
-  await settle(() => frameLog.at(-1)?.scrollTop === 10 && frameLog.at(-1)?.scrollHeight === 60)
-  const midGrown = frameLog.at(-1)
-  check('post-shrink grow frame keeps the mid position', midGrown.scrollTop === 10 && midGrown.scrollHeight === 60, JSON.stringify(midGrown))
+  check('post-shrink grow frame keeps the mid position', await settled(() => frameLog.at(-1)?.scrollTop === 10 && frameLog.at(-1)?.scrollHeight === 60), JSON.stringify(frameLog.at(-1)))
 
   instance.unmount()
   process.exit(failed)

--- a/scripts/verify-scrollbar-gutter.tsx
+++ b/scripts/verify-scrollbar-gutter.tsx
@@ -17,7 +17,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle, settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -29,7 +29,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
 ])
 
 const COLS = 100, ROWS = 40
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -136,12 +135,13 @@ const clickAt = (col: number, row: number) => {
 }
 
 // ── 1. 默认 timeline ──
-await settle(() => {
-  const snap = gutterSnapshot()
-  return snap.ticks.length > 0 && snap.chevrons.length === 2 && snap.thumbs.length === 0
-})
+// 各块断言均在 settle 捕获的同一快照 snap 上求值：等待条件与断言共用快照，无分叉。
 {
-  const snap = gutterSnapshot()
+  let snap = gutterSnapshot()
+  await settled(() => {
+    snap = gutterSnapshot()
+    return snap.ticks.length > 0 && snap.chevrons.length === 2 && snap.thumbs.length === 0
+  })
   check('默认 timeline：rail tick + chevron 存在', snap.ticks.length > 0 && snap.chevrons.length === 2,
     `ticks=${snap.ticks.length} chevrons=${snap.chevrons.length}`)
   check('默认 timeline：无 ██ 滑块', snap.thumbs.length === 0, `thumbs=${snap.thumbs.length}`)
@@ -149,34 +149,35 @@ await settle(() => {
 
 // ── 2. 切 scrollbar：██ 贴底，无 chevron/tick ──
 setGutter('scrollbar')
-await settle(() => {
-  const snap = gutterSnapshot()
-  const [, bottom] = gutterRange()
-  return snap.thumbs.length >= 2 && snap.chevrons.length === 0 && snap.ticks.length === 0 &&
-    snap.thumbs[snap.thumbs.length - 1] === bottom - 1
-})
 {
-  const snap = gutterSnapshot()
+  let snap = gutterSnapshot()
+  let bottom = gutterRange()[1]
+  await settle(() => {
+    snap = gutterSnapshot()
+    bottom = gutterRange()[1]
+    return snap.thumbs.length >= 2 && snap.chevrons.length === 0 && snap.ticks.length === 0 &&
+      snap.thumbs[snap.thumbs.length - 1] === bottom - 1
+  })
   check('scrollbar：██ 滑块出现', snap.thumbs.length >= 2, `thumbs=${snap.thumbs.length}`)
   check('scrollbar：无 timeline glyph', snap.chevrons.length === 0 && snap.ticks.length === 0,
     `chevrons=${snap.chevrons.length} ticks=${snap.ticks.length}`)
-  const [top, bottom] = gutterRange()
   check('scrollbar：钉底滑块贴底', snap.thumbs[snap.thumbs.length - 1] === bottom - 1,
     `last=${snap.thumbs[snap.thumbs.length - 1]} bottom=${bottom}`)
 }
 
 // ── 3. 上滚（whale 滚出视口）：滑块在轨道内且离开底端 ──
 await wheel(true, 16)
-await settle(() => {
-  const snap = gutterSnapshot()
-  const [top, bottom] = gutterRange()
-  if (snap.thumbs.length < 2) return false
-  const first = snap.thumbs[0]!, last = snap.thumbs[snap.thumbs.length - 1]!
-  return first >= top && last < bottom - 1
-})
 {
-  const snap = gutterSnapshot()
-  const [top, bottom] = gutterRange()
+  let snap = gutterSnapshot()
+  let range = gutterRange()
+  await settle(() => {
+    snap = gutterSnapshot()
+    range = gutterRange()
+    if (snap.thumbs.length < 2) return false
+    const first = snap.thumbs[0]!, last = snap.thumbs[snap.thumbs.length - 1]!
+    return first >= range[0] && last < range[1] - 1
+  })
+  const [top, bottom] = range
   check('上滚后滑块存在（非 whale）', snap.thumbs.length >= 2, `thumbs=${JSON.stringify(snap.thumbs)}`)
   if (snap.thumbs.length > 0) {
     const first = snap.thumbs[0]!, last = snap.thumbs[snap.thumbs.length - 1]!
@@ -189,8 +190,8 @@ await settle(() => {
 {
   const [top] = gutterRange()
   clickAt(COLS, top + 1)
-  await settle(() => screenLines().slice(0, 24).some(l => l.includes('问题 1')))
-  const lines = screenLines()
+  let lines: string[] = []
+  await settle(() => { lines = screenLines(); return lines.slice(0, 24).some(l => l.includes('问题 1')) })
   check('点击轨道顶后滚到顶（问题 1 可见）', lines.slice(0, 24).some(l => l.includes('问题 1')),
     `top4=${JSON.stringify(lines.slice(0, 4).map(l => l.trimEnd().slice(0, 24)))}`)
 }
@@ -214,21 +215,17 @@ const hasGutterGlyph = (): boolean => {
   return anyGlyph
 }
 setGutter('hidden')
-await settle(() => !hasGutterGlyph())
-{
-  const anyGlyph = hasGutterGlyph()
-  check('hidden：右缘无任何 gutter glyph', !anyGlyph)
-}
+check('hidden：右缘无任何 gutter glyph', await settled(() => !hasGutterGlyph()))
 
 // ── 6. 切回 timeline：rail 恢复 ──
 await wheel(false, 30)
 setGutter('timeline')
-await settle(() => {
-  const snap = gutterSnapshot()
-  return snap.ticks.length === 8 && snap.chevrons.length === 2
-})
 {
-  const snap = gutterSnapshot()
+  let snap = gutterSnapshot()
+  await settle(() => {
+    snap = gutterSnapshot()
+    return snap.ticks.length === 8 && snap.chevrons.length === 2
+  })
   check('切回 timeline：rail 恢复', snap.ticks.length === 8 && snap.chevrons.length === 2,
     `ticks=${snap.ticks.length} chevrons=${snap.chevrons.length}`)
 }

--- a/scripts/verify-session-browser-layout.mjs
+++ b/scripts/verify-session-browser-layout.mjs
@@ -26,6 +26,7 @@ import React from 'react'
 import { render, ThemeProvider } from '../lib/types/ui.js'
 import { SessionBrowser } from '../lib/types/screens/SessionBrowser.js'
 import { setLang } from '../lib/types/i18n.js'
+import { sleep } from './lib/term-test.mjs'
 
 const { Terminal } = xtermPkg
 
@@ -34,8 +35,6 @@ function check(name, ok, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-
 const summary = (over) => ({
   id: 'id',
   kind: { kind: 'root' },
@@ -155,6 +154,8 @@ for (const lang of ['zh', 'en']) {
       ),
       { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
     )
+    // 固定窗口（原因见下方 "Fixed sleeps kept on purpose" 注释）：断言是
+    // 布局不变量，空帧/旧帧上也成立，轮询会立即返回、测不到新帧。
     await sleep(620)
 
     const inspect = (label) => {
@@ -200,11 +201,13 @@ for (const lang of ['zh', 'en']) {
     stdout.columns = wide[0]
     stdout.rows = wide[1]
     stdout.emit('resize')
+    // 固定窗口（同上）：resize 重绘前后不变量都成立，无可轮询的转变条件。
     await sleep(260)
     inspect(`resized to ${wide[0]}x${wide[1]}`)
 
     instance.unmount()
     term.dispose()
+    // 卸载收尾 pacing：让 unmount 的异步清理在下一轮挂载前排空。
     await sleep(20)
   }
 }

--- a/scripts/verify-session-browser.mjs
+++ b/scripts/verify-session-browser.mjs
@@ -31,7 +31,7 @@ import { render } from '../lib/types/ui.js'
 import { Chat } from '../lib/types/screens/Chat.js'
 import { setLang } from '../lib/types/i18n.js'
 import instances from '../lib/types/ink/instances.js'
-import { settle } from './lib/term-test.mjs'
+import { settle, settled, sleep } from './lib/term-test.mjs'
 
 const { Terminal } = xtermPkg
 
@@ -40,8 +40,6 @@ function check(name, ok, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
-
 const COLS = 110
 const ROWS = 34
 
@@ -268,19 +266,17 @@ await settle(() => screen().includes('❯'))
 stdin.write('/resume')
 await settle(() => flat(screen()).includes('/resume'))
 stdin.write('\r')
-await settle(() =>
-  /Resume session/.test(flat(screen())) && /gamma/.test(screen()) && /❯\s*gamma/.test(screen()))
+check('the browser opens as a screen', await settled(() => /Resume session/.test(flat(screen()))), flat(screen()).slice(0, 120))
+check('conversations are listed', await settled(() => /gamma/.test(screen()) && /beta/.test(screen()) && /alpha/.test(screen())))
 let s = screen()
-check('the browser opens as a screen', /Resume session/.test(flat(s)), flat(s).slice(0, 120))
-check('conversations are listed', /gamma/.test(s) && /beta/.test(s) && /alpha/.test(s))
 check('the current model-switch lineage is not offered as another conversation', !/before model switch/.test(s) && !/after model switch/.test(s))
 check('delegated runs are NOT listed by default', !/delegated one/.test(s) && !/delegated two/.test(s))
-check('but they are counted', /2 runs folded/.test(flat(s)), flat(s).slice(0, 200))
+check('but they are counted', await settled(() => /2 runs folded/.test(flat(screen()))), flat(screen()).slice(0, 200))
 check('a session with no conversation is never a row', !/^\s*❯?\s*tmp\b/m.test(s))
-check('and it is counted too', /1 empty/.test(flat(s)), flat(s).slice(0, 200))
-check('the count reflects only what is shown', /3 sessions/.test(flat(s)), flat(s).slice(0, 200))
-check('metadata rides under each title', /2\.0 KB/.test(flat(s)) && /deepseek-v4-pro/.test(flat(s)))
-check('focus starts on the MRU top row (gamma)', /❯\s*gamma/.test(s), s.split('\n').filter(l => l.includes('❯')).join('|'))
+check('and it is counted too', await settled(() => /1 empty/.test(flat(screen()))), flat(screen()).slice(0, 200))
+check('the count reflects only what is shown', await settled(() => /3 sessions/.test(flat(screen()))), flat(screen()).slice(0, 200))
+check('metadata rides under each title', await settled(() => /2\.0 KB/.test(flat(screen())) && /deepseek-v4-pro/.test(flat(screen()))))
+check('focus starts on the MRU top row (gamma)', await settled(() => /❯\s*gamma/.test(screen())), screen().split('\n').filter(l => l.includes('❯')).join('|'))
 
 // ── held arrow keys ─────────────────────────────────────────────────────
 // A held key (or a paste) arrives as several key events out of ONE stdin
@@ -288,12 +284,9 @@ check('focus starts on the MRU top row (gamma)', /❯\s*gamma/.test(s), s.split(
 // the cursor; a handler reading its start position from the render closure
 // would compute them all from the same row and keep only the last.
 stdin.write('\x1b[B\x1b[B') // two ↓ in one chunk
-await settle(() => /❯\s*alpha/.test(screen()))
-s = screen()
-check('two arrows in one chunk move two rows, not one', /❯\s*alpha/.test(s), s.split('\n').filter(l => l.includes('❯')).join('|'))
+check('two arrows in one chunk move two rows, not one', await settled(() => /❯\s*alpha/.test(screen())), screen().split('\n').filter(l => l.includes('❯')).join('|'))
 stdin.write('\x1b[A\x1b[A') // two ↑ back to the top
-await settle(() => /❯\s*gamma/.test(screen()))
-check('and back again', /❯\s*gamma/.test(screen()))
+check('and back again', await settled(() => /❯\s*gamma/.test(screen())))
 // Control bytes this screen does not claim must never be typed into the
 // search box. A chord arriving as raw C0 (here two ctrl+s in one chunk, which
 // the parser hands over as literal control characters rather than as the
@@ -309,10 +302,8 @@ check('and the list is untouched by them', /gamma/.test(screen()) && /alpha/.tes
 
 // ── search ──────────────────────────────────────────────────────────────
 stdin.write('alph')
-await settle(() => /alpha/.test(screen()) && !/gamma/.test(screen()) && /❯\s*alpha/.test(screen()))
-s = screen()
-check('typing filters the list', /alpha/.test(s) && !/gamma/.test(s), flat(s).slice(0, 200))
-check('the cursor lands on the surviving row', /❯\s*alpha/.test(s))
+check('typing filters the list', await settled(() => /alpha/.test(screen()) && !/gamma/.test(screen())), flat(screen()).slice(0, 200))
+check('the cursor lands on the surviving row', await settled(() => /❯\s*alpha/.test(screen())))
 // Fixed window kept: the assertion condition (/alpha/) already holds before
 // the backspace — the only change is one query character, which these
 // regexes cannot distinguish ('alpha' contains 'alph'), so a settle would
@@ -321,21 +312,18 @@ await windowed(() => stdin.write('\x7f'), 300) // backspace
 s = screen()
 check('backspace widens the query again', /alpha/.test(s))
 stdin.write('\x1b') // Esc clears the query first
-await settle(() => /gamma/.test(screen()) && /Resume session/.test(flat(screen())))
-s = screen()
-check('Esc clears the query rather than leaving', /gamma/.test(s) && /Resume session/.test(flat(s)))
+check('Esc clears the query rather than leaving',
+  await settled(() => /gamma/.test(screen()) && /Resume session/.test(flat(screen()))))
 
 // ── reveal the delegated runs ───────────────────────────────────────────
 stdin.write('\x13') // ctrl+s
-await settle(() => /audit run/.test(screen()))
+check('ctrl+s reveals the delegated runs', await settled(() => /audit run/.test(screen())), flat(screen()).slice(0, 300))
 s = screen()
-check('ctrl+s reveals the delegated runs', /audit run/.test(s), flat(s).slice(0, 300))
 check('nothing is folded any more', /0 runs folded/.test(flat(s)) || !/runs folded/.test(flat(s)))
 const runLine = s.split('\n').find((l) => l.includes('audit run')) ?? ''
 check('a run is indented under its parent', /^\s{3,}/.test(runLine), JSON.stringify(runLine))
 stdin.write('\x13') // fold them back
-await settle(() => !/audit run/.test(screen()))
-check('ctrl+s folds them away again', !/audit run/.test(screen()))
+check('ctrl+s folds them away again', await settled(() => !/audit run/.test(screen())))
 
 // ── rename, and the cursor that follows it ──────────────────────────────
 stdin.write('\x1b[B') // ↓ → beta
@@ -344,28 +332,24 @@ await settle(() => /❯\s*beta/.test(screen()))
 // so poll the accumulating frame bytes for the same condition.
 stdout.frames.length = 0
 stdin.write('\x12') // ctrl+r → rename
-await settle(() => /✎ beta/.test(flat(toPlain(stdout.frames.join('')))))
-s = toPlain(stdout.frames.join(''))
-check('rename prefills the editor with the focused title', /✎ beta/.test(flat(s)), flat(s).slice(-160))
+check('rename prefills the editor with the focused title',
+  await settled(() => /✎ beta/.test(flat(toPlain(stdout.frames.join(''))))),
+  flat(toPlain(stdout.frames.join(''))).slice(-160))
 stdin.write('renamed')
 await settle(() => /betarenamed/.test(screen()))
 stdin.write('\r')
-await settle(() => channel.calls.rename.length === 1)
 check(
   'the rename call hit the intended session',
-  channel.calls.rename.length === 1 && channel.calls.rename[0][0] === 's-mid',
+  await settled(() => channel.calls.rename.length === 1 && channel.calls.rename[0][0] === 's-mid'),
   JSON.stringify(channel.calls.rename),
 )
-await settle(() => {
-  const row = screen().split('\n').find((l) => l.includes('betarenamed')) ?? ''
-  return /❯\s*betarenamed/.test(row)
-})
-s = screen()
-const renamedRow = s.split('\n').find((l) => l.includes('betarenamed')) ?? ''
 check(
   'the cursor followed the renamed session to its new position',
-  /❯\s*betarenamed/.test(renamedRow),
-  JSON.stringify(renamedRow),
+  await settled(() => {
+    const row = screen().split('\n').find((l) => l.includes('betarenamed')) ?? ''
+    return /❯\s*betarenamed/.test(row)
+  }),
+  JSON.stringify(screen().split('\n').find((l) => l.includes('betarenamed')) ?? ''),
 )
 
 // ── delete: the guard, the cancel, the commit ───────────────────────────
@@ -373,19 +357,21 @@ check(
 // on the same line, so the per-cell diff legitimately emits only the changed
 // characters and a regex over those bytes can never match.
 stdin.write('\x04') // ctrl+d
-await settle(() => /Delete "betarenamed"/.test(flat(screen())))
-check('the confirmation names the focused session', /Delete "betarenamed"/.test(flat(screen())), flat(screen()).slice(-220))
+check('the confirmation names the focused session',
+  await settled(() => /Delete "betarenamed"/.test(flat(screen()))), flat(screen()).slice(-220))
 // Negative probe (Ctrl+Enter must NOT confirm): nothing is supposed to
 // change, so a settle would return immediately — keep the fixed window.
 await windowed(() => stdin.write('\x1b[13;5u'), 400) // Ctrl+Enter must not confirm
 check('Ctrl+Enter does not confirm an irreversible delete', channel.calls.delete.length === 0, JSON.stringify(channel.calls.delete))
 stdin.write('\x1b') // Esc cancels
-await settle(() => !/Delete "/.test(flat(screen())) && channel.calls.delete.length === 0)
-check('Esc cancels the confirmation', !/Delete "/.test(flat(screen())) && channel.calls.delete.length === 0)
+check('Esc cancels the confirmation',
+  await settled(() => !/Delete "/.test(flat(screen())) && channel.calls.delete.length === 0))
 stdin.write('\x04')
 await settle(() => /Delete "betarenamed"/.test(flat(screen())))
 stdin.write('\x1b[13u\x1b[13u')
-await settle(() =>
+// 先等屏幕呈现删除结果（两次 Enter 同批处理完毕），再断言「恰好一次」：
+// 直接对 delete.length === 1 轮询可能在第二次 Enter 生效前提前通过。
+const deleteEffectsPainted = await settled(() =>
   /Deleted session betarenamed/.test(flat(screen())) && /2 sessions/.test(flat(screen())))
 check(
   'repeated Enter commits one delete, on the session the confirmation named',
@@ -395,17 +381,17 @@ check(
 // The notice line names what was deleted, so "gone" is asserted on the list
 // itself: one fewer session, and no row carrying that title any more.
 s = screen()
-check('the browser says what it did, on the screen the user is looking at', /Deleted session betarenamed/.test(flat(s)), flat(s).slice(-200))
+check('the browser says what it did, on the screen the user is looking at', deleteEffectsPainted && /Deleted session betarenamed/.test(flat(s)), flat(s).slice(-200))
 check('the deleted row leaves the list', /2 sessions/.test(flat(s)) && !s.split('\n').some(l => /^[❯\s]*betarenamed/.test(l)), flat(s).slice(0, 200))
 
 // ── resume failure detail ──────────────────────────────────────────────────
 stdin.write('\r')
-await settle(() => /corrupt session log: seq gap in committed region/.test(flat(screen())))
+const failureShown = await settled(() => /corrupt session log: seq gap in committed region/.test(flat(screen())))
 s = screen()
 check('a failed resume stays in the browser', /Resume session/.test(flat(s)), flat(s).slice(0, 180))
 check(
   'the browser shows the real resume failure',
-  /corrupt session log: seq gap in committed region/.test(flat(s)),
+  failureShown,
   flat(s).slice(-220),
 )
 check(
@@ -416,9 +402,8 @@ check(
 
 // ── leaving ─────────────────────────────────────────────────────────────
 stdin.write('\x1b')
-await settle(() => !/Resume session/.test(flat(screen())))
-s = screen()
-check('Esc leaves the browser and restores the conversation', !/Resume session/.test(flat(s)), flat(s).slice(0, 160))
+check('Esc leaves the browser and restores the conversation',
+  await settled(() => !/Resume session/.test(flat(screen()))), flat(screen()).slice(0, 160))
 
 instance.unmount()
 instances.delete(process.stdout)

--- a/scripts/verify-session-color-recap.tsx
+++ b/scripts/verify-session-color-recap.tsx
@@ -30,7 +30,7 @@ const [
   { render },
   { Chat },
   { setLang },
-  { settle, viewportLines },
+  { settle, settled, sleep, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -65,8 +65,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 function screenText(): string {
   return viewportLines(term, ROWS).join('\n')
@@ -239,41 +237,34 @@ const instance = await render(
     patchConsole: false,
   },
 )
-await settle(() => screenText().includes('我的会话'))
-
 // ── 1. session 名标签显示在输入框顶边框右上角（开关开启时）────────────
-let row = borderRow()
-check('输入框顶边框存在', row !== undefined)
-check('顶边框右侧渲染会话名标签（与右圆角留白）', row !== undefined && row.text.includes(' 我的会话 ──╮'), row?.text ?? '')
-const defaultFg = borderFgColor()
-check('未设置颜色时边框为主题 promptBorder 灰蓝', defaultFg === 0x55606f, `0x${defaultFg?.toString(16) ?? '?'}`)
+check('输入框顶边框存在', await settled(() => borderRow() !== undefined))
+check('顶边框右侧渲染会话名标签（与右圆角留白）', await settled(() => borderRow()?.text.includes(' 我的会话 ──╮') === true), borderRow()?.text ?? '')
+check('未设置颜色时边框为主题 promptBorder 灰蓝', await settled(() => borderFgColor() === 0x55606f), `0x${borderFgColor()?.toString(16) ?? '?'}`)
 
 // ── 1b. 开关关闭时标签隐藏（默认关，settings `promptSessionLabel`）────
 channel.promptSessionLabel = false
 channel.emit()
-await settle(() => {
+check('关闭开关后会话名标签隐藏', await settled(() => {
   const r = borderRow()
   return r !== undefined && !r.text.includes('我的会话')
-})
-check('关闭开关后会话名标签隐藏', borderRow() !== undefined && !borderRow()!.text.includes('我的会话'))
+}))
 channel.promptSessionLabel = true
 channel.emit()
-await settle(() => borderRow()?.text.includes(' 我的会话 ──╮') === true)
-check('重新开启后标签恢复（右上角）', borderRow()?.text.includes(' 我的会话 ──╮') === true)
+check('重新开启后标签恢复（右上角）', await settled(() => borderRow()?.text.includes(' 我的会话 ──╮') === true))
 
 // ── 2. /color <name> 设置会话强调色并重绘边框 ──────────────────────────
 stdin.write('/color red')
 await settle(() => screenText().includes('/color red'))
 stdin.write('\r')
-// 渲染完成信号 = 通知上屏（React commit 后才可见）。
+// 渲染完成信号 = 通知上屏（React commit 后才可见）；这个门强于下方各断言
+// （屏上可见 ⇒ mock 已记录），并为下一条命令的按键 pacing——保留 settle。
 await settle(() => screenText().includes('会话颜色已设为 red'))
 check('/color red 调用 setSessionColor', channel.setColorCalls.length === 1, JSON.stringify(channel.setColorCalls))
 check('setSessionColor 收到 red', channel.setColorCalls[0] === 'red', String(channel.setColorCalls[0]))
 check('会话状态记录颜色 red', channel.sessionColor === 'red', channel.sessionColor)
 check('通知说明已设置', channel.notifications.includes('会话颜色已设为 red'), JSON.stringify(channel.notifications))
-await settle(() => borderFgColor() === 0xe5484d)
-const redFg = borderFgColor()
-check('边框重绘为会话红 #E5484D', redFg === 0xe5484d, `0x${redFg?.toString(16) ?? '?'}`)
+check('边框重绘为会话红 #E5484D', await settled(() => borderFgColor() === 0xe5484d), `0x${borderFgColor()?.toString(16) ?? '?'}`)
 
 // ── 3. /color status 与未知色名 ────────────────────────────────────────
 stdin.write('/color status')
@@ -296,9 +287,7 @@ stdin.write('\r')
 await settle(() => screenText().includes('已清除会话颜色'))
 check('/color reset 调用 setSessionColor(\'\')', channel.setColorCalls.length === 2 && channel.setColorCalls[1] === '', JSON.stringify(channel.setColorCalls))
 check('会话颜色清空', channel.sessionColor === '', channel.sessionColor)
-await settle(() => borderFgColor() === 0x55606f)
-const resetFg = borderFgColor()
-check('边框恢复主题色', resetFg === 0x55606f, `0x${resetFg?.toString(16) ?? '?'}`)
+check('边框恢复主题色', await settled(() => borderFgColor() === 0x55606f), `0x${borderFgColor()?.toString(16) ?? '?'}`)
 
 // ── 5. 无参 /color 打开调色板选择器，方向键 + Enter 应用 ──────────────
 stdin.write('/color')
@@ -307,44 +296,38 @@ stdin.write('\r')
 // 注意：不能拿「会话强调色」当 picker 已开的信号——命令补全下拉的
 // cmd-desc-color 描述（「设置当前会话强调色…」）也含这串字，settle 会
 // 秒匹配到 dropdown 导致后续按键错位。色点行「● red」只出现在 picker 里。
-await settle(() => screenText().includes('● red'), { timeoutMs: 10000 })
-let screen = screenText()
-check('无参 /color 打开调色板选择器', screen.includes('● red') && screen.includes('● blue'))
-check('选择器聚焦当前色（reset 后无当前色 → 首行 red）', /❯[^\n]*● red/u.test(screen), screen.split('\n').find(l => l.includes('●')) ?? '')
+check('无参 /color 打开调色板选择器', await settled(() => screenText().includes('● red') && screenText().includes('● blue'), { timeoutMs: 10000 }))
+check('选择器聚焦当前色（reset 后无当前色 → 首行 red）', await settled(() => /❯[^\n]*● red/u.test(screenText())), screenText().split('\n').find(l => l.includes('●')) ?? '')
 stdin.write('\x1b[B') // ↓：red → orange
-await settle(() => /❯[^\n]*● orange/u.test(screenText()), { timeoutMs: 10000 })
-check('方向键移动焦点到 orange', /❯[^\n]*● orange/u.test(screenText()))
+check('方向键移动焦点到 orange', await settled(() => /❯[^\n]*● orange/u.test(screenText()), { timeoutMs: 10000 }))
 // Chat 对模态 Enter 有 80ms 去重（lastModalEnterAtRef，防 \r\n 双事件）：
 // 本 harness 处理快时，打开 picker 的 Enter 与应用 Enter 落在同一窗口内，
 // 第二个 \r 会被吞掉（Esc 不受影响，实测 picker 活着但不应用）。留出
 // 处理时间间隙，与 verify-thinking-display 的 120ms sleep 同一理由。
 await sleep(200)
 stdin.write('\r')
+// 生效上屏是强于下方断言的门（屏上可见 ⇒ mock 已记录），并为后续按键
+// pacing——保留 settle。
 await settle(() => screenText().includes('会话颜色已设为 orange'), { timeoutMs: 10000 })
 check('选择器 Enter 应用 orange', channel.setColorCalls.at(-1) === 'orange', JSON.stringify(channel.setColorCalls))
-check('选择器应用后关闭', !screenText().includes('● red') && !screenText().includes('● orange'))
-check('选择器设置后边框重绘为橙色 #F76B15', borderFgColor() === 0xf76b15, `0x${borderFgColor()?.toString(16) ?? '?'}`)
+check('选择器应用后关闭', await settled(() => !screenText().includes('● red') && !screenText().includes('● orange')))
+check('选择器设置后边框重绘为橙色 #F76B15', await settled(() => borderFgColor() === 0xf76b15), `0x${borderFgColor()?.toString(16) ?? '?'}`)
 
 // ── 6. /recap 面板：摘要 + 建议标题 + 一键应用 ─────────────────────────
 stdin.write('/recap')
 await settle(() => screenText().includes('/recap'))
 stdin.write('\r')
-await settle(() => screenText().includes('最近在修会话颜色与 recap'))
-screen = screenText()
-check('recap 摘要渲染', screen.includes('最近在修会话颜色与 recap'))
-check('建议标题渲染', screen.includes('建议标题') && screen.includes('会话标识 PR'))
-check('应用按钮渲染', screen.includes('应用'))
+check('recap 摘要渲染', await settled(() => screenText().includes('最近在修会话颜色与 recap')))
+check('建议标题渲染', await settled(() => screenText().includes('建议标题') && screenText().includes('会话标识 PR')))
+check('应用按钮渲染', await settled(() => screenText().includes('应用')))
 
 stdin.write('a')
-await settle(() => channel.renameCalls.length === 1)
-check('按 a 应用标题走 renameSession', channel.renameCalls[0] === '会话标识 PR', JSON.stringify(channel.renameCalls))
+check('按 a 应用标题走 renameSession', await settled(() => channel.renameCalls[0] === '会话标识 PR'), JSON.stringify(channel.renameCalls))
 check('会话标题已更新', channel.sessionTitle === '会话标识 PR', channel.sessionTitle)
-await settle(() => screenText().includes('已应用'))
-check('面板标记已应用', screenText().includes('已应用'))
+check('面板标记已应用', await settled(() => screenText().includes('已应用')))
 
 stdin.write('\x1b')
-await settle(() => !screenText().includes('建议标题'))
-check('Esc 关闭 recap 面板', !screenText().includes('建议标题'))
+check('Esc 关闭 recap 面板', await settled(() => !screenText().includes('建议标题')))
 
 await instance.unmount()
 setLang('zh')

--- a/scripts/verify-session-tree.tsx
+++ b/scripts/verify-session-tree.tsx
@@ -279,16 +279,16 @@ function family() {
 
 // ── 屏幕层：无头组装 ─────────────────────────────────────────────────────
 {
-  const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { SessionTree }] = await Promise.all([
+  const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { SessionTree }, { settle, settled, sleep }] = await Promise.all([
     import('node:stream'),
     import('react'),
     import('@xterm/headless'),
     import('../src/ui.js'),
     import('../src/screens/SessionTree.js'),
+    import('./lib/term-test.mjs'),
   ])
 
   const COLS = 120, ROWS = 32
-  const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
   const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
   class FakeStdout extends Writable {
     columns = COLS; rows = ROWS; isTTY = true
@@ -332,37 +332,34 @@ function family() {
     </AlternateScreen>,
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(600)
-
-  check('screen: 标题渲染', text().includes('会话树'))
-  check('screen: 树行渲染（根问句）', text().includes('u0-问根'))
-  check('screen: fork 分支渲染（新方向）', text().includes('f1-新方向'))
-  check('screen: 连接线渲染', text().includes('├─') || text().includes('└─'))
-  check('screen: 预览面板渲染', text().includes('预览'))
+  check('screen: 标题渲染', await settled(() => text().includes('会话树')))
+  check('screen: 树行渲染（根问句）', await settled(() => text().includes('u0-问根')))
+  check('screen: fork 分支渲染（新方向）', await settled(() => text().includes('f1-新方向')))
+  check('screen: 连接线渲染', await settled(() => text().includes('├─') || text().includes('└─')))
+  check('screen: 预览面板渲染', await settled(() => text().includes('预览')))
 
   // Enter 打开操作菜单（焦点在活动叶 = live 会话，无切换选项）
   stdin.write('\r')
-  await sleep(250)
-  check('screen: Enter 打开操作菜单', text().includes('回退到这里') && text().includes('从这分叉'))
+  check('screen: Enter 打开操作菜单', await settled(() => text().includes('回退到这里') && text().includes('从这分叉')))
   check('screen: live 会话不提供切换选项', !text().includes('切换到该分支'))
   // Esc 关菜单，移到死分支（F2:14）再开：切换选项出现
   stdin.write('\x1b')
-  await sleep(150)
+  await settle(() => !text().includes('回退到这里'))
   stdin.write('\x1b[B\x1b[B\x1b[B')
+  // 焦点移动只改高亮样式，translateToString 读不到——无可观测文本条件，
+  // 保留固定 pacing 等按键被处理。
   await sleep(200)
   stdin.write('\r')
-  await sleep(250)
-  check('screen: 死分支提供切换选项', text().includes('切换到该分支'))
+  check('screen: 死分支提供切换选项', await settled(() => text().includes('切换到该分支')))
 
   // 字母直达：f = 从这分叉（焦点在 F2:14，经 channel 记录并关屏）
   stdin.write('f')
-  await sleep(300)
   check(
     'screen: 字母直达执行分叉',
-    calls.length === 1 && calls[0]!.sessionId === 'F2' && calls[0]!.mode === 'fork',
+    await settled(() => calls.length === 1 && calls[0]!.sessionId === 'F2' && calls[0]!.mode === 'fork'),
     JSON.stringify(calls),
   )
-  check('screen: 执行成功后关屏', closed === true)
+  check('screen: 执行成功后关屏', await settled(() => closed === true))
   await inst.unmount()
 
   // 再开一次：Esc 退出（无查询时）
@@ -378,10 +375,11 @@ function family() {
     </AlternateScreen>,
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
-  await sleep(400)
+  // 等新实例的界面就绪再发 Esc（前一实例 unmount 已离开 alt-screen，
+  // 标题只会出现在新帧里）。
+  await settle(() => text().includes('会话树'))
   stdin.write('\x1b')
-  await sleep(200)
-  check('screen: Esc 直接退出', closed === true)
+  check('screen: Esc 直接退出', await settled(() => closed === true))
   await inst2.unmount()
 }
 

--- a/scripts/verify-shrink-anchored-pad.tsx
+++ b/scripts/verify-shrink-anchored-pad.tsx
@@ -23,15 +23,14 @@
 process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Box, Text }, { sleep }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
     import('@xterm/headless'),
     import('../src/ui.js'),
+    import('./lib/term-test.mjs'),
   ])
-
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 let failed = 0
 function check(name: string, ok: boolean, extra = ''): void {
@@ -63,6 +62,7 @@ const bufferLines = (): string[] => {
     (buffer.getLine(row)?.translateToString(true) ?? '').replace(/\s+$/, ''),
   )
 }
+// 语义与 lib settle 不同（超时响亮 FAIL 而非静默返回），按 R6 就地保留。
 const waitFor = async (what: string, pred: () => boolean): Promise<void> => {
   for (let attempt = 0; attempt < 100; attempt++) {
     if (pred()) return
@@ -125,10 +125,23 @@ const edited = Array.from({ length: ROWS + 1 }, (_, index) => label(index))
 edited[2] = 'MARKER-STRANDED-ROW'
 edited[5] = 'MARKER-VISIBLE-ROW'
 setLines(edited)
-await waitFor('edit painted', () => bufferLines().some(line => line.includes('MARKER-VISIBLE-ROW')))
+// 等待与断言共用同一快照 observed：谓词即下方全部 check 条件的合取（旧谓词
+// 只等 marker 出现，弱于「恰好一次 + 旧文本清除 + 相邻关系」的断言条件）。
+let observed: string[] = []
+await waitFor('edit painted', () => {
+  observed = bufferLines()
+  const markerRows = observed
+    .map((line, row) => (line.includes('MARKER-VISIBLE-ROW') ? row : -1))
+    .filter(row => row >= 0)
+  const oldTextRows = observed
+    .map((line, row) => (line === label(5) ? row : -1))
+    .filter(row => row >= 0)
+  const neighborRow = observed.findIndex(line => line === label(6))
+  return markerRows.length === 1 && oldTextRows.length === 0
+    && neighborRow >= 0 && markerRows[0] === neighborRow - 1
+})
 
 {
-  const observed = bufferLines()
   const markerRows = observed
     .map((line, row) => (line.includes('MARKER-VISIBLE-ROW') ? row : -1))
     .filter(row => row >= 0)

--- a/scripts/verify-shrink.mjs
+++ b/scripts/verify-shrink.mjs
@@ -108,14 +108,18 @@ function check(name, ok, extra = '') {
 
   // Shrink: 60 -> 40 lines.
   instance.rerender(React.createElement(App, { lineCount: 40 }))
+  // 等待与断言共用同一快照 viewport：谓词覆盖下方全部语义断言的条件
+  // （含 marker——旧谓词更弱，缺 marker 项），断言在同一快照上求值，无分叉。
+  let viewport = []
   await settle(() => {
-    const lines = tailWindow()
-    const nums = lines
+    viewport = tailWindow()
+    const nums = viewport
       .map(l => /^line (\d+) padded content$/.exec(l.trim()))
       .filter(Boolean)
       .map(match => Number(match[1]))
-    return !lines.some(l => /line (4\d|5\d) padded/.test(l)) &&
-      nums.length > 0 && nums[nums.length - 1] === 39
+    return !viewport.some(l => /line (4\d|5\d) padded/.test(l)) &&
+      nums.length > 0 && nums[nums.length - 1] === 39 &&
+      viewport.some(l => l.includes('BOTTOM_PINNED_MARKER'))
   })
   const shrinkBytes = stdout.frames.slice(framesBefore).join('')
 
@@ -129,13 +133,7 @@ function check(name, ok, extra = '') {
     !/\x1b\[2J|\x1b\[3J/.test(shrinkBytes),
   )
 
-  // 2-4. xterm 重建的视口语义断言。
-  const buf = term.buffer.active
-  const start = Math.max(0, buf.length - ROWS)
-  const viewport = []
-  for (let y = start; y < buf.length; y++) {
-    viewport.push((buf.getLine(y)?.translateToString(true) ?? '').replace(/\s+$/, ''))
-  }
+  // 2-4. xterm 重建的视口语义断言（在 settle 捕获的同一快照 viewport 上）。
   const markerRow = viewport.findIndex(l => l.includes('BOTTOM_PINNED_MARKER'))
   check('marker visible in viewport', markerRow >= 0)
   check(

--- a/scripts/verify-shutdown-stderr.tsx
+++ b/scripts/verify-shutdown-stderr.tsx
@@ -96,6 +96,9 @@ try {
 check('shutdown detach does not absorb unexpected stdin errors', unexpectedErrorEscaped)
 
 stdin.write('x')
+// Stability probe (state must NOT change): receivedInput is already '' and
+// must stay '' after the write drains — polling would return immediately,
+// so keep the fixed one-tick window.
 await new Promise(resolve => setImmediate(resolve))
 check('detached Ink does not consume input meant for the replacement process', receivedInput === '')
 

--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -11,15 +11,13 @@
  */
 import { createChannel } from '../lib/types/dsh-adapter/channel.js'
 import { LOCAL_COMMANDS } from '../lib/types/commands.js'
-import { settle } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
-
-const tick = () => new Promise(resolve => setTimeout(resolve, 20))
 
 // Multicast: `commands/change` and `skills/change` each have MORE than one
 // subscriber inside the channel (the menu merge and the command registration),
@@ -101,19 +99,15 @@ check(
   !channel.commandList.some(command => command.name === 'i-h'),
 )
 
-await settle(() =>
-  channel.commandList.some(command => command.name === 'i-h') &&
-  channel.commandList.some(command => command.name === 'helper'))
-
 // ---- async phase: user-invocable skills merged, marked, deduped
-const names = channel.commandList.map(command => command.name)
-check('user-invocable skill merged (i-h)', names.includes('i-h'))
-check('user-invocable skill merged (helper)', names.includes('helper'))
+check('user-invocable skill merged (i-h)', await settled(() => channel.commandList.some(command => command.name === 'i-h')))
+check('user-invocable skill merged (helper)', await settled(() => channel.commandList.some(command => command.name === 'helper')))
 check(
   'skill entries carry the skill marker + description',
-  channel.commandList.some(command =>
-    command.name === 'i-h' && command.skill === true && command.description === 'Interactive help skill'),
+  await settled(() => channel.commandList.some(command =>
+    command.name === 'i-h' && command.skill === true && command.description === 'Interactive help skill')),
 )
+const names = channel.commandList.map(command => command.name)
 check('model-only skill excluded', !names.includes('secret'))
 check(
   'registry command wins a name collision',
@@ -139,13 +133,9 @@ if (skillsChange === undefined || skillsChange.length === 0) {
 } else {
   check('skills/change handler captured', true)
   fire('skills/change')
-  await settle(() =>
-    channel.commandList.some(command => command.name === 'newskill') &&
-    !channel.commandList.some(command => command.name === 'helper'))
-  const refreshed = channel.commandList.map(command => command.name)
-  check('removed skill leaves the menu', !refreshed.includes('helper'))
-  check('added skill enters the menu', refreshed.includes('newskill'))
-  check('kept skill stays', refreshed.includes('i-h'))
+  check('removed skill leaves the menu', await settled(() => !channel.commandList.some(command => command.name === 'helper')))
+  check('added skill enters the menu', await settled(() => channel.commandList.some(command => command.name === 'newskill')))
+  check('kept skill stays', channel.commandList.some(command => command.name === 'i-h'))
 }
 
 // ---- skills/change with a failed read keeps the last-good skill list
@@ -157,14 +147,14 @@ ctx.get = (name) => {
 let warned = 0
 ctx.logger = { warn() { warned += 1 } }
 fire('skills/change')
-await settle(() => warned >= 1)
 {
-  const after = channel.commandList.map(command => command.name)
   check(
     'failed skill read keeps locals + registry and logs a warning',
-    after.includes('plan') && warned >= 1,
+    await settled(() => channel.commandList.some(command => command.name === 'plan') && warned >= 1),
     `warned=${warned}`,
   )
+  // keep 语义：完成信号（warned）落定后同步判定，轮询已成立的条件测不到误清。
+  const after = channel.commandList.map(command => command.name)
   check(
     'failed skill read restores the last-good skills',
     after.includes('i-h') && after.includes('newskill'),
@@ -183,14 +173,13 @@ ctx.get = (name) => {
 }
 warned = 0
 fire('skills/change')
-await settle(() => warned >= 1)
 {
-  const after = channel.commandList.map(command => command.name)
   check(
     'incomplete observation logs a warning',
-    warned >= 1,
+    await settled(() => warned >= 1),
     `warned=${warned}`,
   )
+  const after = channel.commandList.map(command => command.name)
   check(
     'incomplete observation keeps the last-good skills',
     after.includes('i-h') && after.includes('newskill'),
@@ -206,15 +195,14 @@ ctx.get = (name) => {
   return undefined
 }
 fire('skills/change')
-await settle(() =>
-  !channel.commandList.some(command => command.name === 'i-h') &&
-  !channel.commandList.some(command => command.name === 'newskill'))
 {
-  const after = channel.commandList.map(command => command.name)
   check(
     'complete empty observation authoritatively clears skills',
-    !after.includes('i-h') && !after.includes('newskill') && after.includes('plan'),
-    after.join(','),
+    await settled(() => {
+      const after = channel.commandList.map(command => command.name)
+      return !after.includes('i-h') && !after.includes('newskill') && after.includes('plan')
+    }),
+    channel.commandList.map(command => command.name).join(','),
   )
 }
 
@@ -236,12 +224,11 @@ await settle(() =>
     skills: [{ name: 'live', description: 'Live skill', invocation: { modelInvocable: true, userInvocable: true } }],
     complete: true,
   })
-  await settle(() => channel.commandList.some(command => command.name === 'live'))
-  check('superseding read repopulates the menu', channel.commandList.some(command => command.name === 'live'))
+  check('superseding read repopulates the menu', await settled(() => channel.commandList.some(command => command.name === 'live')))
   pending[0].reject(new Error('stale scan failed'))
   // Stability probe (nothing may change, nothing may warn): a settle over an
   // already-true condition returns immediately — keep the fixed window.
-  await tick()
+  await sleep(20)
   check('stale read failure logs no warning', staleWarned === 0, `warned=${staleWarned}`)
   check(
     'stale read failure does not touch the live menu',
@@ -277,11 +264,10 @@ await settle(() =>
     { name: 'review', description: 'Shadow skill (review)', invocation: { modelInvocable: true, userInvocable: true } },
   )
   fire('skills/change')
-  await settle(() => typeof registered.get('i-h')?.handler === 'function')
 
   check(
     'user-invocable skill is registered as a real command',
-    registered.has('i-h') && typeof registered.get('i-h').handler === 'function',
+    await settled(() => registered.has('i-h') && typeof registered.get('i-h')?.handler === 'function'),
   )
   check('model-only skill is not registered', !registered.has('secret'))
   check(
@@ -317,9 +303,8 @@ await settle(() =>
     agent.followups.length = 0
     const outcome = await descriptor.handler({ agent, rawInput: ' 做年终总结', signal: undefined })
     check('kernel path reports success', outcome?.kind === 'success', JSON.stringify(outcome))
-    await settle(() => agent.followups.length === 1)
+    check('kernel path delivers exactly one message', await settled(() => agent.followups.length === 1))
     const gesture = agent.followups[0]
-    check('kernel path delivers exactly one message', agent.followups.length === 1)
     check(
       'kernel path submits the gesture as a plain user message with args',
       gesture?.source?.kind === 'user' && gesture.content?.[0]?.text === '/i-h 做年终总结',

--- a/scripts/verify-subagent-settle.tsx
+++ b/scripts/verify-subagent-settle.tsx
@@ -16,18 +16,18 @@ process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'kitty'
 process.env.DSH_TUI_THEME = 'dark'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
+  import('./lib/term-test.mjs'),
 ])
 
 const COLS = 100
 const ROWS = 32
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log((ok ? 'PASS' : 'FAIL') + '  ' + name + (extra ? '  (' + extra + ')' : ''))
@@ -113,7 +113,8 @@ await render(
   { stdout, stdin, stderr, exitOnCtrlC: false, patchConsole: false, onFrame: () => { frameCount++ } },
 )
 
-// 开机动画（LogoV2 splash）落定后再测
+// 开机动画（LogoV2 splash）落定后再测——动画时长是墙钟语义，无可轮询的
+// 定格条件，保留固定窗口。
 await sleep(1800)
 
 // ---- 控制组：2 张 running 卡片 → 空闲窗口内必须有帧 ----
@@ -131,6 +132,8 @@ channelRows.forEach(row => {
   sub.stopReason = 'completed'
 })
 bump()
+// 过渡帧吸收窗：completed 重排的收尾帧无可轮询的完成条件，保留固定窗口
+// （countIdleFrames 自带的 300ms 预滚同理）。
 await sleep(300)
 
 const settledFrames = await countIdleFrames(1000)

--- a/scripts/verify-subagent-stream-batching.tsx
+++ b/scripts/verify-subagent-stream-batching.tsx
@@ -29,7 +29,7 @@ process.env.HOME = isolatedHome
 process.env.USERPROFILE = isolatedHome
 mkdirSync(joinPath(isolatedHome, '.dsh-tui'), { recursive: true })
 
-const [{ Context }, { createChannel }, { SubagentActivityStore }, { settle }] = await Promise.all([
+const [{ Context }, { createChannel }, { SubagentActivityStore }, { settled, sleep }] = await Promise.all([
   import('@deepseek-ai/cordis'),
   import('../src/dsh-adapter/channel.js'),
   import('../src/dsh-adapter/subagents.js'),
@@ -41,7 +41,6 @@ function check(name: string, ok: boolean, extra = ''): void {
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 
 // ── snapshot 计数插桩：包一层原方法 ──
 let snapshotCalls = 0
@@ -85,9 +84,7 @@ const chunk = (text: string) => ({ type: 'assistant/chunk', data: { chunk: { typ
 ;(ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit('subagent/start', {
   id: 'child-agent', runId: 'run-1', provider: 'fake-provider',
 })
-await settle(() => channel.subagents.length === 1 && channel.subagents[0]?.agentId === 'child-agent')
-const linked = channel.subagents.length === 1 && channel.subagents[0]!.agentId === 'child-agent'
-check('subagent/start 建立 tracked subagent', linked, JSON.stringify(channel.subagents.map(s => s.agentId)))
+check('subagent/start 建立 tracked subagent', await settled(() => channel.subagents.length === 1 && channel.subagents[0]?.agentId === 'child-agent'), JSON.stringify(channel.subagents.map(s => s.agentId)))
 
 // ── 1. chunk 风暴：200 个 delta 同步连发（事件循环同一 tick 内）──
 const BURST = 200

--- a/scripts/verify-submit.mjs
+++ b/scripts/verify-submit.mjs
@@ -18,7 +18,7 @@
  * Run with plain node against the compiled lib: `node scripts/verify-submit.mjs`
  */
 import { createChannel } from '../lib/types/dsh-adapter/channel.js'
-import { settle } from './lib/term-test.mjs'
+import { settle, settled } from './lib/term-test.mjs'
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -28,7 +28,8 @@ function check(name, ok, extra = '') {
 
 const sleep = ms => new Promise(r => setTimeout(r, ms))
 // 投递链（sendChain）落定：expandMentions + followup/steer 都是微任务级，
-// settle 轮询到断言条件出现（./lib/term-test.mjs）。
+// 异步状态的断言一律 `check(..., await settled(() => cond))`——等待与断言
+// 共用同一谓词（./lib/term-test.mjs）；等待后只操作不断言的地方用 settle。
 
 const handlers = new Map()
 const ctx = {
@@ -81,15 +82,13 @@ const channel = createChannel(ctx, agent, {
 
 // ---- followup (Tab queue) path
 channel.submit('  第一条消息  ')
-await settle(() => followupCalls.length === 1 && followupCalls[0]?.content?.[0]?.text === '第一条消息')
-check('submit → agent.followup', followupCalls.length === 1 && followupCalls[0]?.content?.[0]?.text === '第一条消息')
-check('submit tracked as pending followup', channel.pending.length === 1 && channel.pending[0]?.placement === 'followup', JSON.stringify(channel.pending))
+check('submit → agent.followup', await settled(() => followupCalls.length === 1 && followupCalls[0]?.content?.[0]?.text === '第一条消息'))
+check('submit tracked as pending followup', await settled(() => channel.pending.length === 1 && channel.pending[0]?.placement === 'followup'), JSON.stringify(channel.pending))
 
 // ---- steer (Enter while working) path
 channel.steer('第二条消息')
-await settle(() => steerCalls.length === 1 && steerCalls[0]?.content?.[0]?.text === '第二条消息')
-check('steer → agent.steer', steerCalls.length === 1 && steerCalls[0]?.content?.[0]?.text === '第二条消息')
-check('steer tracked as pending steer', channel.pending.length === 2 && channel.pending[1]?.placement === 'steer', JSON.stringify(channel.pending))
+check('steer → agent.steer', await settled(() => steerCalls.length === 1 && steerCalls[0]?.content?.[0]?.text === '第二条消息'))
+check('steer tracked as pending steer', await settled(() => channel.pending.length === 2 && channel.pending[1]?.placement === 'steer'), JSON.stringify(channel.pending))
 check('blank steer ignored', channel.steer('   ') === undefined && steerCalls.length === 1)
 
 // ---- claimed event retires the pending item (delivery)
@@ -107,8 +106,7 @@ if (discardedHandler) {
 
 // ---- removePending pulls a message back out of the inbox
 channel.steer('撤回我')
-await settle(() => channel.pending.length === 1)
-check('steer for removal tracked', channel.pending.length === 1, JSON.stringify(channel.pending))
+check('steer for removal tracked', await settled(() => channel.pending.length === 1), JSON.stringify(channel.pending))
 const removed = channel.removePending(channel.pending[0]?.id ?? '')
 check('removePending → agent.inbox.remove', removed === true && inboxRemovals.length === 1)
 check('removePending clears the item', channel.pending.length === 0)
@@ -149,8 +147,7 @@ const interruptChannel = createChannel(ctx, interruptAgent, {
 })
 check('interruptAndDeliver trims and counts', interruptChannel.interruptAndDeliver(['插话一', '   ', '插话二']) === 2)
 check('interruptAndDeliver cancels without keepInbox', interruptCalls.length === 1 && interruptCalls[0].options === undefined, JSON.stringify(interruptCalls))
-await settle(() => interruptFollowups.length === 2 && interruptChannel.pending.length === 2)
-check('re-queued without waiting for idle (all texts)', interruptFollowups.length === 2 && interruptChannel.pending.length === 2, JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
+check('re-queued without waiting for idle (all texts)', await settled(() => interruptFollowups.length === 2 && interruptChannel.pending.length === 2), JSON.stringify(interruptFollowups.map(m => m.content?.[0]?.text)))
 check('re-queued as followup', interruptChannel.pending.every(p => p.placement === 'followup'))
 resolveIdle?.()
 
@@ -211,8 +208,7 @@ const convergenceChannel = createChannel(ctx, convergenceAgent, {
   activity: false,
 })
 convergenceChannel.interruptAndDeliver(['取消后立即恢复'])
-await settle(() => convergenceFollowups.length === 1 && convergenceChannel.pending.length === 1)
-check('cancel convergence does not depend on whenIdle', convergenceFollowups.length === 1 && convergenceChannel.pending.length === 1, JSON.stringify(convergenceFollowups))
+check('cancel convergence does not depend on whenIdle', await settled(() => convergenceFollowups.length === 1 && convergenceChannel.pending.length === 1), JSON.stringify(convergenceFollowups))
 
 // No whenIdle observer: delivery still uses the same convergence wake.
 const fallbackCalls = []
@@ -233,7 +229,6 @@ const fallbackChannel = createChannel(ctx, fallbackAgent, {
   activity: false,
 })
 fallbackChannel.interruptAndDeliver(['兜底投递'])
-await settle(() => fallbackCalls.length === 1 && fallbackChannel.pending.length === 1)
-check('no-whenIdle agent still receives the wake', fallbackCalls.length === 1 && fallbackChannel.pending.length === 1, JSON.stringify(fallbackCalls))
+check('no-whenIdle agent still receives the wake', await settled(() => fallbackCalls.length === 1 && fallbackChannel.pending.length === 1), JSON.stringify(fallbackCalls))
 
 process.exit(failed)

--- a/scripts/verify-terminal-queries.tsx
+++ b/scripts/verify-terminal-queries.tsx
@@ -7,6 +7,7 @@ import { PassThrough, Writable } from 'node:stream'
 import React, { useEffect } from 'react'
 import { render, Text, useStdin } from '../src/ui.js'
 import { oscColor } from '../src/ink/terminal-querier.js'
+import { settled, sleep } from './lib/term-test.mjs'
 
 class FakeStdout extends Writable {
   columns = 80
@@ -71,15 +72,6 @@ function QueryProbe(): React.ReactNode {
   return <Text>terminal query probe</Text>
 }
 
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let i = 0; i < 100; i++) {
-    if (predicate()) return
-    await sleep(10)
-  }
-  assert.fail('timed out waiting for terminal-query state')
-}
-
 const stdin = new FakeStdin()
 const stdout = new FakeStdout()
 const instance = await render(<QueryProbe />, {
@@ -90,7 +82,10 @@ const instance = await render(<QueryProbe />, {
   patchConsole: false,
 })
 
-await waitFor(() => stdout.output.includes('\x1b]11;?') && stdout.output.includes('\x1b[>0q'))
+assert.ok(
+  await settled(() => stdout.output.includes('\x1b]11;?') && stdout.output.includes('\x1b[>0q')),
+  'timed out waiting for the OSC 11 / XTVERSION queries to be written',
+)
 // Stability probe (must NOT change): raw mode is already true here and must
 // stay true while the replies are late — a settle on the already-true
 // condition would return immediately, so keep a fixed delay window.
@@ -98,11 +93,11 @@ await sleep(450)
 assert.equal(stdin.isRaw, true, 'late terminal replies must remain protected by raw mode')
 
 stdin.write('\x1b]11;rgb:0c0c/0c0c/0c0c\x1b\\\x1b[?61;4c')
-await waitFor(() => oscSettled)
+assert.ok(await settled(() => oscSettled), 'timed out waiting for the OSC 11 reply to settle')
 assert.equal(stdin.isRaw, true, 'the concurrent XTVERSION batch must retain raw mode')
 
 stdin.write('\x1bP>|xterm.js(5.5.0)\x1b\\\x1b[?61;4c')
-await waitFor(() => !stdin.isRaw)
+assert.ok(await settled(() => !stdin.isRaw), 'timed out waiting for raw mode to be released')
 assert.deepEqual(visibleInput, [], 'terminal responses must not reach input listeners')
 
 instance.unmount()

--- a/scripts/verify-text-background.tsx
+++ b/scripts/verify-text-background.tsx
@@ -2,7 +2,7 @@
 
 process.env.FORCE_COLOR = '3'
 
-const [{ PassThrough, Writable }, React, { render, ThemeProvider, Text }, { settle }] =
+const [{ PassThrough, Writable }, React, { render, ThemeProvider, Text }, { settled }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -60,11 +60,10 @@ const instance = await render(
   },
 )
 
-await settle(() => stdout.frames.join('').includes('\x1b[48;2;255;215;95m'))
+const hasBackground = await settled(() => stdout.frames.join('').includes('\x1b[48;2;255;215;95m'))
 await instance.unmount()
 
-const output = stdout.frames.join('')
-if (!output.includes('\x1b[48;2;255;215;95m')) {
+if (!hasBackground) {
   throw new Error('Text raw backgroundColor did not reach terminal output')
 }
 

--- a/scripts/verify-thinking-display.tsx
+++ b/scripts/verify-thinking-display.tsx
@@ -17,7 +17,7 @@ const [
   { render },
   { Chat },
   { setLang },
-  { settle, viewportLines },
+  { settle, settled, sleep, viewportLines },
 ] = await Promise.all([
   import('node:stream'),
   import('react'),
@@ -52,8 +52,6 @@ class FakeStdin extends PassThrough {
   ref() { return this }
   unref() { return this }
 }
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 function screenText(): string {
   return viewportLines(term, ROWS).join('\n')
@@ -186,57 +184,47 @@ const instance = await render(
     patchConsole: false,
   },
 )
-await settle(() => screenText().includes('SECRET_REASONING_TRACE'))
-
-check('切换前流式思考行可见', screenText().includes('SECRET_REASONING_TRACE'))
+check('切换前流式思考行可见', await settled(() => screenText().includes('SECRET_REASONING_TRACE')))
 
 stdin.write('/thinking')
 await settle(() => screenText().includes('/thinking'))
 stdin.write('\r')
-await settle(() => screenText().includes('思考过程显示'))
 
-let screen = screenText()
-check('对话框明确这是思考过程显示设置', screen.includes('思考过程显示'))
-check('对话框明确不改变模型思考行为', screen.includes('不改变模型的思考行为'))
-check('隐藏项说明模型仍会照常思考', screen.includes('模型仍会照常思考'))
+check('对话框明确这是思考过程显示设置', await settled(() => screenText().includes('思考过程显示')))
+check('对话框明确不改变模型思考行为', await settled(() => screenText().includes('不改变模型的思考行为')))
+check('隐藏项说明模型仍会照常思考', await settled(() => screenText().includes('模型仍会照常思考')))
 
 stdin.write('\x1b[B')
 // 排序 sleep 保留：选中项移动只改高亮色，不改可见文本，屏上无可 settle 的内容。
 await sleep(120)
 stdin.write('\r')
 // 对话框盖住转录区时「思考行不可见」早已成立，settle 屏幕条件会提前返回；
-// 通知只在确认处理后才写入，才是确认已生效的信号（也是下方断言之一）。
-await settle(() => channel.notifications.includes('思考过程：隐藏'))
-
-screen = screenText()
-check('隐藏立即生效，不出现质量警告', !screen.includes('可能降低质量'))
-check('隐藏后思考行不可见', !screen.includes('SECRET_REASONING_TRACE'))
+// 通知只在确认处理后才写入，才是确认已生效的信号——先断言它作为门，
+// 其余断言在门后读已落定状态。
+check('通知准确说明思考过程已隐藏', await settled(() => channel.notifications.includes('思考过程：隐藏')), JSON.stringify(channel.notifications))
+check('隐藏立即生效，不出现质量警告', !screenText().includes('可能降低质量'))
+check('隐藏后思考行不可见', await settled(() => !screenText().includes('SECRET_REASONING_TRACE')))
 check('隐藏后模型 effort 保持不变', channel.reasoningEffort === 'max', channel.reasoningEffort)
 check('隐藏不调用 setEffort', channel.setEffortCalls.length === 0, JSON.stringify(channel.setEffortCalls))
-check('通知准确说明思考过程已隐藏', channel.notifications.includes('思考过程：隐藏'), JSON.stringify(channel.notifications))
 
 setLang('en')
 stdin.write('/thinking')
 await settle(() => screenText().includes('/thinking'))
 stdin.write('\r')
-await settle(() => screenText().includes('Thinking display'))
 
-screen = screenText()
-check('English dialog describes thinking display', screen.includes('Thinking display'))
-check('English dialog says model behavior is unchanged', screen.includes('does not change model behavior'))
-check('English shown option describes conversation visibility', screen.includes("Show DeepSeek's reasoning"))
+check('English dialog describes thinking display', await settled(() => screenText().includes('Thinking display')))
+check('English dialog says model behavior is unchanged', await settled(() => screenText().includes('does not change model behavior')))
+check('English shown option describes conversation visibility', await settled(() => screenText().includes("Show DeepSeek's reasoning")))
 
 stdin.write('\x1b[A')
 // 排序 sleep 保留：选中项移动只改高亮色，不改可见文本，屏上无可 settle 的内容。
 await sleep(120)
 stdin.write('\r')
-await settle(() => screenText().includes('SECRET_REASONING_TRACE'))
 
-screen = screenText()
-check('showing reasoning again takes effect immediately', screen.includes('SECRET_REASONING_TRACE'))
+check('showing reasoning again takes effect immediately', await settled(() => screenText().includes('SECRET_REASONING_TRACE')))
 check('showing reasoning keeps model effort unchanged', channel.reasoningEffort === 'max', channel.reasoningEffort)
 check('showing reasoning does not call setEffort', channel.setEffortCalls.length === 0, JSON.stringify(channel.setEffortCalls))
-check('English notification says reasoning is shown', channel.notifications.includes('Thinking display: shown'), JSON.stringify(channel.notifications))
+check('English notification says reasoning is shown', await settled(() => channel.notifications.includes('Thinking display: shown')), JSON.stringify(channel.notifications))
 
 await instance.unmount()
 setLang('zh')

--- a/scripts/verify-timeline-rail.tsx
+++ b/scripts/verify-timeline-rail.tsx
@@ -20,7 +20,7 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, { LOCAL_COMMANDS, completeCommands }, { settle, settled, sleep }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -32,7 +32,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, Alternat
 ])
 
 const COLS = 100, ROWS = 40
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -117,15 +116,18 @@ const inst = await render(
   </AlternateScreen>,
   { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
 )
-await settle(() => {
-  const snap = railSnapshot()
-  if (snap.ticks.length !== 8 || snap.activeRow === null || snap.upRow === null || snap.downRow === null) return false
-  // 断言同条件：初始 sticky 滚动到底与 rail active 重算之间存在竞争，
-  // 只等「tick 出现」在快 runner 上会断到 active 尚未对齐的帧（块 1 的
-  // 顶部锚定断言随机红）。settle 必须包含块 1 断言的同一不变量——active
-  // 与视口顶行的轮次归属一致；真回归时此条件永不成立，超时后断言照常红。
-  const owner = topOwningTurn()
-  return owner !== null && snap.ticks.indexOf(snap.activeRow) === owner - 1
+let bootSnap = railSnapshot()
+let bootOwner: number | null = null
+await settled(() => {
+  bootSnap = railSnapshot()
+  if (bootSnap.ticks.length !== 8 || bootSnap.activeRow === null || bootSnap.upRow === null || bootSnap.downRow === null) return false
+  // 断言同条件（#561 修复，保持）：初始 sticky 滚动到底与 rail active 重算
+  // 之间存在竞争，只等「tick 出现」在快 runner 上会断到 active 尚未对齐的
+  // 帧（块 1 的顶部锚定断言随机红）。settle 必须包含块 1 断言的同一不变量
+  // ——active 与视口顶行的轮次归属一致；真回归时此条件永不成立，超时后
+  // 断言照常红。块 1 的断言直接在本次捕获的快照上求值，无重读分叉。
+  bootOwner = topOwningTurn()
+  return bootOwner !== null && bootSnap.ticks.indexOf(bootSnap.activeRow) === bootOwner - 1
 })
 
 function screenLines(): string[] {
@@ -175,6 +177,9 @@ function topOwningTurn(): number | null {
   }
   return null
 }
+// 逐事件 pacing sleep 保留：滚轮事件需要逐个进入 hover/scroll 路径，无可
+// 轮询的逐步条件；clickAt/hoverAt 的固定窗口同时是场景 5/6b「无操作/无卡」
+// 稳定性探针的现身时间，必须保留。
 const wheel = async (up: boolean, times: number) => {
   for (let i = 0; i < times; i++) {
     stdin.write(`\x1b[<${up ? 64 : 65};90;30M`)
@@ -192,26 +197,33 @@ const hoverAt = async (col: number, row: number) => {
 }
 
 // ── 1. 底部：rail 出现，8 tick，恰一个 ━━，active 顶部锚定 ──
+// 断言在 boot settle 捕获的同一快照上求值（#561 语义保持）。
 {
-  const snap = railSnapshot()
+  const snap = bootSnap
   check('rail 出现（▲/▼/tick 齐）', snap.upRow !== null && snap.downRow !== null && snap.ticks.length > 0,
     `up=${snap.upRow} down=${snap.downRow} ticks=${snap.ticks.length}`)
   check('恰 8 个 tick', snap.ticks.length === 8, `ticks=${snap.ticks.length}`)
   check('恰一个 ━━（active）', snap.activeRow !== null && snap.ticks.filter(y => y === snap.activeRow).length === 1,
     `active=${snap.activeRow}`)
-  const owner = topOwningTurn()
   const activeIndex = snap.activeRow !== null ? snap.ticks.indexOf(snap.activeRow) : -1
-  check('active = 视口顶行所属轮次（顶部锚定，非最新轮）', owner !== null && activeIndex === owner - 1,
-    `active#${activeIndex + 1} vs 顶行属于问题 ${owner}`)
+  check('active = 视口顶行所属轮次（顶部锚定，非最新轮）', bootOwner !== null && activeIndex === bootOwner - 1,
+    `active#${activeIndex + 1} vs 顶行属于问题 ${bootOwner}`)
 }
 
 // ── 2. 上滚 4 格：active 随边界移动且与顶行轮次一致 ──
 await wheel(true, 4)
 {
-  const snap = railSnapshot()
+  // 等待与断言共用同一快照：谓词即两条 check 条件的合取（#561 同款不变量）。
+  let snap = railSnapshot()
+  let owner: number | null = null
+  await settle(() => {
+    snap = railSnapshot()
+    owner = topOwningTurn()
+    return snap.ticks.length === 8 && snap.activeRow !== null
+      && owner !== null && snap.ticks.indexOf(snap.activeRow) === owner - 1
+  })
   check('上滚后仍恰 8 tick / 恰一个 ━━', snap.ticks.length === 8 && snap.activeRow !== null,
     `ticks=${snap.ticks.length} active=${snap.activeRow}`)
-  const owner = topOwningTurn()
   const activeIndex = snap.activeRow !== null ? snap.ticks.indexOf(snap.activeRow) : -1
   check('上滚后 active 与顶行轮次一致', owner !== null && activeIndex === owner - 1,
     `active#${activeIndex + 1} vs 顶行属于问题 ${owner}`)
@@ -224,12 +236,10 @@ await wheel(true, 4)
   check('第 3 个 tick 存在', tickRow !== undefined, `ticks=${JSON.stringify(snap.ticks)}`)
   if (tickRow !== undefined) {
     await clickAt(COLS, tickRow + 1)
-    const lines = screenLines()
-    check('点击后 问题 3 跳到转译区顶', lines.slice(0, 3).some(l => l.includes('问题 3')),
-      `top3=${JSON.stringify(lines.slice(0, 3).map(l => l.trimEnd()))}`)
-    const snap2 = railSnapshot()
-    check('点击后 ━━ 移到该 tick', snap2.activeRow === tickRow,
-      `active=${snap2.activeRow} expected=${tickRow}`)
+    check('点击后 问题 3 跳到转译区顶', await settled(() => screenLines().slice(0, 3).some(l => l.includes('问题 3'))),
+      `top3=${JSON.stringify(screenLines().slice(0, 3).map(l => l.trimEnd()))}`)
+    check('点击后 ━━ 移到该 tick', await settled(() => railSnapshot().activeRow === tickRow),
+      `active=${railSnapshot().activeRow} expected=${tickRow}`)
   }
 }
 
@@ -238,15 +248,13 @@ await wheel(true, 4)
   const snap = railSnapshot()
   if (snap.downRow !== null) {
     await clickAt(COLS, snap.downRow + 1)
-    const lines = screenLines()
-    check('▼ 后 问题 4 到顶', lines.slice(0, 3).some(l => l.includes('问题 4')),
-      `top3=${JSON.stringify(lines.slice(0, 3).map(l => l.trimEnd()))}`)
+    check('▼ 后 问题 4 到顶', await settled(() => screenLines().slice(0, 3).some(l => l.includes('问题 4'))),
+      `top3=${JSON.stringify(screenLines().slice(0, 3).map(l => l.trimEnd()))}`)
     const snap2 = railSnapshot()
     if (snap2.upRow !== null) {
       await clickAt(COLS, snap2.upRow + 1)
-      const lines2 = screenLines()
-      check('▲ 后 问题 3 回到顶', lines2.slice(0, 3).some(l => l.includes('问题 3')),
-        `top3=${JSON.stringify(lines2.slice(0, 3).map(l => l.trimEnd()))}`)
+      check('▲ 后 问题 3 回到顶', await settled(() => screenLines().slice(0, 3).some(l => l.includes('问题 3'))),
+        `top3=${JSON.stringify(screenLines().slice(0, 3).map(l => l.trimEnd()))}`)
     } else {
       check('▲ 行存在', false, 'upRow missing')
     }
@@ -280,20 +288,13 @@ await wheel(false, 20)
   check('第 2 个 tick 存在（悬停目标）', tickRow !== undefined, `ticks=${JSON.stringify(snap.ticks)}`)
   if (tickRow !== undefined) {
     await hoverAt(COLS, tickRow + 1)
-    const lines = screenLines()
-    const cardText = lines.some(l => {
-      const right = l.slice(55, 96)
-      return right.includes('问题 2')
-    })
-    const cardBorder = lines.some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')
-      || l.slice(55, 97).includes('╰') || l.slice(55, 97).includes('╯'))
-    check('悬停弹出预览卡（含 问题 2）', cardText,
-      `right-half=${JSON.stringify(lines.filter(l => l.includes('问题 2')).slice(0, 2))}`)
-    check('预览卡圆角边框', cardBorder)
+    check('悬停弹出预览卡（含 问题 2）', await settled(() => screenLines().some(l => l.slice(55, 96).includes('问题 2'))),
+      `right-half=${JSON.stringify(screenLines().filter(l => l.includes('问题 2')).slice(0, 2))}`)
+    check('预览卡圆角边框', await settled(() => screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')
+      || l.slice(55, 97).includes('╰') || l.slice(55, 97).includes('╯'))))
     // 移开：回到转译区中部（无 handler 的文本上）
     await hoverAt(30, 20)
-    const lines2 = screenLines()
-    check('移开后预览卡消失', !lines2.some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')),
+    check('移开后预览卡消失', await settled(() => !screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮'))),
       'border still present')
   }
 }
@@ -317,8 +318,7 @@ await wheel(false, 20)
   const row = snap.ticks[2]
   if (row !== undefined) {
     stdin.write(`\x1b[<35;${COLS};${row + 1}M`)
-    await settle(() => screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')))
-    check('停留 350ms 后预览卡出现', screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮')))
+    check('停留 350ms 后预览卡出现', await settled(() => screenLines().some(l => l.slice(55, 97).includes('╭') || l.slice(55, 97).includes('╮'))))
     await hoverAt(30, 20)
   }
 }
@@ -339,11 +339,12 @@ await wheel(false, 20)
   ;(stdout as any).columns = COLS
   stdout.emit('resize')
   term.resize(COLS, ROWS)
+  // 等待与断言共用同一快照。
+  let snap = railSnapshot()
   await settle(() => {
-    const snap = railSnapshot()
+    snap = railSnapshot()
     return snap.ticks.length === 8 && snap.upRow !== null
   })
-  const snap = railSnapshot()
   check('恢复 100 列 rail 回来', snap.ticks.length === 8 && snap.upRow !== null,
     `ticks=${snap.ticks.length} up=${snap.upRow}`)
 }
@@ -379,11 +380,12 @@ await inst.unmount()
     </AlternateScreen>,
     { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
   )
+  // 等待与断言共用同一快照。
+  let snap = railSnapshot()
   await settle(() => {
-    const snap = railSnapshot()
+    snap = railSnapshot()
     return snap.ticks.length === 12 && snap.activeRow !== null
   })
-  const snap = railSnapshot()
   check('工具重会话：rail 覆盖全部 12 轮', snap.ticks.length === 12,
     `ticks=${snap.ticks.length}（折叠窗口内仅 ~5 轮）`)
   check('工具重会话：恰一个 ━━', snap.activeRow !== null, `active=${snap.activeRow}`)
@@ -391,16 +393,18 @@ await inst.unmount()
   const firstTick = snap.ticks[0]
   if (firstTick !== undefined) {
     await clickAt(COLS, firstTick + 1)
-    // 揭示跳转先画转录区、━━ 后移：两条断言的条件都到位才算落定。
+    // 揭示跳转先画转录区、━━ 后移：两条断言的条件都到位才算落定；断言在
+    // settle 捕获的同一快照上求值。
+    let lines = screenLines()
+    let snap2 = railSnapshot()
     await settle(() => {
-      const snap = railSnapshot()
-      return screenLines().slice(0, 6).some(l => l.includes('问题 1'))
-        && snap.activeRow !== null && snap.ticks.indexOf(snap.activeRow) === 0
+      lines = screenLines()
+      snap2 = railSnapshot()
+      return lines.slice(0, 6).some(l => l.includes('问题 1'))
+        && snap2.activeRow !== null && snap2.ticks.indexOf(snap2.activeRow) === 0
     })
-    const lines = screenLines()
     check('点击折叠 tick：问题 1 揭示并到顶', lines.slice(0, 6).some(l => l.includes('问题 1')),
       `top6=${JSON.stringify(lines.slice(0, 4).map(l => l.trimEnd().slice(0, 30)))}`)
-    const snap2 = railSnapshot()
     // 揭示后 sticky header 占 1 行 → 视口缩 1 → 整个 tick 块平移；按
     // 轮次索引断言（━�� 在第 0 个 tick 上），不按屏幕行号。
     check('揭示后 ━━ 移到首 tick（问题 1）', snap2.activeRow !== null && snap2.ticks.indexOf(snap2.activeRow) === 0,

--- a/scripts/verify-trace-scene.tsx
+++ b/scripts/verify-trace-scene.tsx
@@ -28,7 +28,7 @@ process.env.FORCE_COLOR = '3'
 // to agree with.
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { TrajectoryScene }, { Chat }, { QuestionStore }, { stringWidth }, { settle }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { TrajectoryScene }, { Chat }, { QuestionStore }, { stringWidth }, { settle, settled, sleep }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -43,8 +43,6 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Traj
 const { miniWakeWidth } = await import('../src/components/trajectory/MiniWake.js')
 const traj = await import('../src/dsh-adapter/trajectory/index.js')
 const instances = (await import('../src/ink/instances.js')).default
-
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
 let failed = 0
 function check(name: string, ok: boolean, extra = ''): void {
@@ -237,26 +235,21 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     }),
     { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
   )
-  // The ledger rows animate in (motion arrive): settle on the FULL asserted
-  // content — returning at the first painted rows would snapshot a frame that
-  // is still growing, and the stale mid-animation frames then poison every
-  // whole-buffer negative check later in this part.
-  await settle(() => {
-    const s = screen()
-    return s.includes('轨迹') && s.includes('read_file') && s.includes('grep_repo')
-      && /web_search\s*×4/.test(s) && (s.includes('RATE_LIMIT') || s.includes('RTY')) && s.includes('▸')
-  })
+  // The ledger rows animate in (motion arrive): each assertion polls its OWN
+  // condition (settled) — snapshotting at the first painted rows would catch a
+  // frame that is still growing, and stale mid-animation frames would poison
+  // every whole-buffer negative check later in this part. The cursor snapshot
+  // `first` is taken only after every arrival condition has settled.
+  check('scene shows its title and totals', await settled(() => screen().includes('轨迹') && /\d+\s*轮/.test(screen())), screen().split('\n')[0]?.trim())
+  check('scene shows both view tabs', await settled(() => screen().includes('时序') && screen().includes('热点')))
+  check('ledger renders tool rows with names', await settled(() => screen().includes('read_file') && screen().includes('grep_repo')))
+  check('ledger folds the burst run', await settled(() => /web_search\s*×4/.test(screen())), /web_search[^\n]*/.exec(screen())?.[0]?.trim())
+  check('ledger surfaces the retry row', await settled(() => screen().includes('RATE_LIMIT') || screen().includes('RTY')))
+  check('ledger renders durations', await settled(() => /\d+(ms|\.\ds)/.test(screen())))
+  check('cursor pointer is visible', await settled(() => screen().includes('▸')))
+  check('wake band renders block glyphs', await settled(() => /[▁▂▃▄▅▆▇█]/.test(screen())))
+  check('hint line documents the keys', await settled(() => screen().includes('查询') || screen().includes('query')))
   const first = screen()
-
-  check('scene shows its title and totals', first.includes('轨迹') && /\d+\s*轮/.test(first), first.split('\n')[0]?.trim())
-  check('scene shows both view tabs', first.includes('时序') && first.includes('热点'))
-  check('ledger renders tool rows with names', first.includes('read_file') && first.includes('grep_repo'))
-  check('ledger folds the burst run', /web_search\s*×4/.test(first), /web_search[^\n]*/.exec(first)?.[0]?.trim())
-  check('ledger surfaces the retry row', first.includes('RATE_LIMIT') || first.includes('RTY'))
-  check('ledger renders durations', /\d+(ms|\.\ds)/.test(first))
-  check('cursor pointer is visible', first.includes('▸'))
-  check('wake band renders block glyphs', /[▁▂▃▄▅▆▇█]/.test(first))
-  check('hint line documents the keys', first.includes('查询') || first.includes('query'))
 
   // The inspector must occupy the same rows no matter where the cursor is —
   // fixed geometry is what keeps cursor movement from resizing the frame.
@@ -269,15 +262,15 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   const before = hintRow(first)
   const rowAtStart = cursorRow(first)
   stdin.write('\x1b[A')
-  await settle(() => cursorRow(screen()) === rowAtStart - 1)
+  const movedUp = await settled(() => cursorRow(screen()) === rowAtStart - 1)
   const afterUp = screen()
   stdin.write('\x1b[A')
-  await settle(() => cursorRow(screen()) === rowAtStart - 2)
+  const movedTwo = await settled(() => cursorRow(screen()) === rowAtStart - 2)
   const afterTwo = screen()
   check('cursor opens pinned to the newest row', rowAtStart >= 0, `row ${rowAtStart}`)
   check(
     '↑ walks the cursor back up the ledger',
-    cursorRow(afterUp) === rowAtStart - 1 && cursorRow(afterTwo) === rowAtStart - 2,
+    movedUp && movedTwo,
     `${rowAtStart} → ${cursorRow(afterUp)} → ${cursorRow(afterTwo)}`,
   )
   check('inspector follows the cursor with no keystroke', afterUp !== first && afterTwo !== afterUp)
@@ -301,27 +294,23 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
 
   // Query mode filters the whole session.
   stdin.write('/')
+  // Fixed pacing kept: same stdin-chunk coalescing hazard as `]` above — the
+  // query text must not arrive in the same chunk as the `/` keystroke.
   await sleep(80)
   stdin.write('tool:read_file')
-  await settle(() => {
+  check('query narrows the ledger', await settled(() => {
     const s = screen()
     return s.includes('read_file') && !s.includes('grep_repo')
-  })
-  const filtered = screen()
-  check('query narrows the ledger', filtered.includes('read_file') && !filtered.includes('grep_repo'))
-  check('query reports its match count', /\d+\/\d+/.test(filtered), /\d+\/\d+[^\n]*/.exec(filtered)?.[0])
+  }))
+  check('query reports its match count', await settled(() => /\d+\/\d+/.test(screen())), /\d+\/\d+[^\n]*/.exec(screen())?.[0])
   stdin.write('\x1b')
-  await settle(() => screen().includes('grep_repo'))
-  check('esc clears the query', screen().includes('grep_repo'))
+  check('esc clears the query', await settled(() => screen().includes('grep_repo')))
 
   // View switching. The hotspot rows animate in (motion arrive); a fixed
-  // sleep races the animation — poll until the view materializes.
+  // sleep races the animation — each check polls its own condition until the
+  // view materializes.
   stdin.write('\x1b[C')
-  let hotspot = ''
-  for (let i = 0; i < 40 && !(hotspot.includes('工具') || hotspot.includes('Tools')); i++) {
-    await sleep(80)
-    hotspot = screen()
-  }
+  const hotspotShown = await settled(() => screen().includes('工具') || screen().includes('Tools'))
   {
     const buf = term.buffer.active
     const all: string[] = []
@@ -329,16 +318,11 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     console.error('--- FULL BUFFER (len=' + buf.length + ' vy=' + buf.viewportY + ') ---')
     console.error(all.join(String.fromCharCode(10)))
   }
-  check('→ switches to the hotspot view', hotspot.includes('工具') || hotspot.includes('Tools'))
-  check('hotspot ranks tools by cost', /web_search|read_file/.test(hotspot))
-  check('hotspot draws bars', /[█▌]/.test(hotspot))
+  check('→ switches to the hotspot view', hotspotShown)
+  check('hotspot ranks tools by cost', await settled(() => /web_search|read_file/.test(screen())))
+  check('hotspot draws bars', await settled(() => /[█▌]/.test(screen())))
   stdin.write('\x1b[D')
-  let backToTimeline = ''
-  for (let i = 0; i < 40 && !backToTimeline.includes('read_file'); i++) {
-    await sleep(80)
-    backToTimeline = screen()
-  }
-  check('← returns to the timeline', backToTimeline.includes('read_file'))
+  check('← returns to the timeline', await settled(() => screen().includes('read_file')))
 
   instance.unmount()
   term.dispose()
@@ -371,16 +355,15 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   // inline geometry — the alt-screen path, which is exactly what the two
   // safety assertions below exist to prove, would go untested.
   for (const value of instances.values()) instances.set(process.stdout, value)
-  await settle(() => screen().includes('conversation line'))
+  const conversationReady = await settled(() => screen().includes('conversation line'))
   const conversation = screen()
   const scrollbackBefore = rowsOf()
-  check('conversation renders before the scene opens', conversation.includes('conversation line'))
+  check('conversation renders before the scene opens', conversationReady)
 
   // Open and close the scene twenty times: any per-round-trip leak compounds
   // into an obvious number rather than hiding as a rounding error.
   for (let round = 0; round < 20; round++) {
     stdin.write('\x14') // Ctrl+T
-    await sleep(round === 0 ? 160 : 60)
     if (round === 0) {
       // Assert the PROTOCOL, not the pixels. `<AlternateScreen>` notifies the
       // Ink instance via `instances.get(process.stdout)`, and this harness
@@ -389,22 +372,25 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
       // can prove is exactly what matters for safety: the alternate buffer was
       // entered, the conversation is off-screen, and (below) the main screen
       // comes back untouched. Scene rendering itself is covered by Part A.
-      const inScene = screen()
-      check('Ctrl+T enters the alternate screen', term.buffer.active.type === 'alternate',
+      check('Ctrl+T enters the alternate screen', await settled(() => term.buffer.active.type === 'alternate'),
         term.buffer.active.type)
-      check('the conversation is no longer on screen', !inScene.includes('conversation line 0'))
-      check('the scene is painted there', /[\u2500-\u259f]/.test(inScene) || inScene.includes('时序'))
+      check('the conversation is no longer on screen', await settled(() => !screen().includes('conversation line 0')))
+      check('the scene is painted there', await settled(() => /[\u2500-\u259f]/.test(screen()) || screen().includes('时序')))
+    } else {
+      // Wait to be IN the scene before closing it (act-only wait → settle).
+      await settle(() => term.buffer.active.type === 'alternate')
     }
     stdin.write('q')
-    await sleep(round === 0 ? 200 : 70)
+    await settle(() => term.buffer.active.type === 'normal')
   }
   // Fixed window kept: this is also the quiescence window for the scrollback
   // accounting below — settling on the restored conversation would sample
   // rowsOf() before the post-restore repaint lands and undercount per-trip.
   await sleep(200)
 
+  const mainRestored = await settled(() => screen().includes('conversation line'))
   const restored = screen()
-  check('main screen returns to the conversation', restored.includes('conversation line'),
+  check('main screen returns to the conversation', mainRestored,
     restored === conversation ? '' : firstDiff(conversation, restored))
 
   // Scrollback accounting. Leaving the alternate screen makes the terminal
@@ -419,26 +405,32 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
 
   // Navigating inside the scene is the common case by far, and it must be free.
   stdin.write('\x14')
+  // Fixed window kept: beforeNav is the baseline of a "must not grow" probe —
+  // it has to be sampled after the open+first paint fully lands (settling on
+  // the alt buffer alone would sample mid-paint).
   await sleep(240)
   const beforeNav = rowsOf()
   for (let i = 0; i < 40; i++) {
     stdin.write(i % 2 === 0 ? '\x1b[A' : '\x1b[B')
-    await sleep(12)
+    await sleep(12) // fixed pacing kept: keystrokes must arrive in separate stdin chunks
   }
   stdin.write('\x1b[C')
-  await sleep(120)
+  await sleep(120) // fixed window kept: stability probe — growth needs wall time to show up
   stdin.write('\x1b[D')
-  await sleep(200)
+  await sleep(200) // fixed window kept: same stability probe
   check('navigating inside the scene adds no scrollback at all', rowsOf() === beforeNav,
     `${beforeNav} → ${rowsOf()} over 42 keystrokes`)
   stdin.write('q')
-  await sleep(200)
+  await settle(() => term.buffer.active.type === 'normal')
 
   // Idle animation must patch, never repaint.
   stdin.write('\x14')
+  // Fixed window kept: the write stream must be quiescent (open paint done)
+  // before it is cleared — clearing too early counts the initial paint's tail
+  // as an "idle" repaint and fails the negative probe below.
   await sleep(200)
   writes.length = 0
-  await sleep(1200)
+  await sleep(1200) // fixed observation window kept: negative probe (no repaint escapes while idle)
   const stream = writes.join('')
   const repaints = [
     ['erase line', /\x1b\[[0-2]?K/],
@@ -452,7 +444,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   check('idle animation does emit style updates', /\x1b\[[\d;]*m/.test(stream), `${stream.length} bytes`)
 
   stdin.write('q')
-  await sleep(120)
+  await settle(() => term.buffer.active.type === 'normal')
   instance.unmount()
   instances.delete(process.stdout)
   term.dispose()
@@ -489,12 +481,14 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
   )
   for (const value of instances.values()) instances.set(process.stdout, value)
+  // Fixed window kept: the write stream must be quiescent (first paint done)
+  // before it is cleared — the "no repaint after DEC 1049 restore" negative
+  // probe below needs a clean baseline.
   await sleep(500)
   writes.length = 0
 
   stdin.write('\x14')
-  await settle(() => term.buffer.active.type === 'alternate')
-  check('frame-restore probe enters the alternate screen', term.buffer.active.type === 'alternate')
+  check('frame-restore probe enters the alternate screen', await settled(() => term.buffer.active.type === 'alternate'))
   instances.get(process.stdout)?.resetPools()
   stdin.write('q')
   // Fixed window kept (negative probe): the assertion below is that NOTHING
@@ -517,6 +511,11 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   const reasoning = Array.from({ length: 80 }, (_, index) =>
     `reasoning line ${String(index).padStart(2, '0')}`,
   ).join('\n')
+  // The publish sequence below is a scripted streaming timeline: the fixed
+  // sleeps are pacing (thinking → open scene → stream on → close → stream on),
+  // reproducing the real cadence the settle-paint race needs; there is no
+  // per-step pollable completion condition, and the final layout is asserted
+  // by the settled() poll after the sequence.
   publish({
     working: true,
     spinnerMode: 'thinking',
@@ -570,7 +569,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   let firstIndex = -1
   let secondIndex = -1
   let gap = Number.POSITIVE_INFINITY
-  for (let attempt = 0; attempt < 187; attempt++) {
+  const noBlankGap = await settled(() => {
     const buffer = term.buffer.active
     lines = Array.from({ length: buffer.length }, (_, row) =>
       buffer.getLine(row)?.translateToString(true) ?? '',
@@ -586,13 +585,12 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     gap = firstIndex < 0 || secondIndex < 0
       ? Number.POSITIVE_INFINITY
       : lines.slice(firstIndex + 1, secondIndex).filter(line => line.trim() === '').length
-    if (firstIndex >= 0 && secondIndex >= 0 && gap <= 1) break
-    await sleep(80)
-  }
+    return firstIndex >= 0 && secondIndex >= 0 && gap <= 1
+  }, { timeoutMs: 15_000, stepMs: 80 })
   const settleWaitedMs = Date.now() - settlePollStart
   check(
     'reasoning that settles in the trajectory leaves no blank answer gap',
-    firstIndex >= 0 && secondIndex >= 0 && gap <= 1,
+    noBlankGap,
     `first=${firstIndex}, second=${secondIndex}, blank=${gap}, buffer=${lines.length}, waited=${settleWaitedMs}ms` +
       (firstIndex < 0 || secondIndex < 0
         ? ' (markers never painted within the 15s window — hung or lost frame, not a layout gap)'
@@ -600,11 +598,9 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   )
 
   stdin.write('\x0f') // Ctrl+O
-  await settle(() => screen().includes('reasoning line 79'))
-  check('Ctrl+O expands settled reasoning after the round trip', screen().includes('reasoning line 79'))
+  check('Ctrl+O expands settled reasoning after the round trip', await settled(() => screen().includes('reasoning line 79')))
   stdin.write('\x0f')
-  await settle(() => !screen().includes('reasoning line 79'))
-  check('a second Ctrl+O folds settled reasoning again', !screen().includes('reasoning line 79'))
+  check('a second Ctrl+O folds settled reasoning again', await settled(() => !screen().includes('reasoning line 79')))
 
   instance.unmount()
   instances.delete(process.stdout)
@@ -655,17 +651,12 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
   )
   for (const value of instances.values()) instances.set(process.stdout, value)
-  await settle(() => {
-    const s = screen()
-    return /ctrl\+t|⌘t/.test(s) && (s.match(/\? 查看快捷键/g) ?? []).length === 1
-  })
 
-  const startup = screen()
-  check('the startup tip teaches the trajectory key', /ctrl\+t|⌘t/.test(startup), '')
+  check('the startup tip teaches the trajectory key', await settled(() => /ctrl\+t|⌘t/.test(screen())), '')
   // The script pins DSH_TUI_LANG=zh, so the hint reads `? 查看快捷键`.
   check('the idle shortcuts hint appears exactly once',
-    (startup.match(/\? 查看快捷键/g) ?? []).length === 1,
-    `${(startup.match(/\? 查看快捷键/g) ?? []).length}`)
+    await settled(() => (screen().match(/\? 查看快捷键/g) ?? []).length === 1),
+    `${(screen().match(/\? 查看快捷键/g) ?? []).length}`)
 
   // B — the wake strip lives on the hint row, and every assertion below is
   // scoped to that row on purpose: the startup tip also names the key, so a
@@ -677,38 +668,33 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
   // contains "/tips", so excluding it pins the finder to the real hint row.
   const hintRowOf = (text: string): string =>
     text.split('\n').find(line => !line.includes('/tips') && (line.includes('shortcuts') || line.includes('快捷键'))) ?? ''
-  const statusArea = hintRowOf(startup)
-  check('the status line carries a live wake strip', /[▁▂▃▄▅▆▇█]/.test(statusArea),
-    statusArea.trim().slice(-42))
-  check('the key hint rides beside the strip while unseen', /ctrl\+t|⌘t/.test(statusArea),
-    statusArea.trim().slice(-42))
+  check('the status line carries a live wake strip', await settled(() => /[▁▂▃▄▅▆▇█]/.test(hintRowOf(screen()))),
+    hintRowOf(screen()).trim().slice(-42))
+  check('the key hint rides beside the strip while unseen', await settled(() => /ctrl\+t|⌘t/.test(hintRowOf(screen()))),
+    hintRowOf(screen()).trim().slice(-42))
 
   // E — exactly one footnote, on the failure.
-  const footnotes = (startup.match(/看完整轨迹|full trajectory/g) ?? []).length
-  check('a failed call carries exactly one trajectory footnote', footnotes === 1, `${footnotes}`)
+  check('a failed call carries exactly one trajectory footnote',
+    await settled(() => (screen().match(/看完整轨迹|full trajectory/g) ?? []).length === 1),
+    `${(screen().match(/看完整轨迹|full trajectory/g) ?? []).length}`)
 
   // Opening the scene marks the failures seen and retires both pointers.
   stdin.write('\x14')
-  await sleep(400)
+  await settle(() => term.buffer.active.type === 'alternate')
   stdin.write('q')
   // Closing the alternate screen restores the main frame first; the hint
-  // retirement and wake repaint may land on a later Ink frame. Poll for the
-  // actual settled condition instead of racing a fixed post-close delay.
-  let after = screen()
-  let afterStatus = hintRowOf(after)
-  for (let attempt = 0; attempt < 25; attempt++) {
-    const hintRetired = !/ctrl\+t|⌘t/.test(afterStatus)
-    const wakePresent = /[▁▂▃▄▅▆▇█]/.test(afterStatus)
-    if (hintRetired && wakePresent && !(after.match(/看完整轨迹|full trajectory/g) ?? []).length) break
-    await sleep(80)
-    after = screen()
-    afterStatus = hintRowOf(after)
-  }
+  // retirement and wake repaint may land on a later Ink frame. Anchor on the
+  // repainted hint row (wake back on screen) before the negative assertions —
+  // a bare negation would come true on the transient blank row mid-close.
+  await settle(() => /[▁▂▃▄▅▆▇█]/.test(hintRowOf(screen())))
   check('the footnote clears once the trajectory has been opened',
-    (after.match(/看完整轨迹|full trajectory/g) ?? []).length === 0, '')
+    await settled(() => (screen().match(/看完整轨迹|full trajectory/g) ?? []).length === 0), '')
   check('the key hint retires once the trajectory has been opened',
-    !/ctrl\+t|⌘t/.test(afterStatus), afterStatus.trim().slice(-42))
-  check('the wake strip stays after the hint retires', /[▁▂▃▄▅▆▇█]/.test(afterStatus), '')
+    await settled(() => {
+      const row = hintRowOf(screen())
+      return /[▁▂▃▄▅▆▇█]/.test(row) && !/ctrl\+t|⌘t/.test(row)
+    }), hintRowOf(screen()).trim().slice(-42))
+  check('the wake strip stays after the hint retires', await settled(() => /[▁▂▃▄▅▆▇█]/.test(hintRowOf(screen()))), '')
 
   instance.unmount()
   instances.delete(process.stdout)
@@ -754,23 +740,24 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
       { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
     )
     for (const value of instances.values()) instances.set(process.stdout, value)
-    let hintRow: string | undefined
-    for (let attempt = 0; attempt < 25; attempt++) {
-      const rows = screen().split('\n')
-      // Same `/tips` guard as hintRowOf above: the glyph class includes the
-      // middle dot, and the logo tip line ("… · /tips 更多技巧") always has
-      // one — when the random startup tip happens to contain "快捷键"
-      // (keys-help, 1/90) the finder matched the TIP row and this check
-      // failed as "wake sits … ends at 104" after polling to exhaustion.
-      hintRow = rows.find(line =>
-        /[▁▂▃▄▅▆▇█▶·]/.test(line)
-        && !line.includes('/tips')
-        && (line.includes('shortcuts') || line.includes('快捷键')))
-      const settledAtRight = hintRow !== undefined
-        && stringWidth(hintRow.replace(/\s+$/, '')) === cols - 1
-      if (settledAtRight || miniWakeWidth(cols) === 0) break
-      await sleep(80)
-    }
+    // Same `/tips` guard as hintRowOf above: the glyph class includes the
+    // middle dot, and the logo tip line ("… · /tips 更多技巧") always has
+    // one — when the random startup tip happens to contain "快捷键"
+    // (keys-help, 1/90) the finder matched the TIP row and this check
+    // failed as "wake sits … ends at 104" after polling to exhaustion.
+    const findHintRow = (): string | undefined => screen().split('\n').find(line =>
+      /[▁▂▃▄▅▆▇█▶·]/.test(line)
+      && !line.includes('/tips')
+      && (line.includes('shortcuts') || line.includes('快捷键')))
+    // The settle predicate is exactly the disjunction of the two branch
+    // assertions below, which re-derive from the settled screen — no weaker
+    // wait condition can diverge from what is checked.
+    await settle(() => {
+      const row = findHintRow()
+      return miniWakeWidth(cols) === 0
+        || (row !== undefined && stringWidth(row.replace(/\s+$/, '')) === cols - 1)
+    })
+    const hintRow = findHintRow()
     if (hintRow === undefined) {
       // Below `miniWakeWidth`'s floor the strip is meant to be absent; above
       // it, a missing row is itself the failure.
@@ -793,7 +780,7 @@ function makeChannel(overrides: Record<string, unknown> = {}): Record<string, un
     instance.unmount()
     instances.delete(process.stdout)
     term.dispose()
-    await sleep(30)
+    await sleep(30) // fixed pacing kept: teardown gap between mounts, no pollable condition
   }
 }
 

--- a/scripts/verify-unseen-report-once.tsx
+++ b/scripts/verify-unseen-report-once.tsx
@@ -18,8 +18,7 @@ import { PassThrough, Writable } from 'node:stream'
 import React from 'react'
 import { render } from '../src/ui.js'
 import { MessageList } from '../src/components/MessageList.js'
-
-const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+import { sleep } from './lib/term-test.mjs'
 
 class Output extends Writable {
   columns = 100

--- a/scripts/verify-whale-toggle.mjs
+++ b/scripts/verify-whale-toggle.mjs
@@ -92,7 +92,9 @@ const stripAnsi = text => text
   .replace(/\x1b\]9;[^\x07]*\x07/g, '')
 const WHALE_OUTLINE = '\x1b[38;2;20;38;96m'
 
-async function renderHeader({ columns, whale }) {
+// `ready`（可选）：call site 断言里比默认文字条件更强的正向条件必须并入
+// 等待谓词（#561 弱条件分叉），否则 settle 等到文字就返回、断言到旧帧。
+async function renderHeader({ columns, whale, ready }) {
   const stdout = new FakeOutput(columns)
   const stderr = new FakeOutput(columns)
   const props = { model: 'whale-model-probe', cwd: '/whale/cwd' }
@@ -112,8 +114,10 @@ async function renderHeader({ columns, whale }) {
     },
   )
   await settle(() => {
-    const plain = stripAnsi(stdout.writes.join(''))
+    const raw = stdout.writes.join('')
+    const plain = stripAnsi(raw)
     return plain.includes('dsh-TUI') && plain.includes('whale-model-probe')
+      && (ready === undefined || ready(raw))
   })
   const raw = stdout.writes.join('')
   await instance.unmount()
@@ -140,7 +144,7 @@ check('setWhale(true) restores the default view', () => {
 })
 
 // Real LogoHeader -> LogoV2 rendering: default, explicit opt-out, and narrow fallback.
-const wideDefault = await renderHeader({ columns: 100 })
+const wideDefault = await renderHeader({ columns: 100, ready: raw => raw.includes(WHALE_OUTLINE) })
 check('wide LogoHeader shows whale by default', () => {
   assert.ok(wideDefault.raw.includes(WHALE_OUTLINE), 'whale palette marker missing')
   assert.ok(wideDefault.plain.includes('dsh-TUI'), 'text logo missing')

--- a/scripts/verify-word-jump.mjs
+++ b/scripts/verify-word-jump.mjs
@@ -37,7 +37,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Writable, PassThrough } from 'node:stream'
 import React from 'react'
-import { settle } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -65,8 +65,6 @@ function makeStreams() {
   stdin.unref = () => stdin
   return { stdout, stderr, stdin }
 }
-
-const sleep = ms => new Promise(r => setTimeout(r, ms))
 
 const submitted = []
 const channel = {
@@ -98,8 +96,11 @@ const instance = await render(
   }),
   { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
 )
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
 await sleep(600)
 
+// 按键间 pacing：每步移动/插入后的光标位置对外不可观测（stdout 被丢弃），
+// 只有最终 submit 可断言——步间保留固定窗口。
 const feed = async seq => {
   stdin.write(seq)
   await sleep(250)
@@ -115,11 +116,10 @@ await feed('Z')
 await feed('\x1b[1;5C') // Ctrl+Right → caret 14 (end of "…world")
 await feed('Q')
 stdin.write('\r')
-await settle(() => submitted.length === 1 && submitted[0] === 'hello ZYXworldQ')
 
 check(
   'caret moves + inserts compose to the expected submitted text',
-  submitted.length === 1 && submitted[0] === 'hello ZYXworldQ',
+  await settled(() => submitted.length === 1 && submitted[0] === 'hello ZYXworldQ'),
   JSON.stringify(submitted),
 )
 

--- a/scripts/verify-working-activity.mjs
+++ b/scripts/verify-working-activity.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { settle } from './lib/term-test.mjs'
+import { settled } from './lib/term-test.mjs'
 
 const testHome = mkdtempSync(join(tmpdir(), 'dsh-tui-activity-home-'))
 process.env.HOME = testHome
@@ -144,8 +144,7 @@ sessionEvent()(agent.session, {
 assert.equal(channel.workingActivity?.phase, 'tool')
 
 const elapsedBeforeTick = channel.workingActivity.turnElapsedMs
-await settle(() => channel.workingActivity.turnElapsedMs >= elapsedBeforeTick + 450)
-assert.ok(channel.workingActivity.turnElapsedMs >= elapsedBeforeTick + 450, '500 ms timer refreshes elapsed state')
+assert.ok(await settled(() => channel.workingActivity.turnElapsedMs >= elapsedBeforeTick + 450), '500 ms timer refreshes elapsed state')
 
 sessionEvent()(agent.session, {
   type: 'tool/result', seq: 3, time: Date.now(),


### PR DESCRIPTION
关联 #566（本 PR 完成其前两项；防回流检查另行跟进）。

## 改动

1. `scripts/lib/term-test.mjs` 新增 `settled(pred)`：轮询到谓词为真后返回谓词终值。用法 `check('label', await settled(() => cond))`——等待条件与断言条件是同一个表达式，`settle` 等 A、断言 B 的分叉（#561 型）在写法上不再可能。
2. `settle` 保留唯一用途：等待某状态后执行操作、无紧随断言。轮询默认超时本地 4s / CI 8s。
3. CI 登记的 106 个脚本全部迁移，按测试组分 5 个 commit：
   - `settled` 折叠约 390 处
   - `sleep` 303 → 259，保留的分三类且均有注释（断言状态不得改变的固定窗口、墙钟/动画语义、无可观测条件的 pacing）
   - `settle` 328 → 114，全部为等待后操作
   - 修复存量弱条件约 30 处，含 `verify-resize-temporal` 等待谓词缺滚动条列锚点（旧 1500ms sleep 掩盖，与其历史连挂记录吻合）

## Review 修正（已并入对应 commit）

独立 review 发现 7 项迁移引入的语义削弱，逐条核实后修复：

1. resize-temporal 两处时间语义：收敛后恢复固定稳定窗 + 终态复比对（首个相等帧之后的迟到漂移不再漏检）
2. askpanel-long-list：焦点标签与「恰一个 ●」恢复同快照合取（半解析帧不能分别骗过两条）
3. login-credentials：恢复卸载后精确计数（迟到的第二条 report 可被发现）
4. compact：负向断言恢复 200ms 观察窗
5. effort-slider zh 段：等待英文描述的死等改为本地化文案（/effort 无 zh 键回退英文，已注明）
6. 4 处「settle 捕获快照后断言」改 `settled`（超时后有最终求值，最后一次轮询与 deadline 之间成立的条件不再拿到过期快照）
7. 3 处缺类别注释的 sleep 补齐

## 验证

- 5 个测试组本地全量通过；review 修正后受影响的 11 个脚本复跑通过；session-workspace 组另加 3 轮通过。
- 46 处剩余「settle 后跟断言」逐处审计：违规 0。
- 已知残余：`verify-keymap` 一次组内运行失败、6 次未复现（原因未查明）；`repro-clipboard.tsx` 断言体仅 Linux 执行，本地只验证到 SKIP 路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
