### PR TITLE
fix(ui): 修复 Rewind 与上下文面板快捷键文案间距

### DIFF
--- a/src/components/RewindPicker.tsx
+++ b/src/components/RewindPicker.tsx
@@ -128,7 +128,7 @@ export function RewindPicker({
   return (
     <Pane color="permission">
       <Box flexDirection="column">
-        <Box marginBottom={1}>
+        <Box marginBottom={1} flexDirection="column">
           <Text color="remember" bold>
             {t('rewind-title')}
           </Text>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -238,8 +238,8 @@ const dict = {
   // ── screens/Chat.tsx ────────────────────────────────────────────────
   'skill-unavailable': { zh: '技能 {{name}} 已不可用或未开放用户直调', en: 'Skill {{name}} is gone or not user-invocable' },
   'context-loaded': { zh: '已加载上下文', en: 'Context loaded' },
-  'context-panel-expand': { zh: '展开', en: 'Expand' },
-  'context-panel-collapse': { zh: '折叠', en: 'Collapse' },
+  'context-panel-expand': { zh: ' 展开', en: ' to expand' },
+  'context-panel-collapse': { zh: ' 折叠', en: ' to collapse' },
   'copied-chars': { zh: '已复制 {{n}} 个字符', en: 'Copied {{n}} characters' },
   'activity-current-preset': { zh: '当前预设  {{name}}', en: 'Current preset  {{name}}' },
   'activity-switch-hint': { zh: '切换      /activity（选择器）或 /activity frames <名>', en: 'Switch      /activity (picker) or /activity frames <name>' },


### PR DESCRIPTION
CLOSE #644 

## 动机

  修复两个终端 UI 文案可读性问题：

  - Rewind 选择器标题与说明文字横向黏连。
  - 上下文面板显示为 Ctrl+PExpand / Ctrl+PCollapse，英文缺少 to，中英文也缺少间距。

  ## 改动

  - RewindPicker 标题块改为纵向布局，使说明文字单独换行。
  - 更新 context-panel-expand 和 context-panel-collapse 的中英文文案：
      - 英文：to expand / to collapse
      - 中文：增加前置空格，避免与 Ctrl+P 黏连。

  - 未改变交互逻辑、快捷键行为或宿主服务边界。

修复效果如下：

<img width="540" height="80" alt="image" src="https://github.com/user-attachments/assets/05fff9e7-27a8-4ce2-b7c0-2bb60197582e" />
<img width="658" height="197" alt="image" src="https://github.com/user-attachments/assets/58799acc-d332-4120-9086-88c326c92ba1" />

  ## 验证

  - pnpm compile
  - sync-profile 检查通过，开发 profile 与工作区产物一致。
  - 已运行完整 pnpm build 及专用回归脚本。

  ## 风险与回滚

  风险较低，仅涉及 TUI 布局属性和本地化字符串。
  如需回滚，可移除以下两个 commit：

  - d46b214 fix(ui) Rewind 与上下文面板快捷键文案间距
  - 5db7648 对应 i18n 文案调整

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the rewind picker layout by displaying its title and subtitle vertically.
  - Refined context panel expand/collapse labels for clearer, more consistent wording in English and Chinese.
  - Added localization for session resume changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
