### PR TITLE
fix(input): preserve empty prompt lines

### DIFF
--- a/scripts/verify-batched-prompt-input.mjs
+++ b/scripts/verify-batched-prompt-input.mjs
@@ -20,11 +20,13 @@ import { settled, sleep, viewportLines } from './lib/term-test.mjs'
 const { Terminal: XTerm } = xtermHeadless
 
 let failed = 0
+/** Print one pass/fail line and keep a running failure count. */
 function check(name, ok, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
   if (!ok) failed += 1
 }
 
+/** Build the writable TTY streams used by the headless prompt harness. */
 function makeStreams(term) {
   const stdout = new Writable({
     write(chunk, _encoding, callback) {

--- a/scripts/verify-batched-prompt-input.mjs
+++ b/scripts/verify-batched-prompt-input.mjs
@@ -12,9 +12,12 @@
  */
 import { PassThrough, Writable } from 'node:stream'
 import React from 'react'
+import xtermHeadless from '@xterm/headless'
 import { render } from '../lib/types/ui.js'
 import { PromptInput } from '../lib/types/components/PromptInput.js'
-import { settled, sleep } from './lib/term-test.mjs'
+import { settled, sleep, viewportLines } from './lib/term-test.mjs'
+
+const { Terminal: XTerm } = xtermHeadless
 
 let failed = 0
 function check(name, ok, extra = '') {
@@ -22,8 +25,16 @@ function check(name, ok, extra = '') {
   if (!ok) failed += 1
 }
 
-function makeStreams() {
-  const stdout = new Writable({ write(_chunk, _encoding, callback) { callback() } })
+function makeStreams(term) {
+  const stdout = new Writable({
+    write(chunk, _encoding, callback) {
+      if (term === undefined) {
+        callback()
+      } else {
+        term.write(String(chunk), callback)
+      }
+    },
+  })
   stdout.columns = 100
   stdout.rows = 30
   stdout.isTTY = true
@@ -67,7 +78,8 @@ const channel = {
   listFiles: async () => [],
 }
 
-const { stdout, stderr, stdin } = makeStreams()
+const term = new XTerm({ cols: 100, rows: 30, scrollback: 100, allowProposedApi: true })
+const { stdout, stderr, stdin } = makeStreams(term)
 const instance = await render(
   React.createElement(PromptInput, {
     channel,
@@ -239,6 +251,30 @@ for (const [index, [label, newlineKey, prefix]] of modifiedCtrlJCases.entries())
     JSON.stringify(submitted),
   )
 }
+
+stdin.write('a')
+await sleep(100)
+stdin.write('\x1b\r')
+await sleep(100)
+stdin.write('\x1b\r')
+await sleep(100)
+stdin.write('b')
+check(
+  'consecutive Option+Enter keeps both blank prompt lines visible',
+  await settled(() => {
+    const lines = viewportLines(term)
+    const top = lines.findIndex(line => line.includes('╭'))
+    const bottom = lines.findIndex((line, index) => index > top && line.includes('╰'))
+    return top >= 0 && bottom - top === 4 && lines.some(line => line.includes('b'))
+  }),
+  viewportLines(term).join('\n'),
+)
+stdin.write('\r')
+check(
+  'consecutive Option+Enter submits both newlines',
+  await settled(() => submitted.at(-1) === 'a\n\nb'),
+  JSON.stringify(submitted),
+)
 
 instance.unmount()
 

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -60,11 +60,13 @@ const isBigInput = (text: string): boolean =>
  */
 const EDITABLE_CONTROL = /[\u0000-\u0009\u000b-\u001f\u007f]/u
 
+/** Normalize editable text so no terminal control characters remain in state. */
 function sanitizeEditableText(text: string): string {
   // Fast path for ordinary and multi-line drafts: newline is intentionally
   // absent from the probe, so a large clean paste returns without regex work.
   if (!EDITABLE_CONTROL.test(text)) return text
   return stripAnsi(text)
+    .replace(/\r\n?/gu, '\n')
     .replace(/\t/gu, '        ')
     .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/gu, '')
 }
@@ -1258,9 +1260,7 @@ export function PromptInput({
       // supports extended key reporting (kitty/modifyOtherKeys allowlist in
       // ink/terminal.ts); Option+Enter (ESC CR) is the fallback on terminals
       // that can't report shift — e.g. macOS Terminal.app (issue #110).
-      const next = value.slice(0, cursor) + '\n' + value.slice(cursor)
-      setInput(next, cursor + 1)
-      setSelectedCommand(0)
+      insertAtCaret('\n')
       return
     }
     if (key.return && expandedRef.current) {

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -2134,7 +2134,7 @@ export function PromptInput({
     return (
       <Text key={absoluteLine} wrap="truncate-end">
         {prefix}
-        {pieces.map((piece, pieceIndex) =>
+        {pieces.length === 0 ? ' ' : pieces.map((piece, pieceIndex) =>
           piece.inverse ? (
             <Text key={pieceIndex} inverse>
               {piece.text}


### PR DESCRIPTION
Fixes #599.\n\n## Summary\n- keep empty visual prompt rows mounted by rendering a blank cell for non-caret empty lines\n- add a headless xterm regression for consecutive Option/Alt+Enter producing a visible blank row between typed lines\n- assert the submitted text still preserves both newline characters\n\n## Verification\n- git diff --check\n- npm run clean && npx tsc -p tsconfig.json\n- node scripts/verify-batched-prompt-input.mjs\n\nNote: this checkout still has the existing package-script issue where 
pm run compile delegates to pnpm --dir dsh-auth install, which fails with packages field missing or empty; I built dsh-auth with npm for local verification before running the project tsc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mouse and double-click text selection with clipboard copying.
  - Added a fullscreen editor with scrolling, line numbers, multiline editing, and dedicated Enter, Ctrl+Enter, and Tab behavior.
  - Added selection replacement and deletion, including support for folded text and grapheme-safe editing.
  - Added Ctrl+J and additional modified Enter input support for multiline prompts.

- **Bug Fixes**
  - Improved multiline prompt rendering so empty visual rows remain visibly blank.
  - Fixed consecutive Option+Enter inputs so blank lines are preserved and submitted correctly.
  - Improved carriage return handling and selection replacement when inserting text with Shift or Meta+Enter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->