### PR TITLE
fix(host): skip TUI silently on non-interactive non-launcher hosts (Web/Tauri)

### DIFF
--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -236,6 +236,13 @@ the same profile installation path as an end-user install.
 stdout is not a TTY. Start the process directly in a terminal rather than
 redirecting its main output to another command or file.
 
+When dsh-tui is only installed in a profile and the DSH composition is started
+by a non-terminal host (Web / Tauri / GUI, stdout piped or null), dsh-tui
+detects that stdout is not a TTY and that the process was not started by the
+`dsh-tui` launcher, and silently skips the TUI frontend (no error, the host
+keeps booting). The error above only appears when `dsh-tui` (or the standalone
+portable build) was explicitly launched without a TTY.
+
 ### `dsh` or `pnpm` cannot be found
 
 Make sure the global npm bin directory is on `PATH`, then open a new terminal.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,6 +249,11 @@ dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui
 
 stdout 不是 TTY。请直接在终端中启动，不要把主进程输出管道到文件或其他命令。
 
+如果 dsh-tui 只是装在某个 profile 里、而实际由 Web / Tauri / GUI 等非终端宿主
+启动 DSH，dsh-tui 会检测到 stdout 不是 TTY 且并非由 `dsh-tui` launcher 启动，
+自动跳过 TUI 前端（不报错、不影响宿主启动）；只有显式执行 `dsh-tui`（含
+standalone 便携版）却没有 TTY 时才会报上面的错误。
+
 ### 找不到 `dsh` 或 `pnpm`
 
 确认全局 npm bin 目录在 `PATH` 中，并重新打开终端。`install.sh` 会在安装前检查

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -201,6 +201,10 @@ const GROUPS = {
 //    与粘性报错、真 Chat 驱动的对话框/状态行/快捷键端到端。
     ["verify-extension-events", ['node', '--import', 'tsx/esm', 'scripts/verify-extension-events.tsx']],
     ["verify-extension-ui", ['node', '--import', 'tsx/esm', 'scripts/verify-extension-ui.tsx']],
+// 非 TTY 宿主门禁回归（Web/Tauri 共存）：profile 装有 dsh-tui 的非终端
+// 宿主（stdout 为 pipe/null）必须静默跳过插件、不 throw、不影响宿主启动；
+// 显式 dsh-tui launcher/standalone 启动无 TTY 仍保留原报错。
+    ["verify-tui-host-mode", ['node', '--import', 'tsx/esm', 'scripts/verify-tui-host-mode.ts']],
 // 会话标题回归：选择器标题宽容读取（带未标记第三方事件的日志
 // 不能让标题退化成目录名），/rename 的最后一条 session/title 优先。
     ["verify-session-titles", ['node', 'scripts/verify-session-titles.mjs']],

--- a/scripts/verify-tui-host-mode.ts
+++ b/scripts/verify-tui-host-mode.ts
@@ -1,0 +1,139 @@
+/**
+ * Non-TTY host gating regression (Web / Tauri coexistence).
+ *
+ * dsh-tui installed in a profile must not fail the whole DSH composition when
+ * the host is not a terminal (stdout piped or null): the plugin skips itself
+ * unless the process was explicitly launched through the dsh-tui launcher
+ * (DSH_TUI_LAUNCHER_VERSION / standalone runtime), which keeps failing loudly.
+ *
+ * Run: node --import tsx/esm scripts/verify-tui-host-mode.ts
+ */
+
+import { Context } from '@deepseek-ai/cordis'
+import { apply, resolveTuiHostMode } from '../src/dsh-adapter/plugin.js'
+import type { Config } from '../src/dsh-adapter/index.js'
+
+let failures = 0
+let checks = 0
+const check = (name: string, ok: boolean, detail = ''): void => {
+  checks += 1
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'} ${name}${ok || detail === '' ? '' : `: ${detail}`}`)
+}
+
+// ── unit: resolveTuiHostMode over the explicit-launch matrix ──────────────
+
+const cases: {
+  name: string
+  stdoutTty: boolean
+  env: Record<string, string>
+  expected: ReturnType<typeof resolveTuiHostMode>
+}[] = [
+  {
+    name: 'tty + no launcher marker → interactive',
+    stdoutTty: true,
+    env: {},
+    expected: 'interactive',
+  },
+  {
+    name: 'tty + launcher marker → interactive',
+    stdoutTty: true,
+    env: { DSH_TUI_LAUNCHER_VERSION: '9.9.9' },
+    expected: 'interactive',
+  },
+  {
+    name: 'no tty + launcher marker → invalid-explicit-launch',
+    stdoutTty: false,
+    env: { DSH_TUI_LAUNCHER_VERSION: '9.9.9' },
+    expected: 'invalid-explicit-launch',
+  },
+  {
+    name: 'no tty + no marker → headless-host',
+    stdoutTty: false,
+    env: {},
+    expected: 'headless-host',
+  },
+]
+
+for (const c of cases) {
+  const actual = resolveTuiHostMode(c.stdoutTty, c.env)
+  check(`${c.name} (got ${actual})`, actual === c.expected)
+}
+
+// Standalone runtime counts as an explicit launch (isStandaloneRuntime reads
+// the real process env, so drive it through the environment).
+const prevStandalone = process.env.DSH_TUI_STANDALONE
+process.env.DSH_TUI_STANDALONE = '1'
+check(
+  'no tty + DSH_TUI_STANDALONE=1 → invalid-explicit-launch',
+  resolveTuiHostMode(false) === 'invalid-explicit-launch',
+)
+if (prevStandalone === undefined) {
+  delete process.env.DSH_TUI_STANDALONE
+} else {
+  process.env.DSH_TUI_STANDALONE = prevStandalone
+}
+
+// ── integration: apply() under a non-TTY stdout ────────────────────────────
+// The gate reads `process.stdout.isTTY` directly; override it for the process
+// and restore afterwards (no own descriptor on real TTYs, so delete restores).
+
+const stdoutIsTTYOwn = Object.prototype.hasOwnProperty.call(process.stdout, 'isTTY')
+const stdoutIsTTYDescriptor = stdoutIsTTYOwn
+  ? Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  : undefined
+Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true })
+
+const prevLauncherVersion = process.env.DSH_TUI_LAUNCHER_VERSION
+delete process.env.DSH_TUI_LAUNCHER_VERSION
+
+const infoLogs: string[] = []
+const ctx = new Context()
+const logger = ctx.logger
+const origInfo = logger.info.bind(logger)
+logger.info = ((message: unknown) => {
+  infoLogs.push(String(message))
+}) as typeof logger.info
+
+try {
+  // headless host: apply resolves, no throw, no render path reached
+  await apply(ctx, {} as unknown as Config)
+  check('headless-host: apply resolves without throwing', true)
+  check(
+    'headless-host: skip reason logged at info level',
+    infoLogs.some((line) => line.includes('skipping the TUI frontend')),
+    infoLogs.join(' | '),
+  )
+
+  // explicit launch without a TTY: the previous loud error is preserved
+  process.env.DSH_TUI_LAUNCHER_VERSION = '9.9.9'
+  let rejected = false
+  let message = ''
+  try {
+    await apply(ctx, {} as unknown as Config)
+  } catch (error) {
+    rejected = true
+    message = error instanceof Error ? error.message : String(error)
+  }
+  check('invalid-explicit-launch: apply rejects', rejected)
+  check(
+    'invalid-explicit-launch: original error message preserved',
+    message.includes('interactive terminal'),
+    message,
+  )
+} finally {
+  logger.info = origInfo
+  if (prevLauncherVersion === undefined) {
+    delete process.env.DSH_TUI_LAUNCHER_VERSION
+  } else {
+    process.env.DSH_TUI_LAUNCHER_VERSION = prevLauncherVersion
+  }
+  if (stdoutIsTTYOwn) {
+    Object.defineProperty(process.stdout, 'isTTY', stdoutIsTTYDescriptor as PropertyDescriptor)
+  } else {
+    Reflect.deleteProperty(process.stdout, 'isTTY')
+  }
+}
+
+console.log(`${checks - failures}/${checks} checks passed`)
+if (failures > 0) process.exit(1)

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -97,6 +97,35 @@ export function initialPromptFromCmdlineArgs(args: readonly string[] | undefined
   return promptArgs.join(' ').trim()
 }
 
