### PR TITLE
fix(ink): 代码块 tab 缩进显示为黑块（#606）

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -33,6 +33,9 @@ const GROUPS = {
     ["verify-askpanel-layout", ['node', '--import', 'tsx/esm', 'scripts/verify-askpanel-layout.tsx']],
     ["repro-toolcards", ['node', '--import', 'tsx/esm', 'scripts/repro-toolcards.tsx']],
     ["repro-diff-split", ['node', '--import', 'tsx/esm', 'scripts/repro-diff-split.tsx']],
+// 代码块 tab 缩进背景回归（issue #606）：tab 展开须继承单元格样式，否则
+// 无背景的空格被 diff 跳过，在 tmux/Windows Terminal 深色底下显示为黑块。
+    ["verify-code-block-tab-background", ['node', '--import', 'tsx/esm', 'scripts/verify-code-block-tab-background.tsx']],
 // 思考块流式视图回归：preview 固定三行且点击切全文/再点收回，full
 // 默认值反向但仍不进入 0 行正文；增量 Markdown 与整段渲染的块间距
 // 一致（真实段落空行保留，代码块后不凭空多一行）。

--- a/scripts/verify-code-block-tab-background.tsx
+++ b/scripts/verify-code-block-tab-background.tsx
@@ -1,0 +1,59 @@
+/**
+ * Regression for issue #606: a TAB inside a background region (code blocks)
+ * must keep that background across its expanded columns. writeLineToScreen
+ * expanded tabs at stylePool.none, so the columns dropped the bg and the diff's
+ * empty-cell optimization skipped them — showing the terminal default bg (black
+ * under tmux / Windows Terminal) while the rest of the line kept its bg.
+ *
+ * Run: node --import tsx/esm scripts/verify-code-block-tab-background.tsx
+ */
+
+process.env.FORCE_COLOR = '3'
+
+const [{ default: Output }, screen, { applyTextStyles }] = await Promise.all([
+  import('../src/ink/output.js'),
+  import('../src/ink/screen.js'),
+  import('../src/ink/colorize.js'),
+])
+
+const { StylePool, CharPool, HyperlinkPool, createScreen, visibleCellAtIndex } = screen
+
+const WIDTH = 40
+const TAB_STOP = 8
+const BG = '#5f5f5f' // the (95,95,95) code-block grey from the issue
+
+const stylePool = new StylePool()
+const charPool = new CharPool()
+const hyperlinkPool = new HyperlinkPool()
+const buffer = createScreen(WIDTH, 1, stylePool, charPool, hyperlinkPool)
+const output = new Output({ width: WIDTH, height: 1, stylePool, screen: buffer })
+
+// A background-styled line starting with a tab (a code line inside a bg Box).
+const line = applyTextStyles('\tX', { backgroundColor: BG })
+output.write(0, 0, line)
+const painted = output.get()
+
+// Tab at column 0 expands to column 8, where 'X' lands; its style is the
+// reference for "background present here".
+const xCell = visibleCellAtIndex(painted.cells, painted.charPool, painted.hyperlinkPool, TAB_STOP, -1)
+if (!xCell || xCell.char !== 'X') {
+  throw new Error(`expected 'X' at column ${TAB_STOP}, got ${JSON.stringify(xCell)}`)
+}
+const bgStyleId = xCell.styleId
+
+const failures: string[] = []
+for (let x = 0; x < TAB_STOP; x++) {
+  const cell = visibleCellAtIndex(painted.cells, painted.charPool, painted.hyperlinkPool, x, -1)
+  if (!cell) {
+    failures.push(`col ${x}: tab cell unstyled — skipped by the diff (terminal default bg)`)
+  } else if (cell.styleId !== bgStyleId) {
+    failures.push(`col ${x}: styleId ${cell.styleId} != 'X' background styleId ${bgStyleId}`)
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error('tab indentation lost the code-block background:\n  ' + failures.join('\n  '))
+}
+
+process.stdout.write('code-block tab background regression passed\n')
+

--- a/src/ink/output.ts
+++ b/src/ink/output.ts
@@ -1071,14 +1071,17 @@ function writeLineToScreen(
     if (codePoint !== undefined && codePoint <= 0x1f) {
       // Not recordable: tab expansion is x-relative, ESC handling varies.
       runAlive = false
-      // Tab (0x09): expand to spaces to reach next tab stop
+      // Tab (0x09): expand to spaces at the tab's OWN style, not stylePool.none.
+      // An unstyled space drops the background and is skipped by the diff's
+      // empty-cell optimization, so a tab inside a bg region (code blocks) shows
+      // the terminal default bg — the black indentation of issue #606.
       if (codePoint === 0x09) {
         const tabWidth = 8
         const spacesToNextStop = tabWidth - (offsetX % tabWidth)
         for (let i = 0; i < spacesToNextStop && offsetX < screenWidth; i++) {
           setCellAt(screen, offsetX, y, {
             char: ' ',
-            styleId: stylePool.none,
+            styleId: character.styleId,
             width: CellWidth.Narrow,
             hyperlink: undefined,
           })


### PR DESCRIPTION
Fixes #606

## 问题
代码块里用 tab 缩进的行，行首缩进显示为纯黑（终端默认底色），而同一行其余部分底色正常。仅在 WSL2 + tmux + Windows Terminal 复现，iTerm2 正常。

## 原因
渲染器 `writeLineToScreen` 展开 tab（0x09）时，把展开出的空格写成 `stylePool.none`（无样式）：

- 这些空格不带背景色；
- 且被 diff 写盘的空格优化（`visibleCellAtIndex`）当作空单元格跳过（光标前移、不重绘）。

于是 tab 列显示的是终端 / tmux 的默认底色——深色配置下即黑块。iTerm2（无 tmux）未复现。

## 修复
tab 展开的空格改为继承 tab 自身的 `styleId`，与「在同一 run 里写等量空格」等价：背景与可见位齐全，不再被跳过，各终端（含 tmux）都正常绘制底色。逻辑改动仅一行（`src/ink/output.ts`）。

## 测试
- 新增聚焦回归 `scripts/verify-code-block-tab-background.tsx`（已登记进 CI `render-scroll` 组）：在屏缓冲层断言背景包裹的 `\tX` 里每个 tab 展开列都携带与 `X` 相同的可见样式、不被 `visibleCellAtIndex` 跳过。修复前红、修复后绿。
- `pnpm compile` 通过；`render-scroll` 组 32 项全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved background colors and other styling when tabs expand in code blocks.
  - Fixed an issue where styles could be lost across tab-spaced cells.

- **Tests**
  - Added regression coverage to verify tab alignment and consistent background styling in rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->