### PR TITLE
fix: 压缩失败后换模型丢上下文——压缩事务与会话切换串行化

### DIFF
--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -225,6 +225,7 @@ change, also run the closest focused script:
 | Prompt queue behavior | `node scripts/verify-queue.mjs` |
 | Goal/todo projection and rendering | `node scripts/verify-channel-goal-todo.mjs` and `node scripts/verify-goal-todo.mjs` |
 | Compaction and folded transcript rows | `node scripts/verify-compact.mjs` |
+| Compaction × session-switch lifecycle (cancel before the fork snapshot, persistence-classified toast) | `node --import tsx/esm scripts/verify-compact-switch.tsx` |
 | Theme loading and persistence | `node --import tsx/esm scripts/verify-themes.mjs` |
 | Scrolling/sticky-bottom behavior | `node scripts/verify-scroll.mjs`, `node scripts/verify-resticky.mjs`, and the matching `repro-*` harness |
 | Fullscreen copy-on-select | `node scripts/verify-copy-on-select.mjs` |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -175,6 +175,7 @@ CI 回归都要跑。窄改动还要跑最近的聚焦脚本：
 | 提示队列行为 | `node scripts/verify-queue.mjs` |
 | Goal/todo 投影与渲染 | `node scripts/verify-channel-goal-todo.mjs` + `node scripts/verify-goal-todo.mjs` |
 | Compaction 与折叠 transcript 行 | `node scripts/verify-compact.mjs` |
+| 压缩 × 会话切换生命周期（取消先于 fork 快照、persistence 分类提示） | `node --import tsx/esm scripts/verify-compact-switch.tsx` |
 | 主题加载与持久化 | `node --import tsx/esm scripts/verify-themes.mjs` |
 | 滚动/粘底行为 | `node scripts/verify-scroll.mjs`、`node scripts/verify-resticky.mjs` 及对应 `repro-*` 环境 |
 | 全屏复制即选区 | `node scripts/verify-copy-on-select.mjs` |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -302,7 +302,7 @@ dsh-tui
 | 新建 | `/new` | 无二次确认——旧会话已持久化，随时可 `/resume` 找回；顺带清空 resume 标记 |
 | 恢复 | `/resume` | 全屏工作目录 / 会话浏览器：顶部目录范围可点击，`←` 进入目录选择、`Enter/→` 查看；宽屏目录栏常驻；打字搜索当前层，`Enter` 恢复、`Tab` 预览、`⌘A` 当前/全部目录快切、`Ctrl+B` 本分支、`Ctrl+S` 子 agent、`Ctrl+R` 重命名、`Ctrl+D` 删除、`Ctrl+X` 清理空壳；右键会话行弹出打开/重命名/删除菜单。长前置上下文的旧会话会渐进恢复真实标题，不再固定显示目录名 |
 | 重命名 | `/rename <标题>` | 立即改名并持久化（写入 session/title 事件，浏览器可读回） |
