### PR TITLE
chore: deslop 微修——ADAPTER.md 标点 + 两处失实注释修正

### DIFF
--- a/ADAPTER.md
+++ b/ADAPTER.md
@@ -23,7 +23,7 @@ UI 层(`screens/`、`components/`、`ink/`、`hooks/`、`utils/`、`cc/`)
 
 `cordis.patch.yml` 里对官方行的干预已快照到 `patch-surface.snapshot.json`:
 
-- **disabled overrides**:24 行。其中 23 行恒定禁用;`command-goal` 仅在
+- **disabled overrides**:24 行。其中 23 行恒定禁用；`command-goal` 仅在
   `dsh-agent-presets` 的 shipped standard preset 实际自带该命令时禁用,
   因而 0.1.2 线与 web-app 对齐,旧 0.1.1-rc.2 仍保留 host `/goal`;web-app 另有 `hmr`
 - **config overrides**:8 行(原有 6 行加 session-telemetry-otel /

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -1607,7 +1607,8 @@ function renderNodeToOutput(
 // AFTER a dirty/removed sibling can contain stale overflow in prevScreen.
 // Disable blit for siblings after a dirty child — but still pass prevScreen
 // TO the dirty child itself so its clean descendants can blit. The dirty
-// child's own blit check already fails (node.dirty=true at line 216), so
+// child's own blit check already fails (node.dirty=true, set by markDirty
+// in dom.ts), so
 // passing prevScreen only benefits its subtree.
 // For removed children we don't know their original position, so
 // conservatively disable blit for all.

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -3305,7 +3305,7 @@ export function Chat({
     return fullscreen ? scene : <AlternateScreen>{scene}</AlternateScreen>
   }
 
-  // Subagent dashboard: displays all active and completed subagents.
+  // Jobs panel: background jobs (running/killed) with kill/inspect actions.
   // Like the browser and settings, it replaces the conversation entirely.
   if (jobsPanelOpen) {
     const panel = (


### PR DESCRIPTION
﻿slop 审计（23 个近期合并 PR）后的实修残余项。审计原计划 12 项，逐项复核后 8 项为误报撤销（详见评论）。

rebase 最新 main 后保留 3 处；原第 2 项 parse-keypress case-D 注释已过时丢弃——上游重构移除了 isFlush/holdTouchedThisCall 机制与该注释，改动目标不复存在：

1. ADAPTER.md:26 半角分号混入中文句（#622 带入）
2. render-node-to-output.ts 注释 "node.dirty=true at line 216" 幻觉行号——改为指向 dom.ts 的 markDirty 稳定引用
3. Chat.tsx jobsPanelOpen 分支头上的 "Subagent dashboard" 复制残留标题——改为如实描述 Jobs panel

另 3 处 PR 描述修正（#645 错误回滚 SHA、#630 代号补名、#631 删自辩节）已直接 gh pr edit 完成，不涉及代码。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overlay rendering when previously covered areas become visible after overlays move or shrink.
  * Improved transcript layout so the page gutter reaches the terminal edge while chat content remains properly inset.

* **Documentation**
  * Corrected punctuation in the patch-surface documentation without changing its meaning or values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->