### PR TITLE
fix(input): 英文长词按词边界换行

### DIFF
--- a/scripts/verify-input-selection.tsx
+++ b/scripts/verify-input-selection.tsx
@@ -8,8 +8,8 @@
  *   阶段 A（真实 PromptInput + AlternateScreen + Chat 式 useInput 持有者）：
  *     拖选→打字替换、反向拖选、Backspace/Delete 删选区、Shift+click 扩展
  *     + 控制器复制（OSC 52 断言）、Esc 仅清选区→再 Esc 清输入、双击选词
- *     （500ms/1 格自检测）、方向键坍缩、CJK 宽字符、fold block 选区钳制
- *     与无选区 consumeSelectionCopy=false。
+ *     （500ms/1 格自检测）、方向键坍缩、CJK 宽字符、英文整词换行与换行词上的
+ *     caret/点击、fold block 选区钳制与无选区 consumeSelectionCopy=false。
  *   阶段 B（真实 Chat）：Ctrl+C 经 Chat→控制器复制选区且保留选区、再打字
  *     替换；无选区 Ctrl+C 保持既有清空语义。
  *
@@ -573,6 +573,51 @@ function makeHarness(cols: number, rows: number): Harness {
     check('A11 controller clear 同步清除折叠 chip 与选区',
       await settled(() => !screenHas('▸ 12 lines') && !screenHas('TAIL')) &&
         controllerBox.current?.consumeSelectionCopy() === false)
+
+    // A12: #607 英文整词换行。COLS=80 时 inputWidth = 80-3-2 = 75（边框/展开钮）。
+    // 70 个 x + 空格 + classification(14) = 85 > 75：硬换行会在词中劈开
+    // （clas|sification），整词换行把 classification 整段带到下一行。
+    const word = 'classification'
+    stdin.write(`${'x'.repeat(70)} ${word}`)
+    check(
+      'A12 长英文词整词换到下一行',
+      await settled(() => {
+        const wpos = findText(word)
+        const xs = findText('xxxxx')
+        return wpos !== null && xs !== null && wpos.row > xs.row
+      }),
+    )
+    const wpos = findText(word)!
+    stdin.write('\x1b[D'.repeat(7))
+    check(
+      'A12 词中 caret 留在换行后的词行',
+      await settled(
+        () => inverseAt(wpos.col + 7, wpos.row) && !inverseAt(wpos.col + 7, wpos.row - 1),
+      ),
+    )
+    click(wpos.col + 3, wpos.row)
+    check(
+      'A12 点击换行词 caret 在词行而非上一行',
+      await settled(
+        () =>
+          (inverseAt(wpos.col + 2, wpos.row) ||
+            inverseAt(wpos.col + 3, wpos.row) ||
+            inverseAt(wpos.col + 4, wpos.row)) &&
+          !inverseAt(wpos.col + 3, wpos.row - 1),
+      ),
+    )
+    dragRange(wpos.col, wpos.col + word.length, wpos.row)
+    const wrapCopies = oscPayloads().length
+    check(
+      'A12 拖选换行词复制整词',
+      await settled(
+        () => inverseAt(wpos.col, wpos.row) && inverseAt(wpos.col + word.length - 1, wpos.row),
+      ) &&
+        controllerBox.current?.consumeSelectionCopy() === true &&
+        (await settled(() => oscPayloads().length === wrapCopies + 1)) &&
+        oscPayloads().at(-1) === word,
+      oscPayloads().at(-1) ?? 'no osc52',
+    )
   } finally {
     app.unmount()
   }

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1945,11 +1945,21 @@ export function PromptInput({
   const visualLines = block
     ? [...headRows, '', ...tailRows]
     : wrapToWidth(value, inputWidth)
-  const caretVisualLine = block
+  // Caret geometry uses the FULL wrap (not `value.slice(0, cursor)`):
+  // word-wrap carry moves already-placed clusters, so a prefix wrap would
+  // disagree with the displayed rows whenever the cursor sits inside a
+  // carried word.
+  const caretPlaced = block
     ? cursor <= block.start
-      ? wrapToWidth(value.slice(0, cursor), inputWidth).length - 1
-      : headRows.length + 1 + wrapToWidth(value.slice(block.end, cursor), inputWidth).length - 1
-    : wrapToWidth(value.slice(0, cursor), inputWidth).length - 1
+      ? caretInText(head, inputWidth, cursor)
+      : caretInText(tail, inputWidth, Math.max(0, cursor - block.end))
+    : caretInText(value, inputWidth, cursor)
+  const caretVisualLine =
+    block && cursor > block.start
+      ? headRows.length + 1 + caretPlaced.line
+      : caretPlaced.line
+  const caretCharCol = caretPlaced.charCol
+  const caretVisualCol = caretPlaced.visualCol
 
   // Fold stats describe the BLOCK (or the whole input when expanded and
   // the ▾ prefix offers a manual whole-input fold). The chip shows the
@@ -2000,27 +2010,6 @@ export function PromptInput({
   // useInput 的滚轮分支需要这份几何（它在这些派生之前注册）。
   if (expanded) {
     editorViewportRef.current = { maxRows: editorMaxRows, total: visualLines.length }
-  }
-
-  // Caret position in the caret's visual row, in two units:
-  // - char index (for slicing the row's characters in the render below)
-  // - visual column (for the physical cursor declaration — CJK characters
-  //   occupy TWO terminal columns, so the raw char count would park the
-  //   cursor mid-character and Windows Terminal would paint the IME
-  //   preedit (pinyin) over the surrounding text).
-  const caretCharCol = () => {
-    const before =
-      block && cursor >= block.end ? value.slice(block.end, cursor) : value.slice(0, cursor)
-    const rows = wrapToWidth(before, inputWidth)
-    const last = rows[rows.length - 1] ?? ''
-    return last.length
-  }
-  const caretVisualCol = () => {
-    const before =
-      block && cursor >= block.end ? value.slice(block.end, cursor) : value.slice(0, cursor)
-    const rows = wrapToWidth(before, inputWidth)
-    const last = rows[rows.length - 1] ?? ''
-    return stringWidth(last)
   }
 
   // Folded chip content: block stats + first-line preview + hover hint,
@@ -2080,7 +2069,7 @@ export function PromptInput({
     }
     let endBlankCaret = false
     if (absoluteLine === caretVisualLine) {
-      const col = Math.min(caretCharCol(), text.length)
+      const col = Math.min(caretCharCol, text.length)
       const clusterEnd = nextGraphemeBoundary(graphemeBoundaries(text), col)
       if (clusterEnd > col) intervals.push([col, clusterEnd])
       else endBlankCaret = col === text.length
@@ -2250,7 +2239,7 @@ export function PromptInput({
     // (padding + gutter included), so those columns ride along and the
     // clamp grows with them.
     column: Math.min(
-      caretVisualCol() +
+      caretVisualCol +
         (expanded
           ? editorGutterCols + 1
           : caretVisualLine === 0 && prefixCols > 0
@@ -2823,46 +2812,87 @@ export function PromptInput({
 }
 
 /**
- * Hard-wrap text into visual rows of at most `width` columns (CJK-aware via
- * stringWidth). Used by the input renderer so long lines wrap instead of
- * truncating, with exact caret-row mapping. Wrapping only ever breaks
- * BETWEEN grapheme clusters: iterating code points would split ZWJ emoji
- * and combining sequences across rows, leaving a broken half at each edge
- * and desyncing the caret's row arithmetic (which walks cluster
- * boundaries).
+ * Grapheme word-wrap for one logical line: break at the last space when
+ * the row overflows; hard-wrap a word that cannot fit; never split a
+ * cluster (ZWJ emoji, combining sequences, CJK wide cells stay whole).
  */
-function wrapToWidth(text: string, width: number): string[] {
-  const rows: string[] = []
+function wrapLineRows(
+  line: string,
+  width: number,
+): Array<{ start: number; end: number }> {
+  if (line === '') return [{ start: 0, end: 0 }]
+  const rows: Array<{ start: number; end: number }> = []
   const segmenter = getGraphemeSegmenter()
-  for (const line of text.split('\n')) {
-    if (line === '') {
-      rows.push('')
-      continue
-    }
-    let current = ''
-    let currentWidth = 0
-    for (const { segment } of segmenter.segment(line)) {
-      const w = stringWidth(segment)
-      if (currentWidth + w > width && current !== '') {
-        rows.push(current)
-        current = segment
-        currentWidth = w
+  let rowStart = 0
+  let currentWidth = 0
+  let offset = 0
+  let lastBreak = -1
+  for (const { segment } of segmenter.segment(line)) {
+    const w = stringWidth(segment)
+    while (currentWidth + w > width && offset > rowStart) {
+      if (lastBreak > rowStart) {
+        rows.push({ start: rowStart, end: lastBreak })
+        rowStart = lastBreak
+        currentWidth = stringWidth(line.slice(rowStart, offset))
+        lastBreak = -1
       } else {
-        current += segment
-        currentWidth += w
+        rows.push({ start: rowStart, end: offset })
+        rowStart = offset
+        currentWidth = 0
+        lastBreak = -1
       }
     }
-    rows.push(current)
+    currentWidth += w
+    offset += segment.length
+    if (segment === ' ') lastBreak = offset
   }
+  rows.push({ start: rowStart, end: offset })
   return rows
+}
+
+/** Wrap text to `width` columns via {@link wrapLineRows} (newlines honoured). */
+function wrapToWidth(text: string, width: number): string[] {
+  return text.split('\n').flatMap(line =>
+    wrapLineRows(line, width).map(r => line.slice(r.start, r.end)),
+  )
+}
+
+/**
+ * Locate `offset` in the wrapped layout of `text`. Uses the full wrap —
+ * not a prefix — so a cursor inside a carried word maps to the displayed
+ * row. At a wrap join the caret stays on the earlier row (after the space).
+ */
+function caretInText(
+  text: string,
+  width: number,
+  offset: number,
+): { line: number; charCol: number; visualCol: number } {
+  let line = 0
+  let lineBase = 0
+  let last = { line: 0, charCol: 0, visualCol: 0 }
+  for (const logical of text.split('\n')) {
+    for (const r of wrapLineRows(logical, width)) {
+      const start = lineBase + r.start
+      const charCol = Math.max(0, offset - start)
+      last = {
+        line,
+        charCol,
+        visualCol: stringWidth(logical.slice(r.start, r.start + charCol)),
+      }
+      if (offset <= lineBase + r.end) return last
+      line++
+    }
+    lineBase += logical.length + 1
+  }
+  return last
 }
 
 /**
  * Inverse of {@link wrapToWidth}: map a click position (visual row index +
- * visual column) back to a UTF-16 offset in the original text. Walks the
- * same grapheme boundaries with the same break rule, so every visual row's
- * start offset is known exactly. Within the clicked row, the caret snaps to
- * the boundary nearest the click: a grapheme whose midpoint lies past the
+ * visual column) back to a UTF-16 offset in the original text. Uses the
+ * same {@link wrapLineRows} row boundaries, so every visual row's start
+ * offset is known exactly. Within the clicked row, the caret snaps to the
+ * boundary nearest the click: a grapheme whose midpoint lies past the
  * click column takes the caret before it, otherwise after.
  */
 function clickToCursorOffset(
@@ -2874,77 +2904,47 @@ function clickToCursorOffset(
 ): number {
   const segmenter = getGraphemeSegmenter()
   let row = 0
-  let offset = 0
+  let lineBase = 0
   for (const line of text.split('\n')) {
-    if (line === '') {
-      if (row === visualLine) return offset
-      row++
-      offset++ // the '\n'
-      continue
-    }
-    let currentWidth = 0
-    for (const { segment } of segmenter.segment(line)) {
-      const w = stringWidth(segment)
-      if (currentWidth + w > width && currentWidth > 0) {
-        if (row === visualLine) return offset // end of the clicked wrapped row
-        row++
-        currentWidth = 0
-      }
+    for (const r of wrapLineRows(line, width)) {
       if (row === visualLine) {
-        // Caret positioning uses the nearest edge. Double-click selection
-        // instead needs the grapheme UNDER the cell: on the second cell of a
-        // CJK/emoji glyph, nearest-edge would point after the glyph (and the
-        // final glyph would select nothing).
-        if (snapWithin === 'grapheme-start' && currentWidth + w > visualCol) return offset
-        if (currentWidth + w / 2 > visualCol) return offset
-        if (currentWidth + w > visualCol) return offset + segment.length
+        let currentWidth = 0
+        let local = 0
+        for (const { segment } of segmenter.segment(line.slice(r.start, r.end))) {
+          const w = stringWidth(segment)
+          // Caret positioning uses the nearest edge. Double-click selection
+          // instead needs the grapheme UNDER the cell: on the second cell of a
+          // CJK/emoji glyph, nearest-edge would point after the glyph (and the
+          // final glyph would select nothing).
+          if (snapWithin === 'grapheme-start' && currentWidth + w > visualCol) {
+            return lineBase + r.start + local
+          }
+          if (currentWidth + w / 2 > visualCol) return lineBase + r.start + local
+          if (currentWidth + w > visualCol) return lineBase + r.start + local + segment.length
+          currentWidth += w
+          local += segment.length
+        }
+        return lineBase + r.end
       }
-      currentWidth += w
-      offset += segment.length
+      row++
     }
-    if (row === visualLine) return offset
-    row++
-    offset++ // the '\n'
+    lineBase += line.length + 1
   }
-  return offset
+  return lineBase
 }
 
 /**
- * Offset range [start, end) of every visual row, mirroring
- * {@link wrapToWidth}'s break rule exactly (breaks BETWEEN grapheme
- * clusters at `width` display columns, hard '\n' rows included). The
- * selection highlight intersects each row with these ranges so offsets
- * map 1:1 onto the rendered row strings.
+ * Offset range [start, end) of every visual row, using the same {@link
+ * wrapLineRows} boundaries as `wrapToWidth`. The selection highlight
+ * intersects each row with these ranges so offsets map 1:1 onto the
+ * rendered row strings.
  */
 function visualLineRanges(text: string, width: number): Array<[number, number]> {
   const ranges: Array<[number, number]> = []
-  const segmenter = getGraphemeSegmenter()
-  let offset = 0
+  let lineBase = 0
   for (const line of text.split('\n')) {
-    if (line === '') {
-      ranges.push([offset, offset])
-      offset++ // the '\n'
-      continue
-    }
-    let start = offset
-    let currentWidth = 0
-    let currentLength = 0
-    for (const { segment } of segmenter.segment(line)) {
-      const w = stringWidth(segment)
-      // `currentLength > 0` is wrapToWidth's `current !== ''` — a row
-      // starting with a zero-width cluster must never break on it.
-      if (currentWidth + w > width && currentLength > 0) {
-        ranges.push([start, offset])
-        start = offset
-        currentWidth = 0
-        currentLength = 0
-      }
-      currentWidth += w
-      currentLength += segment.length
-      offset += segment.length
-    }
-    ranges.push([start, offset])
-    offset++ // the '\n'
+    for (const r of wrapLineRows(line, width)) ranges.push([lineBase + r.start, lineBase + r.end])
+    lineBase += line.length + 1
   }
   return ranges
 }


### PR DESCRIPTION
Fixes #607

输入框行尾的长英文词不再从中间切断，改为整词换到下一行。比一行还长的词仍按 grapheme 硬折。折行、光标、点击和选区共用同一套边界。

验证：`node --import tsx/esm scripts/verify-input-selection.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wrapping for long English words in PromptInput.
  * Keystrokes, caret movement, and clicks now stay aligned with wrapped lines.
  * Double-clicking, dragging, and copying preserve complete words across wrapped lines.
  * Improved handling of grapheme clusters, CJK text, whitespace, and explicit line breaks.
  * Normalized carriage returns and improved multiline text insertion.
  * Empty rendered lines now display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->