-| 压缩 | `/compact` | 手动触发 DSH compaction；**回合运行中拒绝**；minimal preset 下不可用；压缩点以 Divider 摘要行呈现 |
+| 压缩 | `/compact` | 手动触发 DSH compaction；**回合运行中拒绝**；minimal preset 下不可用；压缩点以 Divider 摘要行呈现。压缩进行中切换会话（`/model`、`/resume`、`/rewind`、`/fork`、`/new`）会**先取消压缩再快照**——后台不再有静默提交的压缩；摘要默认用当前路由模型（换模型后即用新模型压缩）。"压缩已生效但落盘失败"会明确提示，不再误报为压缩失败 |
 | 导出 | `/export` | 从完整 session log 导出 Markdown（含 thinking 与工具调用分节），文件 `dsh-tui-export-<时间戳>.md` 落在当前会话 cwd |
 | 清屏 | `/clear` | 只清视图，不动会话日志 |
 | 删除 | `/resume` 里 `Ctrl+D` | 删除日志目录与 MRU 条目（有确认） |

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -301,6 +301,10 @@ const GROUPS = {
 // （全量/截断/继承前缀跳过）、SessionTree 屏幕无头组装
 // （渲染、Enter 菜单、字母直达执行、Esc）。
     ["verify-session-tree", ['node', '--import', 'tsx/esm', 'scripts/verify-session-tree.tsx']],
+// 压缩 × 会话切换生命周期：压缩进行中 /model、/resume、/rewind 等必须先
+// abort 并等压缩落定再 fork 快照（后台提交 checkpoint = "压缩失败后换模型
+// 丢上下文"事故根因）；persistence 类失败与通用失败分开提示。
+    ["verify-compact-switch", ['node', '--import', 'tsx/esm', 'scripts/verify-compact-switch.tsx']],
 // 裸 ● 空行回归：纯思考/纯工具步骤（无文本块）的 assistant/message
 // 不得创建空 assistant 行，否则思考块折叠后转录里多出一个只有
 // ● 前缀、内容为空的行。

--- a/scripts/verify-compact-switch.tsx
+++ b/scripts/verify-compact-switch.tsx
@@ -1,0 +1,228 @@
+/**
+ * 压缩 × 会话切换生命周期回归（真实 channel.compact / switchModel + 可控
+ * fake compaction 服务）：
+ *
+ *  1. 取消先于快照——压缩进行中 /model：switchModel 必须先 abort 并等压缩
+ *     落定、再 sessions.fork（顺序断言），fork 的 seed 不含任何压缩产物；
+ *     toast 报「已取消并切换」，且不再追加误导性的通用「压缩失败」。
+ *  2. persistence 分类——checkpoint 已提交但落盘失败（code:'persistence'）
+ *     的拒绝必须与通用失败分开提示（含「压缩已生效」语义，不再裸报失败）。
+ *  3. 已落定不阻塞——压缩正常完成后切换不再触发取消路径。
+ *
+ * 背景：长会话 /compact 的摘要 LLM 很慢，用户等不及直接 /model；旧实现
+ * fork 快照先走、旧压缩事务在后台照常提交 checkpoint，新会话从"只剩摘要"
+ * 的日志开始——用户视角即"压缩失败换了模型，上下文直接丢失"。
+ *
+ * 运行：node --import tsx/esm scripts/verify-compact-switch.tsx
+ */
+// 隔离家目录：switchModel 会把选择写进 ~/.dsh-tui/model.json（modelPrefs
+// 在模块加载时按 homedir() 解析）。必须在 import src 之前；HOME 与
+// USERPROFILE 成对设置，两个平台都隔离。
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+const reproHome = mkdtempSync(join(tmpdir(), 'dshtui-compact-switch-'))
+process.env.HOME = reproHome
+process.env.USERPROFILE = reproHome
+
+const [{ createChannel }] = await Promise.all([
+  import('../src/dsh-adapter/channel.js'),
+])
+
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+async function settle(cond: () => boolean, ms = 3000): Promise<boolean> {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (cond()) return true
+    await sleep(25)
+  }
+  return cond()
+}
+
+// ---- 事件与 agent 桩 --------------------------------------------------------
+let seq = 0
+let now = Date.now()
+function ev(type: string, data: Record<string, unknown>): Record<string, unknown> {
+  return { seq: seq++, time: (now += 5), type, data }
+}
+function makeEvents(turns = 2): Array<Record<string, unknown>> {
+  const events: Array<Record<string, unknown>> = []
+  for (let turn = 0; turn < turns; turn++) {
+    events.push(ev('turn/start', { turn }))
+    events.push(ev('user/message', { source: { kind: 'user' }, content: [{ type: 'text', text: `问题 ${turn}` }] }))
+    events.push(ev('assistant/message', {
+      turn, step: 0,
+      message: { role: 'assistant', content: [{ type: 'text', text: `回答 ${turn}` }] },
+      usage: { inputTokens: 100, outputTokens: 50 },
+    }))
+    events.push(ev('turn/end', { turn, reason: { kind: 'completed' } }))
+  }
+  return events
+}
+const stubAgentCtx = { on: () => () => {} }
+function makeAgent(id: string, sessionEvents: readonly unknown[]) {
+  return {
+    id,
+    status: 'idle',
+    session: { id: `s-${id}`, seq: sessionEvents.length, events: sessionEvents, header: {} },
+    ctx: stubAgentCtx,
+    followup() {},
+    steer() {},
+    inbox: { remove: () => true },
+  } as never
+}
+
+// ---- 可控 compaction 服务：记录 abort 时机，由剧本决定落定方式 ---------------
+type Script = { kind: 'hang-until-abort' } | { kind: 'reject'; code?: string; message: string } | { kind: 'resolve' }
+function makeCompaction(script: Script) {
+  const calls: Array<{ agentId: string; abortedAt: number | undefined }> = []
+  return {
+    calls,
+    async compactNow(agent: { id: string }, signal: AbortSignal): Promise<unknown> {
+      const call = { agentId: agent.id, abortedAt: undefined as number | undefined }
+      calls.push(call)
+      if (script.kind === 'resolve') {
+        await sleep(30)
+        return { shadowedSeqs: [1, 2] }
+      }
+      if (script.kind === 'reject') {
+        await sleep(30)
+        throw Object.assign(new Error(script.message), script.code === undefined ? {} : { code: script.code })
+      }
+      // hang-until-abort：模拟慢摘要流——仅在 abort 后以 abort 原因拒绝
+      // （region.ts 的 signal.throwIfAborted 语义）。
+      await new Promise<void>((resolve, reject) => {
+        const onAbort = () => {
+          call.abortedAt = Date.now()
+          reject(signal.reason instanceof Error ? signal.reason : new Error('aborted'))
+        }
+        if (signal.aborted) onAbort()
+        else signal.addEventListener('abort', onAbort, { once: true })
+      })
+      return undefined
+    },
+  }
+}
+
+// ---- 组装 ctx：sessions.fork / agents.create 记录调用顺序 --------------------
+function assemble(script: Script) {
+  const order: string[] = []
+  const stamps = new Map<string, number>()
+  const mark = (name: string) => {
+    order.push(name)
+    stamps.set(name, Date.now())
+  }
+  const compaction = makeCompaction(script)
+  let agentCounter = 0
+  const services: Record<string, unknown> = {
+    sessions: {
+      fork(session: { events: readonly unknown[] }) {
+        mark('fork')
+        return { events: [...session.events] }
+      },
+    },
+    agents: {
+      async create(options: { sessionId: string; seed: readonly unknown[] }) {
+        mark('create')
+        agentCounter += 1
+        return { agent: makeAgent(`fork-${agentCounter}`, options.seed), dispose: async () => {} }
+      },
+    },
+    llm: {
+      listProviders: () => [{ id: 'fake-provider' }],
+      listModels: async () => [{ provider: 'fake-provider', id: 'model-b', name: 'Model B' }],
+    },
+    compaction,
+  }
+  const handlers = new Map<string, unknown>()
+  const ctx = {
+    on(event: string, handler: unknown) {
+      handlers.set(event, handler)
+      return () => handlers.delete(event)
+    },
+    get(name: string) {
+      return services[name]
+    },
+    logger: { warn() {} },
+  }
+  const agent = makeAgent('a1', makeEvents())
+  const channel = createChannel(ctx as never, agent as never, {
+    model: 'model-a',
+    cwd: '/tmp/demo',
+    provider: 'fake-provider',
+    activity: false,
+  })
+  return { order, stamps, compaction, channel, agent }
+}
+const toasts = (channel: { notifications: readonly { text: string }[] }) =>
+  channel.notifications.map(item => item.text).join('\n')
+
+// ==== 场景 1：压缩进行中 /model —— 取消必须先于 fork ==========================
+{
+  const { order, stamps, compaction, channel } = assemble({ kind: 'hang-until-abort' })
+  channel.compact()
+  const started = await settle(() => compaction.calls.length === 1)
+  check('scene1: compactNow invoked', started)
+  check('scene1: no fork before switch', !order.includes('fork'))
+
+  const switchResult = await channel.switchModel('fake-provider', 'model-b')
+  check('scene1: switch succeeds', switchResult === true, JSON.stringify(order))
+  // 严格顺序：abort 时间戳必须不晚于 fork——取消等待完成后才允许快照 seed。
+  const abortedAt = compaction.calls[0]?.abortedAt
+  const forkAt = stamps.get('fork')
+  check(
+    'scene1: abort strictly precedes the fork snapshot',
+    abortedAt !== undefined && forkAt !== undefined && abortedAt <= forkAt,
+    `abortedAt=${String(abortedAt)} forkAt=${String(forkAt)}`,
+  )
+
+  // toast：取消提示出现；随后不追加通用「压缩失败」（抑制闩）。
+  await settle(() => channel.notifications.length >= 2)
+  await sleep(150)
+  const text = toasts(channel)
+  check('scene1: cancel toast shown', text.includes('已取消并切换'), text)
+  check('scene1: no misleading generic failure toast', !/压缩失败 ·/.test(text), text)
+  // seed 快照不含压缩产物（checkpoint 事件从未写入——abort 先于提交）。
+  check('scene1: fork happened after cancel', order.includes('fork'), JSON.stringify(order))
+}
+
+// ==== 场景 2：persistence 分类提示 ============================================
+{
+  const { channel } = assemble({ kind: 'reject', code: 'persistence', message: 'flush io error' })
+  channel.compact()
+  await settle(() => channel.notifications.length >= 2)
+  await sleep(150)
+  const text = toasts(channel)
+  check('scene2: flush-failed toast distinguishes committed state', text.includes('压缩已生效') && text.includes('落盘'), text)
+  check('scene2: not the generic failure line', !/压缩失败 ·/.test(text), text)
+}
+
+// ==== 场景 3：通用失败仍走原提示 ==============================================
+{
+  const { channel } = assemble({ kind: 'reject', message: 'Codex error: usage limit' })
+  channel.compact()
+  await settle(() => channel.notifications.length >= 2)
+  await sleep(150)
+  const text = toasts(channel)
+  check('scene3: generic failure toast keeps the error', /压缩失败 ·.*usage limit/.test(text), text)
+}
+
+// ==== 场景 4：压缩已落定后切换不触发取消 ======================================
+{
+  const { order, compaction, channel } = assemble({ kind: 'resolve' })
+  channel.compact()
+  const done = await settle(() => channel.notifications.some(item => item.text.includes('已压缩')))
+  check('scene4: compaction completed', done, toasts(channel))
+  const switchResult = await channel.switchModel('fake-provider', 'model-b')
+  check('scene4: switch succeeds', switchResult === true, JSON.stringify(order))
+  const text = toasts(channel)
+  check('scene4: no cancel toast for a settled compaction', !text.includes('已取消并切换'), text)
+  check('scene4: compaction ran exactly once', compaction.calls.length === 1, String(compaction.calls.length))
+}
+
+process.exit(failed)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -2561,6 +2561,41 @@ export function createChannel(
     }).catch(() => {})
   }
 