+/**
+ * How this process should treat the TUI frontend, given the terminal it runs on.
+ *
+ * Three startup identities exist:
+ *  1. `dsh-tui` / standalone — the user explicitly asked for the terminal UI;
+ *  2. Web / Tauri / other GUI hosts — the profile merely has dsh-tui installed
+ *     and the current process is NOT a dsh-tui frontend. stdout is a pipe or
+ *     null there, and mounting a TUI would fail the whole composition.
+ *
+ * The official launcher (and the standalone runtime) mark explicit launches,
+ * so an explicit `dsh-tui` run without a TTY keeps failing loudly, while
+ * foreign hosts skip the plugin and let the host boot.
+ */
+export type TuiHostMode = 'interactive' | 'invalid-explicit-launch' | 'headless-host'
+
+export function resolveTuiHostMode(
+  stdoutIsTTY = process.stdout.isTTY === true,
+  env: NodeJS.ProcessEnv = process.env,
+): TuiHostMode {
+  if (stdoutIsTTY) {
+    return 'interactive'
+  }
+
+  const explicitTuiLaunch =
+    env.DSH_TUI_LAUNCHER_VERSION !== undefined || isStandaloneRuntime()
+
+  return explicitTuiLaunch ? 'invalid-explicit-launch' : 'headless-host'
+}
+
 export async function apply(ctx: Context, config: Config): Promise<void> {
   // /restart handoff diagnosis: the replacement process is marked by env and
   // logs its boot progress to ~/.dsh-tui/restart.log (ordinary launches stay
@@ -153,11 +182,23 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     sampleAt(5000, 'stdin state +5s')
     sampleAt(12000, 'stdin state +12s')
   }
