### PR TITLE
fix(render): 冷启动历史补画改为刷帧对齐保持——快机上历史 user 行不再消失 (#574)

### DIFF
--- a/scripts/lib/modern-widths.mjs
+++ b/scripts/lib/modern-widths.mjs
@@ -1,0 +1,61 @@
+/**
+ * 取证 harness 的「现代终端」宽度 provider（issue #574 取证沉淀）。
+ *
+ * xterm-headless 默认 Unicode provider 是旧表：Emoji_Presentation 字符
+ * （⚓ U+2693 等）量 1 格；现代真实终端（Windows Terminal / kitty /
+ * ghostty / iTerm2 按 EastAsianWidth W）画 2 格，src/ink/stringWidth.ts
+ * 也量 2（#101 的 Doctrine：量宽跟随真实终端）。两侧不一致时，就地重绘
+ * 含这类字符的行必然错位——app 以为是宽字符第二格而不重写的格子，在
+ * 终端里是独立一格：旧帧残影滞留、后续宽字被半个覆盖丢弃（#574 现场
+ * 思考行的「⚓⠧ 思  ·」残状）。断言这类行的回归脚本必须先让 harness
+ * 与真实终端同宽，否则红的是 xterm.js 旧表，不是产品代码。
+ *
+ * 宽度口径直接委托 app 的 stringWidth（单码点粒度，与 provider 的
+ * wcwidth 语义一致），单一真源不漂移。
+ *
+ * 本模块顶层 import TypeScript 源——只可被 `node --import tsx/esm`
+ * 运行的脚本引入；纯 node 脚本（如 verify-working-activity）请勿引入
+ * （它们也不需要：断言不含 Emoji_Presentation 字符的行）。
+ */
+const { stringWidth } = await import('../../src/ink/stringWidth.js')
+
+/** 单码点宽度（wcwidth 语义：0/1/2），带缓存——xterm 逐码点查询。 */
+const table = new Map()
+const wcwidth = cp => {
+  let w = table.get(cp)
+  if (w === undefined) {
+    w = stringWidth(String.fromCodePoint(cp))
+    if (w !== 0 && w !== 1 && w !== 2) w = 1
+    table.set(cp, w)
+  }
+  return w
+}
+
+// charProperties 位布局照抄 @xterm/headless 6.0.0 内建 provider：
+//   property = (charKind << 3) | (width << 1) | (shouldJoin ? 1 : 0)
+// 组合符（width 0）并入前格宽度（shouldJoin），与内建语义一致。
+// 若升级 xterm 后布局变化，这里要与内建实现同步（typings 不导出这些
+// 静态方法，只能对照打包源码核对）。
+const charProperties = (cp, preceding) => {
+  let w = wcwidth(cp)
+  let join = w === 0 && preceding !== 0
+  if (join) {
+    const precedingWidth = (preceding >> 1) & 3
+    if (precedingWidth === 0) join = false
+    else if (precedingWidth > w) w = precedingWidth
+  }
+  return (0 << 3) | ((w & 3) << 1) | (join ? 1 : 0)
+}
+
+const VERSION = 'dsh-modern-eaw'
+
+/**
+ * 注册并启用现代宽度 provider（幂等：重复注册同名版本会抛错，故先查）。
+ * @param {import('@xterm/headless').Terminal} term
+ */
+export function activateModernEmojiWidths(term) {
+  if (!term.unicode.versions.includes(VERSION)) {
+    term.unicode.register({ version: VERSION, wcwidth, charProperties })
+  }
+  term.unicode.activeVersion = VERSION
+}

--- a/scripts/repro-inline-scrollback.tsx
+++ b/scripts/repro-inline-scrollback.tsx
@@ -17,7 +17,7 @@ process.env.TERM_PROGRAM = 'WezTerm'  // DEC-2026 同步输出路径（与真机
 process.env.DSH_TUI_THEME = 'dark'    // 跳过 OSC 11 探测，保持确定性
 process.env.DSH_TUI_LANG = 'zh'       // 固定中文 UI（splash 标语断言）
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { sleep }, { activateModernEmojiWidths }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
@@ -25,6 +25,7 @@ const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat
   import('../src/screens/Chat.js'),
   import('../src/dsh-adapter/questions.js'),
   import('./lib/term-test.mjs'),
+  import('./lib/modern-widths.mjs'),
 ])
 
 const COLS = 100
