### PR TITLE
修复：Ctrl+J 在扩展键协议下无法换行

### DIFF
--- a/scripts/verify-batched-prompt-input.mjs
+++ b/scripts/verify-batched-prompt-input.mjs
@@ -190,7 +190,9 @@ check(
 // remain a usable multiline fallback instead of submitting the first line.
 channel.working = false
 const multilineCases = [
-  ['Ctrl+J', '\n', 'ctrl'],
+  ['Ctrl+J (legacy LF)', '\n', 'ctrl'],
+  ['Ctrl+J (CSI-u)', '\x1b[106;5u', 'csi-u'],
+  ['Ctrl+J (modifyOtherKeys)', '\x1b[27;5;106~', 'modify-other-keys'],
   ['Option+Enter', '\x1b\r', 'option'],
   ['Shift+Enter', '\x1b[13;2u', 'shift'],
 ]
@@ -208,6 +210,32 @@ for (const [index, [label, newlineKey, prefix]] of multilineCases.entries()) {
     `${label} inserts a newline before Enter submits the multiline draft`,
     await settled(() => submitted.length === index + 3
       && submitted[index + 2] === `${prefix} first\n${prefix} second`),
+    JSON.stringify(submitted),
+  )
+}
+
+// Enhanced protocols distinguish extra modifiers that legacy LF cannot carry.
+// Only exact Ctrl+J is the fallback; modified variants stay available to other
+// bindings instead of silently changing the draft.
+const modifiedCtrlJCases = [
+  ['Ctrl+Shift+J', '\x1b[106;6u', 'ctrl-shift'],
+  ['Ctrl+Alt+J', '\x1b[106;7u', 'ctrl-alt'],
+  ['Ctrl+Super+J', '\x1b[106;13u', 'ctrl-super'],
+]
+for (const [index, [label, newlineKey, prefix]] of modifiedCtrlJCases.entries()) {
+  stdin.write(`${prefix} first`)
+  await sleep(100)
+  stdin.write(newlineKey)
+  await sleep(100)
+  stdin.write(`${prefix} second`)
+  await sleep(100)
+  stdin.write('\r')
+
+  const submission = multilineCases.length + index + 2
+  check(
+    `${label} does not insert a Ctrl+J fallback newline`,
+    await settled(() => submitted.length === submission + 1
+      && submitted[submission] === `${prefix} first${prefix} second`),
     JSON.stringify(submitted),
   )
 }

--- a/scripts/verify-keymap.mjs
+++ b/scripts/verify-keymap.mjs
@@ -93,6 +93,7 @@ check('other actions keep their defaults reserved', reserved.has('ctrl+o') && re
 check('fixed: ctrl+u kill-line reserved', isFixedReserved('ctrl+u'))
 check('fixed: ctrl+return reserved', isFixedReserved('ctrl+return'))
 check('fixed: ctrl+w reserved', isFixedReserved('ctrl+w'))
+check('fixed: ctrl+j newline fallback reserved', isFixedReserved('ctrl+j'))
 check('free combo not reserved', !isFixedReserved('ctrl+n'))
 
 // ---- settings drafts ------------------------------------------------------

--- a/scripts/verify-keys.tsx
+++ b/scripts/verify-keys.tsx
@@ -125,6 +125,12 @@ check('CSI 13;5u is ctrl+return (interruptSend path)', new Feeder().feed('\x1b[1
 check('modifyOtherKeys CSI 27;2;13~ is shift+return', new Feeder().feed('\x1b[27;2;13~'), [
   ret({ shift: true }, '\x1b[27;2;13~'),
 ])
+check('CSI 106;5u is ctrl+j', new Feeder().feed('\x1b[106;5u'), [
+  named('j', '\x1b[106;5u', { ctrl: true }),
+])
+check('modifyOtherKeys CSI 27;5;106~ is ctrl+j', new Feeder().feed('\x1b[27;5;106~'), [
+  named('j', '\x1b[27;5;106~', { ctrl: true }),
+])
 
 // --- 2. merged with following text ----------------------------------------
 

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1203,10 +1203,11 @@ export function PromptInput({
       return
     }
 
-    // Ctrl+J is the only portable multiline fallback when a terminal cannot
-    // report modifiers on Enter. The parser names its bare LF `enter`, while
-    // the physical Enter key arrives as CR (`return`).
-    if (input === '\n' && event?.keypress.name === 'enter') {
+    // Ctrl+J is the portable multiline fallback when a terminal cannot
+    // report modifiers on Enter. Legacy terminals deliver bare LF (`enter`),
+    // while kitty/modifyOtherKeys encode it as an exact Ctrl+J key.
+    const isCtrlJ = input === 'j' && key.ctrl && !key.shift && !key.meta && !key.super
+    if ((input === '\n' && event?.keypress.name === 'enter') || isCtrlJ) {
       insertAtCaret('\n')
       return
     }

--- a/src/utils/keymap.ts
+++ b/src/utils/keymap.ts
@@ -302,6 +302,7 @@ export const FIXED_RESERVED_COMBOS: readonly string[] = [
   'ctrl+u', // kill line
   'ctrl+k', // kill to end
   'ctrl+w', // kill word
+  'ctrl+j', // newline fallback (legacy LF / extended key reporting)
   'ctrl+left', // word jump
   'ctrl+right', // word jump
   'ctrl+return', // newline (multi-line input)


### PR DESCRIPTION
Fixes #541

支持 Kitty CSI-u 和 modifyOtherKeys 编码的 Ctrl+J 换行，保留 legacy LF，并仅匹配精确 Ctrl+J。

验证：`pnpm build`；聚焦键盘回归。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiline input handling for Ctrl+J across legacy and extended keyboard encoding formats.
  * Ctrl+J now inserts a newline consistently, while modified combinations avoid unintended fallback newlines.
  * Fixed keyboard shortcut conflict handling so reserved combinations remain available and valid custom mappings can be retained.
  * Added regression coverage to ensure surrounding text remains correctly concatenated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->