### PR TITLE
fix(input): 历史翻页被补全菜单截胡——召回斜杠命令后 ↓ 无法找回草稿

### DIFF
--- a/scripts/verify-prompt-history-overlay.mjs
+++ b/scripts/verify-prompt-history-overlay.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Regression: a history walk must own ↑/↓ until it returns to the draft.
+ *
+ * A recalled entry can itself satisfy an overlay grammar — recalling
+ * `/model` opens the slash-command menu the moment it lands in the input
+ * (`suggestions.length > 0`). Before the fix, ↑/↓ on such an entry
+ * navigated the MENU instead of the history: the stashed draft became
+ * unreachable via ↓, and Esc (menu open → clear input) destroyed the
+ * recalled entry without restoring the draft either — recovery required
+ * Ctrl+R. The fix gates both overlay branches on `historyIndex < 0` so the
+ * walk keeps walking until the draft comes back.
+ *
+ * Run after build: `node scripts/verify-prompt-history-overlay.mjs`.
+ */
+import { PassThrough, Writable } from 'node:stream'
+import React from 'react'
+import xtermHeadless from '@xterm/headless'
+import { render } from '../lib/types/ui.js'
+import { PromptInput } from '../lib/types/components/PromptInput.js'
+import { settled, sleep, viewportLines } from './lib/term-test.mjs'
+
+const { Terminal: XTerm } = xtermHeadless
+
+let failed = 0
+/** Print one pass/fail line and keep a running failure count. */
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** Build the writable TTY streams used by the headless prompt harness. */
+function makeStreams(term) {
+  const stdout = new Writable({
+    write(chunk, _encoding, callback) {
+      if (term === undefined) {
+        callback()
+      } else {
+        term.write(String(chunk), callback)
+      }
+    },
+  })
+  stdout.columns = 100
+  stdout.rows = 30
+  stdout.isTTY = true
+  const stderr = new Writable({ write(_chunk, _encoding, callback) { callback() } })
+  stderr.isTTY = true
+  const stdin = new PassThrough()
+  stdin.isTTY = true
+  stdin.setRawMode = () => stdin
+  stdin.setEncoding = () => stdin
+  stdin.ref = () => stdin
+  stdin.unref = () => stdin
+  return { stdout, stderr, stdin }
+}
+
+const submitted = []
+const commands = []
+const channel = {
+  mode: { id: 'default', plan: false },
+  modeIndex: 0,
+  cycleMode() {},
+  commandList: [
+    { name: 'skills', description: 'List available skills' },
+    { name: 'model', description: 'Show the active model' },
+  ],
+  commandCompletions(input) {
+    if (input !== '/skills' && input !== '/model') return []
+    const name = input.slice(1)
+    return [{ name, description: name, commandLine: input, replacement: `${input} ` }]
+  },
+  notifications: [],
+  pending: [],
+  working: false,
+  notify() {},
+  submit(text) { submitted.push(text) },
+  steer() {},
+  interruptAndDeliver() { return 0 },
+  removePending() { return false },
+  stageImage() {},
+  listFiles: async () => [],
+}
+
+const term = new XTerm({ cols: 100, rows: 30, scrollback: 100, allowProposedApi: true })
+const { stdout, stderr, stdin } = makeStreams(term)
+await render(
+  React.createElement(PromptInput, {
+    channel,
+    helpOpen: false,
+    onToggleHelp() {},
+    onRunCommand(name) { commands.push(name); return true },
+    selectionActive: false,
+  }),
+  { stdout, stderr, stdin, exitOnCtrlC: false, patchConsole: false },
+)
+
+const UP = '\x1b[A'
+const DOWN = '\x1b[B'
+/** True when some viewport row contains the text (input echo assertion). */
+const shows = (text) => viewportLines(term).some(line => line.includes(text))
+
+// 首帧挂载 pacing：等 React 树完成首次渲染与输入监听挂接，无单一可观测条件。
+await sleep(500)
+
+// Seed the history: one plain message, then a slash command — the command
+// entry is the one that reopens the menu when recalled.
+stdin.write('plain one')
+await sleep(150)
+stdin.write('\r')
+await settled(() => submitted.length === 1, JSON.stringify({ submitted }))
+await sleep(150)
+stdin.write('/model')
+await sleep(150)
+stdin.write('\r')
+await settled(() => commands.length === 1 && commands[0] === 'model', JSON.stringify({ commands }))
+await sleep(150)
+
+// Type a draft but do NOT submit it.
+stdin.write('draft 草稿')
+await sleep(200)
+check('draft typed into the input', await settled(() => shows('draft 草稿')))
+
+// ↑ recalls `/model` — the slash menu opens over it (this is the trap).
+stdin.write(UP)
+check('up recalls the /model history entry', await settled(() => shows('/model')))
+
+// ↓ must return to the draft even though the menu is open over `/model`.
+stdin.write(DOWN)
+check(
+  'down past the newest entry restores the draft despite the open menu',
+  await settled(() => shows('draft 草稿')),
+)
+
+// The walk also continues UP through menu-opening entries: ↑↑ from the
+// draft reaches `plain one` past `/model`.
+stdin.write(UP)
+await settled(() => shows('/model'))
+stdin.write(UP)
+check(
+  'up continues through the menu-opening entry to the older one',
+  await settled(() => shows('plain one')),
+)
+
+// ↓↓ returns all the way to the draft, and Enter submits it — the draft
+// was never lost.
+stdin.write(DOWN)
+await settled(() => shows('/model'))
+stdin.write(DOWN)
+await settled(() => shows('draft 草稿'))
+await sleep(150)
+stdin.write('\r')
+check(
+  'draft submits intact after the round trip',
+  await settled(() => submitted.length === 2 && submitted[1] === 'draft 草稿'),
+  JSON.stringify({ submitted, commands }),
+)
+
+console.log(failed === 0 ? '\nAll prompt-history-overlay checks passed' : `\n${failed} check(s) FAILED`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1381,7 +1381,11 @@ export function PromptInput({
       return
     }
     if (key.upArrow) {
-      if (fileOverlayOpen) {
+      // A history walk owns the arrows until it returns to the draft: a
+      // recalled entry can itself open the @ menu or the slash menu (e.g.
+      // `/model`), and letting the overlay navigate here strands the stashed
+      // draft — Down would cycle menu rows instead of walking back.
+      if (fileOverlayOpen && historyIndex.current < 0) {
         setFileSelected(index =>
           index <= 0 ? fileMatches.length - 1 : index - 1,
         )
@@ -1417,7 +1421,7 @@ export function PromptInput({
         setInput(value, prevLineStart + Math.min(cursorColumn(value, cursor), prevLine.length))
         return
       }
-      if (overlayOpen) {
+      if (overlayOpen && historyIndex.current < 0) {
         setSelectedCommand(index =>
           index <= 0 ? suggestions.length - 1 : index - 1,
         )
@@ -1436,7 +1440,8 @@ export function PromptInput({
       return
     }
     if (key.downArrow) {
-      if (fileOverlayOpen) {
+      // Same history-walk ownership as ↑ above.
+      if (fileOverlayOpen && historyIndex.current < 0) {
         setFileSelected(index =>
           index >= fileMatches.length - 1 ? 0 : index + 1,
         )
@@ -1495,7 +1500,7 @@ export function PromptInput({
         setInput(value, nextLineStart + Math.min(cursorColumn(value, cursor), nextLine.length))
         return
       }
-      if (overlayOpen) {
+      if (overlayOpen && historyIndex.current < 0) {
         setSelectedCommand(index =>
           index >= suggestions.length - 1 ? 0 : index + 1,
         )


### PR DESCRIPTION
## 变更摘要 / Summary

修复历史翻页被补全菜单截胡：输入框打着草稿时按 ↑ 召回的历史条目若以 `/` 开头（如 `/model`），斜杠补全菜单随之弹开，`if (overlayOpen)` 的菜单导航分支在 ↑/↓ 处理链上先于历史分支命中——↓ 变成菜单循环，暂存的草稿无法找回（Esc 只会清空输入框，草稿同样回不来，只能 Ctrl+R）。

修复：`PromptInput.tsx` 两个菜单的导航分支（命令菜单 ×2、@ 文件菜单 ×2）加 `historyIndex.current < 0` 门控——历史漫步期间方向键归历史所有，回到草稿（`historyIndex` 复位）后菜单导航恢复。改动 4 行 + 1 个回归脚本。

## 关联 / Related

Closes #672

## 变更类型 / Type

- [x] fix — 修复缺陷

## 验证 / Verification

- [x] `pnpm build`（compile + 全部构建门禁 ALL PASS）
- [x] 聚焦回归脚本：`node scripts/verify-prompt-history-overlay.mjs`（新增，5 项全过）；相邻套件 `verify-batched-prompt-input.mjs`、`verify-input-selection.tsx` 均通过
- [x] 反向验证：stash 修复后重跑新脚本，3 项 FAIL（草稿不可达，Enter 误执行召回的 `/model`：`commands: ["model","model"]`）——脚本确实钉住该 bug
- [x] 真机手动演练：Windows Terminal + Windows 11，复现路径（`/model` 进历史 → 打草稿 → ↑ 召回（菜单弹开）→ ↓ 还原草稿 → ↑↑/↓↓ 往返 → Enter 原样提交）修复前必现、修复后通过，截图见 #672 评论

```text
node scripts/verify-prompt-history-overlay.mjs
PASS: draft typed into the input
PASS: up recalls the /model history entry
PASS: down past the newest entry restores the draft despite the open menu
PASS: up continues through the menu-opening entry to the older one
PASS: draft submits intact after the round trip
All prompt-history-overlay checks passed
```

## 自查 / Checklist

- [x] 只改了 `src/`，没有手改或提交 `lib/` 下的生成产物（改动：PromptInput.tsx + 新增回归脚本）
- [x] 官方 `@deepseek-ai/*` 的 import 仍只出现在 `src/dsh-adapter/` 内（本 PR 未新增任何 import）
- [x] 无用户可见的行为/配置/快捷键变更需要 README 同步（修复恢复既有预期行为）
- [x] 未改 `cordis.patch.yml`
- [x] 只暂存了显式路径，没有用 `git add .` / `git add -A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added background-agent status information to the prompt footer.
  * Empty-prompt Left Arrow can open background-session requests when available.

* **Bug Fixes**
  * Improved prompt history navigation when suggestions or command menus are displayed.
  * Preserved unsent drafts while navigating history and restored them for submission.

* **Tests**
  * Added automated regression coverage for history navigation, menu-opening entries, draft restoration, and submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
