### PR TITLE
fix(selection): 滚轮滚动时选区跟随内容且拖拽中不因出界清除

### DIFF
--- a/scripts/repro-user-drag-wheel-render.tsx
+++ b/scripts/repro-user-drag-wheel-render.tsx
@@ -162,6 +162,8 @@ async function runScenario(withSelection: boolean, seekTicks?: number): Promise<
   lines: string[]
   seekTicks: number
   activeDecstbm: number
+  selectionBeforeWheel: { anchor: { col: number; row: number } | null; focus: { col: number; row: number } | null }
+  selectionAfterWheel: { anchor: { col: number; row: number } | null; focus: { col: number; row: number } | null }
 }> {
   const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
   const writes: string[] = []
@@ -230,8 +232,19 @@ async function runScenario(withSelection: boolean, seekTicks?: number): Promise<
     await sleep(70)
   }
 
+  const beforeWheelState = instances.get(process.stdout)?.selection
+  const selectionBeforeWheel = {
+    anchor: beforeWheelState?.anchor ? { ...beforeWheelState.anchor } : null,
+    focus: beforeWheelState?.focus ? { ...beforeWheelState.focus } : null,
+  }
+
   wheel(stdin, 'up', 7)
   await sleep(180)
+  const afterWheelState = instances.get(process.stdout)?.selection
+  const selectionAfterWheel = {
+    anchor: afterWheelState?.anchor ? { ...afterWheelState.anchor } : null,
+    focus: afterWheelState?.focus ? { ...afterWheelState.focus } : null,
+  }
   if (withSelection) {
     stdin.write(`\x1b[<32;${Math.min(COLS - 2, markerCol + 34)};${Math.min(ROWS - 6, markerRow + 3) + 1}M`)
   }
@@ -249,11 +262,19 @@ async function runScenario(withSelection: boolean, seekTicks?: number): Promise<
   await instance.unmount()
   instances.delete(process.stdout)
   term.dispose()
-  return { lines, seekTicks: usedSeekTicks, activeDecstbm }
+  return { lines, seekTicks: usedSeekTicks, activeDecstbm, selectionBeforeWheel, selectionAfterWheel }
 }
 
 const selected = await runScenario(true)
 const control = await runScenario(false, selected.seekTicks)
+check(
+  '拖动选区时滚轮同时移动 anchor/focus',
+  selected.selectionBeforeWheel.anchor !== null && selected.selectionAfterWheel.anchor !== null &&
+    selected.selectionBeforeWheel.focus !== null && selected.selectionAfterWheel.focus !== null &&
+    selected.selectionBeforeWheel.anchor.row !== selected.selectionAfterWheel.anchor.row &&
+    selected.selectionBeforeWheel.focus.row !== selected.selectionAfterWheel.focus.row,
+  `before=${JSON.stringify(selected.selectionBeforeWheel)} after=${JSON.stringify(selected.selectionAfterWheel)}`,
+)
 
 checkCoherent('拖选+滚轮', selected.lines)
 checkCoherent('无选区对照', control.lines)

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -36,7 +36,7 @@ import { applyPositionedHighlight, type MatchPosition, scanPositions } from './r
 import createRenderer, { type Renderer } from './renderer.js';
 import { CellWidth, CharPool, cellAt, createScreen, HyperlinkPool, isEmptyCellAt, migrateScreenPools, StylePool } from './screen.js';
 import { applySearchHighlight } from './searchHighlight.js';
