### PR TITLE
feat(permission)：接入动态权限预设 registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ sh install.sh
 
 ## 权限与安全边界
 
-`dsh-TUI` 不实现独立沙箱，而是使用当前 DSH profile 的文件、Shell、sandbox 与 approval 策略。仓库提供的 profile 在非 Windows 平台默认采用工作区约束与审批；Windows 当前没有对应的沙箱后端，组合会退回到 `danger-full-access` 且不弹审批。在包含敏感凭证或不可信仓库的环境中启动前，请先检查 profile 配置。
+> **Windows 安全警告：** Windows profile 默认使用 `danger-full-access`，且 approval 默认是 `never`。这会授予工具不受限制的访问权限；在敏感凭证或不可信仓库环境中启动前，务必先检查并收紧 profile 配置。
+
+`dsh-TUI` 不实现独立沙箱，而是使用当前 DSH profile 的文件、Shell、sandbox 与 approval 策略。权限预设来自 DSH `permissionPresets` registry：服务缺失时使用 legacy 三项兼容名册；服务已挂载但为空、损坏或不一致时标记为 unavailable，TUI fail closed，不伪造名册。可用 registry 按声明顺序提供第三方预设，只有符合既有 command-token 语法的 ID 才进入补全，`custom` 只显示为当前态，不是可选择目标；切换始终走官方 `/permission <preset>` 命令。若外部 `/permission` 命令本身未注册，输入沿用现有默认命令/model dispatch。在包含敏感凭证或不可信仓库的环境中启动前，请先检查 profile 配置。
 
 详见[权限边界与已知限制](docs/architecture.md#权限与安全边界)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -263,7 +263,7 @@ so keep using `Ctrl`.
 | Session | `/new` new session · `/resume` working-directory/session browser (visible directory scope, search, preview, cross-project, sub-agent runs folded) · `/rename` rename session · `/recap` session recap (apply the suggested title in one key; `/settings` can enable an auto-summary on session open — on by default: a divider + `Recap:` line appears at the bottom of the transcript when resuming, and bows out once you send a new message) · `/workspace resume|rename|open` manage workspaces · `/clear` clear screen · `/compact` compact · `/export` export Markdown · `/trace` trace timeline (or `Ctrl+T`) · `/rewind` rewind picker (same as double-`Esc` on empty input) · `/tree` session family tree (every fork branch stitched together; hover previews a node, click opens a rewind/fork-here/adopt-branch menu) · `/fork` copy the current session into a resumable twin (the original is untouched) · `/btw <question>` side question (never interrupts the main turn, writes no history) |
 | Status | `/context` loaded-context details · `/status` session info · `/cost` token usage · `/doctor` environment self-check · `/config` configuration sources · `/init` create AGENTS.md · `/settings` settings panel (namespace read/edit) |
 | Model | `/model` two-level picker (a pinned **Recently used** group first — the last 10 switched models, persisted at `~/.dsh-tui/model-recents.json` — then provider groups; Enter drills into a group's models; a single provider with no recents skips straight to the list; **switching = fork continuation, history preserved**) · `/effort` reasoning effort (slider / `status` / `<id>`) · `/preset` agent preset (**cannot switch once the session has started** — blank-only) · `/thinking` thinking display · `/tokens` token details · `/activity` working animation (`frames <name>` / `status`) · `/theme` theme picker · `/color` (bare opens the palette picker; `<name>` sets directly; `status`/`reset`) session accent color (input border + session-name chip at the top-right, per-session; chip off by default, enable in `/settings`) · `/lang` zh/en UI switch (also selectable in `/settings`) |
-| Accounts/Policy | `/provider` add a model provider (includes the bundled dsh-auth **subscription OAuth sign-in** branch — ChatGPT / Claude / Grok, no API key; same source as `/auth status\|login\|logout`) · `/login` credential & account status · `/logout` logout notes · `/permissions` permission notes · `/add-dir` file-policy scope · `/hooks` · `/mcp` |
+| Accounts/Policy | `/provider` add a model provider (includes the bundled dsh-auth **subscription OAuth sign-in** branch — ChatGPT / Claude / Grok, no API key; same source as `/auth status\|login\|logout`) · `/login` credential & account status · `/logout` logout notes · `/permission` dynamic preset/status notes · `/add-dir` file-policy scope · `/hooks` · `/mcp` |
 | Skills | `/skills` lists skills discovered by DSH; user-invocable skills join the `/` menu as `/name` |
 | Other | `/agents` subagent list · `/plugins check <path>` plugin diagnostics · `/update` auto-update and restart · `/vim` vim editing mode toggle · `/terminal-setup` · `/connect` · `/help` · `/exit` (aliases `/quit` `/q`) |
 | Registry | `/plan` `/goal` `/feedback` `/permission` (DSH command-registry plugins, merged into the `/` menu automatically with the plugin) |
@@ -383,8 +383,11 @@ chat / tool base events ──> persisted Session log ──> TUI / Web
 - Tool-level approval is implemented: the approval service + TUI answerer (CC-style
   approval panel) consumes the approval stream, and privilege-escalation commands pop
   an approval bar. `/permission` preset switching comes from dsh-base's
-  `permission-presets` plugin and is available in the profile composition by default;
-  the bare `cordis.yml` composition does not mount that plugin (no `/permission` command).
+  `permission-presets` plugin and is available in the profile composition by default.
+  If that registry service is absent, TUI uses its legacy three-row compatibility
+  roster; a malformed mounted service is unavailable and fails closed. If the
+  external `/permission` command is not registered, input keeps the existing
+  default/model dispatch behavior.
 - `/connect` `/hooks` are CC-named placeholders: the corresponding
   capabilities have no equivalent mechanism on the DSH side, and the commands give an
   explicit explanation rather than staying silent.
@@ -450,13 +453,21 @@ responsible for their maintenance and security.
 
 ## Permissions and Security Boundary
 
+> **Windows security warning:** The Windows profile defaults to `danger-full-access` with approval set to `never`. Tools therefore have unrestricted access; before starting in an environment with sensitive credentials or an untrusted repository, inspect and tighten the profile configuration.
+
 `dsh-TUI` does not implement a separate sandbox. It uses the filesystem,
-shell, sandbox, and approval policies of the active DSH profile. The supplied
-profile uses workspace confinement and approvals by default on non-Windows
-platforms. Windows currently has no corresponding sandbox backend, so the
-composition falls back to `danger-full-access` without approval prompts.
-Inspect the profile before starting it around sensitive credentials or an
-untrusted repository.
+shell, sandbox, and approval policies of the active DSH profile. Permission
+presets come from the mounted DSH `permissionPresets` registry: third-party
+presets appear automatically in the picker in registry order, while only IDs
+accepted by the existing command-token grammar enter completion. `custom` is a
+current-state label only, never a selectable target. Switching always uses the
+official `/permission <preset>` command.
+When the `permissionPresets` service is absent, TUI keeps its legacy three-row
+compatibility roster. A mounted but unusable service is marked unavailable and
+fails closed instead of inventing a roster. If the external `/permission` command
+is not registered, input follows the existing default/model dispatch path. Inspect
+the profile before starting it around sensitive credentials or an untrusted
+repository.
 
 See [Permissions and security boundary](docs/architecture.en.md#permissions-and-security-boundary)
 for details.

--- a/docs/architecture.en.md
+++ b/docs/architecture.en.md
@@ -132,6 +132,15 @@ mounted by `cordis.patch.yml`:
 - MCP, shell, filesystem tools, and custom presets expand what the model can
   access and should be treated as code-execution surfaces in the same policy
   domain.
+- `/permission` reads the mounted DSH `permissionPresets` registry in declared
+  order. Third-party presets appear in the picker automatically; only IDs that
+  fit the existing command-token grammar enter Tab completion. `custom` is a
+  current-state projection, never a selectable target.
+- The TUI distinguishes `runtime`, `legacy`, and `unavailable`: the legacy
+  three-row roster is used only when the service is truly absent. A mounted
+  service that is empty, inconsistent, broken, or unsafe fails closed instead
+  of inferring identity from sandbox/approval knobs. All switches still call
+  the official `/permission <preset>` command.
 
 Inspect the active profile patch before running in an untrusted repository; the
 visual TUI alone does not describe the effective policy.
@@ -154,8 +163,11 @@ visual TUI alone does not describe the effective policy.
   Agent's asynchronous flush; the persistence plugin is the fallback.
 - The tool-level approval panel is implemented (approval service + TUI
   answerer); `/permission` preset switching is provided by the dsh-base
-  `permission-presets` plugin and works in profile compositions — the bare
-  `cordis.yml` mounts only the approval service, not `permission-presets`.
+  `permission-presets` plugin and works in profile compositions. When that
+  registry service is absent, TUI uses its legacy three-row compatibility roster;
+  a malformed mounted service is unavailable and fails closed. If the external
+  `/permission` command is not registered, input follows the existing
+  default/model dispatch behavior.
 - `/vim`, `/connect`, and `/hooks` are compatibility placeholders,
   not evidence that those DSH capabilities are mounted.
 - There is no automated full-flow suite that requires real model credentials;
@@ -166,7 +178,7 @@ visual TUI alone does not describe the effective policy.
 
 | Goal | Method |
 | --- | --- |
-| Environment and profile | Run `/doctor`, `/config`, and `/permissions` inside the TUI |
+| Environment and profile | Run `/doctor`, `/config`, and `/permission status` inside the TUI |
 | stderr diagnostics | `DSH_TUI_DEBUG=1 dsh --profile dsh-tui` |
 | Raw ANSI frames | `DSH_TUI_RENDER_LOG=/path/to/render.log dsh --profile dsh-tui` |
 | Theme regression | `node --import tsx/esm scripts/verify-themes.mjs` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,12 @@ answerer（`approval/request` waterfall），仅允许一次/拒绝两种决定�
   或脱敏片段。
 - MCP、Shell、文件工具和自定义 preset 都会扩展模型可见能力，应当视为同一权限域
   内的代码执行入口。
+- `/permission` 的可切换名册由已挂载的 DSH `permissionPresets` registry 提供，
+  保持 registry 声明顺序；第三方预设会自动进入 picker，只有符合既有命令 token
+  语法的 ID 进入 Tab 补全。`custom` 只作为 registry 投影出的当前态，不是目标。
+- TUI 将服务状态区分为 runtime、legacy、unavailable：只有服务确实缺失时才保留
+  旧三项 legacy 兼容；服务已挂载但损坏、空或数据不一致时 fail closed，不从
+  sandbox/approval 组合猜测当前预设。所有切换仍调用官方 `/permission <preset>`。
 
 在不可信仓库中运行前，检查实际 profile patch，而不是只看 TUI 的视觉界面。
 
@@ -127,9 +133,10 @@ answerer（`approval/request` waterfall），仅允许一次/拒绝两种决定�
   不可连接回退下一个，全部不可用时粘贴报"无可用剪贴板工具"）。剪贴板图片
   导出为临时文件插入路径（0700 私有目录、0600 文件），不内嵌图片块。
 - 退出路径优先恢复终端并结束进程，不等待 Agent 异步落盘；持久化插件负责兜底。
-- 工具级审批面板已实现（approval 服务 + TUI answerer）；`/permission` 的沙箱
-  预设切换由 dsh-base 的 `permission-presets` 插件提供，profile 组合下可用；
-  裸组合 `cordis.yml` 只挂了 approval 服务，未挂 `permission-presets`。
+- 工具级审批面板已实现（approval 服务 + TUI answerer）；`/permission` 的预设
+  切换由 dsh-base 的 `permission-presets` 插件提供。registry 服务缺失时使用三项
+  legacy 兼容名册；服务已挂载但空、损坏或不一致时标记 unavailable 并 fail closed，
+  不伪造旧名册。若外部 `/permission` 命令未注册，输入沿用现有默认命令/model dispatch。
 - `/vim`、`/connect`、`/hooks` 是兼容占位命令，不代表对应 DSH 能力已挂载。
 - 没有一套需要真实模型凭证的自动化全流程测试；CI 使用 headless renderer 与假服务，
   真实模型集成仍需要在目标终端手动验证。
@@ -138,7 +145,7 @@ answerer（`approval/request` waterfall），仅允许一次/拒绝两种决定�
 
 | 目的 | 方式 |
 | --- | --- |
-| 环境与 profile | TUI 内运行 `/doctor`、`/config`、`/permissions` |
+| 环境与 profile | TUI 内运行 `/doctor`、`/config`、`/permission status` |
 | stderr 调试 | `DSH_TUI_DEBUG=1 dsh --profile dsh-tui` |
 | 原始 ANSI 帧 | `DSH_TUI_RENDER_LOG=/path/to/render.log dsh --profile dsh-tui` |
 | 主题回归 | `node --import tsx/esm scripts/verify-themes.mjs` |

--- a/docs/interaction.en.md
+++ b/docs/interaction.en.md
@@ -412,7 +412,7 @@ zh; unmapped registry commands fall back to the registry's own text.
 | Sessions | `/new`, `/resume`, `/rename`, `/recap` (recent-activity summary + one-key suggested title), `/workspace resume|rename|open`, `/clear`, `/compact`, `/export`, `/btw`, `/trace` (trajectory scene, also `Ctrl+T`), `/rewind` (time travel, same as double-`Esc` on an empty input) |
 | Status | `/context`, `/status`, `/cost`, `/balance` (official DeepSeek balance: summary row + hover details, click to refresh), `/config`, `/doctor`, `/init`, `/agents`, `/settings` |
 | Model and display | `/model`, `/effort`, `/thinking`, `/tokens`, `/activity`, `/preset`, `/theme`, `/color` (session accent color: bare opens the palette picker, `<name>` sets directly, `status`/`reset`; input border + session-name chip at the top-right, per-session; chip off by default, enable in `/settings`), `/lang` |
-| Account and policy | `/provider`, `/login`, `/logout`, `/permissions`, `/add-dir`, `/hooks`, `/mcp`, `/plugins` (`check <path>` validates a plugin manifest) |
+| Account and policy | `/provider`, `/login`, `/logout`, `/permission`, `/add-dir`, `/hooks`, `/mcp`, `/plugins` (`check <path>` validates a plugin manifest) |
 | Skills | `/skills` lists skills DSH discovers from the active profile, user, and project; user-invocable skills join the menu as `/name` |
 | Other | `/update`, `/vim` (vim editing mode toggle — see “Editing keys”), `/terminal-setup`, `/connect`, `/help`, `/exit` (aliases `/quit`, `/q`) |
 | Registry | `/plan`, `/goal`, and any other command registered by the DSH composition |
@@ -432,6 +432,7 @@ Additional forms:
 - `/effort` opens the reasoning-effort slider (←/→ adjusts live);
   `/effort <id>` sets a level directly; `/effort status` reports the current one.
 - `/theme <name>` and `/theme status` are described in the theme guide.
+- `/permission` reads the DSH `permissionPresets` registry, preserving registry order for the picker and completion. Third-party presets need no TUI hard-coding; `custom` is a current-state label only, never a selectable target. When the registry service is absent, TUI uses its legacy three-row compatibility roster; a mounted but broken service is unavailable and fails closed. If the external `/permission` command is not registered, input follows the existing default/model dispatch path.
 - `/lang` toggles the interface language (see “Interface language”).
 - `/compact` compresses the session history; unavailable under the minimal
   preset (bash + editor only).

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -363,7 +363,7 @@ transcript。
 | 会话 | `/new`、`/resume`、`/rename`、`/recap`（最近活动摘要 + 建议标题一键应用；设置 `recapOnOpen` 开启时打开会话自动出分隔线 + `回顾：` 摘要行，发送新消息后消失，默认开）、`/workspace resume|rename|open`、`/clear`、`/compact`、`/export`、`/btw`、`/trace`（轨迹场景，亦可 `Ctrl+T`）、`/rewind`（时间回溯，同空输入双击 `Esc`） |
 | 状态 | `/context`、`/status`、`/cost`、`/balance`（DeepSeek 官方余额：摘要行 + hover 明细，点击刷新）、`/config`、`/doctor`、`/init`、`/agents`、`/settings` |
 | 模型与显示 | `/model`、`/effort`、`/thinking`、`/tokens`、`/activity`、`/preset`、`/theme`、`/color`（会话强调色：无参打开调色板选择器，`<名>` 直接设置，`status`/`reset`；输入框边框 + 右上角会话名标签，按会话保存；标签默认关闭，`/settings` 可开）、`/lang` |
-| 账号与策略 | `/provider`、`/login`、`/logout`、`/permissions`、`/add-dir`、`/hooks`、`/mcp`、`/plugins`（`check <路径>` 校验插件清单） |
+| 账号与策略 | `/provider`、`/login`、`/logout`、`/permission`、`/add-dir`、`/hooks`、`/mcp`、`/plugins`（`check <路径>` 校验插件清单） |
 | Skills | `/skills` 浏览 DSH 从当前 profile、用户与项目发现的技能；可直调技能以 `/name` 加入菜单 |
 | 其他 | `/update`、`/vim`（vim 编辑模式开关，见「输入编辑」）、`/terminal-setup`、`/connect`、`/help`、`/exit`（别名 `/quit`、`/q`） |
 | 注册表 | `/plan`、`/goal`，以及当前 DSH 组合注册的其他命令 |
@@ -382,6 +382,7 @@ dsh-TUI 不预装通用技能；技能内容与发现规则由 DSH 及当前组�
 - `/effort` 打开推理强度滑杆（←/→ 实时调整）；`/effort <id>` 直接设定，
   `/effort status` 查看当前档位。
 - `/theme <name>` 与 `/theme status` 见主题文档。
+- `/permission` 的名册来自 DSH `permissionPresets` registry，按声明顺序显示并参与补全；第三方预设无需 TUI 硬编码，`custom` 只显示当前态，不是可选目标。registry 服务缺失时 TUI 使用三项 legacy 兼容名册；服务已挂载但损坏、为空或不一致时标记 unavailable 并 fail closed。若外部 `/permission` 命令未注册，输入沿用现有默认命令/model dispatch。
 - `/lang` 切换中英界面语言（见「界面语言」）。
 - `/compact` 压缩会话历史；minimal preset（仅 bash+编辑器）下不可用。
 - `/thinking` 扩展思考显示开关，仅本次界面状态、**不持久化**。

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -255,7 +255,7 @@ dsh-tui
 | `/provider` | 无 | 交互式添加模型提供方向导（持久化 profile + key） |
 | `/login` | 无 | 凭证状态（来源、存储可写性、base URL） |
 | `/logout` | 无 | 登出说明（env 来源需删环境变量并重启） |
-| `/permissions` | 无 | 权限策略与审批通道说明 |
+| `/permission` | 无 / `<preset>` / `status` | 查看当前权限预设与策略说明；无参时打开由 DSH `permissionPresets` registry 提供的选择器，参数通过官方命令切换。服务缺失时使用 legacy 三项名册，挂载但损坏时 unavailable；外部命令未注册时沿用默认命令/model dispatch |
 | `/add-dir` | 无 | 文件策略范围说明（以工作目录为根） |
 | `/hooks` | 无 | 占位：DSH hooks 未在组合中挂载时给出说明 |
 | `/mcp` | 无 | MCP 连接状态（工具按 `mcp__服务器__工具` 分组）；未配置时给出 `cordis.patch.yml` 插入示例 |
@@ -282,7 +282,7 @@ dsh-TUI 不预装通用技能。`/skills` 浏览 DSH 从当前 profile、用户�
 | `/plan` | `[off\|message]` 计划模式；`/plan off` 退出 |
 | `/goal` | 设置/查看会话目标 |
 | `/feedback` | 提交使用反馈 |
-| `/permission` | 查看/切换权限预设（read-only / workspace-write / danger-full-access；非所有组合都有） |
+| `/permission` | 查看/切换 DSH `permissionPresets` registry 的预设；第三方预设按 registry 顺序显示，`custom` 只作为当前态，不是选择目标；服务缺失时使用 legacy 三项名册，服务已挂载但损坏时标记 unavailable；外部命令未注册时沿用默认命令/model dispatch |
 
 > 这些命令的行为由 DSH 命令注册表实现，本仓库只做菜单并入、补全与分发；
 > 未知命令会作为普通消息发给模型。
@@ -381,7 +381,7 @@ dsh-TUI 不预装通用技能。`/skills` 浏览 DSH 从当前 profile、用户�
 - `/doctor` 自检：Node/平台、API key、模型路由、cwd、上下文窗口、会话存储、插件宿主。
 - `/provider` 交互向导添加模型提供方（密钥写入 `~/.dsh/.credentials.yaml` 0600，界面只显示 `••••••`）。
 - `/init` 创建 AGENTS.md；`/agents` 子代理列表；`/login` `/logout` 凭证管理；
-  `/permissions` `/add-dir` 权限说明；`/hooks` `/vim` `/connect` 为占位（DSH 无对应机制，给明确说明）。
+  `/permission` `/add-dir` 权限说明；`/hooks` `/vim` `/connect` 为占位（DSH 无对应机制，给明确说明）。
 
 ---
 

--- a/scripts/verify-extension-events.tsx
+++ b/scripts/verify-extension-events.tsx
@@ -373,7 +373,7 @@ await sleep(800)
     event.text === '消毒检查' ? { cancel: true, reason: '拦截\x1b[31m\x07原因' } : undefined)
   channel.submit('消毒检查')
   check('tui/input cancel: reason sanitized before toasting',
-    await settled(() => notified('拦截 [31m 原因')
+    await settled(() => notified('拦截 原因')
       && !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
         .some(item => item.text.includes('\x1b'))))
   dispose()

--- a/scripts/verify-extension-ui.tsx
+++ b/scripts/verify-extension-ui.tsx
@@ -342,7 +342,7 @@ const plugin = pluginCtx
   }
   plugin.tuiStatus.set('demo', '构建\x1b[31m中')
   check('tuiStatus: control chars stripped',
-    statusStore.getSnapshot()[0]?.text === '构建 [31m中', JSON.stringify(statusStore.getSnapshot()[0]?.text))
+    statusStore.getSnapshot()[0]?.text === '构建中', JSON.stringify(statusStore.getSnapshot()[0]?.text))
   // Scalar-only coercion: a non-scalar text is refused with a warn — never
   // rendered as "[object Object]", and NOT treated as a clear either.
   plugin.tuiStatus.set('scalar', { nope: true } as unknown as string)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -57,6 +57,15 @@ export interface CommandCompletion extends LocalCommand {
 export type CommandChildren = (canonicalPath: readonly string[]) => readonly CommandCompletionNode[]
 
 /**
+ * Whether a value can occupy one command-completion token. Keep this aligned
+ * with the grammar accepted by {@link completeCommands}; callers that need an
+ * empty prefix handle that case separately.
+ */
+export function isCommandCompletionToken(value: string): boolean {
+  return /^[a-z0-9_.:\/-]+$/iu.test(value)
+}
+
+/**
  * The built-in slash commands (name + description pairs). Plugin-registered
  * commands merge in at runtime; locals win on name collisions.
  */
@@ -227,7 +236,7 @@ export function completeCommands(
   // Token charset includes `. : /` so provider/model specs (e.g.
   // `deepseek/deepseek-v4-flash`, `openai/gpt-4.1`) survive as ONE token —
   // the /model completion matches its candidates against the whole spec.
-  if (!/^[a-z0-9_.:\/-]*(?:[\t ]+[a-z0-9_.:\/-]*)*$/iu.test(body)) return []
+  if (!body.split(/[\t ]+/u).every(token => token === '' || isCommandCompletionToken(token))) return []
   const trailingSeparator = /[\t ]$/u.test(body)
   const tokens = body.split(/[\t ]+/u)
   const prefix = trailingSeparator ? '' : (tokens.pop() ?? '')
@@ -245,7 +254,7 @@ export function completeCommands(
   const normalizedPrefix = prefix.toLowerCase()
   return candidates.flatMap(candidate => {
     const completionToken = matchingCompletionToken(candidate, normalizedPrefix)
-    if (completionToken === undefined) return []
+    if (completionToken === undefined || !isCommandCompletionToken(completionToken)) return []
     const path = [...tokens, completionToken]
     const commandLine = `/${path.join(' ')}`
     return [{

--- a/src/components/PermissionsPicker.tsx
+++ b/src/components/PermissionsPicker.tsx
@@ -4,32 +4,26 @@ import { Box, Text } from '../ui.js'
 import { Pane } from './design-system/Pane.js'
 import { Select } from './Select.js'
 import { HintLine } from './design-system/HintLine.js'
+import type { PermissionPresetOption } from '../dsh-adapter/channel.js'
 
 /**
  * `/permission` sandbox-preset picker. The command itself is registered by
  * the harness side (dsh-sandbox-policy / dsh-base permission-presets row);
  * bare `/permission` opens this picker and Enter dispatches
  * `/permission <preset>` through the same external-command path a hand-typed
- * argument takes. The list mirrors the `sandbox/mode` vocabulary the session
- * modes use (`sessionModes.ts`), so the ✓ mark stays consistent with the
- * mode the TUI derives from the session log.
+ * argument takes. The roster comes from the adapter snapshot so host plugins
+ * can contribute additional preset identities without UI changes.
  */
-export const PERMISSION_PRESET_IDS = [
-  'read-only',
-  'workspace-write',
-  'danger-full-access',
-] as const
-
-export type PermissionPresetId = (typeof PERMISSION_PRESET_IDS)[number]
-
 export function PermissionsPicker({
+  options,
   focusIndex,
-  currentMode,
+  currentValue,
   cwd,
   onPick,
 }: {
+  options: readonly PermissionPresetOption[]
   focusIndex: number
-  currentMode: string | undefined
+  currentValue: string | undefined
   cwd: string
   /** Mouse pick (fullscreen): clicked row's absolute index (Chat applies
    *  the same code path as the keyboard Enter). */
@@ -44,13 +38,25 @@ export function PermissionsPicker({
           </Text>
         </Box>
         <Select
-          options={[
-            { value: 'read-only', label: t('permission-preset-readonly'), description: t('permission-preset-readonly-desc') },
-            { value: 'workspace-write', label: t('permission-preset-workspace-write'), description: t('permission-preset-workspace-write-desc') },
-            { value: 'danger-full-access', label: t('permission-preset-full-access'), description: t('permission-preset-full-access-desc') },
-          ]}
+          options={options.map(option => ({
+            value: option.value,
+            label: option.value === 'read-only'
+              ? t('permission-preset-readonly')
+              : option.value === 'workspace-write'
+                ? t('permission-preset-workspace-write')
+                : option.value === 'danger-full-access'
+                  ? t('permission-preset-full-access')
+                  : option.name,
+            description: option.value === 'read-only'
+              ? t('permission-preset-readonly-desc')
+              : option.value === 'workspace-write'
+                ? t('permission-preset-workspace-write-desc')
+                : option.value === 'danger-full-access'
+                  ? t('permission-preset-full-access-desc')
+                  : option.description ?? option.name,
+          }))}
           focusIndex={focusIndex}
-          selectedValue={currentMode}
+          selectedValue={currentValue}
           onPick={onPick ? index => onPick(index) : undefined}
         />
         <Text dimColor italic>

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -27,7 +27,7 @@ import { renderContextSections, renderPrompt } from '@deepseek-ai/dsh-system-pro
 import { loadBaselineInstructions } from '@deepseek-ai/dsh-agent-instructions'
 import type { Context } from '@deepseek-ai/cordis'
 import { extname, isAbsolute, join } from 'node:path'
-import { completeCommands, HIDDEN_COMMAND_NAMES, isLocalCommandName, LOCAL_COMMANDS, parseCommandName, type CommandCompletion, type CommandCompletionNode, type LocalCommand } from '../commands.js'
+import { completeCommands, HIDDEN_COMMAND_NAMES, isCommandCompletionToken, isLocalCommandName, LOCAL_COMMANDS, parseCommandName, type CommandCompletion, type CommandCompletionNode, type LocalCommand } from '../commands.js'
 import { clearResumeTarget, forgetSession, readResumeTarget, touchSession, writeResumeTarget } from '../sessionHistory.js'
 import { appendSessionTitle, defaultMaxScanned, deleteSessionLog, ensureLegacySessionEventTypes, readSessionEventsFromFile, readSessionEventsFromLog, sessionsRoots } from './compat/index.js'
 import {
@@ -179,6 +179,131 @@ function normalizeRewindPromptDecision(
 /** Toast-bound plugin text (veto reasons, handled notices, rewind summaries)
  *  is render-path data too: same sanitization, toast-width cap. */
 const NOTICE_CELLS = 200
+
+const PERMISSION_PRESET_CUSTOM = 'custom'
+const PERMISSION_PRESET_NAME_CELLS = 120
+const PERMISSION_PRESET_DESCRIPTION_CELLS = 400
+
+type PermissionPresetService = {
+  names?: unknown
+  current?: (events: readonly SessionEvent[]) => unknown
+  optionOf?: (name: string) => unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object'
+}
+
+function legacyPermissionPresetOptions(): readonly PermissionPresetOption[] {
+  return [
+    {
+      value: 'read-only',
+      name: t('permission-preset-readonly'),
+      description: t('permission-preset-readonly-desc'),
+    },
+    {
+      value: 'workspace-write',
+      name: t('permission-preset-workspace-write'),
+      description: t('permission-preset-workspace-write-desc'),
+    },
+    {
+      value: 'danger-full-access',
+      name: t('permission-preset-full-access'),
+      description: t('permission-preset-full-access-desc'),
+    },
+  ]
+}
+
+function legacyPermissionPresetSnapshot(sandbox: SessionModeSpec['sandbox']): PermissionPresetSnapshot {
+  const options = legacyPermissionPresetOptions()
+  const currentOption = sandbox === undefined ? undefined : options.find(option => option.value === sandbox)
+  return {
+    availability: 'legacy',
+    options,
+    ...(currentOption === undefined
+      ? {}
+      : { current: { ...currentOption, kind: 'preset' as const } }),
+  }
+}
+
+function unavailablePermissionPresetSnapshot(): PermissionPresetSnapshot {
+  return { availability: 'unavailable', options: [] }
+}
+
+function normalizePermissionPresetOption(value: unknown): PermissionPresetOption | undefined {
+  if (!isRecord(value) || typeof value.value !== 'string' || typeof value.name !== 'string') return undefined
+  const name = cleanRenderText(value.name, PERMISSION_PRESET_NAME_CELLS)
+  if (name === '') return undefined
+  if (value.description !== undefined && typeof value.description !== 'string') return undefined
+  const description = value.description === undefined
+    ? undefined
+    : cleanRenderText(value.description, PERMISSION_PRESET_DESCRIPTION_CELLS)
+  if (value.description !== undefined && description === '') return undefined
+  return {
+    value: value.value,
+    name,
+    ...(description === undefined || description === '' ? {} : { description }),
+  }
+}
+
+function permissionPresetSnapshotFromService(
+  service: unknown,
+  events: readonly SessionEvent[],
+): PermissionPresetSnapshot {
+  if (!isRecord(service)) return unavailablePermissionPresetSnapshot()
+  const runtime = service as PermissionPresetService
+  try {
+    const capturedNames = runtime.names
+    const current = runtime.current
+    const optionOf = runtime.optionOf
+    if (!Array.isArray(capturedNames) || capturedNames.length === 0) return unavailablePermissionPresetSnapshot()
+    if (typeof current !== 'function' || typeof optionOf !== 'function') return unavailablePermissionPresetSnapshot()
+
+    const names = [...capturedNames]
+    const seen = new Set<string>()
+    for (const name of names) {
+      if (typeof name !== 'string' || name.trim() === '' || name === PERMISSION_PRESET_CUSTOM || seen.has(name)) {
+        return unavailablePermissionPresetSnapshot()
+      }
+      seen.add(name)
+    }
+
+    const options: PermissionPresetOption[] = []
+    for (const name of names) {
+      const option = normalizePermissionPresetOption(optionOf(name))
+      if (option === undefined || option.value !== name) return unavailablePermissionPresetSnapshot()
+      options.push({ ...option })
+    }
+
+    const currentValue = current(events)
+    if (typeof currentValue !== 'string' || (currentValue !== PERMISSION_PRESET_CUSTOM && !seen.has(currentValue))) {
+      return unavailablePermissionPresetSnapshot()
+    }
+    const currentOption = normalizePermissionPresetOption(optionOf(currentValue))
+    if (currentOption === undefined || currentOption.value !== currentValue) return unavailablePermissionPresetSnapshot()
+    if (currentValue !== PERMISSION_PRESET_CUSTOM) {
+      const rosterOption = options.find(option => option.value === currentValue)
+      if (
+        rosterOption === undefined
+        || rosterOption.name !== currentOption.name
+        || rosterOption.description !== currentOption.description
+      ) {
+        return unavailablePermissionPresetSnapshot()
+      }
+    }
+
+    return {
+      availability: 'runtime',
+      options,
+      current: {
+        ...currentOption,
+        kind: currentValue === PERMISSION_PRESET_CUSTOM ? 'custom' : 'preset',
+      },
+    }
+  } catch {
+    return unavailablePermissionPresetSnapshot()
+  }
+}
 
 /** `tui/rewind-done` return normalization: the first non-empty STRING is the
  *  summary; anything else is not a decision. */
@@ -523,6 +648,8 @@ export interface Channel {
    *  the prompt-input border + session label chip accent (cc/sessionColors). */
   readonly sessionColor: string
   readonly agentId: string
+  /** TUI-owned generation that changes on every live Agent rebind. */
+  readonly agentBindingGeneration: number
   /** `dsh-tui.recapOnOpen` (default on): auto-summarize the session tail
    *  into the dim AutoRecapRow when the session opens/resumes. Read live
    *  (settings service), so a `/settings` change applies on the next
@@ -786,6 +913,8 @@ export interface Channel {
   readonly modeIndex: number
   /** Shift+Tab: advance to the next configured session mode. */
   cycleMode(): Promise<void>
+  /** Read the official permission preset roster and current identity. */
+  permissionPresets(): PermissionPresetSnapshot
   /** The preset the CURRENT session runs under (issue #8), resolved from its
    *  log at create/resume time; undefined when no roster is mounted. */
   readonly agentPreset: string | undefined
@@ -933,6 +1062,31 @@ export interface PresetOption {
   isDefault: boolean
 }
 
+export type PermissionPresetAvailability = 'runtime' | 'legacy' | 'unavailable'
+
+export interface PermissionPresetOption {
+  readonly value: string
+  readonly name: string
+  readonly description?: string
+}
+
+export interface PermissionPresetCurrent {
+  readonly value: string
+  readonly name: string
+  readonly description?: string
+  readonly kind: 'preset' | 'custom'
+}
+
+/**
+ * Adapter-owned permission roster snapshot. `options` never contains the
+ * official `custom` sentinel; it is represented only by `current`.
+ */
+export interface PermissionPresetSnapshot {
+  readonly availability: PermissionPresetAvailability
+  readonly options: readonly PermissionPresetOption[]
+  readonly current?: PermissionPresetCurrent
+}
+
 /** @internal */
 /** One user message submitted while the model was working, not yet claimed
  *  by a turn. `steer` lands at the next step boundary of the running turn;
@@ -964,6 +1118,8 @@ export interface ChannelState {
   sessionColor: string
   autoRecapOnOpen: boolean
   agentId: string
+  /** TUI-owned generation that changes on every live Agent rebind. */
+  agentBindingGeneration: number
   model: string
   provider: string
   tokens: TokenUsage
@@ -1134,6 +1290,8 @@ export interface ChannelState {
   modeIndex: number
   /** Shift+Tab session-mode advance (see the public Channel type). */
   cycleMode(): Promise<void>
+  /** Read the official permission preset roster and current identity. */
+  permissionPresets(): PermissionPresetSnapshot
   /** The preset the current session runs under (see the public Channel type). */
   agentPreset: string | undefined
   /** The roster's presets for the `/preset` picker (see the public Channel type). */
@@ -2347,7 +2505,7 @@ export function createChannel(
       }
       // `undefined` = not registered; a handler error surfaces as its
       // message so the user sees why the command failed.
-      return execution?.result.text ?? ''
+      return execution === undefined ? undefined : execution.result.text ?? ''
     } catch (error) {
       return error instanceof Error ? error.message : String(error)
     }
@@ -2608,6 +2766,7 @@ export function createChannel(
     ])
   }
 
+  let agentBindingGeneration = 0
   const state: ChannelState = {
     effortLevels: undefined,
     version: 0,
@@ -2627,6 +2786,7 @@ export function createChannel(
       return (ns?.value as Record<string, unknown> | undefined)?.recapOnOpen !== false
     },
     agentId: agent.id,
+    agentBindingGeneration: 0,
     model: options.model,
     provider: options.provider,
     tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, peak: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, idle: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
@@ -2791,13 +2951,23 @@ export function createChannel(
           ]
         }
         if (path.length === 1 && path[0] === 'permission') {
-          // Sandbox-preset vocabulary of the `/permission` picker — Tab
-          // completes it for keyboard users, Enter still dispatches.
-          return [
-            { name: 'read-only', description: 'Read-only session: no file writes, no commands', descriptionKey: 'permission-preset-readonly-desc' },
-            { name: 'workspace-write', description: 'Read/write inside the workspace; writes need a prior read', descriptionKey: 'permission-preset-workspace-write-desc' },
-            { name: 'danger-full-access', description: 'Unrestricted access, no approvals', descriptionKey: 'permission-preset-full-access-desc' },
-          ]
+          const snapshot = state.permissionPresets()
+          return snapshot.options
+            .filter(option => isCommandCompletionToken(option.value))
+            .map(option => ({
+              name: option.value,
+              description: option.description ?? option.name,
+              ...(option.value === 'read-only'
+                ? { descriptionKey: 'permission-preset-readonly-desc' }
+                : option.value === 'workspace-write'
+                  ? { descriptionKey: 'permission-preset-workspace-write-desc' }
+                  : option.value === 'danger-full-access'
+                    ? { descriptionKey: 'permission-preset-full-access-desc' }
+                    : {}),
+              ...(snapshot.current?.kind === 'preset' && snapshot.current.value === option.value
+                ? { tag: 'current' }
+                : {}),
+            }))
         }
         if (path.length === 1 && path[0] === 'plan') {
           return [
@@ -4501,6 +4671,16 @@ export function createChannel(
       state.emit()
       state.notify(t('activity-indicator-switched', { name }))
       return true
+    },
+    permissionPresets() {
+      let service: unknown
+      try {
+        service = ctx.get('permissionPresets')
+      } catch {
+        return unavailablePermissionPresetSnapshot()
+      }
+      if (service === undefined) return legacyPermissionPresetSnapshot(state.mode.sandbox)
+      return permissionPresetSnapshotFromService(service, agent.session.events)
     },
     async listPresets() {
       const presets = rosterOf(ctx)
@@ -6724,6 +6904,8 @@ ${output}
   }
 
   const bindAgent = (): void => {
+    agentBindingGeneration += 1
+    state.agentBindingGeneration = agentBindingGeneration
     for (const dispose of agentSubscriptions) dispose()
     stopActivityTick()
     // Cancel state and deferred interrupt delivery belong to one bound agent.

--- a/src/dsh-adapter/sanitize.ts
+++ b/src/dsh-adapter/sanitize.ts
@@ -19,8 +19,13 @@ import { stringWidth } from '../ink/stringWidth.js'
 
 /** Sanitize an already-string value for the render path. */
 export function cleanRenderText(value: string, maxCells: number): string {
+  // Remove complete ANSI control sequences before stripping control bytes.
+  // Otherwise an SGR such as ESC[31m becomes the visible garbage "[31m".
+  const withoutAnsi = value
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/gu, '')
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '')
   // eslint-disable-next-line no-control-regex -- deliberate: sanitize untrusted render-path text
-  const flat = value.replace(/[\x00-\x1f\x7f-\x9f]/g, ' ').replace(/\s+/g, ' ').trim()
+  const flat = withoutAnsi.replace(/[\x00-\x1f\x7f-\x9f]/g, ' ').replace(/\s+/g, ' ').trim()
   if (stringWidth(flat) <= maxCells) return flat
   let out = ''
   for (const ch of flat) {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -358,6 +358,7 @@ const dict = {
   'permission-root-hint': { zh: '当前文件系统策略以工作目录为根：{{cwd}}', en: 'Current filesystem policy is rooted at the working directory: {{cwd}}' },
   'permission-path-hint': { zh: '模型工具相对路径均解析自该目录；跨目录访问由 fs-policy 拦截。', en: 'Relative paths of model tools resolve from this directory; cross-directory access is blocked by fs-policy.' },
   'permission-current': { zh: '当前预设  {{name}}', en: 'Current preset  {{name}}' },
+  'permission-roster-unavailable': { zh: '权限预设名册不可用', en: 'Permission preset roster unavailable' },
   'permission-picker-title': { zh: '权限预设', en: 'Permission preset' },
   'permission-preset-readonly': { zh: '只读', en: 'Read-only' },
   'permission-preset-readonly-desc': { zh: '会话只读：不写文件、不执行命令', en: 'Read-only session: no file writes, no commands' },

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -15,6 +15,7 @@ import { actionMatches } from '../utils/keymap.js'
 import { formatTokens } from '../cc/format.js'
 import { homeDir } from '../utils/paths.js'
 import type { LlmModelInfo, LlmProviderInfo } from '../dsh-adapter/types.js'
+import { cleanRenderText, cleanScalarText } from '../dsh-adapter/sanitize.js'
 import {
   deriveModelGroups,
   modelPickerLanding,
@@ -22,7 +23,7 @@ import {
   RECENTS_GROUP_PROVIDER,
 } from '../modelGroups.js'
 import { readModelRecents, recordModelUse, type ModelRecentsRef } from '../modelRecents.js'
-import { sessionCwdMatches, type Channel, type ChatRow, type EffortOption, type PresetOption, type SkillInfo } from '../dsh-adapter/channel.js'
+import { sessionCwdMatches, type Channel, type ChatRow, type EffortOption, type PermissionPresetSnapshot, type PresetOption, type SkillInfo } from '../dsh-adapter/channel.js'
 import type { QuestionStore } from '../dsh-adapter/questions.js'
 import { TuiDialogStore } from '../dsh-adapter/dialogs.js'
 import { TuiStatusStore } from '../dsh-adapter/status.js'
@@ -71,7 +72,7 @@ import { ActivityPicker } from '../components/ActivityPicker.js'
 import { ColorPicker } from '../components/ColorPicker.js'
 import { EffortSlider } from '../components/EffortSlider.js'
 import { PresetPicker } from '../components/PresetPicker.js'
-import { PermissionsPicker, PERMISSION_PRESET_IDS } from '../components/PermissionsPicker.js'
+import { PermissionsPicker } from '../components/PermissionsPicker.js'
 import { PlanPicker } from '../components/PlanPicker.js'
 import { LangPicker } from '../components/LangPicker.js'
 import { ThemePicker, getThemeOptions } from '../components/ThemePicker.js'
@@ -114,6 +115,29 @@ import {
 
 /** Shared empty snapshot for hosts whose channel has no event log. */
 const NO_EVENTS: readonly SessionEvent[] = []
+
+const PERMISSION_RESULT_CELLS = 200
+
+function cleanPermissionError(error: unknown): string {
+  try {
+    if (error instanceof Error) {
+      return typeof error.message === 'string'
+        ? cleanRenderText(error.message, PERMISSION_RESULT_CELLS)
+        : ''
+    }
+    return cleanScalarText(error, PERMISSION_RESULT_CELLS)
+  } catch {
+    return ''
+  }
+}
+
+function clonePermissionPresetSnapshot(snapshot: PermissionPresetSnapshot): PermissionPresetSnapshot {
+  return {
+    availability: snapshot.availability,
+    options: snapshot.options.map(option => ({ ...option })),
+    ...(snapshot.current === undefined ? {} : { current: { ...snapshot.current } }),
+  }
+}
 
 /** Row kinds the message-selection cursor can land on. */
 const SELECTABLE_KINDS = new Set<ChatRow['kind']>([
@@ -336,6 +360,20 @@ export function Chat({
    * list while the fresh one loads, exactly as the boolean era did.
    */
   const [overlay, dispatchOverlay] = React.useReducer(chatOverlayReducer, NO_OVERLAY)
+  // Chat and PromptInput both receive one parsed stdin batch. Keep the
+  // permission focus synchronous so arrow+Enter in the same batch uses the
+  // post-arrow row rather than the previous render's index.
+  const permissionOverlayFocusRef = React.useRef<{ overlay: unknown; index: number } | null>(null)
+  if (overlay.kind === 'permission') {
+    // Seed each concrete picker instance once. Subsequent renders from
+    // channel/store updates must not overwrite a focus change that has already
+    // been applied synchronously for an arrow+Enter batch.
+    if (permissionOverlayFocusRef.current?.overlay !== overlay) {
+      permissionOverlayFocusRef.current = { overlay, index: overlay.index }
+    }
+  } else {
+    permissionOverlayFocusRef.current = null
+  }
   const [models, setModels] = React.useState<readonly LlmModelInfo[]>([])
   /** Provider display identities for the /model group level; refreshed alongside `models`. */
   const [providerInfos, setProviderInfos] = React.useState<readonly LlmProviderInfo[]>([])
@@ -875,15 +913,22 @@ export function Chat({
    * result text lands as a notification. `rawInput` carries the text after
    * the command name (`/plan off` → ` off`).
    */
-  /** Localized display name of a sandbox mode id (`read-only` /
-   *  `workspace-write` / `danger-full-access`), for `/permission status`. */
-  const permissionPresetName = (id: string | undefined): string => {
-    switch (id) {
-      case 'read-only': return t('permission-preset-readonly')
-      case 'workspace-write': return t('permission-preset-workspace-write')
-      case 'danger-full-access': return t('permission-preset-full-access')
-      default: return id ?? '—'
-    }
+  /** Route every permission switch through the official command path. */
+  const runPermissionCommand = (rawInput: string): void => {
+    const originAgentBinding = channel.agentBindingGeneration
+    void channel.runExternalCommand('permission', rawInput).then((text) => {
+      if (channel.agentBindingGeneration !== originAgentBinding) return
+      if (text === undefined) {
+        channel.notify(t('command-not-found', { name: 'permission' }), { color: 'error' })
+        return
+      }
+      const cleaned = typeof text === 'string' ? cleanRenderText(text, PERMISSION_RESULT_CELLS) : ''
+      if (cleaned !== '') channel.notify(cleaned)
+    }).catch((error: unknown) => {
+      if (channel.agentBindingGeneration !== originAgentBinding) return
+      const detail = cleanPermissionError(error)
+      if (detail !== '') channel.notify(detail, { color: 'error' })
+    })
   }
 
   /** Hot-swap the UI language (`/lang <id>` and the LangPicker both land
@@ -1590,19 +1635,27 @@ export function Chat({
       case 'permission': {
         // The command itself is registered by dsh-sandbox-policy (dsh-base
         // permission-presets row): bare `/permission` opens the preset
-        // picker (read-only / workspace-write / danger-full-access) and
+        // picker and
         // Enter dispatches `/permission <preset>` through the same
         // external-command path a hand-typed argument takes. `/permission
-        // status` prints the policy explainer (absorbed from the removed
-        // `/permissions` command); other arguments pass through verbatim.
+        // status` prints the policy explainer; other arguments pass through
+        // verbatim.
         // When the row is not mounted the default external path (or the
         // model, when nothing is registered) wins.
         const mounted = channel.commandList.some(command => command.external && command.name === 'permission')
         const parts = rawInput.trim().split(/\s+/).filter(Boolean)
         if (mounted && parts[0] === 'status') {
           setHelpOpen(false)
+          const snapshot = channel.permissionPresets()
+          if (snapshot.options.some(option => option.value === 'status')) {
+            runPermissionCommand(rawInput)
+            return true
+          }
+          const currentName = snapshot.availability === 'unavailable'
+            ? t('permission-roster-unavailable')
+            : snapshot.current?.name ?? '—'
           channel.pushLocal('/permission', [
-            t('permission-current', { name: permissionPresetName(channel.mode.sandbox) }),
+            t('permission-current', { name: currentName }),
             t('permission-policy-hint'),
             t('permission-approval-hint'),
             t('permission-root-hint', { cwd: channel.cwd }),
@@ -1612,22 +1665,31 @@ export function Chat({
         }
         if (mounted && parts.length === 0) {
           setHelpOpen(false)
-          const index = (PERMISSION_PRESET_IDS as readonly string[]).indexOf(channel.mode.sandbox ?? '')
+          const snapshot = channel.permissionPresets()
+          if (snapshot.availability === 'unavailable' || snapshot.options.length === 0) {
+            runPermissionCommand(rawInput)
+            return true
+          }
+          const currentValue = snapshot.current?.kind === 'preset' ? snapshot.current.value : undefined
+          const currentIndex = currentValue === undefined
+            ? -1
+            : snapshot.options.findIndex(option => option.value === currentValue)
+          const index = currentIndex >= 0
+            ? currentIndex
+            : Math.min(1, snapshot.options.length - 1)
           dispatchOverlay({
             type: 'open',
-            overlay: { kind: 'permission', index: index >= 0 ? index : 1 },
+            overlay: {
+              kind: 'permission',
+              index,
+              snapshot: clonePermissionPresetSnapshot(snapshot),
+            },
           })
           return true
         }
         if (mounted) {
           setHelpOpen(false)
-          void channel.runExternalCommand('permission', rawInput).then((text) => {
-            if (text !== undefined && text !== '') {
-              channel.notify(text)
-            } else if (text === undefined) {
-              channel.notify(t('command-not-found', { name: 'permission' }), { color: 'error' })
-            }
-          })
+          runPermissionCommand(rawInput)
           return true
         }
         return false
@@ -2513,16 +2575,18 @@ export function Chat({
     }
     if (overlay.kind === 'permission') {
       if (key.upArrow || key.downArrow) {
-        dispatchOverlay({ type: 'move', delta: key.upArrow ? -1 : 1, count: PERMISSION_PRESET_IDS.length })
+        const currentIndex = permissionOverlayFocusRef.current?.index ?? overlay.index
+        const nextIndex = wrapIndex(currentIndex, key.upArrow ? -1 : 1, overlay.snapshot.options.length)
+        permissionOverlayFocusRef.current = { overlay, index: nextIndex }
+        dispatchOverlay({ type: 'set-index', kind: 'permission', index: nextIndex })
       } else if (plainReturn) {
-        const id = PERMISSION_PRESET_IDS[overlay.index]
+        const currentIndex = permissionOverlayFocusRef.current?.index ?? overlay.index
+        const option = overlay.snapshot.options[currentIndex]
+        permissionOverlayFocusRef.current = null
         dispatchOverlay({ type: 'close' })
-        if (id !== undefined) {
-          void channel.runExternalCommand('permission', ` ${id}`).then((text) => {
-            if (text !== undefined && text !== '') channel.notify(text)
-          })
-        }
+        if (option !== undefined) runPermissionCommand(` ${option.value}`)
       } else if (key.escape) {
+        permissionOverlayFocusRef.current = null
         dispatchOverlay({ type: 'close' })
       }
       return
@@ -3048,7 +3112,8 @@ export function Chat({
     workspaceTargetCount: workspaceTargets.length,
     effortOptionCount: effortOptions.length,
     presetOptionCount: presetOptions.length,
-  })
+  }) && !(overlay.kind === 'permission'
+    && (approvalSnapshot !== null || questionSnapshot !== null || dialogSnapshot !== null))
 
   // The sticky header pins the turn owning the viewport top row
   // (timeline.activeId, reported by MessageList) — scrolled up to an old
@@ -3517,20 +3582,18 @@ export function Chat({
               />
             </Box>
           )}
-          {overlay.kind === 'permission' && (
+          {overlay.kind === 'permission' && overlay.snapshot.options.length > 0 && (
             <Box flexDirection="column" marginTop={1}>
               <PermissionsPicker
+                options={overlay.snapshot.options}
                 focusIndex={overlay.index}
-                currentMode={channel.mode.sandbox}
+                currentValue={overlay.snapshot.current?.value}
                 cwd={channel.cwd}
                 onPick={(index) => {
+                  if (approvalSnapshot !== null || questionSnapshot !== null || dialogSnapshot !== null) return
+                  const option = overlay.snapshot.options[index]
                   dispatchOverlay({ type: 'close' })
-                  const id = PERMISSION_PRESET_IDS[index]
-                  if (id !== undefined) {
-                    void channel.runExternalCommand('permission', ` ${id}`).then((text) => {
-                      if (text !== undefined && text !== '') channel.notify(text)
-                    })
-                  }
+                  if (option !== undefined) runPermissionCommand(` ${option.value}`)
                 }}
               />
             </Box>

--- a/src/screens/chatOverlay.ts
+++ b/src/screens/chatOverlay.ts
@@ -28,7 +28,7 @@
  *      picker can paint the previous list while the fresh one loads,
  *      exactly as before.
  */
-import type { ChatRow } from '../dsh-adapter/channel.js'
+import type { ChatRow, PermissionPresetSnapshot } from '../dsh-adapter/channel.js'
 import type { TuiRewindMode } from '../dsh-adapter/extension-events.js'
 import type { TuiWorkspaceCommandResult } from '../workspaces.js'
 
@@ -62,7 +62,7 @@ export type ChatOverlay =
   | { kind: 'effort'; index: number }
   | { kind: 'preset'; index: number }
   | { kind: 'theme'; index: number }
-  | { kind: 'permission'; index: number }
+  | { kind: 'permission'; index: number; snapshot: PermissionPresetSnapshot }
   | { kind: 'plan'; index: number }
   | { kind: 'lang'; index: number }
   | { kind: 'history'; query: string; cursor: number; focus: number }
@@ -117,7 +117,7 @@ export type ChatOverlayAction =
    *  with the authoritative focus (model list / preset roster), or a mouse
    *  click on a row of a panel that stays open (effort slider, workspace
    *  flow). Ignored unless that panel is still up. */
-  | { type: 'set-index'; kind: 'model' | 'preset' | 'effort' | 'workspace-flow' | 'rewind' | 'file-actions'; index: number }
+  | { type: 'set-index'; kind: 'model' | 'preset' | 'effort' | 'permission' | 'workspace-flow' | 'rewind' | 'file-actions'; index: number }
   /** Edit the history-search draft (query text, caret, focused match). */
   | { type: 'history-edit'; query?: string; cursor?: number; focus?: number }
   /** Workspace flow: an action is running (keys except Esc are swallowed). */
@@ -256,6 +256,8 @@ export function dialogOverlayVisible(
       return gates.effortOptionCount > 1
     case 'preset':
       return gates.presetOptionCount > 0
+    case 'permission':
+      return overlay.snapshot.options.length > 0
     default:
       return true
   }

--- a/src/tips.ts
+++ b/src/tips.ts
@@ -375,8 +375,8 @@ export const TIPS: readonly Tip[] = [
   {
     id: 'cmd-permission',
     group: 'commands',
-    zh: '/permission 弹出权限预设选择器（只读/工作区读写/完全访问）',
-    en: '/permission opens the permission-preset picker (read-only/workspace-write/full)',
+    zh: '/permission 弹出由 DSH registry 提供的权限预设选择器',
+    en: '/permission opens the DSH registry-backed permission-preset picker',
   },
   {
     id: 'cmd-plan-goal',


### PR DESCRIPTION
## 修改说明

本 PR 将 dsh-TUI 的权限预设读取改为消费 DSH 官方 `permissionPresets` registry，并保持官方 `/permission <preset>` 作为唯一切换路径。

- 新增 `runtime`、`legacy`、`unavailable` 三态快照；服务缺失时保留 legacy 兼容名册，服务已挂载但为空、损坏或不一致时 fail closed。
- 按 registry 声明顺序驱动状态、补全和 picker，第三方预设自动可见；`custom` 仅作为当前身份显示，不进入选择或补全。
- 权限 overlay 打开时冻结完整快照，统一 typed、键盘和鼠标切换语义，并用 Agent 绑定代次丢弃跨会话陈旧响应。
- 清洗 ANSI、控制字符和不安全显示文本，补充动态 `status` 命名空间处理。
- 同步中英文用户文档，并在 README 保留 Windows `danger-full-access` / approval `never` 安全警示。

## 兼容性

- 未挂载 `permissionPresets` 服务：继续使用旧三项兼容行为。
- 已挂载但不可用的服务：显示名册不可用，不伪造旧名册。
- 外部 `/permission` 命令未注册：沿用现有默认命令/model dispatch 行为。
- 未修改 DSH 核心、Cordis 配置、策略文件或正式用户 profile。

## 验证

- `pnpm verify:permission-presets`：通过（测试脚本仅保留本地，未纳入本 PR）。
- `pnpm build`：通过。
- `pnpm verify:package`：通过（1343 files / 25 entry targets）。
- `git diff --check`：通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `/permission` dynamically discovers available permission presets, including third-party options and custom states.
  - Permission selections display localized labels and descriptions, with safe fallback behavior when services or presets are unavailable.
  - Permission dialogs and command results are more reliable when switching between active sessions.

- **Bug Fixes**
  - Improved sanitization by removing terminal escape sequences and unsafe control characters.
  - Invalid command-completion tokens are now rejected more consistently.

- **Documentation**
  - Renamed `/permissions` to `/permission` and updated related guidance and verification instructions.
  - Documented fallback behavior and Windows’ unrestricted default access with approvals disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
