### PR TITLE
fix(channel): 会话切换/清屏卫生——子代理投影重置、staged 图片作用域、resume 竞争守卫 + 按键/recap/stderr 修复

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -335,6 +335,10 @@ const GROUPS = {
     ["verify-compact", ['node', '--import', 'tsx/esm', 'scripts/verify-compact.mjs']],
     ["verify-channel-goal-todo", ['node', '--import', 'tsx/esm', 'scripts/verify-channel-goal-todo.mjs']],
     ["verify-whale-toggle", ['node', '--import', 'tsx/esm', 'scripts/verify-whale-toggle.mjs']],
+// 会话切换/清屏卫生：子代理投影（行 map/任务描述队列/仪表盘快照）随
+// 切换重置、/clear 后在途子代理卡可回现、staged image token 会话作用域
+// （switchModel 不泄漏）、resumeTo 竞争切换守卫、recap 预算从新到旧收容。
+    ["verify-session-reset-hygiene", ['node', '--import', 'tsx/esm', 'scripts/verify-session-reset-hygiene.tsx']],
 // /tree 与 /fork 回归：sessionTree 纯模型（条目提取、回退/分叉边界、
 // 家族拼接、扁平化/过滤、整轮丢弃预警）、compat 预算读取器
 // （全量/截断/继承前缀跳过）、SessionTree 屏幕无头组装

--- a/scripts/verify-keymap.mjs
+++ b/scripts/verify-keymap.mjs
@@ -108,6 +108,14 @@ check('conflict: history → ctrl+v refused (owned by paste)', draftComboConflic
 check('conflict: paste → ctrl+u refused (fixed kill-line)', draftComboConflicts('paste', ['ctrl+u']))
 check('no conflict: history restating ctrl+r', !draftComboConflicts('history', ['ctrl+r']))
 check('no conflict: fresh combo ctrl+n', !draftComboConflicts('history', ['ctrl+n']))
+// Restating an action's OWN default (even one that is also fixed-reserved
+// for the editor, like dashboard's ctrl+a / showAll's ctrl+e) changes
+// nothing about what shadows what — it must not read as a conflict.
+check('no conflict: dashboard restating its fixed-reserved default ctrl+a', !draftComboConflicts('dashboard', ['ctrl+a']))
+check('no conflict: showAll restating its fixed-reserved default ctrl+e', !draftComboConflicts('showAll', ['ctrl+e']))
+check('conflict: showAll claiming ctrl+a (dashboard owns it)', draftComboConflicts('showAll', ['ctrl+a']))
+check('conflict: dashboard claiming ctrl+e (showAll owns it)', draftComboConflicts('dashboard', ['ctrl+e']))
+check('conflict: another action cannot borrow the fixed ctrl+u', draftComboConflicts('dashboard', ['ctrl+u']))
 resetKeymapOverrides()
 
 // ---- live Chat: Alt+V triggers the paste branch ---------------------------

--- a/scripts/verify-session-reset-hygiene.tsx
+++ b/scripts/verify-session-reset-hygiene.tsx
@@ -1,0 +1,230 @@
+/**
+ * 会话切换/清屏卫生回归（审计 M4/M5/M6/L1/N1 修复）。
+ *
+ * 真实 cordis Context + 真实 createChannel + 假 agents/sessions/attachments 服务：
+ *   1. 会话切换（/new）重置子代理投影——快照清空、行 map 清空，重复 agentId 重建卡片而非孤儿更新；
+ *   2. 排队的任务描述不跨会话泄漏到新会话第一张卡；
+ *   3. /clear 只清行 map——同会话在途子代理的下一个事件重建卡片，仪表盘继续跟踪；
+ *   4. staged image token 是会话作用域——switchModel 后不随旧 token 附图发送；
+ *   5. resumeTo 的竞争切换守卫——await 期间被 /new 抢先提交时，恢复放弃且不动新会话；
+ *   6. recap 预算从新到旧收容——超长旧消息不再饿死最新交互（collectRecentActivity 单元断言）。
+ *
+ * 运行：node --import tsx/esm scripts/verify-session-reset-hygiene.tsx
+ */
+process.env.FORCE_COLOR = '3'
+
+// 家目录隔离：channel 构造路径会 touch 用户目录，先切临时目录再 import。
+const { mkdtempSync, mkdirSync } = await import('node:fs')
+const { tmpdir } = await import('node:os')
+const { join: joinPath } = await import('node:path')
+const isolatedHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-reset-hygiene-'))
+process.env.HOME = isolatedHome
+process.env.USERPROFILE = isolatedHome
+mkdirSync(joinPath(isolatedHome, '.dsh-tui'), { recursive: true })
+
+const [{ Context }, { createChannel }, { collectRecentActivity }, { settled, sleep }] = await Promise.all([
+  import('@deepseek-ai/cordis'),
+  import('../src/dsh-adapter/channel.js'),
+  import('../src/dsh-adapter/recap.js'),
+  import('./lib/term-test.mjs'),
+])
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+interface FakeAgent {
+  id: string
+  status: string
+  options: Record<string, unknown>
+  ctx: unknown
+  session: { id: string; seq: number; events: unknown[]; header: Record<string, unknown> }
+  followup(message: unknown): void
+  steer(message: unknown): void
+  inbox: { remove(): boolean }
+  cancel(): void
+  whenIdle(): Promise<void>
+}
+
+function makeAgent(id: string, sessionId: string): FakeAgent {
+  const session = { id: sessionId, seq: 0, events: [], header: {} }
+  return {
+    id,
+    status: 'idle',
+    options: {},
+    ctx: { on: () => () => {} },
+    session,
+    followup() {},
+    steer() {},
+    inbox: { remove: () => true },
+    cancel() {},
+    whenIdle: () => Promise.resolve(),
+  } as FakeAgent
+}
+const makeHandle = (agent: FakeAgent) => ({ agent, dispose: () => Promise.resolve() })
+
+const subagentRows = (channel: { rows: Array<{ kind: string }> }) => channel.rows.filter(row => row.kind === 'subagent')
+
+// ── 场景 1+2：/new 重置子代理投影、任务描述队列 ──────────────────────────
+{
+  const ctx = new Context()
+  const provide = (ctx as unknown as { provide(name: string, value: unknown): void }).provide.bind(ctx)
+  const emit = (event: string, ...args: unknown[]) =>
+    (ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit(event, ...args)
+  const initial = makeAgent('agent-a', 'sess-a')
+  provide('agents', {
+    get: (id: string) => (id === 'sub-1' ? { session: { id: 'child-sess' }, options: {} } : undefined),
+    create: () => Promise.resolve(makeHandle(makeAgent('agent-b', 'sess-b'))),
+  })
+  const channel = createChannel(ctx as never, initial as never, {
+    model: 'm0', cwd: '/tmp/demo', provider: 'p0', activity: false,
+  })
+
+  // 排队一条任务描述（旧会话的 Task 工具调用，尚未被 subagent/start 消费）。
+  emit('session/event', initial.session, {
+    type: 'tool/call',
+    data: { callId: 'c0', name: 'task', arguments: JSON.stringify({ description: 'stale task' }) },
+  })
+  emit('subagent/start', { id: 'sub-1', runId: 'r1', provider: 'p0' })
+  check('1a. subagent/start 建卡 + 快照跟踪', await settled(() => channel.subagents.length === 1 && subagentRows(channel).length === 1))
+  check('1b. 排队描述被本会话消费（卡片显示 stale task）', subagentRows(channel)[0]?.subagent?.description === 'stale task', String(subagentRows(channel)[0]?.subagent?.description))
+
+  check('1c. /new 成功', (await channel.newSession()) === true)
+  check('1d. 仪表盘快照随切换清空', channel.subagents.length === 0, JSON.stringify(channel.subagents.map(s => s.agentId)))
+  check('1e. 行 map 清空（无孤儿可更新）', subagentRows(channel).length === 0)
+
+  // 旧会话的 child 事件不得再被路由（session 链接已断）。
+  emit('session/event', { id: 'child-sess' }, { type: 'tool/call', data: { callId: 'cx', name: 'Grep', arguments: '{}' } })
+  check('1f. 旧 child 会话事件不再入投影', subagentRows(channel).length === 0)
+
+  // 场景 2：切换后再排一条描述，不得泄漏到新会话的第一张卡。
+  emit('session/event', (channel as unknown as { agentId: string }).agentId === 'agent-b' ? initial.session : initial.session, {
+    type: 'tool/call',
+    data: { callId: 'c1', name: 'task', arguments: JSON.stringify({ description: 'pre-switch task' }) },
+  })
+  await channel.newSession()
+  emit('subagent/start', { id: 'sub-2', runId: 'r2', provider: 'p0' })
+  check('2. 新会话首卡不吃旧队列描述（默认标签）', await settled(() => {
+    const row = subagentRows(channel)[0]
+    return row !== undefined && row.subagent?.description === 'p0 task'
+  }), String(subagentRows(channel)[0]?.subagent?.description))
+
+  // 重复 agentId：map 已清 → 必须重建为新行（修复前是孤儿更新，卡片永不回屏）。
+  emit('subagent/start', { id: 'sub-2', runId: 'r2b', provider: 'p0' })
+  check('1g. 重复 agentId 重建卡片（非孤儿更新）', subagentRows(channel).length === 1)
+}
+
+// ── 场景 3：/clear 后在途子代理卡片可回现 ───────────────────────────────
+{
+  const ctx = new Context()
+  const provide = (ctx as unknown as { provide(name: string, value: unknown): void }).provide.bind(ctx)
+  const emit = (event: string, ...args: unknown[]) =>
+    (ctx as unknown as { emit(event: string, ...args: unknown[]): void }).emit(event, ...args)
+  const initial = makeAgent('agent-c', 'sess-c')
+  const childSession = { id: 'child-c' }
+  provide('agents', {
+    get: (id: string) => (id === 'sub-c' ? { session: childSession, options: {} } : undefined),
+  })
+  const channel = createChannel(ctx as never, initial as never, {
+    model: 'm0', cwd: '/tmp/demo', provider: 'p0', activity: false,
+  })
+
+  emit('subagent/start', { id: 'sub-c', runId: 'r3', provider: 'p0' })
+  check('3a. 子代理卡建立', await settled(() => subagentRows(channel).length === 1))
+
+  channel.clear()
+  check('3b. /clear 清走卡片', subagentRows(channel).length === 0)
+  check('3c. 仪表盘继续跟踪（同会话在途）', channel.subagents.length === 1)
+
+  emit('session/event', childSession, { type: 'tool/call', data: { callId: 'cc', name: 'Grep', arguments: '{}' } })
+  check('3d. 在途子代理下一个事件重建卡片', subagentRows(channel).length === 1)
+}
+
+// ── 场景 4：staged image 不跨 switchModel 泄漏 ──────────────────────────
+{
+  const ctx = new Context()
+  const provide = (ctx as unknown as { provide(name: string, value: unknown): void }).provide.bind(ctx)
+  const initial = makeAgent('agent-d', 'sess-d')
+  const switched = makeAgent('agent-d2', 'sess-d2')
+  const sent: unknown[][] = []
+  initial.followup = message => sent.push((message as { content: unknown[] }).content)
+  switched.followup = message => sent.push((message as { content: unknown[] }).content)
+  provide('agents', { create: () => Promise.resolve(makeHandle(switched)) })
+  provide('sessions', { fork: () => ({ events: [] }) })
+  provide('attachments', {
+    imageLimits: {
+      maxImageBytes: 1_000_000,
+      maxImagesPerMessage: 4,
+      maxMessageImageBytes: 4_000_000,
+      mediaTypes: ['image/png'],
+    },
+    saveImage: () => Promise.resolve({ ref: 'img-1', mediaType: 'image/png', bytes: 8 }),
+  })
+  const channel = createChannel(ctx as never, initial as never, {
+    model: 'm0', cwd: '/tmp/demo', provider: 'p0', activity: false,
+  })
+
+  const token = await channel.stageImage({ data: new Uint8Array([1]), mediaType: 'image/png' })
+  check('4a. stageImage 签发 token', token === '[Image #1]', token)
+  channel.submit(`see ${token}`)
+  check('4b. 切换前发送附带图片块', await settled(() => sent.length === 1
+    && (sent[0] as Array<{ type: string }>).filter(block => block.type === 'image').length === 1))
+  check('4c. switchModel 成功', (await channel.switchModel('p0', 'm1')) === true)
+  channel.submit(`see ${token}`)
+  check('4d. 切换后同 token 不再附图（会话作用域）', await settled(() => sent.length === 2
+    && (sent[1] as Array<{ type: string }>).filter(block => block.type === 'image').length === 0))
+}
+
+// ── 场景 5：resumeTo 竞争切换守卫 ────────────────────────────────────────
+{
+  const ctx = new Context()
+  const provide = (ctx as unknown as { provide(name: string, value: unknown): void }).provide.bind(ctx)
+  const initial = makeAgent('agent-e', 'sess-e')
+  const resumed = makeAgent('agent-e2', 'sess-target')
+  let resolveResume!: (handle: unknown) => void
+  provide('agents', {
+    create: () => Promise.resolve(makeHandle(makeAgent('agent-e3', 'sess-e3'))),
+    resume: () => new Promise(resolve => { resolveResume = resolve }),
+  })
+  const channel = createChannel(ctx as never, initial as never, {
+    model: 'm0', cwd: '/tmp/demo', provider: 'p0', activity: false,
+  })
+
+  const pending = channel.resumeTo('sess-target')
+  await sleep(30) // resume 体停在 agents.resume
+  check('5a. /new 在 resume 的 await 窗口内抢先提交', (await channel.newSession()) === true)
+  check('5b. 此刻活跃会话是 /new 的', (channel as unknown as { agentId: string }).agentId === 'agent-e3')
+  resolveResume(makeHandle(resumed))
+  const result = await pending
+  check('5c. 竞争后 resume 放弃（ok=false）', result.ok === false, JSON.stringify(result))
+  check('5d. 新会话未被踩踏（agentId 不变）', (channel as unknown as { agentId: string }).agentId === 'agent-e3')
+}
+
+// ── 场景 6：recap 预算从新到旧收容（N1 单元断言） ────────────────────────
+{
+  const message = (role: 'user' | 'assistant', text: string) => ({
+    type: role === 'user' ? 'user/message' : 'assistant/message',
+    seq: 0,
+    time: 0,
+    data: role === 'user'
+      ? { content: [{ type: 'text', text }] }
+      : { message: { content: [{ type: 'text', text }] } },
+  })
+  const events = [1, 2, 3, 4, 5, 6].map(n => message(n % 2 === 0 ? 'assistant' : 'user', `msg${n}-`.repeat(1500)))
+  const payload = collectRecentActivity(events as never, 6000)
+  check('6a. 最新交互进入 payload', payload.includes('msg6-'), `len=${payload.length}`)
+  check('6b. 吞预算的旧消息不再独占 payload', !payload.includes('msg1-'), payload.slice(0, 40))
+  const mixed = [
+    message('user', 'old-short'),
+    message('assistant', 'x'.repeat(5800)),
+    message('user', 'newest-question'),
+  ]
+  const mixedPayload = collectRecentActivity(mixed as never, 6000)
+  check('6c. 混合预算下最新短消息完整保留', mixedPayload.includes('newest-question'))
+  check('6d. 输出保持时间顺序（旧→新）', mixedPayload.indexOf('x'.repeat(20)) < mixedPayload.indexOf('newest-question'))
+}
+
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -1936,6 +1936,25 @@ export function createChannel(
     state.subagents = subagentStore.snapshot()
     syncSubagentRows(state.subagents)
   }
+  /** Drop the subagent row map (transcript wipe): the next event for a still
+   *  live subagent re-creates its card as a fresh row instead of feeding a
+   *  row object no transcript holds (update-only orphan). */
+  const dropSubagentRows = (): void => {
+    subagentStreamDirty = false
+    subagentRowsByAgentId.clear()
+  }
+  /** Full subagent reset for a session swap: the row map, the queued task
+   *  descriptions and the store itself are all scoped to the OLD agent's
+   *  session. Leaked into the adopted one, they would keep dead subagents in
+   *  the dashboard snapshot until new events overwrite it, grow the row map
+   *  without bound across swaps, and hand a stale queued description to the
+   *  new session's first card. */
+  const resetSubagentProjection = (): void => {
+    dropSubagentRows()
+    pendingTaskDescriptions.length = 0
+    subagentStore.reset()
+    state.subagents = []
+  }
   // foldRows incremental cursor (see foldRows): rows only append past the
   // fold line, so each pass touches only newly-eligible rows.
   const foldCursor: { rows: unknown; index: number } = { rows: null, index: 0 }
@@ -2196,6 +2215,7 @@ export function createChannel(
     toolCards.clear()
     nextRowId = 0
     state.rows.length = 0
+    resetSubagentProjection()
     // Goal/todo/title are session-scoped; the replay re-derives them for
     // the session being entered (or leaves them empty).
     state.todos = []
@@ -2248,6 +2268,11 @@ export function createChannel(
     touchSession(childId)
     state.emit()
     void oldHandle?.dispose().catch(() => {})
+    // The staged-image map is session-scoped (the same contract the
+    // resumeTo/newSession tails enforce): tokens typed against the rewound
+    // conversation must not ride into the fork's next send, and the epoch
+    // bump fences saves still in flight for the old session.
+    clearStagedImages()
     return sourceSessionId
   }
   /** Monotonic token: only the latest `interruptAndDeliver` re-queues, so a
@@ -4062,6 +4087,11 @@ export function createChannel(
       // (and commit its checkpoint) once we leave it for the target — cancel
       // and await it before any target read.
       await settleManualCompaction()
+      // Identity pin for the rival-swap guard below: everything between here
+      // and the adoption can await (veto, preset, route, agents.resume), and
+      // an interrupt-queued /new or a second /resume may commit a different
+      // swap in that window.
+      const entrySession = agent.session
       let handle: AgentHandle
       // Compat boundary: register vouched-for legacy event types (e.g.
       // activity/status from pre-#143 logs) in every reachable dsh-session
@@ -4117,6 +4147,17 @@ export function createChannel(
           { color: 'warning', timeoutMs: 8000 },
         )
       }
+      // Rival-swap guard (rewindToNode's entrySession check, applied to the
+      // resume path): the awaits above can straddle another session swap
+      // committing first, and adopting now would stomp the newer session's
+      // live transcript with this target's replay. Free the just-created
+      // handle and bail — the live session stays exactly as the rival left
+      // it, and the persisted target simply stays in /resume.
+      if (agent.session !== entrySession) {
+        void handle.dispose().catch(() => {})
+        state.notify(t('resume-session-changed'), { color: 'error' })
+        return { ok: false, reason: 'failed', error: 'live session changed during resume' }
+      }
       // Replay the persisted history into a fresh transcript (same reset as
       // rewindTo, plus the context window which the replay re-derives).
       streaming = undefined
@@ -4128,6 +4169,7 @@ export function createChannel(
       toolCards.clear()
       nextRowId = 0
       state.rows.length = 0
+      resetSubagentProjection()
       // Goal/todo/title are session-scoped; the replay re-derives them for
       // the session being entered (or leaves them empty).
       state.todos = []
@@ -4319,6 +4361,7 @@ export function createChannel(
       lastTextDelta.clear()
       nextRowId = 0
       state.rows.length = 0
+      resetSubagentProjection()
       // Goal/todo/title are session-scoped; the replay re-derives them for
       // the session being entered (or leaves them empty).
       state.todos = []
@@ -4513,6 +4556,7 @@ export function createChannel(
       toolCards.clear()
       nextRowId = 0
       state.rows.length = 0
+      resetSubagentProjection()
       // Goal/todo/title are session-scoped; the replay re-derives them for
       // the session being entered (or leaves them empty).
       state.todos = []
@@ -4575,6 +4619,9 @@ export function createChannel(
       touchSession(childId)
       state.emit()
       void oldHandle?.dispose().catch(() => {})
+      // Staged image tokens were typed against the pre-switch conversation;
+      // resumeTo/newSession already drop theirs on the swap — same contract.
+      clearStagedImages()
       // Persist the choice so the next boot and `/new` start on it (same
       // contract as /preset and /effort; issues #14/#30). A failed
       // write keeps the live switch but warns it will not survive a restart.
@@ -4594,6 +4641,11 @@ export function createChannel(
       streaming = undefined
       reasoning = undefined
       toolCards.clear()
+      // In-flight subagents keep streaming after the wipe; clearing the row
+      // map lets their next event re-create the card as a fresh row instead
+      // of feeding a row object no transcript holds (the store keeps live
+      // tracking for the dashboard — same session, still running).
+      dropSubagentRows()
       state.activeToolCount = 0
       state.responseChars = 0
       state.rows.push({

--- a/src/dsh-adapter/childStderr.ts
+++ b/src/dsh-adapter/childStderr.ts
@@ -58,6 +58,12 @@ function redirectInheritedStderr(options: childProcess.SpawnOptions): childProce
   return undefined
 }
 
+/** Cap on the unterminated tail: a child that never emits a newline (progress
+ * bars, single-line JSON streams) must not grow the line buffer without bound
+ * — past the cap the partial line is flushed to the sink (which applies its
+ * own display-length truncation) and the buffer restarts empty. */
+const MAX_PENDING_CHARS = 64 * 1024
+
 /** Drain a piped stderr stream, forwarding complete lines (and the unterminated tail) to the sink. */
 function drainLines(stream: NodeJS.ReadableStream, sink: (line: string) => void): void {
   let pending = ''
@@ -68,6 +74,10 @@ function drainLines(stream: NodeJS.ReadableStream, sink: (line: string) => void)
       sink(pending.slice(0, newline))
       pending = pending.slice(newline + 1)
       newline = pending.indexOf('\n')
+    }
+    if (pending.length > MAX_PENDING_CHARS) {
+      sink(pending)
+      pending = ''
     }
   })
   stream.on('end', () => {

--- a/src/dsh-adapter/recap.ts
+++ b/src/dsh-adapter/recap.ts
@@ -60,14 +60,20 @@ export function collectRecentActivity(events: readonly SessionEvent[], limitChar
 
   const tail = entries.slice(-RECAP_RECENT_TURNS * 2)
   let budget = limitChars
-  const lines: string[] = []
-  for (const entry of tail) {
-    const text = entry.text.length > budget ? entry.text.slice(0, budget) : entry.text
-    lines.push(`${entry.role}: ${text}`)
-    budget -= text.length + entry.role.length + 2
+  // Admit NEWEST first: the recap exists to summarize where the session
+  // STANDS, so the most recent exchanges must survive a long entry eating
+  // the budget — oldest-first admission lets one oversized message starve
+  // every exchange after it (the very ones a recap is for).
+  const picked: Array<{ role: 'user' | 'assistant'; text: string }> = []
+  for (const entry of [...tail].reverse()) {
     if (budget <= 0) break
+    const text = entry.text.length > budget ? entry.text.slice(0, budget) : entry.text
+    picked.push({ role: entry.role, text })
+    budget -= text.length + entry.role.length + 2
   }
-  return lines.join('\n')
+  // Present in chronological order (oldest → newest) for readable quoting.
+  picked.reverse()
+  return picked.map(entry => `${entry.role}: ${entry.text}`).join('\n')
 }
 
 /**

--- a/src/dsh-adapter/subagents.ts
+++ b/src/dsh-adapter/subagents.ts
@@ -241,6 +241,15 @@ export class SubagentActivityStore {
     this.notify()
   }
 
+  /** Drop all tracked subagents and session links (session swap: the old
+   * session's children were disposed with their parent — nothing may keep
+   * routing events of a session the channel no longer projects). */
+  reset(): void {
+    this.states.clear()
+    this.sessionToAgent.clear()
+    this.notify()
+  }
+
   snapshot(): SubagentState[] { return Array.from(this.states.values()).map(state => ({ ...state, output: [...state.output], outputEvents: [...state.outputEvents], toolCalls: state.toolCalls.map(tool => ({ ...tool })), tokens: state.tokens ? { ...state.tokens } : undefined })) }
   get(agentId: string): SubagentState | undefined { return this.snapshot().find(state => state.agentId === agentId) }
   subscribe(listener: () => void): () => void { this.listeners.add(listener); return () => this.listeners.delete(listener) }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -186,6 +186,7 @@ const dict = {
   'resume-unavailable': { zh: '恢复不可用——agents 服务未加载', en: 'Resume unavailable — agents service not loaded' },
   'resume-failed': { zh: '恢复失败 · {{err}}', en: 'Resume failed · {{err}}' },
   'resume-attach-failed': { zh: '已恢复会话，但工作区挂载失败 · {{err}}', en: 'Session resumed, but workspace attachment failed · {{err}}' },
+  'resume-session-changed': { zh: '会话已切换，恢复已放弃', en: 'The session changed; the resume was dropped' },
   'new-session-while-working': { zh: '回合运行中，无法新建会话', en: 'Cannot start a new session while a turn is running' },
   'new-session-unavailable': { zh: '新建会话不可用——agents 服务未加载', en: 'New session unavailable — agents service not loaded' },
   'new-session-failed': { zh: '新建会话失败 · {{err}}', en: 'New session failed · {{err}}' },

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -1217,7 +1217,8 @@ export function Chat({
       case 'new': {
         // One-shot `/new` (issue #25): the old session stays persisted and
         // is recoverable via /resume, so discarding the live view is
-        // non-destructive — no CC-style "press /new again" confirmation.        setHelpOpen(false)
+        // non-destructive — no CC-style "press /new again" confirmation.
+        setHelpOpen(false)
         void channel.newSession().then((ok) => {
           if (!ok) return
           // A new session is a fresh terminal page, not merely an emptied
@@ -2776,7 +2777,11 @@ export function Chat({
     }
     if (actionMatches('dashboard', input, key)) {
       // The subagent dashboard key (default Ctrl+A) opens the dashboard.
+      // Consume the key: without the stop the prompt editor's readline
+      // binding ALSO fires (Ctrl+A moves the caret to line start), so one
+      // press both opens the overlay and jumps the cursor.
       setSubagentDashboardOpen(true)
+      event.stopImmediatePropagation()
       return
     }
     if (actionMatches('contextPanel', input, key) && loadedContextVisible) {
@@ -2892,13 +2897,20 @@ export function Chat({
       // CC's app:redraw (default Ctrl+L) — clear the physical terminal and
       // repaint.
       instances.get(process.stdout)?.forceRedraw()
+      // Consume: same readline-shadowing rule as dashboard/showAll below.
+      event.stopImmediatePropagation()
     } else if (actionMatches('showAll', input, key)) {
       setShowAllMessages(previous => !previous)
+      // Ctrl+E is also the editor's line-end binding — stop the press from
+      // additionally moving the caret (one press, one meaning).
+      event.stopImmediatePropagation()
     } else if (actionMatches('todoFold', input, key)) {
       // Fold/unfold the GoalTodoPanel todo section (default Ctrl+Q) — works
       // mid-turn too: the collapsed line keeps the done/total count and the
       // live task preview, so long todo lists stop crowding the prompt.
       setTodoCollapsed(previous => !previous)
+      // Consume: same readline-shadowing rule as dashboard/showAll above.
+      event.stopImmediatePropagation()
     } else if (plainReturn && !isSticky) {
       // Enter while scrolled up returns to the bottom (CC's pill: the
       // affordance now exists whenever the view is off the bottom, not

--- a/src/utils/keymap.ts
+++ b/src/utils/keymap.ts
@@ -333,11 +333,24 @@ export function isFixedReserved(raw: string): boolean {
  */
 export function draftComboConflicts(action: ShortcutActionId, combos: readonly string[]): boolean {
   const others = new Set<string>()
+  const own = new Set<string>()
   for (const spec of SHORTCUT_ACTIONS) {
-    if (spec.id === action) continue
+    if (spec.id === action) {
+      // Restating a combo this action already binds — a default or the
+      // current override — changes nothing about what shadows what; it must
+      // not read as a conflict. This is what lets dashboard re-save its own
+      // ctrl+a default even though that combo is also fixed-reserved for
+      // the editor line-start (the dual-use the defaults themselves encode).
+      for (const raw of spec.defaults) own.add(canonicalComboString(raw))
+      for (const combo of effectiveCombos(spec.id)) own.add(canonicalCombo(combo))
+      continue
+    }
     for (const combo of effectiveCombos(spec.id)) others.add(canonicalCombo(combo))
   }
-  return combos.some(combo => isFixedReserved(combo) || others.has(canonicalComboString(combo)))
+  return combos.some(combo => {
+    if (own.has(canonicalComboString(combo))) return false
+    return isFixedReserved(combo) || others.has(canonicalComboString(combo))
+  })
 }
 
 /**


### PR DESCRIPTION
## 背景

对 main 做了两轮只读审计（投影层 / 快捷键卫生 / 会话切换状态机 / 资源作用域），共 10 条发现；本 PR 落地其中 9 条可修项，1 条（grants 每次判定同步读盘）为有意的 live-revoke 设计，维持备注不改。

## 修复清单

### channel.ts（会话切换/清屏卫生）

- **子代理投影重置（审计 M4+L1）**：`subagentRowsByAgentId`、`pendingTaskDescriptions`、`SubagentActivityStore`、`state.subagents` 原先在全部 6 个会话切换路径与 `/clear` 上都不重置——切会话后 Ctrl+A 仪表盘残留旧会话子代理（直到新事件覆盖）、行 map 跨会话无界增长、`/clear` 后仍在跑的子代理卡片变孤儿行（更新永不回显）、旧会话排队的任务描述会串到新会话第一张卡。现在：
  - 四条切换路径（`newSession` / `resumeTo` / `switchModel` / `adoptForkedAgent`，rewind/tree/fork 共用后者）统一调用新增的 `resetSubagentProjection()` 全量重置；
  - `/clear` 调用新增的 `dropSubagentRows()` 只清行 map——同会话在途子代理的下一个事件会重建卡片，仪表盘继续实时跟踪。
- **staged 图片作用域（M5）**：`switchModel` 与 `adoptForkedAgent` 尾部补 `clearStagedImages()`（此前仅 resumeTo/newSession 有）——粘贴的 `[Image #N]` token 不再跨换模型/回退泄漏进新会话的下一次发送，epoch bump 同时把在途的图片保存在旧会话侧拦掉（fail closed）。
- **resumeTo 竞争切换守卫（M6）**：入口捕获 `entrySession`，`agents.resume` 等 await 之后、采纳之前复查——窗口内被 `/new` 等抢先提交时，dispose 刚创建的 handle 并放弃（`rewindToNode` 的 entrySession 守卫同款语义），不再用旧目标的 replay 踩踏新会话的 transcript。新增 i18n 键 `resume-session-changed`。

### Chat.tsx（按键卫生）

- **M1**：dashboard / redraw / showAll / todoFold 四个全局快捷键分支补 `event.stopImmediatePropagation()`——Ctrl+A/Ctrl+E 不再同时触发面板与输入框的行首/行尾跳转（一次按键一个行为）。
- **M3**：`/new` 分支的 `setHelpOpen(false)` 从注释行里拆回独立语句——新建会话时 help 浮层正确关闭。

### keymap.ts

- **M2**：`draftComboConflicts` 允许重申动作自身的默认/当前绑定（含 ctrl+a / ctrl+e 这类同时固定保留给编辑器的双重身份键）——与函数文档声明一致，`/settings` 里重存 dashboard=ctrl+a 不再被误报冲突拒绝。

### recap.ts

- **N1**：`collectRecentActivity` 收容方向改为**从新到旧**（输出仍按时间序呈现）——此前最旧的一条超长消息（>6KB 的日志粘贴等）会吃光预算，最新的交互被静默丢弃，而那正是 recap 存在的意义所在。

### childStderr.ts

- **N2**：`drainLines` 对无换行长流（进度条 / 单行 JSON）加 64KB 未终止尾行上限，超限冲给 sink（下游本有 200 字符截断 + 去重冷却），缓冲清空重启。

## 回归与验证

- 新增 `scripts/verify-session-reset-hygiene.tsx`（24 断言，登记 channel-ui 组）：真实 cordis Context + createChannel，覆盖上述 1/2/3/4/5/6 场景；**stash 撤掉修复后 7 项红、恢复后全绿**（双向验证）。
- `verify-keymap` 追加 5 条 draft 冲突断言（自默认重申放行 / 他人占用仍拒 / 固定保留仍拒）。
- 本地：`pnpm build` 全绿（含 i18n 新键双语门禁）、`tsc --noEmit` 干净、四 required 组中 channel-ui 与 input-terminal 全绿；render-scroll / session-workspace 的个别失败（osc8-sanitize POSIX 断言、update-extract 需 python3、update-checksum 真网络、standalone-cache-guard POSIX 权限）均为 stash 实证的预存环境问题，与本批零文件交集。
- 基于 origin/main@f79f615 rebase，无冲突。

## 审计报告中未修的项

- N3（grants `allows()` 每次 readFileSync+parse）：保留 live-revoke 语义，如后续要优化建议按 mtime 短路，单独走 PR。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic permission presets and plugin-provided themes.
  - Added clearer guidance for unavailable permissions and theme customization.
  - Improved recap selection to prioritize the newest activity.

- **Bug Fixes**
  - Improved session switching, clearing, and resuming to prevent stale activity, queued tasks, and staged images from carrying over.
  - Prevented unbounded memory growth when processing long child-process output.
  - Prevented shortcut keys from triggering unintended prompt-editor actions.
  - Improved keymap validation for valid default and override combinations.
  - Added messaging when session restoration is abandoned after a session change.

- **Tests**
  - Added regression coverage for session reset, keymap conflicts, themes, permissions, and workspace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->