### PR TITLE
fix(smooth-streaming): 揭示唤醒改用 DefaultLane，消除 beta.3 流式期 #185 闪退

### DIFF
--- a/scripts/instr-nested-updates.mjs
+++ b/scripts/instr-nested-updates.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Instrument the DEV react-reconciler for nested-update (#185) diagnosis.
+ * Edits node_modules/react-reconciler/cjs/react-reconciler.development.js in
+ * place (original saved next to it as .instr-orig); re-applies from the
+ * pristine backup on every run so edits to this script take effect.
+ *
+ * Patches:
+ *  1. commit-end counter (commitRootImpl): after every commit appends
+ *     nestedUpdateCount to __traj and `lanes:remaining` to __lanes, tracks
+ *     __maxNested, logs [NESTED++] once the count reaches 3.
+ *  2. getRootForUpdatedFiber throw site: records the source fiber's nearest
+ *     function-component name into __ics and logs [NESTED-THROW].
+ *  3. sets globalThis.__recPatched = true so repro scripts can assert the
+ *     patch is loaded.
+ *
+ * Run: node scripts/instr-nested-updates.mjs   (then run a repro with
+ * NODE_ENV=development; production builds are untouched)
+ */
+import { readFileSync, writeFileSync, copyFileSync, existsSync } from 'node:fs'
+
+const file = 'node_modules/react-reconciler/cjs/react-reconciler.development.js'
+const MARKER = '__INSTR_NESTED_V3__'
+
+if (!existsSync(file + '.instr-orig')) copyFileSync(file, file + '.instr-orig')
+// Always start from the pristine copy so script edits apply cleanly.
+let src = readFileSync(file + '.instr-orig', 'utf8')
+
+// 1. commit-end counter — exact anchor from commitRootImpl
+const counterAnchor = `        0 !== (endTime & 261930) && 0 !== (remainingLanes & 42)
+          ? ((nestedUpdateScheduled = !0),
+            startViewTransitionStartTime === rootWithNestedUpdates
+              ? nestedUpdateCount++
+              : ((nestedUpdateCount = 0),
+                (rootWithNestedUpdates = startViewTransitionStartTime)))
+          : (nestedUpdateCount = 0);`
+const counterPatched = counterAnchor + `
+        (globalThis.__traj ??= []).push(nestedUpdateCount);
+        (globalThis.__lanes ??= []).push(endTime + ':' + remainingLanes);
+        if (nestedUpdateCount > (globalThis.__maxNested ?? 0)) globalThis.__maxNested = nestedUpdateCount;
+        if (nestedUpdateCount >= 3) console.error('[NESTED++] count=' + nestedUpdateCount + ' lanes=' + endTime + ' remaining=' + remainingLanes);`
+if (!src.includes(counterAnchor)) {
+  console.error('instr-nested-updates: counter anchor not found — reconciler drifted?')
+  process.exit(1)
+}
+src = src.replace(counterAnchor, counterPatched)
+
+// 2. residue-source tracker — who dispatches while work is in flight.
+//    (a) commit-phase dispatch: executionContext & CommitContext (≠ 0)
+//    (b) interleaved between-slices arrival: root === workInProgressRoot
+//        while NOT in render/commit execution (timer callback between slices)
+//    Both land in pendingLanes after the commit → the remainingLanes residue
+//    that the commit-end rule counts as a nested update.
+const schedAnchor = `      markRootUpdated$1(root, lane);`
+const schedPatched = `      try {
+        var __ctx = (executionContext & 4) !== 0 ? 'commit'
+          : (root === workInProgressRoot && (executionContext & 2) === 0) ? 'interleaved'
+          : null;
+        if (__ctx !== null) {
+          var __m = (globalThis.__residue ??= new Map());
+          var __n = getComponentNameFromFiber(fiber) || ('tag' + fiber.tag);
+          var __s = new Error('residue-site').stack || '';
+          // key by the first app (non-reconciler, non-node) stack frame so
+          // distinct setState sites on the same fiber stay separate
+          var __f = (__s.split('\\n').find(function (l) {
+            return l.includes('/src/') && !l.includes('instr-nested')
+          }) || '').trim().replace(/^at\s+/, '');
+          var __k = __ctx + ':' + __n + ':lane' + lane + ' @' + __f;
+          var __e = __m.get(__k);
+          if (__e === undefined) __m.set(__k, { count: 1, stack: __s });
+          else __e.count++;
+        }
+      } catch (e) {}
+      markRootUpdated$1(root, lane);`
+if (!src.includes(schedAnchor)) {
+  console.error('instr-nested-updates: schedule anchor not found — reconciler drifted?')
+  process.exit(1)
+}
+src = src.replace(schedAnchor, schedPatched)
+
+// 3. throw site — record the victim (source fiber's component name)
+const throwAnchor = `    function getRootForUpdatedFiber(sourceFiber) {
+      if (nestedUpdateCount > NESTED_UPDATE_LIMIT)`
+const throwPatched = `    function getRootForUpdatedFiber(sourceFiber) {
+      if (nestedUpdateCount > NESTED_UPDATE_LIMIT) {
+        try {
+          globalThis.__ics = globalThis.__ics || new Map();
+          let f = sourceFiber, nm = '?';
+          while (f) { const t = f.elementType; if (typeof t === 'function') { nm = t.displayName || t.name || '?'; break; } f = f.return; }
+          globalThis.__ics.set('THROW@' + nm, { count: nestedUpdateCount, stack: new Error('throw-site').stack, ctx: 0 });
+          console.error('[NESTED-THROW] source=' + nm + ' count=' + nestedUpdateCount);
+        } catch (e) {}
+      }
+      if (nestedUpdateCount > NESTED_UPDATE_LIMIT)`
+if (!src.includes(throwAnchor)) {
+  console.error('instr-nested-updates: throw anchor not found — reconciler drifted?')
+  process.exit(1)
+}
+src = src.replace(throwAnchor, throwPatched)
+
+src += `\n/* ${MARKER} */\nglobalThis.__recPatched = true;\n`
+writeFileSync(file, src)
+console.log('instr-nested-updates: patched', file, '(original at .instr-orig)')

--- a/scripts/repro-185-reveal.tsx
+++ b/scripts/repro-185-reveal.tsx
@@ -1,0 +1,293 @@
+/**
+ * beta.3 #185 repro — smoothReveal driver (fourth loop path after #662/#669).
+ *
+ * Difference from repro-185.tsx: the channel mock sets `smoothStreaming: true`,
+ * so MessageList subscribes to the reveal store via useSyncExternalStore. Every
+ * advancing 33ms reveal tick then forces a SYNCLANE store rerender
+ * (forceStoreRerender hardcodes SyncLane), which preempts/discards the
+ * in-flight DefaultLane streaming render; each sync commit ends with Default
+ * work pending → the commit-end lane test counts a nested update with no
+ * reset → 50 consecutive dirty commits → the next scheduleUpdateOnFiber on
+ * the root throws minified #185 from whichever timer happens to fire
+ * (ClockContext tick, thinking-spinner setFrame, …) → uncaught → process exit.
+ *
+ * Run for the real crash (minified #185, exit 1):
+ *   NODE_ENV=production node --import tsx/esm scripts/repro-185-reveal.tsx
+ * Run instrumented (dev reconciler logs [NESTED++] / [NESTED-THROW]):
+ *   node scripts/instr-nested-updates.mjs   # once, patches node_modules dev build
+ *   NODE_ENV=development node --import tsx/esm scripts/repro-185-reveal.tsx
+ * Expected pre-fix: crash within a few seconds of streaming start.
+ * Expected post-fix: runs to completion, exit 0.
+ *
+ * Env: SMOOTH=0 — control run with the reveal store disabled (same feed);
+ *      FEEDERS="4,7,11,17" — feeder timer cadences (the tuning knob);
+ *      COLS (default 110).
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, reveal] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/components/smoothReveal.js'),
+])
+
+const COLS = Number(process.env.COLS ?? 110)
+const ROWS = 32
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 1000, allowProposedApi: true })
+
+const rawChunks: string[] = []
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { rawChunks.push(String(chunk)); term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+// Initialized BEFORE the crash handlers so finish() can never hit a TDZ
+// ReferenceError that would mask the original crash (review P2).
+const startedAt = Date.now()
+/** Set when the streaming loop starts; 0 = never reached it. */
+let streamStartedAt = 0
+let crashed: unknown = null
+function onCrash(err: unknown): void {
+  crashed = err
+  console.error('\n!!!! PROCESS CRASH !!!!')
+  console.error(err)
+  finish(1)
+}
+process.on('uncaughtException', onCrash)
+process.on('unhandledRejection', onCrash)
+
+const listeners = new Set<() => void>()
+let subCount = 0
+let versionReads = 0
+let _version = 0
+const channel: any = {
+  get version() { versionReads++; return _version },
+  set version(v: number) { _version = v },
+  rows: [] as any[],
+  status: 'idle',
+  sessionTitle: 'repro-185-reveal',
+  agentId: 'repro-185-reveal',
+  model: 'deepseek-v4-flash',
+  reasoningEffort: 'max',
+  mode: { plan: false },
+  modeIndex: 0,
+  displayCwd: '/tmp/demo',
+  contextBarEnabled: false,
+  contextSegments: undefined,
+  contextWindow: undefined,
+  lastUsage: undefined,
+  tps: undefined,
+  tpsSamples: [],
+  workingActivity: undefined,
+  activityFrames: undefined,
+  commandCompletions: [],
+  tokens: { input: 120, output: 45 },
+  cwd: '/tmp/demo',
+  gitBranch: 'main',
+  working: true,
+  spinnerMode: 'requesting',
+  responseChars: 0,
+  activeToolCount: 1,
+  turnStart: Date.now(),
+  lastUserText: '长会话流式压测',
+  pending: [],
+  commandList: [],
+  notifications: [],
+  // >>> the beta.3 driver: MessageList subscribes to the reveal store <<<
+  // SMOOTH=0 runs the identical scenario with the reveal store off (control
+  // group: if only the SMOOTH=1 run crashes, the reveal wakeup is the driver).
+  smoothStreaming: process.env.SMOOTH !== '0',
+  subscribe(cb: () => void) { subCount++; listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {},
+  cancel: () => {},
+  clear: () => {},
+  notify: () => {},
+  listModels: () => Promise.resolve([]),
+  listSessions: () => [],
+  setResumeTarget: () => {},
+  loadOlder: () => {},
+  mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) cb() }
+
+// Reveal-store probe: count advancing ticks (each one forces a SyncLane
+// store rerender pre-fix).
+let revealTicks = 0
+reveal.subscribeReveal(() => { revealTicks++ })
+
+let id = 0
+const codeBlock = (n: number, lang: string) =>
+  '```' + lang + '\n' + Array.from({ length: n }, (_, i) =>
+    `const handleRequest${i} = async (req: Request, res: Response): Promise<void> => { // 第 ${i} 行，故意写得很长，让窄终端里一定折行，从而撑高测量高度`
+  ).join('\n') + '\n```'
+
+// --- long session: 10 turns, mixed tool cards + markdown --------------------
+for (let turn = 0; turn < 10; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `历史问题 ${turn}：分析一下模块 ${turn} 的实现` })
+  channel.rows.push({ id: id++, kind: 'reasoning', text: `用户在问模块 ${turn}。`.repeat(4), streaming: false, durationMs: 1500 })
+  for (let t = 0; t < 3; t++) {
+    channel.rows.push({
+      id: id++, kind: 'tool', text: '',
+      tool: {
+        callId: `h${turn}-${t}`, name: t % 2 ? 'Read' : 'Bash',
+        argsText: t % 2 ? `{"file_path": "/tmp/demo/src/mod${turn}/file${t}.ts"}` : `{"command": "rg -n 'export' src/mod${turn} | head -40", "description": "list exports"}`,
+        argsFull: '{}',
+        status: 'ok', startedAt: Date.now() - 600000, durationMs: 30,
+        resultText: Array.from({ length: 12 + ((turn + t) % 5) * 6 }, (_, i) => `export function helper_${turn}_${t}_${i}(input: unknown): Promise<Result<unknown>> { /* 历史结果行 ${i}，长度凑一凑 */ return null }`).join('\n'),
+      },
+    })
+  }
+  channel.rows.push({
+    id: id++, kind: 'assistant', streaming: false,
+    text: `模块 ${turn} 的结论：\n\n- 入口在 \`src/mod${turn}/index.ts\`\n- 关键逻辑如下：\n\n${codeBlock(18 + (turn % 4) * 8, 'ts')}\n\n| 项 | 值 |\n| --- | --- |\n| 行数 | ${300 + turn * 17} |\n| 复杂度 | 高 |\n`,
+  })
+}
+
+const stdin = new FakeStdin()
+const stdout = new FakeStdout()
+
+class Trap extends React.Component<{ children: React.ReactNode }, { err: unknown }> {
+  override state = { err: null as unknown }
+  static getDerivedStateFromError(err: unknown): { err: unknown } { return { err } }
+  override componentDidCatch(err: unknown, info: unknown): void {
+    // A boundary-caught error (e.g. #185 thrown inside a commit) never reaches
+    // uncaughtException — record it as a crash so the run cannot false-pass.
+    crashed = err
+    console.error('TRAPPED RENDER ERROR:', err)
+    console.error('component stack:', (info as { componentStack?: string })?.componentStack)
+    finish(1)
+  }
+  override render(): React.ReactNode { return this.state.err ? null : this.props.children }
+}
+
+const chatTree = (
+  <Trap>
+    <Chat channel={channel} questionStore={new QuestionStore()} onExit={() => {}} />
+  </Trap>
+)
+await render(
+  <AlternateScreen>
+    {chatTree}
+  </AlternateScreen>,
+  { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
+)
+
+// status metrics ticking ~10/s (channel bumps without row changes)
+const ticker = setInterval(() => { channel.responseChars += 7; bump() }, 100)
+// second independent bump source (spinner cadence) to crowd the event loop
+const ticker2 = setInterval(() => { bump() }, 47)
+
+await sleep(800)
+
+// --- live turn: long streamed markdown+code, fast cadence -------------------
+channel.rows.push({ id: id++, kind: 'user', text: '把 AAA 项目的核心模块完整讲一遍，带上代码' }); bump()
+await sleep(150)
+
+const think = { id: id++, kind: 'reasoning', text: '', streaming: true, durationMs: undefined as number | undefined }
+channel.rows.push(think); bump()
+for (const c of ['用户要完整讲解，', '需要覆盖架构、', '关键代码与数据流。']) { think.text += c; bump(); await sleep(120) }
+think.streaming = false; think.durationMs = 900; bump()
+
+const finalMsg = { id: id++, kind: 'assistant', text: '', streaming: true }
+channel.rows.push(finalMsg); bump()
+
+// Build the streamed doc: prose + fenced code with long wrapping lines + tables.
+// DOC_SECTIONS is the second tuning knob: the per-commit render cost grows
+// with the streamed row's markdown length, so a longer doc means slower
+// late-stream renders — slow enough that a mid-render timer dispatch (clock,
+// measure deferral) is guaranteed, making EVERY commit end dirty regardless
+// of the reveal store. Keep it short enough that the SMOOTH=0 control
+// finishes before renders cross that threshold; the reveal store's 30fps
+// forced SyncLane commits climb the counter from the very first seconds.
+const sections = Number(process.env.DOC_SECTIONS ?? 24)
+const docChunks: string[] = ['好，完整梳理一遍 AAA 项目的核心模块。\n\n']
+for (let s = 0; s < sections; s++) {
+  docChunks.push(`\n## ${s + 1}. 子系统 ${s + 1}：职责与入口\n\n`)
+  docChunks.push(`子系统 ${s + 1} 负责请求生命周期第 ${s + 1} 阶段的编排。`.repeat(2) + '\n\n')
+  for (const ln of codeBlock(10 + (s % 3) * 6, 'ts').split('\n')) docChunks.push(ln + '\n')
+  docChunks.push('\n| 指标 | 数值 | 说明 |\n| --- | --- | --- |\n')
+  for (let r = 0; r < 5; r++) docChunks.push(`| 指标${s}-${r} | ${(s + 1) * (r + 2) * 137} | 这是一行表格说明文字，用来占宽 |\n`)
+  docChunks.push('\n')
+}
+
+// Feed the doc through several INDEPENDENT timers at staggered cadences — a
+// fast SSE burst, not a render-paced loop. A serial `bump(); await sleep()`
+// loop alternates with renders (each chunk gets consumed by its own render,
+// commits end clean, the nested counter keeps resetting); independent timers
+// fire during in-flight renders, so updates land mid-render and the commit
+// ends with DefaultLane residue. Cadence is the tuning knob: slow enough that
+// WITHOUT the reveal store (SMOOTH=0) plain Default renders frequently end
+// clean (control survives), fast enough that the reveal tick's forced SyncLane
+// render — every 33ms, preempting/discarding in-flight Default work — keeps
+// ending dirty (SMOOTH=1 counter climbs to 50).
+const feederMs = (process.env.FEEDERS ?? '4,7,11,17').split(',').map(Number)
+streamStartedAt = Date.now()
+let ci = 0
+const feeders = feederMs.map(ms =>
+  setInterval(() => {
+    if (ci >= docChunks.length) return
+    finalMsg.text += docChunks[ci++]!
+    bump()
+  }, ms),
+)
+await new Promise<void>(resolve => {
+  const check = setInterval(() => {
+    if (ci >= docChunks.length) { clearInterval(check); resolve() }
+  }, 100)
+})
+for (const f of feeders) clearInterval(f)
+finalMsg.streaming = false
+channel.working = false
+bump()
+await sleep(3000)
+clearInterval(ticker)
+clearInterval(ticker2)
+await sleep(300)
+
+finish(0)
+
+function finish(code: number): void {
+  const allRaw = rawChunks.join('')
+  const hit185 = /Maximum update depth|Minified React error #185/.test(allRaw)
+  console.log('\n==== repro-185-reveal summary ====')
+  console.log('chunks:', rawChunks.length, ' elapsed:', Date.now() - startedAt, 'ms stream:', streamStartedAt ? `${Date.now() - streamStartedAt}ms` : 'n/a')
+  console.log('crashed:', crashed ? String(crashed).slice(0, 300) : false)
+  console.log('error #185 text in output:', hit185)
+  console.log('max nested count seen:', (globalThis as any).__maxNested ?? 0, '(dev patch only; crashes at 51)')
+  console.log('reveal advancing ticks:', revealTicks, ' version:', reveal.getRevealVersion(), ' timer running:', reveal.isRevealTimerRunning())
+  // lanes profile from the dev-reconciler patch: does the SyncLane bit (the
+  // reveal store's forced rerender) carry the dirty commits?
+  const laneLog = ((globalThis as any).__lanes ?? []) as string[]
+  if (laneLog.length > 0) {
+    const dirty = laneLog.filter(s => (Number(s.split(':')[1]) & 42) !== 0)
+    const dirtySync = dirty.filter(s => (Number(s.split(':')[0]) & 2) !== 0)
+    console.log(`lanes profile: ${laneLog.length} commits, dirty ${dirty.length}, dirty-with-SyncLane ${dirtySync.length}`)
+  }
+  // residue sources: who dispatched updates into in-flight work
+  const residue = (globalThis as any).__residue as Map<string, { count: number; stack: string }> | undefined
+  if (residue && residue.size > 0) {
+    const top = [...residue.entries()].sort((a, b) => b[1].count - a[1].count).slice(0, 8)
+    console.log('residue dispatchers (phase:component:lane @site):')
+    for (const [k, v] of top) console.log(`  ${k} x${v.count}`)
+  }
+  console.log('channel subscribes:', subCount, ' version getter reads:', versionReads, ' version:', _version)
+  process.exit(crashed || hit185 ? 1 : code)
+}

--- a/scripts/repro-185-reveal.tsx
+++ b/scripts/repro-185-reveal.tsx
@@ -22,6 +22,16 @@
  * Env: SMOOTH=0 — control run with the reveal store disabled (same feed);
  *      FEEDERS="4,7,11,17" — feeder timer cadences (the tuning knob);
  *      COLS (default 110).
+ *
+ * Residual chain (fixed in the follow-up commit): with the reveal wakeup
+ * already on DefaultLane, a slow-terminal regime — DOC_SECTIONS=96
+ * FEEDERS=3,5,7,9 COLS=80 — still crashed #185 in ~12s of streaming: the
+ * Chat channel useSyncExternalStore kept forcing SyncLane renders per feed
+ * bump, and the timeline report effect re-dispatched setTimeline on every
+ * commit (its signature pinned to heightsVersion, bumped by the growing
+ * streamed row), so no commit ever ended clean. The follow-up moved the
+ * channel subscription to useDefaultLaneWakeup and made the timeline report
+ * value-deduped; the same config then survives a full 7-minute stream.
  */
 process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'WezTerm'

--- a/scripts/verify-auto-recap.tsx
+++ b/scripts/verify-auto-recap.tsx
@@ -25,7 +25,7 @@ const [
   { render, AlternateScreen },
   { Chat },
   { setLang },
-  { settle, screenHas, findText, viewportLines },
+  { settle, settled, screenHas, findText, viewportLines },
   { stringWidth },
 ] = await Promise.all([
   import('node:stream'),
@@ -311,8 +311,11 @@ channel.autoRecapOnOpen = true
 channel.agentId = 'probe-5'
 channel.emit()
 await settle(() => channel.recapCallCount === 5)
-await settle(() => screenHas(term, '回顾：'))
-check('重新开启后切会话恢复灰行', screenHas(term, 'AUTO_RECAP_SUMMARY'))
+// 直接 settle 到摘要落屏，不能 settle 到「回顾：」就立即断言摘要：灰行在
+// recap 在途时先画占位行「回顾：正在总结最近活动…」（同样含此前缀），摘要
+// 经 promise.then 另行落屏——两帧之间该断言是竞态（PR #680 把会话切换的
+// 唤醒从 uSES 同步渲染改为 DefaultLane 排期后，占位帧在 CI 上真实出现）。
+check('重新开启后切会话恢复灰行', await settled(() => screenHas(term, 'AUTO_RECAP_SUMMARY')))
 stdin.write('继续')
 await settle(() => screenHas(term, '继续'))
 stdin.write('\r')

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -938,18 +938,32 @@ export function MessageList({
     upId: upTurnIndex === null ? null : timelineTurns[upTurnIndex]!.id,
     downId: downTurnIndex === null ? null : timelineTurns[downTurnIndex]!.id,
   }
-  const lastTimelineReportRef = React.useRef('')
+  const lastTimelineReportRef = React.useRef<TimelineSnapshot | null>(null)
   React.useEffect(() => {
-    // O(1) signature: the memo key pins the turns' geometry identity
-    // (heights/window/base/rows-length) and the three ids pin the
-    // viewport-derived targets. Any top change bumps the geometry key, so
-    // the report still fires exactly when the snapshot content changes —
-    // without rebuilding an O(turns) joined string per commit.
-    const sig = `${timelineMemoRef.current?.key ?? ''}#a${timeline.activeId}#u${timeline.upId}#d${timeline.downId}`
-    if (sig !== lastTimelineReportRef.current) {
-      lastTimelineReportRef.current = sig
-      onTimeline?.(timeline)
-    }
+    // Value-level dedup, not geometry-key-level: the memo key pins to
+    // heightsVersion, which a GROWING streamed row bumps on every commit,
+    // so a key-pinned signature re-reports an identical snapshot every
+    // commit of a long stream. Each report is a setState dispatched into
+    // Chat from this passive effect; it lands as pending residue at commit
+    // end, keeping the commit dirty and feeding React's nested-update
+    // counter (50 consecutive dirty commits → error #185, the beta.3
+    // crash). The O(turns) compare below is integer/string-reference
+    // compares only — cheap next to the joined-string signature the memo
+    // key replaced, and it fires exactly when the snapshot content changes.
+    const prev = lastTimelineReportRef.current
+    if (
+      prev !== null &&
+      prev.activeId === timeline.activeId &&
+      prev.upId === timeline.upId &&
+      prev.downId === timeline.downId &&
+      prev.turns.length === timeline.turns.length &&
+      prev.turns.every((t, i) => {
+        const n = timeline.turns[i]!
+        return t.id === n.id && t.top === n.top && t.folded === n.folded && t.preview === n.preview
+      })
+    ) return
+    lastTimelineReportRef.current = timeline
+    onTimeline?.(timeline)
   })
 
   // Post-commit: measure mounted rows, derive the content-space base from

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -22,7 +22,8 @@ import { stringWidth } from '../ink/stringWidth.js'
 import { truncateToWidth } from '../ink/truncateToWidth.js'
 import { clipPreview, type TimelineSnapshot, type TimelineTurn } from '../ink/timeline-rail.js'
 import type { ToolBackground } from '../tuiDisplayPrefs.js'
-import { getRevealVersion, revealLengthOf, revealTextOf, subscribeReveal } from './smoothReveal.js'
+import { getRevealVersion, revealLengthOf, revealTextOf } from './smoothReveal.js'
+import { useRevealVersion } from '../hooks/useRevealVersion.js'
 
 /**
  * Transcript rows rendered in the Claude Code visual language: user prompts
@@ -430,13 +431,17 @@ export function MessageList({
 
   // --- layout virtualization ---------------------------------------------
   const { columns, rows: termRows } = useTerminalSize()
-  // Smooth-reveal wakeups: the scheduler's tick bumps this store, re-running
+  // Smooth-reveal wakeups: the scheduler's tick bumps this hook, re-running
   // MessageList so the revealed `text`/line-count reads below feed fresh
   // values through the same MemoRow-prop pipeline an arriving chunk uses —
   // memo miss → re-render → post-commit height re-measure. Without this
   // subscription a reveal living in child state would change row heights
   // invisibly to the virtualization (stale cached heights → blank bands).
-  React.useSyncExternalStore(subscribeReveal, getRevealVersion)
+  // DefaultLane on purpose (useRevealVersion): a useSyncExternalStore wakeup
+  // would force a SyncLane render per 33ms tick, and each such commit ending
+  // with streaming work still pending feeds React's nested-update counter
+  // until error #185 kills the process (beta.3).
+  useRevealVersion()
   // Measured row heights, remembered after a row unmounts so virtualization
   // can compute total content height. Bounded: row ids grow monotonically
   // and rows are never removed from the transcript (foldRows keeps the

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -12,10 +12,8 @@ import { formatDuration } from '../../cc/format.js'
 import type { ToolBackground } from '../../tuiDisplayPrefs.js'
 import type { Theme } from '../../theme.js'
 import type { ClickEvent } from '../../ink/events/click-event.js'
-import { getRevealVersion, revealLinesOf, snapReveal, subscribeReveal } from '../smoothReveal.js'
-
-const NOOP_REVEAL_SUBSCRIBE = (_listener: () => void): (() => void) => () => {}
-const getNoRevealVersion = (): number => 0
+import { revealLinesOf, snapReveal } from '../smoothReveal.js'
+import { useRevealVersion } from '../../hooks/useRevealVersion.js'
 
 type Props = {
   tool: ToolRow
@@ -428,10 +426,10 @@ export function AssistantToolUseMessage({
   // MessageList owns the single production subscription and passes a version
   // prop only to active reveal rows. Standalone consumers keep the fallback
   // subscription so the component contract remains self-contained.
-  React.useSyncExternalStore(
-    revealVersion === undefined ? subscribeReveal : NOOP_REVEAL_SUBSCRIBE,
-    revealVersion === undefined ? getRevealVersion : getNoRevealVersion,
-  )
+  // DefaultLane on purpose (useRevealVersion): a useSyncExternalStore wakeup
+  // forces a SyncLane render per tick, and repeated sync commits ending with
+  // streaming work pending feed React's nested-update counter (error #185).
+  useRevealVersion(revealVersion === undefined)
   const isRunning = tool.status === 'running'
   const isError = tool.status === 'error'
   const displayArgs = verbose ? tool.argsFull ?? tool.argsText : tool.argsText

--- a/src/hooks/useDefaultLaneWakeup.ts
+++ b/src/hooks/useDefaultLaneWakeup.ts
@@ -1,0 +1,29 @@
+import React from 'react'
+
+/**
+ * Store-change wakeup without useSyncExternalStore. A uSES notification
+ * forces a SYNCLANE re-render (forceStoreRerender hardcodes lane 2); when
+ * the store bumps faster than renders finish — streaming several chunks per
+ * frame on a slow terminal — each forced sync render preempts the in-flight
+ * DefaultLane render and its commit ends with work still pending, which
+ * React's commit-end lane accounting counts as a nested update. 50
+ * consecutive dirty commits throw error #185 from whatever timer dispatches
+ * next (the beta.3 crash; here the channel store is the bump source). A
+ * manual subscription dispatches setState from the notify callback at
+ * DEFAULT lane (no current event → DefaultEventPriority): the wakeup
+ * coalesces into the in-flight render instead of preempting it, so bursts
+ * collapse into one render per window and commits end clean.
+ *
+ * Use only where the uSES return value is discarded and store fields are
+ * read fresh during render — the hook trades uSES's tearing protection for
+ * coalescing, which is exactly what such call sites want.
+ */
+export function useDefaultLaneWakeup(subscribe: (listener: () => void) => () => void): void {
+  const [, bump] = React.useState(0)
+  React.useEffect(() => {
+    // Catch up on any notification that fired between the first render and
+    // this effect's mount — the subscription alone would miss it.
+    bump(n => n + 1)
+    return subscribe(() => bump(n => n + 1))
+  }, [subscribe])
+}

--- a/src/hooks/useRevealVersion.ts
+++ b/src/hooks/useRevealVersion.ts
@@ -1,0 +1,33 @@
+import React from 'react'
+import { getRevealVersion, subscribeReveal } from '../components/smoothReveal.js'
+
+/**
+ * Reveal-frame wakeup as a React hook — bumps once per advancing ~30fps
+ * scheduler tick so consumers re-run their render-phase cursor reads
+ * ({@link revealTextOf}/{@link revealLinesOf}) and feed fresh slices through
+ * the MemoRow prop pipeline. The returned number is a render trigger only;
+ * its value carries no meaning.
+ *
+ * Deliberately NOT useSyncExternalStore: a store change forces a SYNCLANE
+ * re-render (forceStoreRerender hardcodes lane 2), and at 30fps that sync
+ * render preempts/discards whatever DefaultLane streaming render is in
+ * flight. Every such sync commit then ends with Default work still pending,
+ * which React's commit-end lane accounting counts as a NESTED update —
+ * 50 consecutive dirty commits throw error #185 from whichever timer
+ * dispatches next, killing the process (beta.3 crash). A manual subscription
+ * dispatches setState from the tick callback at DEFAULT lane instead (no
+ * current event → resolveEventPriority → DefaultEventPriority): the wakeup
+ * coalesces into the in-flight render instead of preempting it, so ticks
+ * collapse into one render per window and commits end clean.
+ */
+export function useRevealVersion(enabled: boolean = true): number {
+  const [version, setVersion] = React.useState(getRevealVersion)
+  React.useEffect(() => {
+    if (!enabled) return
+    // Catch up on any tick that fired between the first render and this
+    // effect's mount — the subscription alone would miss it.
+    setVersion(getRevealVersion())
+    return subscribeReveal(() => setVersion(getRevealVersion()))
+  }, [enabled])
+  return version
+}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -14,6 +14,7 @@ import { isPlainReturnInput, modLabel } from '../utils/modifiers.js'
 import { actionMatches } from '../utils/keymap.js'
 import { formatTokens } from '../cc/format.js'
 import { homeDir } from '../utils/paths.js'
+import { useDefaultLaneWakeup } from '../hooks/useDefaultLaneWakeup.js'
 import type { LlmModelInfo, LlmProviderInfo } from '../dsh-adapter/types.js'
 import { cleanRenderText, cleanScalarText } from '../dsh-adapter/sanitize.js'
 import {
@@ -268,8 +269,13 @@ export function Chat({
   trajectorySeen?: boolean
 }) {
   const writeRaw = React.useContext(TerminalWriteContext)
-  // Re-render whenever the channel mutates; rows/status are read fresh below.
-  React.useSyncExternalStore(channel.subscribe, () => channel.version)
+  // Re-render whenever the channel mutates; rows/status are read fresh
+  // below. DefaultLane on purpose — useSyncExternalStore would force a
+  // SyncLane render per version bump; during fast streaming those sync
+  // renders preempt the in-flight DefaultLane render, every commit ends
+  // with work pending, and React's commit-end lane accounting feeds the
+  // nested-update counter until it throws error #185 (beta.3 crash).
+  useDefaultLaneWakeup(channel.subscribe)
   // Re-render on language switches so the whole UI hot-swaps its strings.
   React.useSyncExternalStore(subscribeLang, getLang)
   // The pending ask-user-question (DSH user-interaction seam): the model's


### PR DESCRIPTION
Closes #681

## 动机

beta.3 用户反馈 resume 大会话（480KB transcript）后发「继续」数秒内 TUI 闪退，生产栈为 minified React error #185（Maximum update depth exceeded），抛出点落在 `ClockContext` tick / 思考 spinner 等定时器回调。#662（beta.2）、#669（beta.3）各修掉一条环路后仍有残留。

## 根因

两条链叠加，都是「commit 收尾时仍有 Sync|InputContinuous|Default 工作 pending → React commit-end lane 规则（`(lanes & 261930) && (remainingLanes & 42)`）计一次嵌套更新且不复位 → 连续 50 次脏 commit 后下一次 `scheduleUpdateOnFiber` 抛 #185」：

1. **smoothReveal 揭示唤醒**：调度器每 33ms 一跳，`MessageList`（及 `AssistantToolUseMessage` 独立渲染回退）经 `useSyncExternalStore` 订阅；store 变更走 `forceStoreRerender`——**硬编码 SyncLane**——每跳强制一次同步渲染，抢占/丢弃在途的 DefaultLane 流式渲染，同步 commit 收尾必有 Default 工作 pending。
2. **channel 订阅 + timeline 上报残留**（首个 commit 修复后、慢终端/高负载下仍可 12 秒内复现）：`Chat` 的 channel `useSyncExternalStore` 每个版本 bump 同样强制 SyncLane 渲染；`MessageList` 的 timeline 上报签名钉在 `heightsVersion` 上，流式行每跳撑高都触发一次 commit 内 `setTimeline`（DefaultLane 残留）。两个来源使 commit 永不干净，计数器单调爬满。

抛出点落在哪个定时器纯属巧合——线上栈的受害者各不相同（ClockContext、spinner、MessageList 延迟测量）正是因此；轻负载时干净 commit 会复位计数器，表现为「有时候崩」。

## 改动

- 新增 `src/hooks/useRevealVersion.ts`：reveal 唤醒改手动订阅 + DefaultLane setState（tick 回调里无 current event，`resolveEventPriority` 落到 DefaultEventPriority）。唤醒并入在途渲染而非抢占，一个渲染窗口内的多跳合并为一次渲染。`MessageList`、`AssistantToolUseMessage` 两处订阅改走该 hook。揭示动画行为不变：游标读数仍在 render 期，version 仅作 MemoRow 的 memo-buster。
- 新增 `src/hooks/useDefaultLaneWakeup.ts`：同一模式用于「订阅只要重渲染、返回值被丢弃」的场景。`Chat` 的 channel 订阅改走该 hook——字段本就在渲染期现读，uSES 的抗撕裂用不到。
- `MessageList` timeline 上报改内容级去重（`id/top/folded/preview` 逐项比较），快照未变不再派发 `setState`；上报时机语义不变（内容变化才报）。
- 新增 `scripts/repro-185-reveal.tsx`（崩溃复现：长会话 + 多定时器投喂 + smoothStreaming；`SMOOTH=0` 对照、`FEEDERS`/`DOC_SECTIONS`/`COLS` 可调）与 `scripts/instr-nested-updates.mjs`（dev reconciler 插桩：嵌套计数轨迹 + commit 期/interleaved 残留派发归因）。
- `scripts/verify-auto-recap.tsx` 步骤 10 断言去竞态：灰行在 recap 在途时先画占位行「回顾：正在总结最近活动…」（同样含「回顾：」前缀），原断言 settle 到前缀就立即查摘要，依赖 uSES 同步渲染把占位与摘要合并为同一帧落屏这一实现细节；改为直接 settle 到摘要落屏再断言。

## 验证

- 复现脚本修复前：`NODE_ENV=production` 下 Minified React error #185 必现（密集投喂 443ms 崩；25ms 投喂 28.5s 崩）；dev 插桩可见 nestedUpdateCount 单调爬至 51 后由 Chat/MessageList 派发撞线，脏 commit 全部带 SyncLane 位。
- 仅修 reveal 链后，慢终端参数（`DOC_SECTIONS=96 FEEDERS=3,5,7,9 COLS=80`）仍 12s 内崩（受害者为 MessageList 延迟测量定时器）——据此定位第二条链。
- 全部修复后：默认参数与慢终端参数均存活（后者跑满 7 分钟流式）；dev 插桩 max nested 峰值 1，536 次 commit 仅 2 次脏，残留派发源清空。
- `scripts/verify-smooth-reveal.tsx`（A–D 全组）、CI 组 render-scroll 33 项、channel-ui 51 项、`pnpm build` 全部门禁通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved smooth-reveal updates during message rendering and streaming.
  - Chat content now refreshes more reliably while messages are arriving.
  - Reduced redundant timeline updates when message layout changes without meaningful content changes.
  - Preserved reveal behavior for standalone tool-use messages and parent-controlled updates.

- **Bug Fixes**
  - Improved stability during long-running conversations and streamed document updates.
  - Reduced rendering-related crashes and timing issues during rapid chat activity.
  - Improved reliability when switching sessions before recap content finishes loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