+  // --- Manual-compaction lifecycle ---------------------------------------
+  // The in-flight /compact transaction: its abort hook plus the settled
+  // promise. Every path that replaces `agent` (rewind / rewind-node /
+  // resume / new / model switch) must cancel and await it BEFORE snapshot-
+  // ting the session. Without this, a slow summarizer keeps running against
+  // the OLD session across the switch and can commit its replacement
+  // checkpoint AFTER the fork snapshot — silently swapping the history the
+  // user believed intact ("compaction failed → /model → context lost").
+  let manualCompaction:
+    | { controller: AbortController; settled: Promise<void> }
+    | undefined
+  /** Compactions cancelled by settleManualCompaction: their rejection is expected. */
+  const cancelledCompactions = new WeakSet<AbortController>()
+
+  /**
+   * Cancel an in-flight manual compaction and wait for it to settle.
+   * Aborting tears the summarizer stream down; dsh-compaction then closes
+   * the transaction with an error end marker and rejects compactNow with
+   * the `cancelled` class — no checkpoint is committed, the surface stays
+   * whole. The settle race is capped so a stuck stream can never wedge the
+   * session switch itself.
+   */
+  const settleManualCompaction = async (): Promise<void> => {
+    const active = manualCompaction
+    if (active === undefined) return
+    manualCompaction = undefined
+    cancelledCompactions.add(active.controller)
+    active.controller.abort(new Error('session switch'))
+    state.notify(t('compact-cancelled-switch'), { color: 'warning', timeoutMs: 4000 })
+    await Promise.race([
+      active.settled,
+      new Promise<void>(resolve => { setTimeout(resolve, 3000) }),
+    ])
+  }
+
   const state: ChannelState = {
     effortLevels: undefined,
     version: 0,
@@ -2990,6 +3025,10 @@ export function createChannel(
           return null
         }
       }
