### PR TITLE
fix(ui): prevent smooth-streaming React update overflow

### DIFF
--- a/scripts/verify-smooth-reveal.tsx
+++ b/scripts/verify-smooth-reveal.tsx
@@ -319,6 +319,62 @@ console.log('--- C: component contracts ---')
   )
 }
 
+// D: long-session tool-card fanout — only MessageList may subscribe to the
+// reveal store in the production path. A single active card is enough to
+// advance the scheduler; settled cards must not each force a store rerender.
+console.log('--- D: long-session reveal subscriber fanout ---')
+{
+  resetRevealForTest()
+  const historyTools: ChatRow[] = Array.from({ length: 80 }, (_, i) => ({
+    id: 1000 + i,
+    kind: 'tool' as const,
+    text: '',
+    fresh: false,
+    tool: {
+      callId: `history-${i}`,
+      name: 'edit',
+      argsText: '{}',
+      argsFull: '{}',
+      status: 'done' as const,
+      resultView: { card: 'generic' as const, title: 'Edited', content: [{ type: 'text' as const, text: 'done' }] },
+      startedAt: Date.now() - 1000,
+      durationMs: 1000,
+    },
+  }))
+  const activeTool: ChatRow = {
+    id: 2000,
+    kind: 'tool',
+    text: '',
+    fresh: true,
+    tool: {
+      callId: 'active-long-session',
+      name: 'edit',
+      argsText: '{}',
+      argsFull: '{}',
+      status: 'running',
+      callView: {
+        card: 'diff',
+        title: 'Edit /src/active.ts',
+        diffs: [{
+          path: '/src/active.ts',
+          oldText: Array.from({ length: 8 }, (_, i) => `old line ${i}`).join('\n'),
+          newText: Array.from({ length: 8 }, (_, i) => `new line ${i}`).join('\n'),
+        }],
+      },
+      startedAt: Date.now(),
+    },
+  }
+  await withTerminal(
+    () => <MessageList rows={[...historyTools, activeTool]} smoothStreaming {...listProps} />,
+    async screen => {
+      await sleep(120)
+      check(screen().includes('old line 0'), 'D1 active tool remains visible with many history cards')
+      await sleep(2200)
+      check(screen().includes('lines (ctrl+o to expand)'), 'D1 active tool reveal completes without nested store updates')
+    },
+  )
+}
+
 console.log('')
 if (failures > 0) {
   console.error(`verify-smooth-reveal: ${failures} FAILURE(S)`)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1058,6 +1058,10 @@ export function MessageList({
           const addMargin = margins.get(row.id) === true
           const tool = row.tool
           const subagent = row.kind === 'subagent' ? row.subagent : undefined
+          const revealVersion = smoothStreaming && row.kind === 'tool' && row.fresh === true &&
+            row.tool?.status === 'running' && row.tool.resultView === undefined
+            ? getRevealVersion()
+            : 0
           // Smooth reveal feeds the SAME flattened text prop a chunk feeds,
           // and keeps the streaming layout alive until the reveal catches up
           // (settling mid-reveal must not snap — a one-shot non-streaming
@@ -1098,6 +1102,7 @@ export function MessageList({
               foldTerminalCommand={foldTerminalCommand}
               smoothStreaming={smoothStreaming}
               fresh={row.fresh === true}
+              revealVersion={revealVersion}
               activityFrames={activityFrames}
               background={rowBackground(row.id)}
               toolCallId={tool?.callId}
@@ -1160,6 +1165,8 @@ type MemoRowProps = {
   smoothStreaming: boolean
   /** Live-arrived row flag (drives tool-card reveal participation). */
   fresh: boolean
+  /** Version tick for active tool reveal; 0 keeps settled rows memoized. */
+  revealVersion: number
   thinkingFold: 'preview' | 'full'
   toolBackground: ToolBackground
   /** Terminal-card header folding (forwarded to tool cards). */
@@ -1232,6 +1239,7 @@ function TranscriptRow({
   diffLayout,
   smoothStreaming,
   fresh,
+  revealVersion,
   thinkingFold,
   toolBackground,
   foldTerminalCommand,
@@ -1403,6 +1411,7 @@ function TranscriptRow({
             toolBackground={toolBackground}
             smoothReveal={smoothStreaming}
             fresh={fresh}
+            revealVersion={revealVersion}
             foldTerminalCommand={foldTerminalCommand}
             onClick={foldOnClick}
             onOpenFile={onOpenFile}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -467,7 +467,7 @@ export function MessageList({
   /** True when frame-budgeted history painting still has batches left
    *  (main-screen open): the layout effect schedules the next slice. */
   const paintPendingRef = React.useRef(false)
-  const paintQueuedRef = React.useRef(false)
+  const paintTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   /** Persistent history-paint edge: how far batched painting has advanced
    *  (index into visibleRows). -1 = not painting / reset (list head change:
    *  rewind, new session, loadOlder — must repaint from scratch). */
@@ -482,9 +482,19 @@ export function MessageList({
   if (listHeadId !== undefined) paintedBaseRef.current = listHeadId
   /** Content-space offset of visibleRows[0] (header + dividers), measured. */
   const baseRef = React.useRef<number | null>(null)
-  const measureQueuedRef = React.useRef(false)
+  const measureTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const [, setMeasureTick] = React.useState(0)
   const [, setScrollTick] = React.useState(0)
+  React.useEffect(() => () => {
+    if (measureTimerRef.current !== null) {
+      clearTimeout(measureTimerRef.current)
+      measureTimerRef.current = null
+    }
+    if (paintTimerRef.current !== null) {
+      clearTimeout(paintTimerRef.current)
+      paintTimerRef.current = null
+    }
+  }, [])
 
   // A width change reflows every row — all measurements are stale.
   const lastColumns = React.useRef(columns)
@@ -996,15 +1006,15 @@ export function MessageList({
         )
       }
     }
-    if (changed && !measureQueuedRef.current) {
-      // Layout corrections can cascade for many rows. Yield between commits
-      // so React does not count the valid convergence as nested updates.
-      measureQueuedRef.current = true
-      queueMicrotask(() => {
-        measureQueuedRef.current = false
+    if (changed && measureTimerRef.current === null) {
+      // Layout corrections can cascade for many rows. Yield to the next
+      // macrotask so React does not count the valid convergence as nested
+      // updates when a streaming/reveal commit is already in flight.
+      measureTimerRef.current = setTimeout(() => {
+        measureTimerRef.current = null
         noteFrameCause('measure')
         setMeasureTick(t => t + 1)
-      })
+      }, 0)
     }
     // History-paint continuation (main-screen open): more never-painted
     // batches remain — schedule the next slice on the macrotask queue so
@@ -1013,10 +1023,9 @@ export function MessageList({
     // enough: each batch's mount+measure work is bounded (~2 viewports),
     // unlike the previous single-commit full mount that saturated the main
     // thread for seconds.
-    if (paintPendingRef.current && !paintQueuedRef.current) {
-      paintQueuedRef.current = true
-      setTimeout(() => {
-        paintQueuedRef.current = false
+    if (paintPendingRef.current && paintTimerRef.current === null) {
+      paintTimerRef.current = setTimeout(() => {
+        paintTimerRef.current = null
         if (!paintPendingRef.current) return
         noteFrameCause('measure')
         setMeasureTick(t => t + 1)

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -14,6 +14,9 @@ import type { Theme } from '../../theme.js'
 import type { ClickEvent } from '../../ink/events/click-event.js'
 import { getRevealVersion, revealLinesOf, snapReveal, subscribeReveal } from '../smoothReveal.js'
 
+const NOOP_REVEAL_SUBSCRIBE = (_listener: () => void): (() => void) => () => {}
+const getNoRevealVersion = (): number => 0
+
 type Props = {
   tool: ToolRow
   /** Adds the top margin between messages (CC: addMargin). */
@@ -68,6 +71,8 @@ type Props = {
   /** Live-arrived row (channel `fresh`): gates reveal participation —
    *  replayed cards must paint complete. */
   fresh?: boolean
+  /** Reveal version supplied by MessageList to avoid one store subscriber per card. */
+  revealVersion?: number
 }
 
 /** Tool display names: DSH emits lowercase tool ids (`bash`); Claude Code
@@ -418,11 +423,15 @@ export function AssistantToolUseMessage({
   foldTerminalCommand = false,
   smoothReveal = false,
   fresh = false,
+  revealVersion,
 }: Props): React.ReactNode {
-  // Reveal-frame wakeups: the shared scheduler bumps its version, which
-  // re-renders this card even while MemoRow props hold still (the reveal
-  // lives outside React — see smoothReveal.ts).
-  React.useSyncExternalStore(subscribeReveal, getRevealVersion)
+  // MessageList owns the single production subscription and passes a version
+  // prop only to active reveal rows. Standalone consumers keep the fallback
+  // subscription so the component contract remains self-contained.
+  React.useSyncExternalStore(
+    revealVersion === undefined ? subscribeReveal : NOOP_REVEAL_SUBSCRIBE,
+    revealVersion === undefined ? getRevealVersion : getNoRevealVersion,
+  )
   const isRunning = tool.status === 'running'
   const isError = tool.status === 'error'
   const displayArgs = verbose ? tool.argsFull ?? tool.argsText : tool.argsText


### PR DESCRIPTION
Closes #668

## Summary

Fixes the React #185 crash that can occur when `dsh-tui.smoothStreaming` is enabled and a message is sent in an existing session.

Two interacting update paths were present:

1. MessageList row-height measurement scheduled `setMeasureTick` with `queueMicrotask`, allowing measurement updates to remain in the same React commit batch as streaming/reveal work. This now uses `setTimeout(0)`.
2. Every mounted `AssistantToolUseMessage` subscribed independently to the global smooth-reveal store. A single `revealTick` synchronously notified all tool-card subscribers, producing the `forceStoreRerender -> revealTick` stack seen in production. MessageList now owns the production subscription and passes the reveal version only to active tool rows; standalone tool-card consumers retain a fallback subscription.

Pending measurement and history-paint timers are also cancelled when MessageList unmounts.

## Verification

- `pnpm build`
- `verify-message-measure-depth`
- `verify-unseen-report-once`
- `verify-smooth-reveal`, including 80 history tool cards + 1 active reveal card
- `verify-divider-stability`
- `repro-thinking`
- `verify-resize-reflow`
- `verify-resize-temporal`
- 3 x 45-second smooth-streaming session reproductions before the second fix
- GitHub CI: build, alpha-compat, render-scroll, input-terminal, session-workspace, channel-ui, flaky-observation, platform-smoke, and ci-gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message list rendering during measurement and progressive history loading.
  * Prevented duplicate rendering updates, reducing unnecessary visual refreshes.
  * Improved cleanup when leaving a conversation or closing the message view, helping prevent delayed updates after navigation.
  * Fixed active tool cards occasionally failing to refresh smoothly while results were revealed.
  * Improved reliability when viewing long conversations with many historical tool cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->