@@ -32,6 +33,9 @@ const ROWS = 20
 const SCROLLBACK = 2000
 const INPUT_MARKER = 'CARET_ANCHOR_7F31'
 const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: SCROLLBACK, allowProposedApi: true })
+// 取证终端与真实终端同宽（⚓ 等 Emoji_Presentation 字符 2 格）——
+// 否则现场思考行落定重绘的断言测的是 xterm 旧表的宽度（#574）。
+activateModernEmojiWidths(term)
 
 const rawChunks: string[] = []
 /** 逐帧账本：buffer 总行数增量 vs 该帧特征（定位污染来源）。 */

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -13,6 +13,7 @@ import { SubagentMessage } from './Chat/SubagentMessage.js'
 import { JobCard } from './Chat/JobCard.js'
 import { isMinimalMode } from '../minimalMode.js'
 import { noteFrameCause, noteListGeometry } from '../ink/geometry-trace.js'
+import { getTerminalFlushTick } from '../ink/flush-tick.js'
 import { InterruptedByUser } from './InterruptedByUser.js'
 import { LogoV2 } from './LogoV2.js'
 import { StreamingMarkdown } from './StreamingMarkdown.js'
@@ -459,15 +460,18 @@ export function MessageList({
   const paintedOnceRef = React.useRef<Set<number>>(new Set())
   const paintedBaseRef = React.useRef<number | undefined>(undefined)
   /** Window-expansion hold: after the window WIDENS (new rows mounted),
-   *  refuse to tighten for a short hold so the mounted rows actually reach
-   *  the terminal. React commits within one ink frame coalesce — a render
-   *  that mounts rows followed by the measure-tick re-render that drops
-   *  them paints only the DROPPED layout, and never-mounted rows have no
-   *  scrollback copy (preset history at boot vanished — CI
-   *  repro-inline-scrollback). After the hold, tightening is visually
-   *  free: those rows sit in scrollback and the diff skips them. */
+   *  refuse to tighten until a frame containing that layout has actually
+   *  been FLUSHED to the terminal (flush-tick based, issue #574). React
+   *  commits and terminal writes are decoupled — the throttled deferred
+   *  leading edge lets a later commit supersede the wide one inside the
+   *  same task, so a wall-clock hold (the old 120ms timer) expires during
+   *  long cold-cache layout work (~190ms on the repro) and the measure-tick
+   *  re-render still drops the rows before a single byte of them was
+   *  written; never-mounted rows have no scrollback copy and preset history
+   *  vanishes. Once flushed, tightening is visually free: those rows sit in
+   *  scrollback and the diff skips them. */
   const lastStartRef = React.useRef<number>(-1)
-  const holdUntilRef = React.useRef<number>(0)
+  const holdFlushTickRef = React.useRef<number>(-1)
   /** True when frame-budgeted history painting still has batches left
    *  (main-screen open): the layout effect schedules the next slice. */
   const paintPendingRef = React.useRef(false)
@@ -745,15 +749,20 @@ export function MessageList({
       }
     }
     // Expansion hold — AFTER the extension so it tracks the FINAL window:
-    // never tighten within the hold window after a widen. React commits
-    // inside one ink frame coalesce; a mount followed by the measure-tick
-    // re-render that drops the row paints only the DROPPED layout, and the
-    // row's painted-once mark (set at the first commit) is a lie.
-    if (lastStartRef.current >= 0 && start > lastStartRef.current && performance.now() < holdUntilRef.current) {
+    // never tighten past a widen until a frame with that layout has been
+    // flushed (getTerminalFlushTick advanced since the widen). A mount
+    // followed by the measure-tick re-render that drops the row paints only
+    // the DROPPED layout, and the row's painted-once mark (set at the first
+    // commit) is a lie; holding until the flush makes the mark real.
+    if (
+      lastStartRef.current >= 0 &&
+      start > lastStartRef.current &&
+      getTerminalFlushTick() === holdFlushTickRef.current
+    ) {
       start = lastStartRef.current
     }
     if (lastStartRef.current < 0 || start < lastStartRef.current) {
-      holdUntilRef.current = performance.now() + 120
+      holdFlushTickRef.current = getTerminalFlushTick()
     }
     lastStartRef.current = start
   }

--- a/src/ink/flush-tick.ts
+++ b/src/ink/flush-tick.ts
@@ -1,0 +1,34 @@
+/**
+ * Monotonic terminal-flush counter for the ported Ink core.
+ *
+ * React commits and terminal writes are decoupled: `scheduleRender`
+ * throttles `onRender` to the frame budget with a deferred leading edge, so
+ * a commit can be SUPERSEDED by a later commit inside the same task before
+ * its layout ever reaches the terminal (the generation guard in
+ * `deferredRender` drops the stale leading frame). Components that treat
+ * "mounted" as "painted" (main-screen scrollback keeps no copy of a row the
+ * window skipped) then lose content: the row unmounted before a single byte
+ * of it was written.
+ *
+ * `noteTerminalFlush()` increments once per completed `writeDiffToTerminal`;
+ * consumers compare the tick to decide whether the layout they committed
+ * has actually been flushed (issue #574: cold-start history vanished on
+ * fast machines exactly because the 120ms wall-clock hold expired during
+ * the first commit's ~190ms of cold-cached yoga before any flush ran).
+ */
+
+/** Flush counter — see the module comment. */
+let flushTick = 0
+
+/** Record one completed terminal frame write. Called from ink's onRender
+ *  after writeDiffToTerminal; test harnesses that bypass ink and write
+ *  frames directly may call it manually to keep consumers in step. */
+export function noteTerminalFlush(): void {
+  flushTick++
+}
+
+/** Current flush tick. Consumers capture it when they widen state and only
+ *  tighten again once the tick has advanced (a frame flushed since). */
+export function getTerminalFlushTick(): number {
+  return flushTick
+}

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -23,6 +23,7 @@ import { FocusManager } from './focus.js';
 import { emptyFrame, type Frame, type FrameEvent } from './frame.js';
 import { dispatchClick, dispatchContextMenu, dispatchDragEvent as bubbleDragEvent, dispatchHover, dispatchWheel, findDragTarget, clearHovered, invalidateNoInterestRect } from './hit-test.js';
 import { logMouseDebug } from '../utils/debug.js';
+import { noteTerminalFlush } from './flush-tick.js';
 import instances from './instances.js';
 import { suppressInputFor } from './input-suppression.js';
 import { LogUpdate } from './log-update.js';
@@ -1037,6 +1038,11 @@ export default class Ink {
     const tWrite = performance.now();
     writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
     const writeMs = performance.now() - tWrite;
+    // One frame reached the terminal. Components holding a widened mount
+    // window until its content is actually flushed (MessageList's paint
+    // expansion hold) key off this tick — a commit can be superseded before
+    // its frame flushes, so "mounted" alone must never unlock tightening.
+    noteTerminalFlush();
 
     // Update blit safety for the NEXT frame. The frame just rendered
     // becomes frontFrame (= next frame's prevScreen). If we applied the


### PR DESCRIPTION
Closes #574

## 症状

`repro-inline-scrollback` 在快机上 3 项断言确定性失败（本机 3/3）：冷启动预置历史的 user 行（`历史问题 0/1`）0 次渲染、现场思考标题行 `思考 ·` 缺失（`rows=-1`）。

## 根因（systematic-debugging 全程取证）

### 缺陷 A：挂载与刷帧脱钩 + 「挂载即已画」记账失真

- ink 的 `scheduleRender` 以 16ms 节流、leading edge 走微任务延迟刷帧——同任务内更晚的 commit 可在首帧落地前**取代**它（`deferredRender` 的 generation guard 注释自认）。
- 冷启动：commit#1 全量挂载（高度未知 → `DEFAULT_ROW_HEIGHT` 偏小 → sticky floor-walk 盖全表）；首轮 ~190ms 冷缓存 yoga 期间，measure-tick 的 `setMeasureTick` 让 commit#2（真实高度 → 窗口收紧到尾部）抢先——**首帧写出的已是窗口化布局，历史头部一个字节都没到终端**（取证：交错日志 `start0=0 → start0=12 → [flush] nextH=89`，全量布局的 ~150 行从未出现）。
- `paintedOnce` 在 commit 时点按 localRefs 记账，被取代的挂载也计入「已画」；原 120ms 墙钟扩张保持本想兜这个缝，但 holdUntil=2018ms、收紧 2086ms 到来前已过期。paint-at-least-once 从此认定一切已画、永不重挂。
- 「快机上」的时序本质：慢机上首帧刷出与 measure 重渲染的调度交错不同，偶尔让全量帧先落地。

### 缺陷 B（取证侧）：xterm-headless 默认 Unicode provider 量宽旧表

`⚓`（U+2693，Emoji_Presentation）真实终端画 2 格、`src/ink/stringWidth.ts` 量 2（#101 Doctrine），但 xterm-headless 默认 provider 量 1。宽度不一致使含 `⚓` 行的就地重绘错位：app 当宽字符第二格不重写的格子滞留旧 spinner 帧、后续宽字被半覆盖丢弃（现场思考行 `⚓⠧ 思  ·` 残状）。这是 harness 保真度缺口，不是产品 bug。

## 修复

| 改动 | 内容 |
|---|---|
| `src/ink/flush-tick.ts`（新） | 单调刷帧计数：`noteTerminalFlush()` 在 `writeDiffToTerminal` 后递增 |
| `src/ink/ink.tsx` | 帧写出后计一笔 |
| `src/components/MessageList.tsx` | 扩张保持从「120ms 墙钟」改为「flush tick 前进才放行」——被取代的挂载必须存活到真实刷帧，`paintedOnce` 记账成真；时间保持删除（刷帧对齐严格强于它） |
| `scripts/lib/modern-widths.mjs`（新） | 取证终端注册与 stringWidth 同源的现代宽度 provider（`charProperties` 位布局照抄 @xterm/headless 6.0.0 内建实现）；仅 tsx 脚本可引入 |
| `scripts/repro-inline-scrollback.tsx` | 启用上述 provider |

## 验证

- `repro-inline-scrollback`：修前 3 项确定性红（3/3 复现）→ 修后 **14/14 绿**，连跑 3 次稳定；三处思考行（历史 ×2 + 现场）全部干净渲染 `⚓ 思考 · 1s`
- `pnpm compile` + `pnpm verify:build` 全过
- 回归组：input-terminal / channel-ui / flaky-observation 全绿；render-scroll 与 session-workspace 的失败项（repro-idle-oscillation、verify-subagent-settle、verify-unseen-report-once、verify-session-cwd、repro-pill）经**干净 main 基线逐一对照**均为 main 预存失败或偶发，与本次改动无关——其中 4 个预存红值得另立跟踪

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji and combining-character width handling for more accurate terminal display.
  * Improved scrollback behavior when rendering modern emoji.
  * Improved drag scrolling and selection stability during viewport changes.
  * Updated message-list virtualization to wait for terminal output before tightening its layout window, reducing rendering inconsistencies.

* **New Features**
  * Added smoother streaming reveals for messages and reasoning.
  * Added support for displaying job rows and opening the jobs view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->