### PR TITLE
docs(links): 收录 dsh-tui-find（跨会话全文搜索）

### DIFF
--- a/docs/links.md
+++ b/docs/links.md
@@ -17,6 +17,7 @@
 | **cc-dsh-notifier** | <https://github.com/baobaolaodie/cc-dsh-notifier> | DeepSeek Harness / Claude Code 会话失焦时的 Windows 原生 Toast 通知与点击跳回（web 与 dsh-tui 双 profile） |
 | **YesPlayMusic ypm skill** | <https://github.com/nagi-studio/YesPlayMusic/tree/master/skills/ypm> | 让 dsh 的 agent 控制本机 YesPlayMusic 音乐播放：查询在放的歌、暂停/继续、切歌（SKILL.md 直接可用） |
 | **dsh-tui-theme** | <https://github.com/xiaoxiaohaigui/dsh-tui-theme> | 樱花粉主题包：昼樱 / 夜樱 / ANSI 三套全键覆盖调色板，终端背景自动跟随（OSC 11，与宿主同阈值），✿ 状态行与 /settings 设置面板（[npm](https://www.npmjs.com/package/dsh-tui-theme)） |
+| **dsh-tui-find** | <https://github.com/xiaoxiaohaigui/dsh-tui-find> | 跨会话全文搜索插件：/find 或 Ctrl+Shift+F 对本机全部 dsh 会话（zstd 帧链 / 明文 JSONL）即时检索，命中词高亮、按会话分组，只读预览 / 复制原文 / 二次确认恢复会话（[npm](https://www.npmjs.com/package/dsh-tui-find)） |
 
 > 本页是社区与第三方项目的链接罗列。所列项目与组织由各自的维护者独立维护，
 > dsh-TUI 仓库与其不存在隶属关系，也不对其内容、质量或安全作任何担保，使用前


### PR DESCRIPTION
按[插件收录与开发规范](https://github.com/T-Auto/dsh-ecosystem-spec/blob/main/docs/plugin-admission-and-development.md)的收录流程提交链接。

**dsh-tui-find** — dsh-TUI 的跨会话全文搜索插件（[GitHub](https://github.com/xiaoxiaohaigui/dsh-tui-find) · [npm](https://www.npmjs.com/package/dsh-tui-find)）：

- `/find <关键词>` / 空参进全屏搜索场景 / `Ctrl+Shift+F` 全局入口，对本机全部 dsh 会话（默认 zstd 帧链压缩、兼容明文 JSONL）做增量即时检索
- 双范围：本仓库（按 cwd 匹配，与 resume 浏览器同语义）⇄ 全部会话；命中词高亮、按会话分组、最近优先排序
- 命中后只读预览上下文（Alt+P）、复制原文（Alt+C）、二次确认后恢复会话（↵）；全程只读、无落盘索引、损坏尾帧容错
- /settings 设置卡片（文案跟随宿主语言）；manifest 通过宿主同款 @dsh-std/manifest v0.15 解析器与投影
- 不追加 surface 事件、不注入凭证、不拦截输入决策（subscriptions / permissions 均为空声明）；dsh-tui ≥ 0.9（v0.15 community-draft 插件体系），MIT

生态市场收录 PR：dsh-tui-ecosystem/dsh-tui-ecosystem#12

本 PR 仅改动 `docs/links.md` 一行（新增表格条目，与上一行连续无空行，npm 为可点击链接）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `dsh-tui-find` project to the friendly links directory.
  * Included its npm link and highlighted cross-session search, result highlighting, grouping, read-only previews, text copying, and session recovery features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->