### PR TITLE
ci(alpha-compat): lane 补全 dsh-auth 48 项回归 [stacked on #622]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,13 @@ jobs:
 
       - run: pnpm verify:alpha-source
 
+      # alpha 线完整验证补全：这两条此前无任何 lane 执行。dsh-auth 的
+      # provider 回归（pnpm build 链内的 build:dsh-auth 已装好其依赖与
+      # 产物）；minimal-preset-tools 断言 code↔ptc 桥接，import lib/
+      # 产物——上面的 pnpm build 已完成编译。
+      - run: pnpm --dir dsh-auth verify
+      - run: pnpm verify:minimal-preset-tools
+
   # 渲染 · 滚动 · resize · 子代理 · picker——与其余组并行；失败互不遮蔽。
   # needs: build：编译只在 build job 发生一次，本组经 artifact 复用产物。
   render-scroll:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,12 +171,11 @@ jobs:
 
       - run: pnpm verify:alpha-source
 
-      # alpha 线完整验证补全：这两条此前无任何 lane 执行。dsh-auth 的
-      # provider 回归（pnpm build 链内的 build:dsh-auth 已装好其依赖与
-      # 产物）；minimal-preset-tools 断言 code↔ptc 桥接，import lib/
-      # 产物——上面的 pnpm build 已完成编译。
+      # dsh-auth 的 48 项 provider 回归此前无任何 lane 执行（build 链只
+      # 构建 dsh-auth 不跑其测试）。build:dsh-auth 已装好依赖与产物，
+      # verify 零额外装配。（勘误：minimal-preset-tools 本就在
+      # verify:build 聚合链里，原 PR 草稿里加的那步是重复执行，已移除。）
       - run: pnpm --dir dsh-auth verify
-      - run: pnpm verify:minimal-preset-tools
 
   # 渲染 · 滚动 · resize · 子代理 · picker——与其余组并行；失败互不遮蔽。
   # needs: build：编译只在 build job 发生一次，本组经 artifact 复用产物。


### PR DESCRIPTION
## 定位：#622 的辅助 PR（stacked）

**合并契约：先合 #622**，之后本 PR diff 自动收敛为纯 CI 增量。

## 真缺口（经 CI 日志实测勘误后收窄为一条）

**`pnpm --dir dsh-auth verify`（48 项 provider 回归）无任何 lane 执行**——build 链只构建 dsh-auth（build:dsh-auth）不跑其测试。本 PR 在 alpha-compat 的 verify:alpha-source 后挂上，build 已备好依赖与产物，零额外装配。

~~minimal-preset-tools 无 lane~~——**勘误**：初版判断有误，实测 CI 日志发现它本就在 `verify:build` 聚合链内执行；初版草稿因此多挂的一步已移除（见 commit 勘误注）。

## 独立验证

- dsh-auth：本地 install+build 后 verify **48 passed, 0 failed**
- 初版（含冗余步）CI 全绿实证过 alpha lane 可跑新步骤；本版仅删冗余步，CI 复跑中

cc @Nagi-ovo——若你倾向直接在 #622 里加，本 PR 即刻关闭，零损失。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with the `0.1.2-alpha.1` release line and broader prerelease channels.
  * Added code-runtime and subagent model-selection settings.
  * Improved user-question routing across supported release versions.
* **Bug Fixes**
  * Legacy `code` preset preferences now migrate to `ptc` when appropriate.
  * Improved preset resolution, switching, persistence, and fallback behavior.
  * Strengthened todo-update, mixed-version, and patch compatibility validation.
* **Documentation**
  * Updated compatibility, configuration, setup, and preset guidance for new release channels and naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->