### PR TITLE
fix(markdown): file-link paint no longer leaks SGR parameter text (ESC stripped by content scrub)

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -47,6 +47,10 @@ const GROUPS = {
 // 安全回归：OSC 出口控制字符剥离 + 超链接 scheme 门禁（安全审查
 // 2026-08-27）——tokenize 提取→回放链路的注入 payload 必须被剥除。
     ["verify-osc8-sanitize", ['node', '--import', 'tsx/esm', 'scripts/verify-osc8-sanitize.tsx']],
+// 文件链接 ANSI 完整性回归：renderCodeSpan 把已上色的路径代码段传入
+// createHyperlink 时，防注入消毒会剥掉合法 \x1b、SGR 参数文本上屏
+// （[38;2;…m 残片）；链接标签的样式序列同样不得残留裸参数。
+    ["verify-markdown-filelink-ansi", ['node', '--import', 'tsx/esm', 'scripts/verify-markdown-filelink-ansi.ts']],
 // 全屏 resize 空白回归：宽度变化清空行高缓存 → scrollHeight 估算塌缩，
 // shrunk 帧冻结的旧 scrollTop 与失准的 clamp 边界越过内容底，整屏裁剪
 // 成"只剩输入框"（Orca pane 宽度抖动的现场取证复现）。

--- a/scripts/verify-markdown-filelink-ansi.ts
+++ b/scripts/verify-markdown-filelink-ansi.ts
@@ -1,0 +1,90 @@
+/**
+ * Markdown 文件链接 ANSI 完整性回归。
+ *
+ * renderCodeSpan 曾把【已上色的】路径代码段直接作为 content 传给
+ * createHyperlink——其防注入消毒会把合法 `\x1b` 剥掉，SGR 参数文本
+ * （`[38;2;…m` / `[39m`）原样上屏（浅色主题 permission `#3F6CC4` 场景）。
+ * 回归断言：路径代码段输出要么带完整 `\x1b` 序列、要么无任何参数残片；
+ * 样式化链接标签（加粗等）同样不得残留 `[1m` 等裸参数。
+ *
+ * Run: node --import tsx/esm scripts/verify-markdown-filelink-ansi.ts
+ */
+
+// supportsHyperlinks 在模块加载时缓存 stdout 探测结果；TERM_PROGRAM=kitty
+// 走 wrapper 的附加终端名单，保证 OSC 8 路径被覆盖且不依赖运行环境。
+process.env.TERM_PROGRAM = 'kitty'
+
+const { default: chalk } = await import('chalk')
+const { applyMarkdown } = await import('../src/cc/markdown.js')
+const { createHyperlink } = await import('../src/cc/hyperlink.js')
+
+let failures = 0
+let checks = 0
+const check = (name: string, ok: boolean, detail = ''): void => {
+  checks += 1
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'} ${name}${ok || detail === '' ? '' : `: ${detail}`}`)
+}
+
+const prevLevel = chalk.level
+chalk.level = 3 // truecolor（38;2;r;g;b）；level 2 会把 rgb 降级成 256 色
+
+try {
+  // ── renderCodeSpan 端到端：路径内联代码 ─────────────────────────────
+  const out = applyMarkdown('看 `src/dsh-adapter/plugin.ts` 这个文件')
+  const bareSgr = (out.match(/\[38;2;/g) ?? []).length
+  const escSgr = (out.match(/\u001b\[38;2;/g) ?? []).length
+  check(
+    '路径代码段不残留裸 SGR 参数文本（每个 [38;2; 都必须带 ESC 前缀）',
+    bareSgr === escSgr,
+    JSON.stringify(out),
+  )
+  check(
+    '路径代码段保留完整真彩色 ESC 序列',
+    out.includes('\u001b[38;2;') && out.includes('src/dsh-adapter/plugin.ts\u001b[39m'),
+    JSON.stringify(out),
+  )
+  check(
+    '路径代码段带 OSC 8 超链接（kitty 环境）',
+    out.includes('\u001b]8;;dsh-file:'),
+    JSON.stringify(out),
+  )
+
+  // ── renderLink：带样式的链接标签 ───────────────────────────────────
+  const linkOut = applyMarkdown('去 [**加粗链接**](https://example.com/x) 看看')
+  check(
+    '样式化链接标签不残留 [1m/[22m 裸参数',
+    !linkOut.includes('[1m') && !linkOut.includes('[22m'),
+    JSON.stringify(linkOut),
+  )
+
+  // ── createHyperlink 直接契约 ────────────────────────────────────────
+  const paint = (text: string): string => `\u001b[38;2;63;108;196m${text}\u001b[39m`
+  const withPainted = createHyperlink('dsh-file:///x', paint('src/dsh-adapter/plugin.ts'), {
+    supportsHyperlinks: true,
+    style: (text: string) => text,
+  })
+  check(
+    '已上色 content 被完整消毒：SGR 序列全剥、仅剩 OSC 8 包裹与纯文本',
+    !withPainted.includes('\u001b[38;') &&
+      !withPainted.includes('[38;2;') &&
+      withPainted.includes('src/dsh-adapter/plugin.ts'),
+    JSON.stringify(withPainted),
+  )
+  const withStyle = createHyperlink('dsh-file:///x', 'src/dsh-adapter/plugin.ts', {
+    supportsHyperlinks: true,
+    style: paint,
+  })
+  check(
+    'style 回调在消毒后上色：ESC 完整、OSC 8 包裹',
+    withStyle.includes(
+      '\u001b]8;;dsh-file:///x\u0007\u001b[38;2;63;108;196msrc/dsh-adapter/plugin.ts\u001b[39m\u001b]8;;\u0007',
+    ),
+    JSON.stringify(withStyle),
+  )
+} finally {
+  chalk.level = prevLevel
+}
+
+console.log(`${checks - failures}/${checks} checks passed`)
+if (failures > 0) process.exit(1)

--- a/src/cc/hyperlink.ts
+++ b/src/cc/hyperlink.ts
@@ -41,11 +41,15 @@ function sanitizeHyperlinkUrl(raw: string): string | null {
 }
 
 // Display text keeps spaces (legitimate in link labels) but drops every
-// other control character: an OSC 8 sequence smuggled into `content` would
-// survive the plain-text wrap verbatim, hijack cell.hyperlink after
-// tokenize, and repaint a phish link over the legitimate URL.
-// Same set minus the space.
-const DISPLAY_TEXT_CONTROL_CHARS = /[\x00-\x1f\x7f-\x9f]/g
+// escape sequence and leftover control character: an OSC 8 sequence
+// smuggled into `content` would survive the plain-text wrap verbatim,
+// hijack cell.hyperlink after tokenize, and repaint a phish link over the
+// legitimate URL. Stripping COMPLETE ANSI sequences (not just the ESC byte)
+// also keeps the display clean when a caller passes an already-painted
+// string — the SGR parameter text would otherwise appear on screen as
+// literal `[38;2;…m` garbage.
+const DISPLAY_TEXT_CONTROL_CHARS =
+  /[\u001b\u009b][[\]()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><~]|\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)|[\x00-\x1f\x7f-\x9f]/g
 
 /**
  * Create a clickable hyperlink using OSC 8 escape sequences.

--- a/src/cc/markdown.ts
+++ b/src/cc/markdown.ts
@@ -92,11 +92,15 @@ function paintInlineCode(text: string): string {
  * without OSC 8 support keep the plain painted code span.
  */
 function renderCodeSpan(token: Tokens.Codespan): string {
-  const painted = paintInlineCode(token.text)
-  if (!looksLikeFilePath(token.text)) return painted
-  if (!supportsHyperlinks()) return painted
-  return createHyperlink(fileLinkUrl(token.text), painted, {
-    style: (text: string) => text,
+  // Paint via the style callback so the permission color is applied AFTER
+  // createHyperlink's anti-smuggle content scrub: passing the painted
+  // string as content would have its ESC bytes stripped, leaving
+  // `[38;2;…m` parameter text on screen.
+  const paint = (text: string): string => paintInlineCode(text)
+  if (!looksLikeFilePath(token.text)) return paint(token.text)
+  if (!supportsHyperlinks()) return paint(token.text)
+  return createHyperlink(fileLinkUrl(token.text), token.text, {
+    style: paint,
   })
 }
 


### PR DESCRIPTION
## 动机

聊天正文/工具卡里的文件路径（内联代码形态）会显示成：

```text
[38;2;63;108;196msrc/dsh-adapter/plugin.ts[39m
```

`38;2;63;108;196` = 浅色主题 `permission` 色 `#3F6CC4` 的真彩色 SGR 参数。根因：

`cc/markdown.ts` 的 `renderCodeSpan` 把**已经上色**的路径代码段（`\x1b[38;2;…m` + 路径 + `\x1b[39m`）直接作为 `content` 传给 `createHyperlink`；而 `createHyperlink` 的防注入消毒（hyperlink.ts:71）按"剥裸控制字符"处理，把合法的 `\x1b` 剥掉、SGR 参数文本 `[38;2;…m` 原样上屏。**带样式的链接标签**（`[**加粗**](url)`）同理残留 `[1m`。

## 改动

- `src/cc/hyperlink.ts`：`DISPLAY_TEXT_CONTROL_CHARS` 从"裸控制字符"改为"**完整 ANSI 序列 + 剩余控制字符**"（复用 childStderr 的 ANSI_PATTERN 形态）——安全契约不变（OSC 8 走私仍被整体剥除），传进来的已上色文本优雅退化为纯文本，不再留参数残片；
- `src/cc/markdown.ts` `renderCodeSpan`：改传**纯文本** + `style: paintInlineCode`——permission 上色挪到消毒**之后**，颜色完整保留；
- `scripts/verify-markdown-filelink-ansi.ts`（新，登记 render-scroll 组，紧邻 verify-osc8-sanitize）：
  - 强制 `chalk.level=3` + `TERM_PROGRAM=kitty`（OSC 8 路径确定覆盖）；
  - 路径代码段：每个 `[38;2;` 都必须带 `\x1b` 前缀、完整 `\x1b[38;2;…路径\x1b[39m` 保留、OSC 8 包裹存在；
  - 样式化链接标签无 `[1m`/`[22m` 残片；
  - createHyperlink 直接契约：已上色 content 被完整消毒；style 回调在消毒后上色输出完整序列。

## 验证

- `scripts/verify-markdown-filelink-ansi.ts`：6/6 通过（修复前探针实测输出为 `[38;2;63;108;196m路径[39m` 残片，修复后为完整 `\x1b[38;2;…m路径\x1b[39m`）；
- `pnpm build`（compile + verify:build 全部门禁）；
- `git diff --check` 干净。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal rendering of Markdown file links with colored or styled text.
  - Preserved complete hyperlink and text-formatting sequences when displaying linked code spans.
  - Prevented raw terminal control sequences and styling fragments from appearing in link labels.
  - Improved compatibility with terminals that support Kitty hyperlinks while maintaining appropriate fallback rendering elsewhere.

- **Tests**
  - Added regression coverage to verify hyperlink sanitization and ANSI formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->