### PR TITLE
fix(input): preserve consecutive blank prompt lines

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -217,6 +217,9 @@ const GROUPS = {
 // stdin 批量按键回归：同一读取内的文本、方向键、文本必须依次基于
 // 前一事件的输入状态执行，不能因 React 批处理读取旧闭包而丢字符。
     ["verify-batched-prompt-input", ['node', 'scripts/verify-batched-prompt-input.mjs']],
+// 连续 Shift/Option+Enter 的空逻辑行必须占真实布局高度（issue #599）；
+// 空 Text 节点不能把 alpha\n\nomega 画成相邻两行。
+    ["verify-prompt-empty-lines", ['node', 'scripts/verify-prompt-empty-lines.mjs']],
 // 快捷键 keymap 回归：共享组合语法、动作注册表与 /settings 改键
 // （Alt+V 粘贴别名、覆盖热更新、保留位集合、草稿冲突校验），以及
 // 真 Chat 里 Alt+V / 改键后的外部编辑器路径。

--- a/scripts/verify-prompt-empty-lines.mjs
+++ b/scripts/verify-prompt-empty-lines.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Regression for issue #599: consecutive modified-Enter presses must keep
+ * every logical blank line visible in the prompt. Empty non-caret Text nodes
+ * have no Yoga height, so a draft like `alpha\n\n\nomega` used to paint alpha
+ * and omega on adjacent rows even though the stored value was correct.
+ *
+ * Run after build: `node scripts/verify-prompt-empty-lines.mjs`.
+ */
+import { PassThrough, Writable } from 'node:stream'
+import React from 'react'
+import xtermHeadless from '@xterm/headless'
+const { Terminal: XTerm } = xtermHeadless
+import { render } from '../lib/types/ui.js'
+import { PromptInput } from '../lib/types/components/PromptInput.js'
+import { settled, sleep, viewportLines } from './lib/term-test.mjs'
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: 80, rows: 16, scrollback: 50, allowProposedApi: true })
+const stdout = new Writable({ write(chunk, _encoding, callback) { term.write(String(chunk), callback) } })
+stdout.columns = 80
+stdout.rows = 16
+stdout.isTTY = true
+const stderr = new Writable({ write(_chunk, _encoding, callback) { callback() } })
+stderr.isTTY = true
+const stdin = new PassThrough()
+stdin.isTTY = true
+stdin.setRawMode = () => stdin
+stdin.setEncoding = () => stdin
+stdin.ref = () => stdin
+stdin.unref = () => stdin
+
+const channel = {
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  sessionColor: '',
+  promptSessionLabel: false,
+  reasoningEffort: 'high',
+  effortLevels: [],
+  commandList: [],
+  notifications: [],
+  pending: [],
+  working: false,
+  cycleMode() {},
+  commandCompletions: () => [],
+  notify() {},
+  submit() {},
+  steer() {},
+  interruptAndDeliver: () => 0,
+  removePending: () => false,
+  stageImage() {},
+  listFiles: async () => [],
+}
+
+const instance = await render(
+  React.createElement(PromptInput, {
+    channel,
+    helpOpen: false,
+    onToggleHelp() {},
+    onRunCommand: () => false,
+    selectionActive: false,
+  }),
+  { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
+)
+
+// First-frame listener setup has no stable external signal.
+await sleep(400)
+stdin.write('alpha')
+await settled(() => viewportLines(term).some(line => line.includes('alpha')))
+stdin.write('\x1b\r')
+await sleep(100)
+stdin.write('\x1b\r')
+await sleep(100)
+stdin.write('\x1b\r')
+await sleep(100)
+stdin.write('omega')
+
+const visible = () => viewportLines(term)
+const rendered = await settled(() => visible().some(line => line.includes('omega')))
+const lines = visible()
+const alphaRow = lines.findIndex(line => line.includes('alpha'))
+const omegaRow = lines.findIndex(line => line.includes('omega'))
+
+check('the full multiline draft renders', rendered && alphaRow >= 0 && omegaRow >= 0, JSON.stringify(lines))
+check(
+  'three consecutive modified-Enters preserve both intervening empty rows',
+  omegaRow - alphaRow === 3,
+  `alphaRow=${alphaRow} omegaRow=${omegaRow} screen=${JSON.stringify(lines)}`,
+)
+
+instance.unmount()
+
+if (failed > 0) {
+  console.error(`verify-prompt-empty-lines: ${failed} assertion(s) failed`)
+  process.exit(1)
+}
+console.log('verify-prompt-empty-lines OK')

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1713,7 +1713,10 @@ export function PromptInput({
       return (
         <Text key={absoluteLine} wrap="truncate-end">
           {prefix}
-          {text}
+          {/* An empty Text node has zero Yoga height. Paint one blank cell so
+              every logical empty line keeps its row (#599); the cell remains
+              visually blank and does not change the stored draft. */}
+          {text === '' ? ' ' : text}
         </Text>
       )
     }


### PR DESCRIPTION
Fixes #599.

## Cause
The draft preserves consecutive newline characters, but an empty non-caret Text row collapses to zero Yoga height. That makes alpha\n\n\nomega paint alpha and omega on adjacent terminal rows.

## Fix
- Paint one blank terminal cell only for an empty non-caret logical row.
- Leave the stored draft, caret, key handling, wrapping, and submission unchanged.
- Add the xterm rendering regression to the input/terminal CI group.

## Causal proof
- Exact parent 4c1d09f1259690352b8854062119f47d04f66523: alpha row 2, omega row 3 (fails).
- This head: alpha row 2, omega row 5 (passes and preserves both blank rows).

## Verification
- pnpm build
- pnpm verify:package (1,335 files / 25 entry targets)
- focused consecutive-newline regression
- full input/terminal group (20/20)
- ask-panel layout and tool-card smoke checks
- git diff --check

No physical macOS/iTerm run was available. The fix uses a single ASCII terminal cell and is terminal-independent; CI can provide the remaining aggregate coverage. Existing Windows-local ask-panel failures were reproduced unchanged on the untouched base and are unrelated to this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the height of blank lines in multiline prompt input.
  * Prevented empty lines from collapsing while keeping their appearance and saved draft content unchanged.

* **Tests**
  * Added regression coverage for consecutive modified-Enter inputs and intervening blank rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->