+      // An in-flight manual compaction must not straddle the fork: cancel it
+      // and wait, or its checkpoint could commit right after the seed snapshot
+      // below and quietly replace history the rewind was meant to preserve.
+      await settleManualCompaction()
       const childId = SessionId(randomUUID())
       // DSH event order is `turn/start → user/message → … → turn/end`, so a
       // message's own seq always sits inside its turn — forking there would
@@ -3508,6 +3547,10 @@ export function createChannel(
         state.notify(t('rewind-unavailable'), { color: 'error' })
         return null
       }
+      // An in-flight manual compaction must not straddle the snapshot below
+      // (live branch) nor keep summarizing the current session while the
+      // rewind targets another — cancel and await it first.
+      await settleManualCompaction()
       // Pin the entry-time session: the awaits below (log load, preset
       // compose, agent create) are windows in which a queued switch
       // (/new, /resume, /model) can swap `agent` — the mutation queue only
@@ -3695,6 +3738,10 @@ export function createChannel(
         state.notify(t('fork-while-working'), { color: 'warning' })
         return false
       }
+      // An in-flight manual compaction must not straddle the fork snapshot:
+      // cancel and await it, or its checkpoint could commit right after the
+      // seed copy below and quietly replace history the fork preserved.
+      await settleManualCompaction()
       const source = agent.session
       const childId = SessionId(randomUUID())
       // No boundary: the whole (turn-closed) log. Slice via sessions.fork for