-  if (!process.stdout.isTTY) {
+  const hostMode = resolveTuiHostMode()
+  if (hostMode === 'invalid-explicit-launch') {
     if (process.env.DSH_TUI_RESTART_CHILD === '1') {
       logRestartEvent('boot: TTY gate failed - stdout is not a TTY')
     }
     throw new Error('dsh-tui requires an interactive terminal (stdout must be a TTY).')
+  }
+  if (hostMode === 'headless-host') {
+    // Web / Tauri / GUI hosts load the plugin from the profile without being
+    // a dsh-tui frontend (stdout is a pipe or null). Mounting a TUI there
+    // would fail the whole composition, so skip quietly and let the host
+    // boot. The launcher marker above keeps explicit `dsh-tui` launches
+    // failing loudly instead of silently producing no UI.
+    ctx.logger.info(
+      'dsh-tui: non-interactive host detected (stdout is not a TTY); skipping the TUI frontend',
+    )
+    return
   }
 
   // The official profile launcher owns the system preset root and replaces


### PR DESCRIPTION
## 动机

`apply()` 开头的硬性 TTY 检查：

```ts
if (!process.stdout.isTTY) {
  throw new Error('dsh-tui requires an interactive terminal (stdout must be a TTY).')
}
```

会让任何装有 dsh-tui 的 profile 在 **Web / Tauri / GUI 等非终端宿主**下启动 DSH 时直接 throw（stdout 是 pipe/null），可能导致整个 plugin composition / Web 服务启动失败。

本次把"插件已安装"和"当前进程要求 dsh-tui 成为 frontend"两个概念分开：显式 `dsh-tui` / standalone 启动（launcher 会设置 `DSH_TUI_LAUNCHER_VERSION`，standalone 有 `DSH_TUI_STANDALONE` 等标记）没有 TTY 时**保留原有报错**；其他宿主加载到插件时**静默跳过 TUI 前端**，不报错、不影响宿主启动。

## 改动

- `src/dsh-adapter/plugin.ts`
  - 新增导出 `resolveTuiHostMode(stdoutIsTTY, env)` → `'interactive' | 'invalid-explicit-launch' | 'headless-host'`（参数可注入，便于测试；`isStandaloneRuntime()` 复用既有实现）；
  - `apply()` 最前面的门禁改为三态：`interactive` 正常挂载；`invalid-explicit-launch` 抛原错误（restart 诊断日志保留）；`headless-host` 记一条 info 日志并 `return`——仍在任何 preset/服务注册/render 之前，headless 下插件是 no-op；
  - restart 诊断块保持在门禁之前，行为不变。
- `scripts/verify-tui-host-mode.ts`（新，登记 `session-workspace` 组）
  - 单元：TTY×launcher marker 四组合 + standalone 组合（`DSH_TUI_STANDALONE=1`）共 5 断言；
  - 集成：覆写 `process.stdout.isTTY=false` 后真实调用 `apply()`——headless 不 throw、info 日志落点正确；显式 launcher 标记下仍以原错误信息 reject。
- `docs/getting-started.md` / `.en.md`：Troubleshooting 小节补充非终端宿主行为说明（双语同步）。

## 验证

- `scripts/verify-tui-host-mode.ts`：9/9 通过；
- `pnpm build`（compile + verify:build 全部门禁）通过；
- `git diff --check` 干净。

行为矩阵：

| stdout TTY | launcher/standalone 标记 | 结果 |
| --- | --- | --- |
| 是 | 任意 | 正常启动 TUI（不变） |
| 否 | 有（显式 dsh-tui / standalone） | 报 `dsh-tui requires an interactive terminal`（不变） |
| 否 | 无（Web/Tauri/GUI 宿主） | 静默跳过插件，宿主继续启动 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TUI behavior now adapts to the launch environment: interactive terminals continue normally, while supported graphical or web hosts skip the TUI and continue loading.
  * Explicit TUI launches without an interactive terminal still display an appropriate error.

* **Bug Fixes**
  * Prevented non-terminal hosts from failing when the TUI is unavailable.

* **Documentation**
  * Expanded troubleshooting guidance for TTY-related launch behavior.

* **Tests**
  * Added regression coverage for interactive, headless, and explicit non-terminal launch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->