### PR TITLE
fix(history): prevent lock contention from blocking input dispatch

### DIFF
--- a/scripts/verify-data-file-perms.tsx
+++ b/scripts/verify-data-file-perms.tsx
@@ -47,7 +47,7 @@ try {
   const { logMouseDebug } = await import('../src/utils/debug.js')
   const { writeIndex } = await import('../src/dsh-adapter/sessions/store.js')
 
-  appendHistory('secret user input / sk-test-123')
+  await appendHistory('secret user input / sk-test-123')
   logMouseDebug('mouse arrive', { x: 1 })
   writeIndex(new Map([['s1', {
     derived: {

--- a/scripts/verify-data-file-perms.tsx
+++ b/scripts/verify-data-file-perms.tsx
@@ -17,7 +17,7 @@
  *
  * 运行：node --import tsx/esm scripts/verify-data-file-perms.tsx
  */
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -63,6 +63,10 @@ try {
   const indexFile = join(dataDir, 'session-index.json')
 
   check('history.jsonl written', readFileSync(historyFile, 'utf8').includes('secret user input'))
+  // 原子替换（复审修复）：写后同目录不得残留 .tmp 中间文件。
+  check('atomic history write leaves no .tmp residue',
+    !readdirSync(dataDir).some(name => name.endsWith('.tmp')),
+    readdirSync(dataDir).join(','))
   check('mouse-debug.log written', readFileSync(mouseLog, 'utf8').includes('mouse arrive'))
   check('history round-trips after perms change', loadHistory().at(0)?.text === 'secret user input / sk-test-123')
   check('session-index.json written', readFileSync(indexFile, 'utf8').includes('secret title'))

--- a/scripts/verify-history-search.mjs
+++ b/scripts/verify-history-search.mjs
@@ -1,6 +1,15 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -66,6 +75,48 @@ try {
   } finally {
     clearTimeout(releaseLiveLock)
     rmSync(liveLock, { recursive: true, force: true })
+  }
+
+  // Ordering under contention: without a local append chain each call races the
+  // file lock on its own, and the later input can land first.
+  const orderingLock = join(fakeHome, '.dsh-tui', 'history.jsonl.lock')
+  mkdirSync(orderingLock)
+  const releaseOrderingLock = setTimeout(() => {
+    rmSync(orderingLock, { recursive: true, force: true })
+  }, 20)
+  try {
+    await Promise.all([
+      appendHistory('order one'),
+      appendHistory('order two'),
+      appendHistory('order three'),
+    ])
+    assert.deepEqual(
+      loadHistory().slice(0, 3).map(entry => entry.text),
+      ['order three', 'order two', 'order one'],
+      'concurrent appends persist in invocation order',
+    )
+  } finally {
+    clearTimeout(releaseOrderingLock)
+    rmSync(orderingLock, { recursive: true, force: true })
+  }
+
+  // Rename failure: appendHistory swallows the error, so the temp file holding
+  // the user's raw input must still be removed.
+  const historyFile = join(fakeHome, '.dsh-tui', 'history.jsonl')
+  const historyBackup = readFileSync(historyFile, 'utf8')
+  const dataDir = join(fakeHome, '.dsh-tui')
+  rmSync(historyFile, { force: true })
+  mkdirSync(join(historyFile, 'blocked'), { recursive: true })
+  try {
+    await appendHistory('rename failure')
+    assert.equal(
+      readdirSync(dataDir).some(name => name.endsWith('.tmp')),
+      false,
+      'a failed rename must not leave the input behind in a temp file',
+    )
+  } finally {
+    rmSync(historyFile, { recursive: true, force: true })
+    writeFileSync(historyFile, historyBackup, { encoding: 'utf8', mode: 0o600 })
   }
 
   const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { HistorySearchDialog }] =

--- a/scripts/verify-history-search.mjs
+++ b/scripts/verify-history-search.mjs
@@ -21,9 +21,9 @@ try {
     'duplicate history text needs distinct React keys',
   )
 
-  appendHistory('你好')
-  appendHistory('知道')
-  appendHistory('你好')
+  await appendHistory('你好')
+  await appendHistory('知道')
+  await appendHistory('你好')
   assert.deepEqual(
     loadHistory().map(entry => entry.text),
     ['你好', '知道', '你好'],
@@ -31,7 +31,7 @@ try {
   )
 
   for (let index = 0; index < 250; index += 1) {
-    appendHistory(`cmd ${index}`)
+    await appendHistory(`cmd ${index}`)
   }
   const capped = loadHistory()
   assert.equal(capped.length, 200, 'persisted history stays capped')
@@ -42,9 +42,31 @@ try {
   mkdirSync(staleLock, { recursive: true })
   const old = new Date(Date.now() - 60_000)
   utimesSync(staleLock, old, old)
-  appendHistory('after stale lock')
+  await appendHistory('after stale lock')
   assert.equal(existsSync(staleLock), false, 'stale history lock is removed')
   assert.equal(loadHistory()[0]?.text, 'after stale lock', 'append recovers after stale lock')
+
+  const liveLock = join(fakeHome, '.dsh-tui', 'history.jsonl.lock')
+  mkdirSync(liveLock)
+  let eventLoopResponsive = false
+  const releaseLiveLock = setTimeout(() => {
+    eventLoopResponsive = true
+    rmSync(liveLock, { recursive: true, force: true })
+  }, 25)
+  try {
+    const started = performance.now()
+    const pendingAppend = appendHistory('after live lock')
+    assert.ok(
+      performance.now() - started < 50,
+      'a live history lock must not block the caller before channel dispatch',
+    )
+    await pendingAppend
+    assert.equal(eventLoopResponsive, true, 'history retries yield to the TUI event loop')
+    assert.equal(loadHistory()[0]?.text, 'after live lock', 'append completes after lock release')
+  } finally {
+    clearTimeout(releaseLiveLock)
+    rmSync(liveLock, { recursive: true, force: true })
+  }
 
   const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { HistorySearchDialog }] =
     await Promise.all([
@@ -115,7 +137,7 @@ try {
         '--import',
         'tsx/esm',
         '--eval',
-        "const { appendHistory } = await import('./src/history.ts'); appendHistory(process.argv[1])",
+        "const { appendHistory } = await import('./src/history.ts'); await appendHistory(process.argv[1])",
         `parallel ${index}`,
       ], {
         cwd: workspace,
@@ -149,4 +171,4 @@ try {
   rmSync(fakeHome, { recursive: true, force: true })
 }
 
-console.log('history search OK (keys, stale lock recovery, empty render, capped persistence)')
+console.log('history search OK (keys, nonblocking locks, empty render, capped persistence)')

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -761,7 +761,7 @@ export function PromptInput({
     historyIndex.current = -1
     setInput('', 0)
     setSelectedCommand(0)
-    appendHistory(trimmed)
+    void appendHistory(trimmed)
     channel.submit(trimmed)
     if (notice) {
       channel.notify(notice, { timeoutMs: 2500 })
@@ -785,7 +785,7 @@ export function PromptInput({
     historyIndex.current = -1
     setInput('', 0)
     setSelectedCommand(0)
-    appendHistory(trimmed)
+    void appendHistory(trimmed)
     channel.steer(trimmed)
     channel.notify(t('input-interrupted-next'), { timeoutMs: 2500 })
   }
@@ -802,7 +802,7 @@ export function PromptInput({
     historyIndex.current = -1
     setInput('', 0)
     setSelectedCommand(0)
-    appendHistory(trimmed)
+    void appendHistory(trimmed)
     channel.submit(trimmed)
     channel.notify(t('input-queued-after-turn'), { timeoutMs: 2500 })
   }
@@ -847,7 +847,7 @@ export function PromptInput({
     setInput('', 0)
     setSelectedCommand(0)
     setFileSelected(0)
-    appendHistory(trimmed)
+    void appendHistory(trimmed)
     channel.notify(t('input-interrupt-immediate'), { timeoutMs: 2500 })
   }
 
@@ -873,7 +873,7 @@ export function PromptInput({
       historyIndex.current = -1
       setInput('', 0)
       setSelectedCommand(0)
-      appendHistory(text.trim())
+      void appendHistory(text.trim())
     }
     return handled
   }

--- a/src/history.ts
+++ b/src/history.ts
@@ -92,14 +92,7 @@ async function loadRawAsync(): Promise<HistoryEntry[]> {
   }
 }
 
-/**
- * Append an input to the persisted history, deduping the immediately
- * previous entry and capping the file at 200 entries.
- * @param text - Input to persist; blank inputs are ignored.
- */
-export async function appendHistory(text: string): Promise<void> {
-  const trimmed = text.trim()
-  if (!trimmed) return
+async function persistEntry(trimmed: string): Promise<void> {
   try {
     await withHistoryLock(async () => {
       const entries = await loadRawAsync()
@@ -117,16 +110,46 @@ export async function appendHistory(text: string): Promise<void> {
       // temp file + rename is atomic on POSIX and Windows alike; the temp
       // keeps mode 0600 — entries carry the full user input text.
       const tmpFile = `${HISTORY_FILE}.${process.pid}.tmp`
-      await writeFile(
-        tmpFile,
-        sliced.map(e => JSON.stringify(e)).join('\n') + '\n',
-        { encoding: 'utf8', mode: 0o600 },
-      )
-      await rename(tmpFile, HISTORY_FILE)
+      try {
+        await writeFile(
+          tmpFile,
+          sliced.map(e => JSON.stringify(e)).join('\n') + '\n',
+          { encoding: 'utf8', mode: 0o600 },
+        )
+        await rename(tmpFile, HISTORY_FILE)
+      } finally {
+        // A failed rename would otherwise leave the user's raw input behind in
+        // the temp file, which appendHistory's best-effort catch swallows.
+        await rm(tmpFile, { force: true })
+      }
     })
   } catch {
     // Best-effort persistence; history still works for the session.
   }
+}
+
+/**
+ * Serializes local appends. The file lock only orders writers across
+ * processes; without this chain two rapid submits can reach it in either
+ * order and loadHistory() would show them reversed.
+ */
+let appendChain: Promise<void> = Promise.resolve()
+
+/**
+ * Append an input to the persisted history, deduping the immediately
+ * previous entry and capping the file at 200 entries.
+ * @param text - Input to persist; blank inputs are ignored.
+ * @returns Resolves once this entry is persisted; callers on the input path
+ * intentionally discard it because persistence is best-effort.
+ */
+export function appendHistory(text: string): Promise<void> {
+  const trimmed = text.trim()
+  if (!trimmed) return Promise.resolve()
+  const queued = appendChain.then(() => persistEntry(trimmed))
+  // persistEntry never rejects, but keep the chain alive regardless so one
+  // failure cannot stall every later append.
+  appendChain = queued.catch(() => {})
+  return queued
 }
 
 /**

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync, readFileSync } from 'node:fs'
-import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import { DATA_DIR } from './utils/paths.js'
@@ -112,12 +112,17 @@ export async function appendHistory(text: string): Promise<void> {
         entries.push({ text: trimmed, ts: Date.now() })
       }
       const sliced = entries.slice(-HISTORY_LIMIT)
+      // Atomic replace: a direct async overwrite exposes truncated bytes to
+      // the synchronous loadHistory() mid-write (review finding). Same-dir
+      // temp file + rename is atomic on POSIX and Windows alike; the temp
+      // keeps mode 0600 — entries carry the full user input text.
+      const tmpFile = `${HISTORY_FILE}.${process.pid}.tmp`
       await writeFile(
-        HISTORY_FILE,
+        tmpFile,
         sliced.map(e => JSON.stringify(e)).join('\n') + '\n',
-        // 0600 on creation: entries carry the full user input text
         { encoding: 'utf8', mode: 0o600 },
       )
+      await rename(tmpFile, HISTORY_FILE)
     })
   } catch {
     // Best-effort persistence; history still works for the session.

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,6 +1,8 @@
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
+import { mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 import { DATA_DIR } from './utils/paths.js'
 
 const HISTORY_DIR = DATA_DIR
@@ -19,15 +21,11 @@ const LOCK_RETRY_LIMIT = 500
 const LOCK_RETRY_DELAY_MS = 5
 const STALE_LOCK_MS = 30_000
 
-function sleepSync(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
-}
-
-function removeStaleHistoryLock(): boolean {
+async function removeStaleHistoryLock(): Promise<boolean> {
   try {
-    const ageMs = Date.now() - statSync(HISTORY_LOCK).mtimeMs
+    const ageMs = Date.now() - (await stat(HISTORY_LOCK)).mtimeMs
     if (ageMs < STALE_LOCK_MS) return false
-    rmSync(HISTORY_LOCK, { recursive: true, force: true })
+    await rm(HISTORY_LOCK, { recursive: true, force: true })
     return true
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
@@ -36,50 +34,62 @@ function removeStaleHistoryLock(): boolean {
   }
 }
 
-function withHistoryLock(write: () => void): void {
+async function withHistoryLock(write: () => Promise<void>): Promise<void> {
   // 0700: history.jsonl holds the user's raw inputs (incl. pasted secrets),
   // so the directory must not be group/world-readable. Mode applies to the
   // creation only; pre-existing dirs are left as-is (no migration chmod).
-  mkdirSync(HISTORY_DIR, { recursive: true, mode: 0o700 })
+  await mkdir(HISTORY_DIR, { recursive: true, mode: 0o700 })
   for (let attempt = 0; attempt < LOCK_RETRY_LIMIT; attempt += 1) {
     try {
-      mkdirSync(HISTORY_LOCK)
+      await mkdir(HISTORY_LOCK)
       try {
-        write()
+        await write()
       } finally {
-        rmSync(HISTORY_LOCK, { recursive: true, force: true })
+        await rm(HISTORY_LOCK, { recursive: true, force: true })
       }
       return
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code
       if (code !== 'EEXIST') throw error
-      if (removeStaleHistoryLock()) continue
-      sleepSync(LOCK_RETRY_DELAY_MS + Math.floor(Math.random() * 5))
+      if (await removeStaleHistoryLock()) continue
+      await delay(LOCK_RETRY_DELAY_MS + Math.floor(Math.random() * 5))
     }
   }
   throw new Error('history lock busy')
 }
 
+function parseRaw(raw: string): HistoryEntry[] {
+  const entries: HistoryEntry[] = []
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    try {
+      const parsed = JSON.parse(trimmed) as Partial<HistoryEntry>
+      if (typeof parsed.text === 'string' && parsed.text.length > 0) {
+        entries.push({ text: parsed.text, ts: typeof parsed.ts === 'number' ? parsed.ts : 0 })
+      }
+    } catch {
+      // Skip malformed lines; the file is best-effort.
+    }
+  }
+  return entries
+}
+
 function loadRaw(): HistoryEntry[] {
   if (!existsSync(HISTORY_FILE)) return []
-  const entries: HistoryEntry[] = []
   try {
-    for (const line of readFileSync(HISTORY_FILE, 'utf8').split('\n')) {
-      const trimmed = line.trim()
-      if (!trimmed) continue
-      try {
-        const parsed = JSON.parse(trimmed) as Partial<HistoryEntry>
-        if (typeof parsed.text === 'string' && parsed.text.length > 0) {
-          entries.push({ text: parsed.text, ts: typeof parsed.ts === 'number' ? parsed.ts : 0 })
-        }
-      } catch {
-        // Skip malformed lines; the file is best-effort.
-      }
-    }
+    return parseRaw(readFileSync(HISTORY_FILE, 'utf8'))
   } catch {
     return []
   }
-  return entries
+}
+
+async function loadRawAsync(): Promise<HistoryEntry[]> {
+  try {
+    return parseRaw(await readFile(HISTORY_FILE, 'utf8'))
+  } catch {
+    return []
+  }
 }
 
 /**
@@ -87,12 +97,12 @@ function loadRaw(): HistoryEntry[] {
  * previous entry and capping the file at 200 entries.
  * @param text - Input to persist; blank inputs are ignored.
  */
-export function appendHistory(text: string): void {
+export async function appendHistory(text: string): Promise<void> {
   const trimmed = text.trim()
   if (!trimmed) return
   try {
-    withHistoryLock(() => {
-      const entries = loadRaw()
+    await withHistoryLock(async () => {
+      const entries = await loadRawAsync()
       // Skip consecutive duplicates (CC behavior: repeated submits of the same
       // command only advance the existing entry's timestamp).
       const last = entries[entries.length - 1]
@@ -102,7 +112,7 @@ export function appendHistory(text: string): void {
         entries.push({ text: trimmed, ts: Date.now() })
       }
       const sliced = entries.slice(-HISTORY_LIMIT)
-      writeFileSync(
+      await writeFile(
         HISTORY_FILE,
         sliced.map(e => JSON.stringify(e)).join('\n') + '\n',
         // 0600 on creation: entries carry the full user input text


### PR DESCRIPTION
## Summary

Prevent live `history.jsonl.lock` contention from blocking the dsh-TUI event loop and delaying prompt submit, steer, queue, interrupt, or slash-command dispatch while preserving serialized, bounded, best-effort input-history persistence.

## Problem

- Expected: best-effort history persistence yields to the event loop and never delays channel dispatch.
- Actual: `appendHistory()` retried a live lock with synchronous `Atomics.wait()` calls before `channel.submit()` or `channel.steer()`, freezing input for several seconds.
- Impact: a second active TUI writer, or any live lock holder, could make sending and rendering appear hung even though the model/runtime path was healthy.

## Reproduction

1. Create a current `$HOME/.dsh-tui/history.jsonl.lock` directory to represent another active writer.
2. Call `appendHistory()` or submit a prompt while that lock remains live.
3. On the synchronous implementation, observe that the caller does not return until the bounded retry loop exhausts after roughly 3.5 seconds.

## Issues Found

Closes #588

## Fix Approach

- Move lock acquisition, stale-lock checks, retry delays, reads, and writes to asynchronous Node APIs.
- Return a promise from `appendHistory()` while keeping PromptInput persistence explicitly fire-and-forget before channel dispatch.
- Preserve the existing retry bound, stale-lock recovery, consecutive dedupe, 200-entry cap, file modes, cross-process serialization, and best-effort failure behavior.
- Extend the focused history verifier with a live-lock timer assertion and await persistence in test-only callers.
- Serialize local appends through a module-local promise chain, so invocation order survives lock contention while `HISTORY_LOCK` keeps cross-process serialization (review follow-up).
- Wrap the temp-file write and rename in `try/finally` with `rm(..., { force: true })`, so a failed rename never leaves the raw input in `${HISTORY_FILE}.<pid>.tmp` (review follow-up).

## Test-First Evidence

- RED: the new live-lock regression took about 3.57 seconds to return and failed the 50 ms caller-return assertion on the synchronous `Atomics.wait()` implementation.
- GREEN: the caller returns immediately, the event-loop timer releases the live lock, the append completes, and the existing 20-process serialization scenario retains every entry.
- RED (ordering): a 30-round probe holding a live lock for 20 ms reversed persisted order in 26 of 30 rounds before the append chain; the new verifier assertion fails on that implementation.
- RED (temp file): forcing `rename()` to fail leaves `history.jsonl.<pid>.tmp` behind, and the new cleanup assertion fails.
- GREEN (both): the ordering assertion and the temp-file cleanup assertion pass across three consecutive verifier runs.

## Test plan

- PASS: `node --import tsx/esm scripts/verify-history-search.mjs`
- PASS: `pnpm build` with pnpm 11.21.0
- PASS: `pnpm verify:package` (1,329 files; 25 entry targets)
- PASS: `node --import tsx/esm scripts/verify-data-file-perms.tsx`

Generated `lib/` output is intentionally not committed.

## Risk / Notes

- `appendHistory()` changes from a synchronous `void` API to an asynchronous `Promise<void>` API; product call sites intentionally discard that promise because persistence is best-effort, while validation callers await it.
- The append chain is per-process; `HISTORY_LOCK` remains the only cross-process ordering mechanism, and the lock format does not change.
- The lock format and cross-process serialization contract do not change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen draft editor with line numbers, scrolling, and explicit send/collapse controls.
  * Added text selection, clipboard copying, selection replacement, deletion, and grapheme-aware highlighting.
  * Improved handling of Enter, Tab, pasted text, and multiline input in the expanded editor.
* **Bug Fixes**
  * History saving no longer blocks the interface or event loop.
  * Improved lock recovery and nonblocking retries during history updates.
  * History files are written atomically, with temporary files cleaned up after failures.
  * History verification now waits for saves to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->