### PR TITLE
fix(context): minimal 不再误报内置 skills

### DIFF
--- a/scripts/verify-minimal-preset-tools.mjs
+++ b/scripts/verify-minimal-preset-tools.mjs
@@ -32,17 +32,26 @@ const bundledSkills = [{
   description: 'Audit code',
   invocation: { modelInvocable: true, userInvocable: true },
   source: 'bundled',
+}, {
+  name: 'manual-only',
+  description: 'Manual only',
+  invocation: { modelInvocable: false, userInvocable: true },
+  source: 'bundled',
 }]
 
-async function loadedContextWith(tools) {
+async function loadedContextWith(tools, complete = true) {
   let unscopedReads = 0
   const skills = {
     async list() {
       unscopedReads += 1
       return bundledSkills
     },
-    async snapshot() {
-      return { skills: bundledSkills, complete: true }
+    async snapshot(options) {
+      if (options?.scope !== agent || options.cwd !== '/tmp') {
+        unscopedReads += 1
+        return { skills: [], complete: true }
+      }
+      return { skills: bundledSkills, complete }
     },
   }
   const ctx = {
@@ -76,7 +85,12 @@ assert.deepEqual(minimalContext.context.skills, [])
 assert.equal(minimalContext.unscopedReads, 0)
 
 const standardContext = await loadedContextWith([bash, editor, { name: 'skill' }])
-assert.deepEqual(standardContext.context.skills, bundledSkills.map(({ name, description }) => ({ name, description })))
+assert.deepEqual(standardContext.context.skills, [{ name: 'audit', description: 'Audit code' }])
 assert.equal(standardContext.unscopedReads, 0)
+
+const incompleteContext = await loadedContextWith([bash, editor, { name: 'skill' }], false)
+assert.deepEqual(incompleteContext.context.skills, [])
+assert.deepEqual(incompleteContext.context.tools.map(tool => tool.name), ['bash', 'str_replace_editor', 'skill'])
+assert.equal(incompleteContext.unscopedReads, 0)
 
 console.log('minimal preset tool filtering verified')

--- a/scripts/verify-minimal-preset-tools.mjs
+++ b/scripts/verify-minimal-preset-tools.mjs
@@ -1,8 +1,10 @@
-/** Regression check: the TUI host tool remains available everywhere except
- * the official two-tool Minimal preset. Run against compiled output. */
+/** Regression checks for the official two-tool Minimal preset. Run against
+ * compiled output. */
 
 import assert from 'node:assert/strict'
+import { createChannel } from '../lib/types/dsh-adapter/channel.js'
 import { filterMinimalPresetTools } from '../lib/types/dsh-adapter/presets.js'
+import { settled } from './lib/term-test.mjs'
 
 const bash = { name: 'bash' }
 const editor = { name: 'str_replace_editor' }
@@ -24,5 +26,57 @@ for (const preset of ['standard', 'code', 'cordis', 'liangshen', undefined]) {
 
 const alreadyTwoTools = { ...assembly, tools: [bash, editor] }
 assert.equal(filterMinimalPresetTools(alreadyTwoTools, 'minimal'), alreadyTwoTools)
+
+const bundledSkills = [{
+  name: 'audit',
+  description: 'Audit code',
+  invocation: { modelInvocable: true, userInvocable: true },
+  source: 'bundled',
+}]
+
+async function loadedContextWith(tools) {
+  let unscopedReads = 0
+  const skills = {
+    async list() {
+      unscopedReads += 1
+      return bundledSkills
+    },
+    async snapshot() {
+      return { skills: bundledSkills, complete: true }
+    },
+  }
+  const ctx = {
+    on: () => () => {},
+    get(name) {
+      if (name === 'systemPrompt') {
+        return { assemble: async () => ({ sections: [], contexts: [], tools, variables: {} }) }
+      }
+      if (name === 'skills') return skills
+      return undefined
+    },
+    logger: { warn() {} },
+  }
+  const agent = {
+    id: 'a1',
+    status: 'idle',
+    session: { id: 's1', seq: 0, events: [] },
+    ctx: { on: () => () => {} },
+    followup() {},
+    steer() {},
+  }
+  const channel = createChannel(ctx, agent, {
+    model: 'deepseek-chat', cwd: '/tmp', provider: 'deepseek', activity: false,
+  })
+  assert.equal(await settled(() => channel.loadedContext !== undefined), true)
+  return { context: channel.loadedContext, unscopedReads }
+}
+
+const minimalContext = await loadedContextWith([bash, editor])
+assert.deepEqual(minimalContext.context.skills, [])
+assert.equal(minimalContext.unscopedReads, 0)
+
+const standardContext = await loadedContextWith([bash, editor, { name: 'skill' }])
+assert.deepEqual(standardContext.context.skills, bundledSkills.map(({ name, description }) => ({ name, description })))
+assert.equal(standardContext.unscopedReads, 0)
 
 console.log('minimal preset tool filtering verified')

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { assembleContextFor, installModelSelection, type Agent, type AgentHandle, type AgentStatus, type CreateAgentOptions, type ModelSelectionRef } from '@deepseek-ai/dsh-agent'
 import type { CommandExecution, CommandRuntime } from '@deepseek-ai/dsh-commands'
-import { isUserInvocable, renderSkillContent, type SkillSummary } from '@deepseek-ai/dsh-skill'
+import { isModelInvocable, isUserInvocable, renderSkillContent, type SkillSummary } from '@deepseek-ai/dsh-skill'
 import type { LlmConfigurableProvider, LlmDiscoveredModel, LlmModelInfo, LlmProviderInfo } from '@deepseek-ai/dsh-llm'
 import {
   createUserMessage,
@@ -5367,17 +5367,16 @@ export function createChannel(
         ...(renderedInstructions?.truncated ?? []).map(file => file.displayPath),
       ])
       files.push(...[...instructionPaths].map(displayPath => ({ displayPath })))
-      // The skills registry is host-plane but scope-layered: preset rows
-      // (skill-filesystem) register into the preset's layer, so the catalog
-      // must be read through the agent's scope chain (serviceForAgent falls
-      // back to the host context when no roster is mounted).
-      const skillsService = serviceForAgent<{
-        list(options?: unknown): Promise<readonly { name: string; description: string }[]>
-      }>(ctx, target, 'skills')
-      if (skillsService !== undefined) {
-        const catalog = await skillsService.list({})
+      // A registry entry reaches the model only through dsh-tool-skill's
+      // catalog, which is gated on that exact tool being visible to the agent.
+      const skillsRegistry = tools.some(tool => tool.name === 'skill')
+        ? skillRegistryFor(target)
+        : undefined
+      if (skillsRegistry !== undefined) {
+        const observation = await skillsRegistry.snapshot(skillViewOptions(target))
         if (target !== agent) return
-        skills.push(...catalog.map(skill => ({
+        if (!observation.complete) return
+        skills.push(...observation.skills.filter(isModelInvocable).map(skill => ({
           name: skill.name,
           description: skill.description,
         })))

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -5375,11 +5375,12 @@ export function createChannel(
       if (skillsRegistry !== undefined) {
         const observation = await skillsRegistry.snapshot(skillViewOptions(target))
         if (target !== agent) return
-        if (!observation.complete) return
-        skills.push(...observation.skills.filter(isModelInvocable).map(skill => ({
-          name: skill.name,
-          description: skill.description,
-        })))
+        if (observation.complete) {
+          skills.push(...observation.skills.filter(isModelInvocable).map(skill => ({
+            name: skill.name,
+            description: skill.description,
+          })))
+        }
       }
     } catch (error) {
       ctx.logger.warn('loaded-context snapshot failed: %o', error)


### PR DESCRIPTION
Minimal 没有挂载 `skill` tool，但 `/context` 仍读取全局 skill registry，因而误报 7 个内置 skill。

让 context projection 与 `dsh-tool-skill` 使用同一可见性规则：仅在 agent 实际拥有 `skill` tool 时，从 agent-scoped snapshot 投影 model-invocable skills。

验证：`pnpm build`、`pnpm verify:package`、聚焦回归、Herdr 真实 minimal TTY `/context`。

Closes #609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loaded-context skill discovery to show only model-invocable skills.
  * Prevented incomplete skill catalogs from exposing skill metadata while retaining the skill tool.
  * Restricted skill reads to scoped snapshots and rejected unscoped requests.
* **Tests**
  * Added regression coverage for Minimal and standard presets.
  * Verified that standard contexts expose the expected model-invocable skills, while Minimal and incomplete contexts expose no skill metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->