### PR TITLE
fix(render): 拖选滚轮禁用污染帧硬件滚动

### DIFF
--- a/scripts/repro-user-drag-wheel-render.tsx
+++ b/scripts/repro-user-drag-wheel-render.tsx
@@ -152,9 +152,10 @@ function checkCoherent(tag: string, lines: string[]): void {
     check(`${tag}: ${marker} 至多出现一次`, rows.length <= 1, `rows=${rows.join(',')}`)
   }
   const found = markerLocations(lines)
-  const sourceIndices = found.map(({ marker }) => TARGET_MARKERS.indexOf(marker))
+  const byRow = [...found].sort((a, b) => a.row - b.row)
+  const sourceIndices = byRow.map(({ marker }) => TARGET_MARKERS.indexOf(marker))
   const ordered = sourceIndices.every((value, index) => index === 0 || value > sourceIndices[index - 1]!)
-  check(`${tag}: User marker 顺序单调`, ordered, found.map(v => `${v.marker}@${v.row}`).join(' '))
+  check(`${tag}: User marker 顺序单调`, ordered, byRow.map(v => `${v.marker}@${v.row}`).join(' '))
 }
 
 async function runScenario(withSelection: boolean, seekTicks?: number): Promise<{

--- a/scripts/repro-user-drag-wheel-render.tsx
+++ b/scripts/repro-user-drag-wheel-render.tsx
@@ -1,0 +1,282 @@
+/**
+ * Windows Terminal fullscreen regression: a long User bubble is selected
+ * while wheel scrolling. Selection overlays mutate the previous screen; that
+ * contaminated frame must never feed the DECSTBM hardware-scroll fast path.
+ *
+ * Two paths start from the same real Chat tree and scroll trajectory:
+ *   A. hold a text selection over the long User bubble while wheeling;
+ *   B. wheel without a selection (golden control).
+ *
+ * Plain-text terminal output must remain coherent/equivalent, and path A must
+ * emit no DECSTBM while the selection is alive. Windows Terminal enables DEC
+ * 2026 through WT_SESSION, matching the reported environment.
+ *
+ * Run: node --import tsx/esm scripts/repro-user-drag-wheel-render.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+process.env.WT_SESSION = 'headless-windows-terminal-probe'
+delete process.env.TERM_PROGRAM
+delete process.env.TMUX
+
+const [
+  { PassThrough, Writable },
+  React,
+  { Terminal: XTerm },
+  { render, AlternateScreen },
+  { Chat },
+  { QuestionStore },
+  { LOCAL_COMMANDS, completeCommands },
+  termTest,
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
+])
+const { default: instances } = await import('../src/ink/instances.js')
+const { stringWidth } = await import('../src/ink/stringWidth.js')
+const { sleep, settled, viewportLines } = termTest
+
+const COLS = 96
+const ROWS = 34
+const TARGET_MARKERS = Array.from({ length: 10 }, (_, i) =>
+  `USR_DRAG_${String(i).padStart(2, '0')}`,
+)
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures++
+}
+
+function makeRows(): any[] {
+  const rows: any[] = []
+  let id = 1
+  for (let turn = 0; turn < 24; turn++) {
+    const userText = turn === 12
+      ? TARGET_MARKERS.map((marker, line) =>
+          `${marker} 长用户消息第 ${line + 1} 行：这里包含足够多的文字来形成带背景色的多行 User 气泡，并用于检查滚轮拖选后的顺序与重复。`,
+        ).join('\n')
+      : `历史用户消息 ${turn}：请检查模块 ${turn} 的行为和边界条件。`
+    rows.push({ id: id++, kind: 'user', text: userText, time: 1_700_000_000_000 + turn * 2000 })
+    rows.push({
+      id: id++,
+      kind: 'assistant',
+      text: `助手回复 ${turn}：${'分析结果与建议。'.repeat(9)}`,
+      time: 1_700_000_000_800 + turn * 2000,
+    })
+  }
+  return rows
+}
+
+function makeChannel(rows: any[]) {
+  const listeners = new Set<() => void>()
+  return {
+    version: 0,
+    rows,
+    status: 'idle',
+    sessionTitle: 'selection-wheel-probe',
+    agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    provider: 'deepseek',
+    reasoningEffort: 'max',
+    effortLevels: [],
+    tokens: { input: 0, output: 0 },
+    cwd: '/tmp/demo',
+    displayCwd: '/tmp/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'requesting',
+    responseChars: 0,
+    activeToolCount: 0,
+    turnStart: 0,
+    pending: [],
+    commandList: LOCAL_COMMANDS,
+    notifications: [],
+    mode: { plan: false, sandbox: undefined },
+    activityFrames: 'claude',
+    agentPreset: undefined,
+    subagents: [],
+    subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+    submit: () => {},
+    cancel: () => {},
+    clear: () => {},
+    notify: () => {},
+    listModels: () => Promise.resolve([]),
+    listSessions: () => Promise.resolve([]),
+    deleteSession: () => Promise.resolve(true),
+    renameSessionTo: () => Promise.resolve(true),
+    setResumeTarget: () => {},
+    loadOlder: () => {},
+    mcpStatus: () => [],
+    pushLocal: () => {},
+    commandCompletions: (input: string) => completeCommands(input),
+  } as any
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  override ref(): this { return this }
+  override unref(): this { return this }
+}
+
+function screenLines(term: InstanceType<typeof XTerm>): string[] {
+  return viewportLines(term, ROWS).map((line: string) => line.replace(/\s+$/, ''))
+}
+
+function wheel(stdin: FakeStdin, direction: 'up' | 'down', ticks: number): void {
+  const button = direction === 'up' ? 64 : 65
+  for (let i = 0; i < ticks; i++) stdin.write(`\x1b[<${button};48;16M`)
+}
+
+function markerLocations(lines: string[]): Array<{ marker: string; row: number }> {
+  const found: Array<{ marker: string; row: number }> = []
+  for (const marker of TARGET_MARKERS) {
+    for (let row = 0; row < lines.length; row++) {
+      if (lines[row]!.includes(marker)) found.push({ marker, row })
+    }
+  }
+  return found
+}
+
+function checkCoherent(tag: string, lines: string[]): void {
+  for (const marker of TARGET_MARKERS) {
+    const rows = lines.flatMap((line, row) => line.includes(marker) ? [row] : [])
+    check(`${tag}: ${marker} 至多出现一次`, rows.length <= 1, `rows=${rows.join(',')}`)
+  }
+  const found = markerLocations(lines)
+  const sourceIndices = found.map(({ marker }) => TARGET_MARKERS.indexOf(marker))
+  const ordered = sourceIndices.every((value, index) => index === 0 || value > sourceIndices[index - 1]!)
+  check(`${tag}: User marker 顺序单调`, ordered, found.map(v => `${v.marker}@${v.row}`).join(' '))
+}
+
+async function runScenario(withSelection: boolean, seekTicks?: number): Promise<{
+  lines: string[]
+  seekTicks: number
+  activeDecstbm: number
+}> {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const writes: string[] = []
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    override _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      const text = String(chunk)
+      writes.push(text)
+      term.write(text, callback)
+    }
+  }
+  class FakeStderr extends Writable {
+    isTTY = true
+    override _write(_chunk: unknown, _encoding: BufferEncoding, callback: () => void): void { callback() }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const tree = (
+    <AlternateScreen>
+      <Chat channel={makeChannel(makeRows())} questionStore={new QuestionStore()} fullscreen />
+    </AlternateScreen>
+  )
+  const instance = await render(tree, {
+    stdout: stdout as any,
+    stdin: stdin as any,
+    stderr: new FakeStderr() as any,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  instances.set(process.stdout, instances.get(stdout)!)
+  instance.rerender(tree)
+  await sleep(800)
+
+  let usedSeekTicks = 0
+  if (seekTicks === undefined) {
+    while (usedSeekTicks < 100 && !screenLines(term).some(line => line.includes(TARGET_MARKERS[4]!))) {
+      wheel(stdin, 'up', 1)
+      usedSeekTicks++
+      await sleep(18)
+    }
+  } else {
+    usedSeekTicks = seekTicks
+    for (let i = 0; i < seekTicks; i++) {
+      wheel(stdin, 'up', 1)
+      await sleep(18)
+    }
+  }
+  await settled(() => screenLines(term).some(line => line.includes(TARGET_MARKERS[4]!)))
+  await sleep(250)
+
+  const before = screenLines(term)
+  const markerRow = before.findIndex(line => line.includes(TARGET_MARKERS[4]!))
+  if (markerRow < 0) throw new Error('target marker did not enter the viewport')
+  const markerLine = before[markerRow]!
+  const markerChar = markerLine.indexOf(TARGET_MARKERS[4]!)
+  const markerCol = stringWidth(markerLine.slice(0, markerChar))
+
+  writes.length = 0
+  if (withSelection) {
+    stdin.write(`\x1b[<0;${markerCol + 2};${markerRow + 1}M`)
+    await sleep(40)
+    const focusRow = Math.min(ROWS - 6, markerRow + 2)
+    stdin.write(`\x1b[<32;${Math.min(COLS - 2, markerCol + 28)};${focusRow + 1}M`)
+    await sleep(70)
+  }
+
+  wheel(stdin, 'up', 7)
+  await sleep(180)
+  if (withSelection) {
+    stdin.write(`\x1b[<32;${Math.min(COLS - 2, markerCol + 34)};${Math.min(ROWS - 6, markerRow + 3) + 1}M`)
+  }
+  wheel(stdin, 'down', 4)
+  await sleep(220)
+
+  const activeRaw = writes.join('')
+  const activeDecstbm = (activeRaw.match(/\x1b\[\d+;\d+r/g) ?? []).length
+  if (withSelection) {
+    stdin.write(`\x1b[<0;${Math.min(COLS - 2, markerCol + 34)};${Math.min(ROWS - 6, markerRow + 3) + 1}m`)
+  }
+  await sleep(700)
+
+  const lines = screenLines(term)
+  await instance.unmount()
+  instances.delete(process.stdout)
+  term.dispose()
+  return { lines, seekTicks: usedSeekTicks, activeDecstbm }
+}
+
+const selected = await runScenario(true)
+const control = await runScenario(false, selected.seekTicks)
+
+checkCoherent('拖选+滚轮', selected.lines)
+checkCoherent('无选区对照', control.lines)
+
+const normalize = (line: string): string => line.replace(/\d+(?:\.\d+)?/g, '#')
+const visualDiffs: string[] = []
+for (let row = 0; row < ROWS; row++) {
+  if (normalize(selected.lines[row] ?? '') !== normalize(control.lines[row] ?? '')) {
+    visualDiffs.push(`row ${row}: A|${selected.lines[row] ?? ''}\n        B|${control.lines[row] ?? ''}`)
+  }
+}
+check('拖选路径与无选区路径最终纯文本画面一致', visualDiffs.length === 0, `${visualDiffs.length} rows differ`)
+if (visualDiffs.length > 0) console.log(visualDiffs.slice(0, 12).join('\n'))
+
+check(
+  '无选区滚轮仍保留 DECSTBM 快路径',
+  control.activeDecstbm > 0,
+  `DECSTBM=${control.activeDecstbm}`,
+)
+check(
+  '选区存活期间禁止 DECSTBM 硬件滚动',
+  selected.activeDecstbm === 0,
+  `DECSTBM=${selected.activeDecstbm}`,
+)
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} failure(s)`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -76,6 +76,10 @@ const GROUPS = {
 // 滚动窗口与 shrink 边界。measure-depth 需生产模式（minified #185）。
     ["verify-message-measure-depth", ['node', '--import', 'tsx/esm', 'scripts/verify-message-measure-depth.tsx'], { NODE_ENV: 'production' }],
     ["verify-scroll", ['node', 'scripts/verify-scroll.mjs']],
+// Windows Terminal 全屏拖选+滚轮回归：长 User 气泡的 selection overlay
+// 会污染上一帧；污染帧不得进入 DECSTBM/shiftRows 硬件滚动，否则带背景
+// 的旧像素被物理搬移后偶发重复/错位。A/B 同轨迹断言终态画面一致。
+    ["repro-user-drag-wheel-render", ['node', '--import', 'tsx/esm', 'scripts/repro-user-drag-wheel-render.tsx']],
     ["verify-shrink", ['node', 'scripts/verify-shrink.mjs']],
 // 高于视口的收缩必须记 anchoredPad：终端 scrollback 不随内容收缩，
 // 高度差公式会少算 1 行 → 上移在视口顶被钳制 → 整帧相对写入链低一行

--- a/src/ink/renderer.ts
+++ b/src/ink/renderer.ts
@@ -160,7 +160,12 @@ export default function createRenderer(
     if (drainNode) markDirty(drainNode)
 
     return {
-      scrollHint: options.altScreen ? getScrollHint() : null,
+      // A contaminated previous frame is unsafe for both blit and hardware
+      // scroll: DECSTBM would shift cells carrying the selection overlay.
+      scrollHint:
+        options.altScreen && !options.prevFrameContaminated
+          ? getScrollHint()
+          : null,
       scrollDrainPending: drainNode !== null,
       screen: renderedScreen,
       viewport: {

--- a/src/ink/renderer.ts
+++ b/src/ink/renderer.ts
@@ -160,10 +160,13 @@ export default function createRenderer(
     if (drainNode) markDirty(drainNode)
 
     return {
-      // A contaminated previous frame is unsafe for both blit and hardware
-      // scroll: DECSTBM would shift cells carrying the selection overlay.
+      // An invalid previous frame is unsafe for both blit and hardware
+      // scroll: DECSTBM would shift selection-overlay cells or pixels from
+      // an absolute node that was just removed.
       scrollHint:
-        options.altScreen && !options.prevFrameContaminated
+        options.altScreen &&
+        !absoluteRemoved &&
+        !options.prevFrameContaminated
           ? getScrollHint()
           : null,
       scrollDrainPending: drainNode !== null,


### PR DESCRIPTION
## 问题

Windows Terminal fullscreen 下，长 User 消息气泡中按住鼠标拖选文字并滚轮时，画面偶发错位和重复渲染。User 行带背景色，因此污染像素比普通文本更明显。

## 根因

selection overlay 会把选区背景直接写入上一帧 `frontFrame.screen`，该帧随后以 `prevFrameContaminated` 标记。

Renderer 原本只用这个标记禁止 blit，却仍返回 `scrollHint`。`log-update` 因此会对同一污染帧执行 `shiftRows`，并向终端发送 DECSTBM/CSI S/T 硬件滚动。Windows Terminal 物理搬移带 selection/User 背景的旧像素后，再叠加普通 diff，可能留下重复与错位。

## 修复

污染帧不再返回 `scrollHint`：

- 选区+滚轮期间退回普通 full diff；
- 选区结束且 cleanup frame 完成后自动恢复 DECSTBM；
- 无选区滚轮仍保留硬件滚动快路径。

## 回归

新增 `scripts/repro-user-drag-wheel-render.tsx` 并登记到 `render-scroll`：

- 真实 `Chat` + `AlternateScreen` + Windows Terminal (`WT_SESSION`) 能力路径；
- 24 轮历史，中间包含带唯一逐行 marker 的长 User 气泡；
- A 路径保持拖选并执行 wheel up/down burst；
- B 路径执行相同滚轮轨迹但无选区；
- 断言 marker 唯一、顺序单调、A/B 最终纯文本画面一致；
- 断言无选区 `DECSTBM>0`、选区存活期间 `DECSTBM=0`。

红→绿证据：

- 修复前：选区期间 `DECSTBM=4`；
- 修复后连续三次：选区期间均为 `0`，无选区均为 `4`。

## 验证

- 新增长 User 拖选滚轮回归连续 3 次通过
- `verify-wheel-selection.ts`
- `repro-drag-select-streaming.tsx`
- `verify-drag-protocol.tsx`
- `repro-fullscreen-ghost.tsx`
- `pnpm smoke`
- `pnpm compile:src`
- 完整 `verify:build`（使用已安装上游包基线）
- `verify:package`：1372 files / 29 entry targets

本地完整 `render-scroll` 32 项中，新回归通过；唯一失败为已有 Windows `verify-osc8-sanitize` 路径断言，与本 PR 三文件无交集。

Closes #664


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling and text selection in Windows Terminal to prevent inconsistent or corrupted screen rendering.
  * Preserved reliable full-screen scrolling while selecting text with an active drag.
  * Prevented invalid scrolling updates from affecting alternate-screen content.

* **Tests**
  * Added regression coverage for selection, wheel scrolling, screen markers, and final rendered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->