@@ -3799,6 +3846,10 @@ export function createChannel(
       // target — a veto leaves the live session and its transcript
       // untouched.
       if (await sessionSwitchVetoed('resume', sessionId)) return { ok: false, reason: 'cancelled' }
+      // The live session's in-flight manual compaction must not keep running
+      // (and commit its checkpoint) once we leave it for the target — cancel
+      // and await it before any target read.
+      await settleManualCompaction()
       let handle: AgentHandle
       // Compat boundary: register vouched-for legacy event types (e.g.
       // activity/status from pre-#143 logs) in every reachable dsh-session
@@ -3968,6 +4019,10 @@ export function createChannel(
       // Plugin veto point (tui/session-switch): no side effects have
       // happened yet — the session id below is not even allocated.
       if (await sessionSwitchVetoed('new')) return false
+      // Leaving the live session: its in-flight manual compaction must not
+      // keep summarizing (and later commit a checkpoint the user believes
+      // cancelled) — cancel and await it first.
+      await settleManualCompaction()
       const sessionId = SessionId(randomUUID())
       let handle: AgentHandle
       // A fresh session composes the caller's DEFAULT preset: the cordis.yml
@@ -4185,6 +4240,11 @@ export function createChannel(
       }
       let seed: readonly SessionEvent[]
       try {
+        // An in-flight manual compaction must not straddle the fork: cancel
+        // it first, or its checkpoint can commit right after this snapshot —
+        // the model-switched child would start from the summary alone while
+        // the user believes the full history carried over ("context lost").
+        await settleManualCompaction()
         // No boundary = fork the whole log (continue the conversation).
         seed = sessions.fork(agent.session).events
       } catch (error) {
@@ -4977,21 +5037,43 @@ export function createChannel(
           state.notify(t('compact-while-working'), { color: 'warning' })
           return
         }
-        const signal = new AbortController().signal
+        const controller = new AbortController()
         state.notify(t('compact-working'))
-        void compactService
-          .compactNow(agent, signal)
-          .then((result) => {
+        // Register the in-flight transaction so any agent-replacing path
+        // (rewind/resume/new/model switch) can cancel it before snapshotting
+        // the session — see settleManualCompaction. `settled` never rejects:
+        // every branch lands in a notification.
+        const settled = (async () => {
+          try {
+            const result = await compactService.compactNow(agent, controller.signal)
             state.notify(result ? t('compact-done') : t('compact-nothing'))
             // Compaction quip rides the next thinking rotation (pi parity).
             if (result) updateWorkingActivity('compaction', () => activityTracker.onCompact('done'))
-          })
-          .catch((error: unknown) => {
+          } catch (error: unknown) {
+            // ManualCompactionError('persistence'): the replacement checkpoint
+            // is ALREADY committed — only the durability flush failed. The
+            // surface is now the summary, so a plain "failed" toast here sent
+            // users to /model expecting full history and finding only the
+            // summary ("context lost"). Distinguish it, structurally — the
+            // TUI must not import the error class across the adapter seam.
+            if ((error as { code?: unknown }).code === 'persistence') {
+              state.notify(t('compact-flush-failed'), { color: 'warning', timeoutMs: 12000 })
+              return
+            }
+            // A switch-initiated abort rejects compactNow with the abort reason;
+            // the cancellation was already toasted above — a second generic
+            // "failed" toast for the same, expected rejection would mislead.
+            if (cancelledCompactions.has(controller)) return
             state.notify(
               t('compact-failed', { err: error instanceof Error ? error.message : String(error) }),
               { color: 'error', timeoutMs: 8000 },
             )
-          })
+          }
+        })()
+        manualCompaction = { controller, settled }
+        void settled.finally(() => {
+          if (manualCompaction?.controller === controller) manualCompaction = undefined
+        })
       })().catch((error: unknown) => {
         // Sync throws from compactNow (e.g. runMaintenance rejecting a
         // non-idle agent right after /resume) reject this IIFE itself;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -203,6 +203,14 @@ const dict = {
   'compact-done': { zh: '会话已压缩', en: 'Conversation compacted' },
   'compact-nothing': { zh: '没有可压缩的内容', en: 'Nothing to compact' },
   'compact-failed': { zh: '压缩失败 · {{err}}', en: 'Compaction failed · {{err}}' },
+  'compact-flush-failed': {
+    zh: '压缩已生效，但落盘检查失败——历史已由摘要替代，请留意会话状态',
+    en: 'Compaction took effect, but its durability flush failed — history is now the summary',
+  },
+  'compact-cancelled-switch': {
+    zh: '压缩进行中，已取消并切换会话',
+    en: 'In-flight compaction cancelled for the session switch',
+  },
   'turn-failed': { zh: '回合出错{{detail}}', en: 'Turn error{{detail}}' },
 
   // ── dsh-adapter/promptDebug.ts（/debug-prompt 成功提示）─────────────


### PR DESCRIPTION
# fix: 压缩失败后换模型丢上下文——压缩事务与会话切换串行化

## 问题

长会话 `/compact` 后切换会话（`/model`、`/resume`、`/rewind`、`/fork`、`/new`），新会话上下文"直接丢失"——历史只剩一条压缩摘要。用户日志实锤（`171f2457`/`933fc77b`/`75a55315`）三个叠加机制：

1. **压缩进行中切换无守卫**：compact 的 signal 从不 abort，慢摘要 LLM 在旧会话后台继续跑完并提交 checkpoint（surface replace 已生效）；
2. **fork 快照先于压缩落定**：换模型 fork 的 seed 不含 checkpoint，但旧会话随后被压缩——用户以为"压缩失败/取消了"，历史实际已被替换；
3. **persistence 类失败误报**：checkpoint 已提交、仅落盘 flush 失败时，compactNow 以"压缩失败"reject——用户误判后换模型，fork 到的 seed 已含 checkpoint，上下文只剩摘要。

另：压缩失败本身常见根因是摘要 LLM 用量超限（日志实证 `Codex error: The usage limit has been reached`）。

## 修复（全部 TUI 侧，DSH 零源码改动）

- `channel.ts`：新增 manualCompaction 生命周期（AbortController + settled promise）。六个替换 agent 的入口（switchModel / rewindTo / rewindToNode / forkSession / resumeTo / newSession）统一 `await settleManualCompaction()`——**先 abort、等落定（3s 竞速上限）、再 fork 快照**，压缩事务不可能再跨越会话切换静默提交。
- `compact()`：持真实 AbortController；`persistence` 类失败（code 结构判别，不跨 adapter import）单独提示"压缩已生效，但落盘检查失败"；切换取消后的 AbortError 拒绝经 WeakSet 抑制闩不再叠加误导性通用失败 toast。
- `i18n.ts`：新增 `compact-flush-failed` / `compact-cancelled-switch` 两键。
- 回归：新增 `scripts/verify-compact-switch.tsx`（16 断言：abort 时间戳严格先于 fork 快照、persistence 分类、通用失败保持、已落定不阻塞、无冗余 toast），登记 channel-ui CI 组。
- 文档：contributing 双语验证对照表、user-guide `/compact` 行为说明。

## 验证

- `verify-compact-switch.tsx` 16/16
- 既有 `verify-compact.mjs` 全过
- `pnpm build` 全绿（含全部 verify:build 门禁）

## 关联

- 事故调查记录（日志取证）见会话档案；摘要模型解析遵循官方 `配置 ?? 日志最后路由 ?? agentOptions`，本 PR 不改 DSH 侧。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session switching, forking, rewinding, resuming, and model changes while compaction is in progress.
  * Compaction now cancels cleanly before session transitions and avoids duplicate or unhandled errors.
  * Added clearer messages for compaction cancellation and persistence failures.

* **Documentation**
  * Clarified compaction behavior during session switches and failure scenarios.

* **Tests**
  * Added focused regression coverage for compaction and session-switch lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->