### PR TITLE
fix(i18n): show localized English names/descriptions for built-in presets in the /preset picker under the en UI language

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -316,6 +316,8 @@ The complete bilingual index is [`docs/README.md`](docs/README.md).
   switched with `/preset`; sessions that already have a conversation cannot switch, while
   blank sessions take effect immediately. The default preset persists in
   `~/.dsh-tui/agent-preset.json`; `/model` selections persist in `~/.dsh-tui/model.json`.
+  Under the `en` UI language the `/preset` picker shows localized English names
+  and descriptions for the built-in presets.
   See [Configuration](docs/configuration.en.md#agent-preset).
 - **Themes**: the `/theme` picker (`auto` follows the system/terminal background,
   built-in `light` / `dark` / `dark-ansi`) accepts static themes from

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -90,6 +90,10 @@ Usage rules:
 
 - `/preset` opens the picker.
 - `/preset <id>` selects directly; `/preset status` reports the current state.
+- Picker names and descriptions come verbatim from each preset's `preset.yml`
+  (written in Chinese). Under the `en` UI language (`/lang en`), the built-in
+  presets (`standard` / `minimal` / `code` / `cordis` / `liangshen`) show
+  localized English names and descriptions; custom presets are shown as-is.
 - A blank session can switch in place. Once a conversation has started, the
   official blank-only rule stores the choice as the new default for `/new` or
   the next launch.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,9 @@ Profile 启动按顺序叠加 `dsh-base`、已安装 bundle、`@deepseek-harness
 
 - `/preset` 打开选择器。
 - `/preset <id>` 直接选择；`/preset status` 查看当前状态。
+- 选择器显示的名称与描述取自各 preset 的 `preset.yml`（中文）。界面语言为
+  `en`（`/lang en`）时，内置 preset（`standard` / `minimal` / `code` / `cordis` /
+  `liangshen`）显示本地化的英文名称与描述；自定义 preset 原样显示。
 - 空白会话可以原地切换。已经产生对话的会话遵循官方 blank-only 规则，选择只会
   保存为新默认值，在 `/new` 或下一次启动时生效。
 - 默认值保存在 `~/.dsh-tui/agent-preset.json`。

--- a/scripts/verify-i18n.ts
+++ b/scripts/verify-i18n.ts
@@ -21,7 +21,8 @@ import { i18nDict, type I18nText } from '../src/i18n.js'
 //   logo-drift-*  src/components/LogoV2.tsx        tOr(`logo-drift-${kind}`)
 //   tree-filter-* src/screens/SessionTree.tsx      t(`tree-filter-${filter}`)
 //   tree-kind-*   src/screens/SessionTree.tsx      t(`tree-kind-${entry.kind}`)
-const DYNAMIC_PREFIXES = ['cmd-desc-', 'traj-sort-', 'traj-proj-', 'logo-drift-', 'tree-filter-', 'tree-kind-']
+//   preset-name-* / preset-desc-*   src/dsh-adapter/channel.ts   tOr(`preset-name-${preset.id}`) — built-in preset display text
+const DYNAMIC_PREFIXES = ['cmd-desc-', 'traj-sort-', 'traj-proj-', 'logo-drift-', 'tree-filter-', 'tree-kind-', 'preset-name-', 'preset-desc-']
 
 let failures = 0
 function fail(msg: string) {

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -74,7 +74,7 @@ import { existsSync, statSync, writeFileSync } from 'node:fs'
 import { logForDebugging } from '../utils/debug.js'
 import { homeDir, LEGACY_DATA_DIR } from '../utils/paths.js'
 import { extractMentions } from '../utils/mentions.js'
-import { getLang, LANGS, t } from '../i18n.js'
+import { getLang, LANGS, t, tOr, type Lang } from '../i18n.js'
 import { AUTO_THEME_NAME } from '../theme.js'
 import { listThemeCatalog } from '../themeCatalog.js'
 import { modeDisplayName, resolveSessionModes, type SessionModeSpec } from '../sessionModes.js'
@@ -3283,13 +3283,25 @@ export function createChannel(
 
   // `/preset <id>` completion: same warm-cache pattern as models. The
   // current/default tags resolve at children() time (sync state reads), so
-  // no cache invalidation is needed on switch.
+  // no cache invalidation is needed on switch. The localized display text,
+  // however, resolves at listPresets() call time — a mid-session /lang
+  // switch invalidates lazily here (lang-keyed warm) so completion hints
+  // never serve the previous language.
   const presetOptionCache = {
+    lang: undefined as Lang | undefined,
     list: undefined as readonly PresetOption[] | undefined,
     load: undefined as Promise<void> | undefined,
   }
+  /** Warm the `/preset <id>` completion roster once per UI language; a
+   *  language change since the last warm drops the stale localized copy. */
   const warmPresetOptions = (): void => {
+    const lang = getLang()
+    if (presetOptionCache.lang !== undefined && presetOptionCache.lang !== lang) {
+      presetOptionCache.list = undefined
+      presetOptionCache.load = undefined
+    }
     if (presetOptionCache.load !== undefined) return
+    presetOptionCache.lang = lang
     presetOptionCache.load = state.listPresets().then((list) => {
       presetOptionCache.list = list
       state.emit()
@@ -5575,15 +5587,30 @@ export function createChannel(
       if (service === undefined) return legacyPermissionPresetSnapshot(state.mode.sandbox)
       return permissionPresetSnapshotFromService(service, agent.session.events)
     },
+    /** Localized roster projection for the /preset picker — resolves
+     *  built-in display text through the dictionary under `en`; the
+     *  Channel.listPresets contract comment carries the full doc. */
     async listPresets() {
       const presets = rosterOf(ctx)
       if (presets === undefined) return []
+      // The roster copies `name`/`description` verbatim from each preset.yml,
+      // and the stock yml files are written in Chinese — the /preset picker
+      // showed them under `en` too. Built-in ids have dictionary surfaces
+      // (preset-name-* / preset-desc-*); under `en` they win via tOr, while
+      // unknown (user-authored) ids fall through to the roster text. Under
+      // `zh` the roster text is kept as-is so a user-edited or upstream-
+      // reworded preset.yml is never shadowed by a stale dictionary copy.
+      const localized = getLang() === 'en'
       try {
         const list = await presets.list()
         return list.map(preset => ({
           id: preset.id,
-          ...(preset.name === undefined ? {} : { name: preset.name }),
-          ...(preset.description === undefined ? {} : { description: preset.description }),
+          ...(preset.name === undefined
+            ? {}
+            : { name: localized ? tOr(`preset-name-${preset.id}`, preset.name) : preset.name }),
+          ...(preset.description === undefined
+            ? {}
+            : { description: localized ? tOr(`preset-desc-${preset.id}`, preset.description) : preset.description }),
           ...(preset.broken === undefined ? {} : { broken: preset.broken }),
           isDefault: preset.id === presets.defaultId,
         }))

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -62,6 +62,22 @@ const dict = {
   'preset-switch-failed': { zh: 'Preset 切换失败 · {{err}}', en: 'Preset switch failed · {{err}}' },
   'preset-switched-pref-failed': { zh: 'Preset 已切换：{{id}}，但默认偏好写入失败（重启后不保留）', en: 'Preset switched: {{id}}, but writing the default preference failed (won\'t persist after restart)' },
   'preset-switched-saved': { zh: 'Preset 已切换：{{id}}（已保存为默认）', en: 'Preset switched: {{id}} (saved as default)' },
+  // Built-in preset display text (issue: the /preset picker showed the raw
+  // preset.yml copy, which is Chinese, even under `en`). zh mirrors the
+  // stock preset.yml `name`/`description` verbatim (zh display keeps the
+  // roster text — see listPresets in channel.ts); en is the localized
+  // surface. Keys resolve per roster id via tOr(`preset-name-${id}`), so
+  // unknown (user-authored) ids fall through untouched.
+  'preset-name-standard': { zh: '标准模式', en: 'Standard' },
+  'preset-desc-standard': { zh: '功能完整的编码 Agent，支持文件编辑、Shell、文件与网页检索、Skills、计划、目标、子代理和工作流。', en: 'Full-featured coding agent: file editing, shell, file & web search, skills, plans, goals, subagents and workflows.' },
+  'preset-name-minimal': { zh: '极简模式', en: 'Minimal' },
+  'preset-desc-minimal': { zh: '仅提供持久 bash 与 str_replace_editor 的双工具编码 Agent。', en: 'A two-tool coding agent exposing only persistent bash and str_replace_editor.' },
+  'preset-name-code': { zh: 'PTC 模式', en: 'PTC' },
+  'preset-desc-code': { zh: '具备标准模式的全部能力，并通过 Code Mode SDK 呈现工具，让模型用一个 TypeScript 程序组合多步操作。', en: 'Everything standard mode offers, with tools exposed through the Code Mode SDK so the model composes multi-step operations in one TypeScript program.' },
+  'preset-name-cordis': { zh: '创造模式', en: 'Creation' },
+  'preset-desc-cordis': { zh: '用于创建自定义 Agent preset：具备标准模式的全部能力，并提供运行时检查、插件实验和 preset 创作指导。', en: 'For authoring custom agent presets: everything standard mode offers plus runtime inspection, plugin experiments and preset-authoring guidance.' },
+  'preset-name-liangshen': { zh: '梁神模式', en: 'Liangshen mode' },
+  'preset-desc-liangshen': { zh: '主 Agent 与子 Agent 首轮均保持 Minimal 双工具，首次工具调用后开放完整目录，压缩后重新锚定。', en: 'Root and delegated agents keep the minimal two-tool pair on the first turn; the full catalog opens after the first tool call and re-anchors after compaction.' },
   'mcp-none-configured': { zh: '未配置 MCP 服务器。', en: 'No MCP servers configured.' },
   'mcp-insert-hint': { zh: '在 profile 补丁层（~/.dsh/profiles/dsh-tui/cordis.patch.yml）insert 一行即可，例：', en: 'Insert one line in the profile patch layer (~/.dsh/profiles/dsh-tui/cordis.patch.yml), e.g.:' },
   'mcp-readme-hint': { zh: '详见仓库 README 的 MCP 章节。', en: 'See the MCP section of the repo README.' },


### PR DESCRIPTION
## Summary

Localize the `/preset` picker: when the UI language is `en`, the built-in presets now display English names and descriptions. Behavior under `zh` and for user-authored presets is unchanged.

Resolves #666

## Background / Motivation

- The stock `preset.yml` files of the built-in presets (`standard` / `minimal` / `code` / `cordis` / `liangshen`) are written in Chinese, and `listPresets()` projects the roster text verbatim — so even an English user (`lang: en`, `/lang en`, or `DSH_TUI_LANG=en`) saw `标准模式`, `梁神模式`, etc. in the picker (repro in #666).
- Permission presets (`permission-preset-*`) already go through `t()`; aligning agent presets with the same i18n system keeps the picker consistent.

## Changes

- `src/i18n.ts`: add 10 dictionary entries, `preset-name-*` / `preset-desc-*`, for the five built-in presets. zh values mirror the stock `preset.yml` copy verbatim (reference only); en values match the official English wording in `docs/configuration.en.md` (Standard / Minimal / PTC / Creation / Liangshen mode).
- `src/dsh-adapter/channel.ts` (`listPresets()`): only when `getLang() === 'en'`, resolve `tOr(\`preset-name-${id}\`, rosterText)`. Unknown ids (user-authored presets) fall through untouched via the `tOr` fallback. Under `zh` the roster text is kept as-is, so a user-edited or upstream-reworded `preset.yml` is never shadowed by a stale dictionary copy.
- `scripts/verify-i18n.ts`: register `preset-name-` / `preset-desc-` as dynamic-prefix families so the dead-key gate passes.
- `docs/configuration.md` / `docs/configuration.en.md` / `README_EN.md`: document the localized picker display (bilingual doc sync).

## How to test

- `pnpm verify:i18n` → ✓ 872 entries (language completeness, placeholder parity, no dead keys)
- `pnpm typecheck` → exit 0
- Focused regression (tsx, `DSH_TUI_LANG=en`): all five presets resolve to English names (Standard / Minimal / PTC / Creation / Liangshen mode) + English descriptions; an unregistered id (`minimal-fork`) passes through verbatim; under `zh` the original text (`梁神模式` …) is preserved — all pass.
- Manual: `DSH_TUI_LANG=en dsh --profile dsh-tui` → `/preset` shows English; `/lang zh` restores Chinese.

## Checklist

- [x] Changes confined to `src/`; generated `lib/` untouched
- [x] Relative imports keep the `.js` suffix; existing 2-space, single-quote, no-semicolon style preserved
- [x] `verify:i18n` (the gate matching this change surface) + `pnpm typecheck` pass
- [x] zh/en docs synced (`docs/configuration.md` ↔ `docs/configuration.en.md`, plus the README_EN bullet)
- [x] No breaking change — preset id resolution, switching, and persistence are untouched; display text only

## Notes for reviewers

- The `zh` branch deliberately passes the roster text through so the dictionary's zh values can never go stale against a reworded `preset.yml`; the dict zh entries are reference copies (noted in a comment).
- Edge case: a user shadowing a built-in id (e.g. `~/.dsh/.agent-presets/standard`) with a custom display name would see the dictionary wording under `en`. I treated a same-id collision as a misconfiguration; happy to adjust if a different policy fits better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English localization for built-in preset names and descriptions in the `/preset` picker.
  * Added Agent View support for monitoring, resuming, backgrounding, and stopping sessions.
  * Added background job status, output updates, completion notifications, and cancellation.
  * Expanded `/provider` with editing, deletion, OAuth subscription sign-in, and model switching after changes.
  * Added localized UI text for provider management, Agent View, background jobs, and related commands.
* **Documentation**
  * Documented preset localization and expanded provider management workflows in English and Chinese guides and the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->