### PR TITLE
fix(statusline): show full mode when it is the base preset

### DIFF
--- a/scripts/verify-effort-slider-ui.mjs
+++ b/scripts/verify-effort-slider-ui.mjs
@@ -64,13 +64,13 @@ const EFFORTS = [
   { id: 'max', name: 'Max' },
 ]
 
-function makeChannel() {
+function makeChannel(options = {}) {
   const setEffortCalls = []
   const cycled = []
   const notifications = []
   const rows = []
-  let modeIndex = 0
-  const MODES = [
+  let modeIndex = options.modeIndex ?? 0
+  let MODES = options.modes ?? [
     { id: 'default', plan: false, sandbox: 'workspace-write', approval: 'ask' },
     { id: 'plan', plan: true, sandbox: 'read-only', approval: 'ask' },
     { id: 'full', plan: false, sandbox: 'danger-full-access', approval: 'never' },
@@ -123,6 +123,12 @@ function makeChannel() {
     async cycleMode() {
       cycled.push(modeIndex)
       modeIndex = (modeIndex + 1) % MODES.length
+      channel.version += 1
+      for (const listener of listeners) listener()
+    },
+    setModesForTest(nextModes, nextIndex = 0) {
+      MODES = nextModes
+      modeIndex = nextIndex
       channel.version += 1
       for (const listener of listeners) listener()
     },
@@ -251,6 +257,10 @@ stdin.write('\x1b[Z')
 check('second backtab → full', await settled(() => channel.mode.id === 'full'), channel.mode.id)
 stdin.write('\x1b[Z')
 check('third backtab → default (no segment)', await settled(() => channel.modeIndex === 0), String(channel.modeIndex))
+channel.setModesForTest([
+  { id: 'full', plan: false, sandbox: 'danger-full-access', approval: 'never' },
+])
+check('index-0 full mode stays visible', await settled(() => screen().includes('full access')), screen().slice(-300))
 
 // 6. zh locale: the slider chrome hot-swaps to the localized strings
 //    (picker i18n branch: picker-title-effort / hint-adjust-done).

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -168,7 +168,10 @@ export function StatusLine({
       node: <Text color="inactiveShimmer">{channel.reasoningEffort}</Text>,
     })
   }
-  if (statusBar.mode && channel.modeIndex > 0) {
+  const modeNeedsExplicitMarker = channel.mode.plan === true
+    || channel.mode.sandbox === 'danger-full-access'
+    || channel.mode.approval === 'never'
+  if (statusBar.mode && (channel.modeIndex > 0 || modeNeedsExplicitMarker)) {
     contextParts.push({
       key: 'mode',
       node: (


### PR DESCRIPTION
Fixes #582.\n\n## Summary\n- keep the shipped index-0 workspace-write baseline unmarked\n- show the statusline mode chip when the active base mode is explicit/high-risk, such as danger-full-access or approval never\n- add a headless regression for index-0 full mode visibility\n\n## Verification\n- git diff --check\n- npm run clean && npx tsc -p tsconfig.json\n- node scripts/verify-effort-slider-ui.mjs\n\nNote: full npm run compile still hits the existing dsh-auth pnpm workspace metadata issue (packages field missing or empty) in this checkout, so I built dsh-auth with npm for local verification before running the project tsc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mode information now remains visible in the status line when plan mode, full-access sandbox mode, or disabled approvals are active—even when the default mode is selected.
  * Status line handling is more reliable for channels without background job information.
  * Long session titles can now be viewed in full via a tooltip.

* **Improvements**
  * Status lines now show running or stopping background jobs, including details such as identifiers, labels, durations, and additional job counts.
  * Added verification coverage for mode visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->