-import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, pickFollowForSelection, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection.js';
+import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, pickFollowForSelection, type SelectionState, selectLineAt, selectWordAt, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection.js';
 import { isDecstbmSafe, SYNC_OUTPUT_SUPPORTED, serializeDiff, supportsDecrqmProbe, supportsExtendedKeys, supportsWin32InputMode, type Terminal, writeDiffToTerminal } from './terminal.js';
 import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ENABLE_WIN32_INPUT_MODE, ERASE_SCREEN, ERASE_SCROLLBACK, SGR_RESET } from './termio/csi.js';
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
@@ -703,8 +703,15 @@ export default class Ink {
       if (this.selection.isDragging) {
         if (hasSelection(this.selection)) {
           captureScrolledRows(this.selection, this.frontFrame.screen, firstRow, lastRow, side);
+          // Record the viewport bounds for finishSelection's deferred
+          // commit-time check: the in-flight drag never clears (a wheel
+          // must not kill the gesture), so a drag that wheeled fully
+          // off-edge is dropped when it ENDS, not while it is running.
+          this.selection.dragBounds = { top: viewportTop, bottom: viewportBottom };
         }
-        shiftAnchor(this.selection, shift, viewportTop, viewportBottom);
+        // allowClear=false: both ends clamp to the edge; the ghost guard
+        // runs at release via dragBounds above.
+        shiftSelectionForFollow(this.selection, shift, viewportTop, viewportBottom, false);
       } else if (
       // Flag-3 guard: the anchor check above only proves ONE endpoint is
       // on scrollbox content. A drag from row 3 (scrollbox) into the
@@ -715,9 +722,9 @@ export default class Ink {
       // straddling selection falls through to NEITHER shift NOR capture:
       // the footer endpoint pins the selection, text scrolls away under
       // the highlight, and getSelectedText reads the CURRENT screen
-      // contents — no accumulation. Dragging branch doesn't need this:
-      // shiftAnchor ignores focus, and the anchor DOES shift (so capture
-      // is correct there even when focus is in the footer).
+      // contents — no accumulation. Both endpoints are text-anchored in
+      // the active drag branch too, so a wheel cannot leave focus on the
+      // old screen row.
       !this.selection.focus || this.selection.focus.row >= viewportTop && this.selection.focus.row <= viewportBottom) {
         if (hasSelection(this.selection)) {
           captureScrolledRows(this.selection, this.frontFrame.screen, firstRow, lastRow, side);

--- a/src/ink/selection.ts
+++ b/src/ink/selection.ts
@@ -58,6 +58,13 @@ export type SelectionState = {
   virtualAnchorRow?: number
   /** Same for focus. */
   virtualFocusRow?: number
+  /** Viewport bounds recorded by the LAST in-drag follow shift. During an
+   *  active drag a wheel that pushes both ends off the same edge CLAMPS
+   *  instead of clearing (the gesture must survive); finishSelection then
+   *  re-checks these bounds and drops the selection if it is still fully
+   *  off-edge at commit time — the ghost-highlight guard is deferred, not
+   *  removed. Undefined while no drag shift has run. */
+  dragBounds?: { top: number; bottom: number }
   /** True if the mouse-down that started this selection had the alt
    *  modifier set (SGR button bit 0x08). On macOS xterm.js this is a
    *  signal that VS Code's macOptionClickForcesSelection is OFF — if it
@@ -110,6 +117,7 @@ export function startSelection(
   s.scrolledOffBelowSW = []
   s.virtualAnchorRow = undefined
   s.virtualFocusRow = undefined
+  s.dragBounds = undefined
   s.lastPressHadAlt = false
 }
 
@@ -135,18 +143,32 @@ export function updateSelection(
   if (!s.focus && s.anchor && s.anchor.col === col && s.anchor.row === row)
     return
   s.focus = { col, row }
+  s.virtualFocusRow = undefined
 }
 
 /**
  * End a drag: clear the dragging flag while keeping anchor/focus so the
  * highlight stays visible and the text can be copied. Call
  * clearSelection to drop the selection after copy or on Esc.
+ *
+ * Deferred ghost guard: a drag that scrolled both ends fully off the same
+ * viewport edge (wheeled away while the button was held) is dropped HERE,
+ * at commit time, instead of during the drag — the in-flight gesture must
+ * survive the wheel, but a committed selection left entirely off-screen
+ * would linger as an invisible ghost (see shiftSelectionForFollow).
  * @param s - the selection state to mutate.
  */
 export function finishSelection(s: SelectionState): void {
   s.isDragging = false
-  // Keep anchor/focus so highlight stays visible and text can be copied.
-  // Clear via clearSelection() on Esc or after copy.
+  if (s.dragBounds !== undefined) {
+    const { top, bottom } = s.dragBounds
+    s.dragBounds = undefined
+    if (selectionFullyOffEdge(s, top, bottom)) {
+      clearSelection(s)
+    }
+  }
+  // Otherwise keep anchor/focus so highlight stays visible and text can be
+  // copied. Clear via clearSelection() on Esc or after copy.
 }
 
 /**
@@ -165,6 +187,7 @@ export function clearSelection(s: SelectionState): void {
   s.scrolledOffBelowSW = []
   s.virtualAnchorRow = undefined
   s.virtualFocusRow = undefined
+  s.dragBounds = undefined
   s.lastPressHadAlt = false
 }
 
@@ -445,6 +468,7 @@ export function extendSelection(
 ): void {
   if (!s.isDragging || !s.anchorSpan) return
   const span = s.anchorSpan
+  s.virtualFocusRow = undefined
   let mLo: Point
   let mHi: Point
   if (span.kind === 'word') {
@@ -665,6 +689,27 @@ export function shiftAnchor(
 }
 
 /**
+ * Whether both ends of the selection are strictly past the SAME edge of
+ * [minRow, maxRow] — the fully-off-screen condition. Rows are read through
+ * the virtual (pre-clamp) trackers so a clamped-then-reversed scroll
+ * evaluates at the TRUE position. Shared by shiftSelectionForFollow's
+ * immediate clear and finishSelection's deferred commit-time check.
+ */
+export function selectionFullyOffEdge(
+  s: SelectionState,
+  minRow: number,
+  maxRow: number,
+): boolean {
+  const rawAnchor = s.virtualAnchorRow ?? s.anchor?.row
+  const rawFocus = s.virtualFocusRow ?? s.focus?.row
+  if (rawAnchor === undefined || rawFocus === undefined) return false
+  return (
+    (rawAnchor < minRow && rawFocus < minRow) ||
+    (rawAnchor > maxRow && rawFocus > maxRow)
+  )
+}
+
+/**
  * Shift the whole selection (anchor + focus + anchorSpan) by dRow, clamped
  * to [minRow, maxRow]. Used when sticky/auto-follow scrolls the ScrollBox
  * while a selection is active — native terminal behavior is for the
@@ -686,10 +731,16 @@ export function shiftAnchor(
  * selection was cleared so the caller can notify React-land subscribers
  * (useHasSelection) — the caller is inside onRender so it can't use
  * notifySelectionChange (recursion), must fire listeners directly.
+ *
+ * `allowClear` is false for ACTIVE DRAGS: a wheel must never kill the
+ * in-flight gesture, so both ends clamp to the edge instead; the clear is
+ * deferred to finishSelection's commit-time check via the recorded
+ * dragBounds. Released selections keep the immediate clear.
  * @param s - the selection state to mutate.
  * @param dRow - signed row offset to shift by.
  * @param minRow - lowest allowed row (viewport top).
  * @param maxRow - highest allowed row (viewport bottom).
+ * @param allowClear - clear when both ends exit the same edge (default true).
  * @returns true when the selection was cleared because it scrolled
  *   entirely off the top, false otherwise.
  */
@@ -698,6 +749,7 @@ export function shiftSelectionForFollow(
   dRow: number,
   minRow: number,
   maxRow: number,
+  allowClear = true,
 ): boolean {
   if (!s.anchor) return false
   // Mirror shiftSelection: compute raw (unclamped) positions from virtual
@@ -714,10 +766,14 @@ export function shiftSelectionForFollow(
     : undefined
   // Both ends strictly past the same edge = selection fully scrolled off
   // (top: follow/wheel-down; bottom: wheel-up). Symmetric clear — a
-  // clamped-to-edge pair would render as a 1-row ghost highlight.
+  // clamped-to-edge pair would render as a 1-row ghost highlight. Skipped
+  // during an active drag: the gesture survives (clamp below), and the
+  // release-time check in finishSelection drops it if still off-edge.
   if (
-    (rawAnchor < minRow && rawFocus !== undefined && rawFocus < minRow) ||
-    (rawAnchor > maxRow && rawFocus !== undefined && rawFocus > maxRow)
+    allowClear &&
+    rawFocus !== undefined &&
+    ((rawAnchor < minRow && rawFocus < minRow) ||
+      (rawAnchor > maxRow && rawFocus > maxRow))
   ) {
     clearSelection(s)
     return true


### PR DESCRIPTION
修复拖选+滚轮：选区随内容平移、拖拽中滚轮不清除（防鬼影规则推迟到松开时判定）；修复 repro-user-drag-wheel-render 时序断言。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection behavior while scrolling with the mouse wheel.
  * Active selections now remain anchored correctly as the viewport moves.
  * Dragging selections beyond the visible area no longer clears them prematurely.
  * Fully off-screen selections are cleared appropriately when selection is completed.
  * Improved handling of selection rendering and focus state during scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->