### PR TITLE
fix(ink): harden terminal image transport

### DIFF
--- a/docs/interaction.en.md
+++ b/docs/interaction.en.md
@@ -43,7 +43,9 @@ compact rich status view of up to three rows when the host exposes
 `tuiStatus.registerView`. Rich views receive only host `Box`, `Text`, `Image`,
 and terminal size; click/hover/drag work in fullscreen, and the view never owns
 the keyboard. `Image` takes decoded RGBA pixels plus a same-size cell fallback:
-the host shows graphics after a successful Kitty probe and otherwise renders
+after a successful Kitty probe, the host centers the image at its natural
+aspect ratio using terminal-reported cell geometry (or a conservative default),
+adding transparent letterboxing and downsampling when needed. Otherwise it renders
 the fallback (including inline, accessibility, and multiplexer sessions).
 Plugins provide the keyboard path for the same action through a
 slash command or `tuiShortcuts`. A refused rich registration returns

--- a/docs/interaction.md
+++ b/docs/interaction.md
@@ -39,8 +39,9 @@ transcript 模式中打开会话全文搜索。全文搜索使用 `n`/`N` 在结
 `Esc` 取消。插件也可以在提示框上方贡献一行纯文本，或在宿主支持
 `tuiStatus.registerView` 时显示最多三行的紧凑富状态；富状态只能使用宿主提供的
 `Box`、`Text`、`Image` 与终端尺寸，点击/悬停/拖动只在 fullscreen 下生效，不会取得键盘；
-`Image` 接收已解码 RGBA 和同尺寸字符回退：宿主探测到 Kitty graphics 时显示图片，
-否则自动显示回退内容（inline、辅助功能模式与多路复用器中同样如此）。
+`Image` 接收已解码 RGBA 和同尺寸字符回退：宿主探测到 Kitty graphics 时按终端
+报告的单元格像素比例（不可用时使用保守默认值）等比居中图片，必要时透明留边并降采样；否则自动显示
+回退内容（inline、辅助功能模式与多路复用器中同样如此）。
 同一动作的键盘路径由插件另行提供 slash 命令或注册 `tuiShortcuts`。富状态注册
 被拒绝时返回 `undefined`；注册成功时返回的 disposer 会同时撤下视图和对应的
 Cordis effect。

--- a/scripts/verify-terminal-images.tsx
+++ b/scripts/verify-terminal-images.tsx
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict'
 import { PassThrough, Writable } from 'node:stream'
+import { inflateSync } from 'node:zlib'
 import chalk from 'chalk'
 import React from 'react'
 import { OverlayAbove } from '../src/components/OverlayAbove.js'
@@ -30,9 +31,15 @@ import {
   type Screen,
   StylePool,
 } from '../src/ink/screen.js'
-import { kittyGraphics } from '../src/ink/terminal-querier.js'
 import {
+  kittyGraphics,
+  terminalCellSizePixels,
+  terminalWindowSizePixels,
+} from '../src/ink/terminal-querier.js'
+import {
+  fitTerminalImageSource,
   isTerminalImageSource,
+  resolveTerminalCellSize,
   TERMINAL_IMAGE_MAX_FRAME_BYTES,
   type TerminalImagePlacement,
   type TerminalImageSource,
@@ -48,6 +55,28 @@ const source: TerminalImageSource = {
 const previousChalkLevel = chalk.level
 chalk.level = 3
 
+function rgbaFromTransmission(transmission: string): {
+  readonly chunks: readonly RegExpMatchArray[]
+  readonly data: Buffer
+  readonly height: number
+  readonly width: number
+} {
+  const chunks = [
+    ...transmission.matchAll(/\x1b_G([^;]+);([^\x1b]*)\x1b\\/gu),
+  ]
+  assert.ok(chunks.length > 0, 'RGBA transmission must contain a Kitty chunk')
+  const firstControl = chunks[0]![1]!
+  const width = Number(/(?:^|,)s=(\d+)(?:,|$)/u.exec(firstControl)?.[1])
+  const height = Number(/(?:^|,)v=(\d+)(?:,|$)/u.exec(firstControl)?.[1])
+  const encoded = Buffer.from(chunks.map(chunk => chunk[2]!).join(''), 'base64')
+  return {
+    chunks,
+    data: firstControl.includes('o=z') ? inflateSync(encoded) : encoded,
+    height,
+    width,
+  }
+}
+
 assert.equal(isTerminalImageSource(source), true)
 assert.equal(
   isTerminalImageSource({ ...source, data: source.data.subarray(1) }),
@@ -55,17 +84,89 @@ assert.equal(
   'RGBA byte length must match dimensions exactly',
 )
 
-const transmission = transmitKittyRgba(101, source)
-const chunks = [...transmission.matchAll(/\x1b_G([^;]+);([^\x1b]*)\x1b\\/gu)]
+const noisyData = new Uint8Array(source.data.byteLength)
+let noise = 0x12345678
+for (let index = 0; index < noisyData.length; index++) {
+  noise = (Math.imul(noise, 1664525) + 1013904223) >>> 0
+  noisyData[index] = noise >>> 24
+}
+const noisySource = { ...source, data: noisyData }
+const transmission = transmitKittyRgba(101, noisySource)
+const decodedTransmission = rgbaFromTransmission(transmission)
+const chunks = decodedTransmission.chunks
 assert.ok(chunks.length > 1, 'large RGBA payload must be chunked')
 assert.ok(chunks.every(match => match[2]!.length <= 4096))
-assert.match(chunks[0]![1]!, /a=t,t=d,f=32,s=40,v=40,i=101/u)
+assert.match(chunks[0]![1]!, /a=t,t=d,f=32,s=40,v=40,i=101,o=z/u)
+assert.deepEqual(decodedTransmission.data, Buffer.from(noisyData))
 assert.doesNotMatch(
   transmission,
   /\x1b_Ga=T,/u,
   'upload must not create an implicit natural-size placement',
 )
-assert.ok(chunks.slice(1).every(match => !match[1]!.includes('f=32')))
+assert.ok(
+  chunks
+    .slice(1)
+    .every(
+      match =>
+        !match[1]!.includes('f=32') && !match[1]!.includes('o=z'),
+    ),
+)
+
+const solidSquare: TerminalImageSource = {
+  data: new Uint8Array(80 * 80 * 4),
+  width: 80,
+  height: 80,
+}
+for (let offset = 0; offset < solidSquare.data.length; offset += 4) {
+  solidSquare.data[offset] = 20
+  solidSquare.data[offset + 1] = 40
+  solidSquare.data[offset + 2] = 60
+  solidSquare.data[offset + 3] = 255
+}
+const fittedSquare = fitTerminalImageSource(
+  solidSquare,
+  6,
+  2,
+  { width: 10, height: 20 },
+)
+assert.deepEqual(
+  [fittedSquare.width, fittedSquare.height],
+  [60, 40],
+  'a square source in a 60x40 pixel box must use a bounded letterbox raster',
+)
+assert.equal(fittedSquare.data[(0 * fittedSquare.width + 9) * 4 + 3], 0)
+assert.equal(fittedSquare.data[(20 * fittedSquare.width + 10) * 4 + 3], 255)
+assert.equal(fittedSquare.data[(20 * fittedSquare.width + 49) * 4 + 3], 255)
+assert.equal(fittedSquare.data[(20 * fittedSquare.width + 50) * 4 + 3], 0)
+
+const tinySquare: TerminalImageSource = {
+  data: new Uint8Array([20, 40, 60, 255]),
+  width: 1,
+  height: 1,
+}
+const fittedTinySquare = fitTerminalImageSource(
+  tinySquare,
+  6,
+  2,
+  { width: 10, height: 20 },
+)
+assert.equal(
+  fittedTinySquare.width * 40,
+  fittedTinySquare.height * 60,
+  'even a tiny source canvas must exactly match the physical cell-box aspect',
+)
+const fittedWideBanner = fitTerminalImageSource(
+  solidSquare,
+  200,
+  1,
+  { width: 9, height: 17 },
+)
+assert.equal(
+  fittedWideBanner.width * 17,
+  fittedWideBanner.height * 1800,
+  'a legal wide placement must retain its exact physical aspect ratio',
+)
+assert.ok(fittedWideBanner.data.byteLength <= 4 * 1024 * 1024)
 
 const guardedPixels = new Uint8Array([9, 1, 2, 3, 4, 9])
 const subarrayTransmission = transmitKittyRgba(102, {
@@ -73,11 +174,8 @@ const subarrayTransmission = transmitKittyRgba(102, {
   width: 1,
   height: 1,
 })
-const subarrayPayload = [
-  ...subarrayTransmission.matchAll(/\x1b_G[^;]+;([^\x1b]*)\x1b\\/gu),
-].map(match => match[1]!).join('')
 assert.deepEqual(
-  Buffer.from(subarrayPayload, 'base64'),
+  rgbaFromTransmission(subarrayTransmission).data,
   Buffer.from([1, 2, 3, 4]),
   'zero-copy encoding must stay within the Uint8Array view boundaries',
 )
@@ -147,8 +245,83 @@ assert.match(
 )
 assert.match(manager.reconcile([]), new RegExp(`a=d,d=I,i=${replacementImageId}`, 'u'))
 
+const sharedManager = new KittyGraphicsManager({ firstImageId: 201 })
+const sharedNodeA = createNode('ink-image')
+const sharedNodeB = createNode('ink-image')
+const sharedNodeC = createNode('ink-image')
+const sharedPlacement = {
+  x: 1,
+  y: 1,
+  columns: 6,
+  rows: 3,
+  source,
+}
+const sharedFirst = sharedManager.reconcile([
+  { ...sharedPlacement, node: sharedNodeA },
+  {
+    ...sharedPlacement,
+    node: sharedNodeB,
+    x: 8,
+    source: { ...source, data: source.data.slice() },
+  },
+])
+assert.equal([...sharedFirst.matchAll(/\x1b_Ga=t,/gu)].length, 1)
+const sharedPlaces = [
+  ...sharedFirst.matchAll(/a=p,i=(\d+),p=(\d+),c=6,r=3,z=(-?\d+)/gu),
+]
+assert.equal(sharedPlaces.length, 2)
+assert.equal(sharedPlaces[0]![1], sharedPlaces[1]![1])
+assert.notEqual(sharedPlaces[0]![2], sharedPlaces[1]![2])
+assert.notEqual(sharedPlaces[0]![3], sharedPlaces[1]![3])
+assert.ok(sharedPlaces.every(match => Number(match[3]) < -1073741824))
+assert.equal(
+  sharedManager.reconcile([
+    { ...sharedPlacement, node: sharedNodeA, source: { ...source, data: source.data.slice() } },
+    {
+      ...sharedPlacement,
+      node: sharedNodeB,
+      x: 8,
+      source: { ...source, data: source.data.slice() },
+    },
+  ]),
+  '',
+  'fresh buffers with identical immutable content must reuse the uploaded image',
+)
+sharedManager.invalidateAll()
+const sharedInvalidated = sharedManager.reconcile([
+  { ...sharedPlacement, node: sharedNodeA },
+  { ...sharedPlacement, node: sharedNodeB, x: 8 },
+])
+assert.equal([...sharedInvalidated.matchAll(/\x1b_Ga=t,/gu)].length, 1)
+assert.equal([...sharedInvalidated.matchAll(/\x1b_Ga=p,/gu)].length, 2)
+const remounted = sharedManager.reconcile([
+  { ...sharedPlacement, node: sharedNodeB, x: 8 },
+  {
+    ...sharedPlacement,
+    node: sharedNodeC,
+    source: { ...source, data: source.data.slice() },
+  },
+])
+assert.doesNotMatch(remounted, /\x1b_Ga=t,/u)
+assert.equal([...remounted.matchAll(/\x1b_Ga=p,/gu)].length, 1)
+assert.equal([...remounted.matchAll(/a=d,d=i,i=\d+,p=\d+/gu)].length, 1)
+assert.doesNotMatch(remounted, /a=d,d=I/u)
+const removeSharedPeer = sharedManager.reconcile([
+  { ...sharedPlacement, node: sharedNodeC },
+])
+assert.match(removeSharedPeer, /a=d,d=i,i=\d+,p=\d+/u)
+assert.doesNotMatch(removeSharedPeer, /a=d,d=I/u)
+assert.equal(
+  [...sharedManager.reconcile([]).matchAll(/a=d,d=I,i=\d+/gu)].length,
+  1,
+  'the last placement must release shared terminal image data exactly once',
+)
+
 const query = kittyGraphics(31)
-assert.equal(query.request, '\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\')
+assert.equal(
+  query.request,
+  '\x1b_Gi=31,s=1,v=1,a=q,t=d,f=32,o=z;eAFjYGBgAAAABAAB\x1b\\',
+)
 const [parsed] = parseMultipleKeypresses(
   INITIAL_STATE,
   '\x1b_Gi=31;OK\x1b\\',
@@ -161,6 +334,59 @@ assert.deepEqual(parsed[0].response, {
   status: 'OK',
 })
 assert.equal(query.match(parsed[0].response), true)
+
+const cellSizeQuery = terminalCellSizePixels()
+const windowSizeQuery = terminalWindowSizePixels()
+assert.equal(cellSizeQuery.request, '\x1b[16t')
+assert.equal(windowSizeQuery.request, '\x1b[14t')
+const [pixelReplies] = parseMultipleKeypresses(
+  INITIAL_STATE,
+  '\x1b[6;20;10t\x1b[4;800;1200t',
+)
+assert.deepEqual(
+  pixelReplies.map(reply =>
+    reply.kind === 'response' ? reply.response : undefined,
+  ),
+  [
+    { type: 'terminalPixelSize', scope: 'cell', height: 20, width: 10 },
+    { type: 'terminalPixelSize', scope: 'window', height: 800, width: 1200 },
+  ],
+)
+assert.ok(
+  pixelReplies[0]?.kind === 'response' &&
+    cellSizeQuery.match(pixelReplies[0].response),
+)
+assert.ok(
+  pixelReplies[1]?.kind === 'response' &&
+    windowSizeQuery.match(pixelReplies[1].response),
+)
+assert.deepEqual(
+  resolveTerminalCellSize(
+    { width: 10, height: 20 },
+    { width: 1200, height: 800 },
+    120,
+    40,
+  ),
+  { width: 10, height: 20 },
+  'the direct cell report must win over the derived window size',
+)
+assert.deepEqual(
+  resolveTerminalCellSize(undefined, { width: 1200, height: 800 }, 120, 40),
+  { width: 10, height: 20 },
+)
+assert.deepEqual(
+  resolveTerminalCellSize(undefined, undefined, 120, 40),
+  undefined,
+)
+assert.deepEqual(
+  resolveTerminalCellSize(
+    { width: 0, height: 0 },
+    { width: 0, height: 0 },
+    120,
+    40,
+  ),
+  undefined,
+)
 
 const stylePool = new StylePool()
 const screen = createScreen(
@@ -199,6 +425,14 @@ const maximalSource: TerminalImageSource = {
   width: 1024,
   height: 1024,
 }
+const fittedMaximal = fitTerminalImageSource(
+  maximalSource,
+  6,
+  2,
+  { width: 10, height: 20 },
+)
+assert.ok(fittedMaximal.width <= 60 && fittedMaximal.height <= 40)
+assert.equal(fittedMaximal.data.byteLength, fittedMaximal.width * fittedMaximal.height * 4)
 assert.equal(
   maximalSource.data.byteLength * 4,
   TERMINAL_IMAGE_MAX_FRAME_BYTES,
@@ -330,6 +564,59 @@ const imageTree = (
     </Box>
   </AlternateScreen>
 )
+
+const interruptedStdin = new FakeStdin()
+const interruptedStdout = new FakeStdout()
+const interruptedTree = imageTree(false)
+const interruptedInstance = await render(interruptedTree, {
+  stdin: interruptedStdin,
+  stdout: interruptedStdout,
+  stderr: new FakeStderr(),
+  exitOnCtrlC: false,
+  patchConsole: false,
+})
+assert.ok(
+  await settled(
+    () =>
+      interruptedStdout.output.includes(query.request) &&
+      interruptedStdout.output.includes(cellSizeQuery.request) &&
+      interruptedStdout.output.includes(windowSizeQuery.request),
+  ),
+  'the interrupted fixture must start its first Kitty capability batch',
+)
+const interruptedInk = instances.get(interruptedStdout)
+assert.ok(interruptedInk)
+const interruptedProbeCount = (): number =>
+  interruptedStdout.output.split(query.request).length - 1
+const probesBeforeInterrupt = interruptedProbeCount()
+interruptedInk.enterAlternateScreen()
+interruptedInk.exitAlternateScreen()
+await new Promise(resolve => setTimeout(resolve, 20))
+assert.equal(
+  interruptedProbeCount(),
+  probesBeforeInterrupt,
+  'an interrupted Kitty probe must stay suspended during reply quarantine',
+)
+assert.ok(
+  await settled(() => interruptedProbeCount() === probesBeforeInterrupt + 1),
+  'an interrupted first Kitty probe must retry after the handoff',
+)
+interruptedStdin.write(
+  '\x1b_Gi=31;OK\x1b\\\x1b[6;20;10t\x1b[4;160;400t' +
+    '\x1bP>|ghostty(1.2.3)\x1b\\' +
+    '\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c',
+)
+assert.ok(
+  await settled(
+    () =>
+      interruptedStdout.output.includes('a=t,t=d,f=32') &&
+      interruptedStdout.output.includes('a=p,i='),
+  ),
+  'the retried Kitty probe must enable and place the waiting image',
+)
+interruptedStdout.isTTY = false
+interruptedInstance.unmount()
+
 const budgetTree = (withLeadingImage: boolean): React.ReactElement => (
   <AlternateScreen>
     <Box width={6} height={2} flexDirection="row">
@@ -377,17 +664,91 @@ assert.ok(
   'fallback cells must render before capability succeeds',
 )
 assert.ok(
-  await settled(() => stdout.output.includes(query.request)),
-  'a laid-out fullscreen image must trigger one Kitty query',
+  await settled(
+    () =>
+      stdout.output.includes(query.request) &&
+      stdout.output.includes(cellSizeQuery.request) &&
+      stdout.output.includes(windowSizeQuery.request),
+  ),
+  'a laid-out fullscreen image must trigger Kitty and pixel-size queries',
 )
-stdin.write('\x1b_Gi=31;OK\x1b\\\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c')
+stdout.columns = 50
+stdout.rows = 10
+stdout.emit('resize')
+stdin.write(
+  '\x1b_Gi=31;OK\x1b\\\x1b[6;20;10t\x1b[4;160;400t' +
+    '\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c',
+)
 assert.ok(
   await settled(
     () =>
-      stdout.output.includes('a=t,t=d,f=32') &&
-      stdout.output.includes('a=p,i='),
+      stdout.output.includes('a=t,t=d,f=32,s=32,v=32') &&
+      stdout.output.includes('a=p,i=') &&
+      stdout.output.split(cellSizeQuery.request).length - 1 === 2,
   ),
-  'a successful query must upload and place RGBA pixels',
+  'a resize during the probe must discard stale metrics and start one refresh',
+)
+assert.doesNotMatch(
+  stdout.output,
+  /a=t,t=d,f=32,s=40,v=40/u,
+  'stale 10x20 cell metrics must never reach a renderer transmission',
+)
+const beforeFreshMetrics = stdout.output.length
+stdin.write('\x1b[4;200;600t\x1b[?61;4c')
+assert.ok(
+  await settled(() => {
+    const refreshed = stdout.output.slice(beforeFreshMetrics)
+    return (
+      refreshed.includes('a=t,t=d,f=32,s=48,v=40') &&
+      refreshed.includes('a=d,d=I,i=')
+    )
+  }),
+  'a 14t-only refresh must upload the derived-ratio variant and retire the old image',
+)
+const cellSizeQueryCount = (): number =>
+  stdout.output.split(cellSizeQuery.request).length - 1
+const beforeResizeBurst = stdout.output.length
+stdout.columns = 60
+stdout.emit('resize')
+assert.ok(
+  await settled(() => cellSizeQueryCount() === 3),
+  'the first supported resize must start one metrics batch',
+)
+stdout.columns = 70
+stdout.emit('resize')
+stdout.columns = 80
+stdout.emit('resize')
+stdin.write(
+  '\x1b[6;20;11t\x1b[4;200;660t' +
+    '\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c',
+)
+assert.ok(
+  await settled(() => cellSizeQueryCount() === 4),
+  'an in-flight resize burst must coalesce into one latest-geometry batch',
+)
+assert.doesNotMatch(
+  stdout.output.slice(beforeResizeBurst),
+  /a=t,t=d,f=32,s=44,v=40/u,
+  'a superseded in-flight cell size must not produce an image variant',
+)
+const beforeLatestMetrics = stdout.output.length
+stdin.write(
+  '\x1b[6;20;9t\x1b[4;200;1600t' +
+    '\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c',
+)
+assert.ok(
+  await settled(() =>
+    stdout.output
+      .slice(beforeLatestMetrics)
+      .includes('a=t,t=d,f=32,s=36,v=40'),
+  ),
+  'the coalesced batch must apply the latest direct cell metrics',
+)
+await new Promise(resolve => setTimeout(resolve, 20))
+assert.equal(
+  cellSizeQueryCount(),
+  4,
+  'the resize burst must not leave another metrics refresh pending',
 )
 const ink = instances.get(stdout)
 assert.ok(ink, 'the rendered tree must retain its Ink instance')
@@ -545,7 +906,19 @@ assert.ok(
   'restoring a source must upload it again',
 )
 const beforeHandoff = stdout.output.length
+const queriesBeforeHandoff = cellSizeQueryCount()
+stdout.emit('resize')
+assert.ok(
+  await settled(() => cellSizeQueryCount() === queriesBeforeHandoff + 1),
+  'a same-grid resize must refresh cell pixels for font and DPI changes',
+)
 ink.enterAlternateScreen()
+stdout.emit('resize')
+assert.equal(
+  cellSizeQueryCount(),
+  queriesBeforeHandoff + 1,
+  'a resize during an external-editor handoff must not write terminal queries',
+)
 const handoffOutput = stdout.output.slice(beforeHandoff)
 const handoffDeleteAt = handoffOutput.indexOf('a=d,d=I,i=')
 const handoffClearAt = handoffOutput.indexOf('\x1b[2J')
@@ -555,14 +928,32 @@ assert.ok(
 )
 const beforeHandoffRestore = stdout.output.length
 ink.exitAlternateScreen()
+stdin.write(
+  '\x1b[6;20;77t\x1b[4;200;6160t' +
+    '\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c',
+)
+await new Promise(resolve => setTimeout(resolve, 20))
+assert.equal(
+  cellSizeQueryCount(),
+  queriesBeforeHandoff + 1,
+  'new terminal queries must wait until late handoff replies are quarantined',
+)
 assert.ok(
   await settled(
     () => {
       const restored = stdout.output.slice(beforeHandoffRestore)
-      return restored.includes('a=t,t=d,f=32') && restored.includes('a=p,i=')
+      return (
+        restored.includes('a=t,t=d,f=32') &&
+        restored.includes('a=p,i=') &&
+        cellSizeQueryCount() === queriesBeforeHandoff + 2
+      )
     },
   ),
-  'returning from an external editor must upload and place visible images again',
+  'returning from an external editor must restore images and refresh deferred metrics',
+)
+stdin.write(
+  '\x1b[6;20;9t\x1b[4;200;1600t' +
+    '\x1b[?61;4c\x1b[?61;4c\x1b[?61;4c',
 )
 stdout.isTTY = false
 const beforeUnmount = stdout.output.length

--- a/scripts/verify-terminal-queries.tsx
+++ b/scripts/verify-terminal-queries.tsx
@@ -9,8 +9,9 @@
 import assert from 'node:assert/strict'
 import { PassThrough, Writable } from 'node:stream'
 import React, { useEffect } from 'react'
-import { AlternateScreen, render, Text, useInput, useStdin } from '../src/ui.js'
-import { oscColor } from '../src/ink/terminal-querier.js'
+import { AlternateScreen, render, renderSync, Text, useInput, useStdin } from '../src/ui.js'
+import instances from '../src/ink/instances.js'
+import { oscColor, TerminalQuerier } from '../src/ink/terminal-querier.js'
 import { supportsDecrqmProbe } from '../src/ink/terminal.js'
 import { settled, sleep } from './lib/term-test.mjs'
 
@@ -123,6 +124,85 @@ function ProbeKeyConsumer(): React.ReactNode {
   useInput(() => {})
   return <Text>decrqm gate</Text>
 }
+
+const suspendedStdout = new FakeStdout()
+let rawModeBorrowCount = 0
+const suspendedQuerier = new TerminalQuerier(suspendedStdout, enabled => {
+  rawModeBorrowCount += enabled ? 1 : -1
+})
+suspendedQuerier.suspend()
+await Promise.all([
+  suspendedQuerier.send(oscColor(11)),
+  suspendedQuerier.flush(),
+])
+assert.equal(suspendedStdout.output, '')
+assert.equal(rawModeBorrowCount, 0)
+suspendedQuerier.resume()
+const resumedQuery = suspendedQuerier.send(oscColor(11))
+const resumedFlush = suspendedQuerier.flush()
+assert.equal(rawModeBorrowCount, 2)
+suspendedQuerier.onResponse({ type: 'osc', code: 11, data: 'rgb:0000/0000/0000' })
+suspendedQuerier.onResponse({ type: 'da1', params: [61, 4] })
+assert.ok(await resumedQuery)
+await resumedFlush
+assert.equal(rawModeBorrowCount, 0)
+suspendedQuerier.dispose()
+
+const handoffStdin = new FakeStdin()
+const handoffStdout = new FakeStdout()
+const handoffInstance = renderSync(
+  <AlternateScreen>
+    <ProbeKeyConsumer />
+  </AlternateScreen>,
+  {
+    stdin: handoffStdin,
+    stdout: handoffStdout,
+    stderr: new FakeStderr(),
+    exitOnCtrlC: false,
+    patchConsole: false,
+  },
+)
+const handoffInk = instances.get(handoffStdout)
+assert.ok(handoffInk)
+assert.equal(handoffStdout.output.includes('\x1b[>0q'), false)
+handoffInk.enterAlternateScreen()
+await new Promise<void>(resolve => setImmediate(resolve))
+assert.equal(
+  handoffStdout.output.includes('\x1b[>0q') ||
+    handoffStdout.output.includes('\x1b[c'),
+  false,
+  'a deferred XTVERSION batch must not write while an external process owns the terminal',
+)
+handoffInk.exitAlternateScreen()
+await sleep(20)
+assert.equal(
+  handoffStdout.output.includes('\x1b[>0q') ||
+    handoffStdout.output.includes('\x1b[c'),
+  false,
+  'the XTVERSION retry must wait for the reply quarantine',
+)
+assert.ok(
+  await settled(
+    () =>
+      handoffStdout.output.includes('\x1b[>0q') &&
+      handoffStdout.output.includes('\x1b[c'),
+  ),
+  'the interrupted XTVERSION probe must retry after the reply quarantine',
+)
+handoffStdin.write('\x1bP>|ghostty(1.2.3)\x1b\\\x1b[?61;4c')
+await new Promise<void>(resolve => setImmediate(resolve))
+const completedXtversionCount =
+  handoffStdout.output.split('\x1b[>0q').length - 1
+handoffInk.enterAlternateScreen()
+handoffInk.exitAlternateScreen()
+await sleep(160)
+assert.equal(
+  handoffStdout.output.split('\x1b[>0q').length - 1,
+  completedXtversionCount,
+  'a completed XTVERSION probe must not repeat after later handoffs',
+)
+handoffInstance.unmount()
+console.log('PASS: handoff suspends terminal queries and retries deferred XTVERSION')
 
 process.env.TERM_PROGRAM = 'Apple_Terminal'
 assert.equal(

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -223,6 +223,7 @@ export default class App extends PureComponent<Props, State> {
 	// Deferred XTVERSION probe (setImmediate). Cleared on unmount so the
 	// DA1 sentinel it flushes cannot land after raw mode is off.
 	xtversionProbe: NodeJS.Immediate | null = null;
+	xtversionAttempted = false;
 	// Timeout durations for incomplete sequences (ms)
 	readonly NORMAL_TIMEOUT = 50; // Short timeout for regular esc sequences
 	readonly PASTE_TIMEOUT = 500; // Longer timeout for paste operations
@@ -468,6 +469,29 @@ export default class App extends PureComponent<Props, State> {
 	override componentDidCatch(error: Error) {
 		this.handleExit(error);
 	}
+	scheduleXtversionProbe = (): void => {
+		if (this.xtversionAttempted || this.xtversionProbe !== null) return;
+		this.xtversionProbe = setImmediate(() => {
+			this.xtversionProbe = null;
+			if (this.rawModeEnabledCount === 0 || this.querier.isSuspended) return;
+			void Promise.all([
+				this.querier.send(xtversion()),
+				this.querier.flush(),
+			]).then(([r]) => {
+				// A handoff may suspend and drain this batch before its sentinel.
+				// Leave it retryable once the reply quarantine has ended.
+				if (this.querier.isSuspended) return;
+				this.xtversionAttempted = true;
+				if (r) {
+					setXtversionName(r.name);
+					logForDebugging(`XTVERSION: terminal identified as "${r.name}"`);
+				} else {
+					logForDebugging("XTVERSION: no reply (terminal ignored query)");
+				}
+			});
+		});
+	};
+
 	handleSetRawMode = (isEnabled: boolean): void => {
 		const { stdin } = this.props;
 		if (!this.isRawModeSupported()) {
@@ -520,26 +544,7 @@ export default class App extends PureComponent<Props, State> {
 				// Deferred to next tick so it fires AFTER the current synchronous
 				// init sequence completes — avoids interleaving with alt-screen/mouse
 				// tracking enable writes that may happen in the same render cycle.
-				this.xtversionProbe = setImmediate(() => {
-					this.xtversionProbe = null;
-					// The original borrower may unmount before this callback runs.
-					// Once sent, TerminalQuerier keeps raw mode held until the reply
-					// and DA1 barrier arrive, so delayed responses cannot echo.
-					if (this.rawModeEnabledCount === 0) {
-						return;
-					}
-					void Promise.all([
-						this.querier.send(xtversion()),
-						this.querier.flush(),
-					]).then(([r]) => {
-						if (r) {
-							setXtversionName(r.name);
-							logForDebugging(`XTVERSION: terminal identified as "${r.name}"`);
-						} else {
-							logForDebugging("XTVERSION: no reply (terminal ignored query)");
-						}
-					});
-				});
+				this.scheduleXtversionProbe();
 			}
 			this.rawModeEnabledCount++;
 			return;

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -45,9 +45,9 @@ import { isDecstbmSafe, SYNC_OUTPUT_SUPPORTED, serializeDiff, supportsDecrqmProb
 import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ENABLE_WIN32_INPUT_MODE, ERASE_SCREEN, ERASE_SCROLLBACK, SGR_RESET } from './termio/csi.js';
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
 import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, setClipboard, supportsTabStatus, wrapForMultiplexer } from './termio/osc.js';
-import { decrqm, kittyGraphics } from './terminal-querier.js';
+import { decrqm, kittyGraphics, terminalCellSizePixels, terminalWindowSizePixels } from './terminal-querier.js';
 import { TerminalWriteProvider } from './useTerminalNotification.js';
-import type { TerminalImagePlacement } from './terminal-image.js';
+import { DEFAULT_TERMINAL_CELL_SIZE, resolveTerminalCellSize, type TerminalImagePlacement } from './terminal-image.js';
 
 // Alt-screen: renderer.ts sets cursor.visible = !isTTY || screen.height===0,
 // which is always false in alt-screen (TTY + content fills screen).
@@ -65,6 +65,7 @@ const ERASE_THEN_HOME_PATCH = Object.freeze({
   type: 'stdout' as const,
   content: ERASE_SCREEN + CURSOR_HOME
 });
+const TERMINAL_REPLY_QUARANTINE_MS = 120;
 
 // Cached per-Ink-instance, invalidated on resize. frame.cursor.y for
 // alt-screen is always terminalRows - 1 (renderer.ts).
@@ -74,6 +75,7 @@ function makeAltScreenParkPatch(terminalRows: number) {
     content: cursorPosition(terminalRows, 1)
   });
 }
+
 export type Options = {
   stdout: NodeJS.WriteStream;
   stdin: NodeJS.ReadStream;
@@ -89,6 +91,9 @@ export default class Ink {
   private readonly kittyGraphicsManager = new KittyGraphicsManager();
   private kittyGraphicsSupported = false;
   private kittyGraphicsProbeStarted = false;
+  private terminalCellMetricsInFlight = false;
+  private terminalCellMetricsRefreshPending = false;
+  private terminalQueryResumeTimer: ReturnType<typeof setTimeout> | null = null;
   private app: App | null = null;
   private scheduleRender: (() => void) & {
     cancel?: () => void;
@@ -373,10 +378,16 @@ export default class Ink {
     // Terminals often emit 2+ resize events for one user action (window
     // settling). Same-dimension events are no-ops; skip to avoid redundant
     // frame resets and renders.
-    if (cols === this.terminalColumns && rows === this.terminalRows) return;
+    if (cols === this.terminalColumns && rows === this.terminalRows) {
+      // A font zoom or DPI move can change cell pixels without changing the
+      // row/column grid. The in-flight guard coalesces duplicate events.
+      this.refreshTerminalCellMetrics();
+      return;
+    }
     noteFrameCause('resize');
     this.terminalColumns = cols;
     this.terminalRows = rows;
+    this.refreshTerminalCellMetrics();
     this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows);
     // Reflow moved every rect the pointer state was tracking: hover sets
     // and the multi-click chain reference pre-resize geometry. Fire the
@@ -456,6 +467,15 @@ export default class Ink {
    */
   enterAlternateScreen(): void {
     this.pause();
+    this.app?.querier.suspend();
+    if (this.terminalQueryResumeTimer !== null) {
+      clearTimeout(this.terminalQueryResumeTimer);
+      this.terminalQueryResumeTimer = null;
+    }
+    // Replies cannot be routed while the child owns stdin. Release every
+    // query hold before cooked mode is restored; an interrupted first Kitty
+    // probe may be attempted again after the handoff.
+    if (!this.kittyGraphicsSupported) this.kittyGraphicsProbeStarted = false;
     this.suspendStdin();
     // Kitty placements are independent of the terminal cell grid: clearing
     // the screen for an external editor does not remove them. Delete every
@@ -520,7 +540,7 @@ export default class Ink {
       // replies, mouse fragments): resumeStdin's drain only covers bytes
       // already buffered, and a stray ESC would clear a non-empty prompt
       // (issue #123 field report).
-      suppressInputFor(120);
+      suppressInputFor(TERMINAL_REPLY_QUARANTINE_MS);
       this.resetFramesForAltScreen();
       this.resume();
     } else {
@@ -539,7 +559,7 @@ export default class Ink {
       '\x1b[?25l' // hide cursor (Ink manages)
       );
       this.resumeStdin();
-      suppressInputFor(120);
+      suppressInputFor(TERMINAL_REPLY_QUARANTINE_MS);
       this.repaint();
       // repaint()'s fresh empty frontFrame would let the blit fast path
       // copy blanks and diff to nothing — same flag forceRedraw() sets.
@@ -553,6 +573,7 @@ export default class Ink {
     // Kitty stack balanced (a well-behaved editor restores our entry, so
     // without the pop we'd accumulate depth on each editor round-trip).
     this.options.stdout.write('\x1b[?1004h' + (supportsWin32InputMode() ? ENABLE_WIN32_INPUT_MODE : supportsExtendedKeys() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS : ''));
+    this.resumeTerminalQueriesAfterHandoff();
   }
   /**
    * One-shot viewport re-anchor for the NEXT main-screen frame: repaint the
@@ -1138,6 +1159,14 @@ export default class Ink {
   resume(): void {
     this.isPaused = false;
     this.renderNow();
+    if (
+      this.terminalCellMetricsRefreshPending &&
+      !this.terminalCellMetricsInFlight &&
+      !this.terminalQueriesSuspended
+    ) {
+      this.terminalCellMetricsRefreshPending = false;
+      this.refreshTerminalCellMetrics();
+    }
   }
 
   /**
@@ -1372,6 +1401,10 @@ export default class Ink {
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
+    }
+    if (this.terminalQueryResumeTimer !== null) {
+      clearTimeout(this.terminalQueryResumeTimer);
+      this.terminalQueryResumeTimer = null;
     }
     // Delete Kitty placements before terminal mode cleanup. This write uses
     // the renderer's own ordered stream, matching the rest of this shutdown
@@ -1621,6 +1654,7 @@ export default class Ink {
     // is skipped, which costs nothing: Terminal.app never answered it.
     if (!supportsDecrqmProbe()) return;
     void Promise.all([querier.send(decrqm(1049)), querier.flush()]).then(([reply]) => {
+      if (this.isUnmounted || this.isPaused || this.terminalQueriesSuspended) return;
       // DECRPM status: 1/3 = set, 2/4 = reset, 0/undefined = unknown.
       // Heal only on a POSITIVE reset — an unanswered probe must not
       // trigger the destructive re-entry.
@@ -1663,6 +1697,8 @@ export default class Ink {
       placements.length === 0 ||
       this.kittyGraphicsProbeStarted ||
       !this.altScreenActive ||
+      this.isPaused ||
+      this.terminalQueriesSuspended ||
       !this.options.stdout.isTTY ||
       process.env.TMUX !== undefined ||
       process.env.STY !== undefined ||
@@ -1675,14 +1711,34 @@ export default class Ink {
     if (querier === undefined) return;
     this.kittyGraphicsProbeStarted = true;
     const queryId = 31;
+    const columns = this.terminalColumns;
+    const rows = this.terminalRows;
     void Promise.all([
       querier.send(kittyGraphics(queryId)),
+      querier.send(terminalCellSizePixels()),
+      querier.send(terminalWindowSizePixels()),
       querier.flush(),
     ])
-      .then(([reply]) => {
+      .then(([reply, cellPixels, windowPixels]) => {
+        if (this.isUnmounted || this.isPaused || this.terminalQueriesSuspended) {
+          return;
+        }
         if (reply === undefined || !reply.status.startsWith('OK')) return;
         this.kittyGraphicsSupported = true;
-        if (this.isUnmounted || this.isPaused || !this.altScreenActive) return;
+        if (
+          columns === this.terminalColumns &&
+          rows === this.terminalRows
+        ) {
+          this.kittyGraphicsManager.setCellSize(
+            resolveTerminalCellSize(cellPixels, windowPixels, columns, rows) ??
+              DEFAULT_TERMINAL_CELL_SIZE,
+          );
+        } else {
+          // The capability result is still valid, but its geometry snapshot
+          // is not. Start one fresh metrics batch after this sentinel.
+          this.refreshTerminalCellMetrics();
+        }
+        if (!this.altScreenActive) return;
         // The preceding frame painted text fallback cells. Force one complete
         // paint so image nodes replace those cells with blank backing before
         // their graphics placements are uploaded.
@@ -1693,6 +1749,102 @@ export default class Ink {
       .catch(() => {
         /* Capability detection is best-effort; fallback remains visible. */
       });
+  }
+
+  /** Refresh image pixel geometry after a resize, coalescing resize bursts. */
+  private refreshTerminalCellMetrics(): void {
+    if (
+      !this.kittyGraphicsSupported ||
+      this.isUnmounted ||
+      !this.options.stdout.isTTY
+    ) {
+      return;
+    }
+    if (this.isPaused || this.terminalQueriesSuspended) {
+      this.terminalCellMetricsRefreshPending = true;
+      return;
+    }
+    const querier = this.app?.querier;
+    if (querier === undefined) return;
+    if (this.terminalCellMetricsInFlight) {
+      this.terminalCellMetricsRefreshPending = true;
+      return;
+    }
+
+    this.terminalCellMetricsInFlight = true;
+    this.terminalCellMetricsRefreshPending = false;
+    const columns = this.terminalColumns;
+    const rows = this.terminalRows;
+    void Promise.all([
+      querier.send(terminalCellSizePixels()),
+      querier.send(terminalWindowSizePixels()),
+      querier.flush(),
+    ])
+      .then(([cellPixels, windowPixels]) => {
+        if (this.isUnmounted) return;
+        if (this.isPaused || this.terminalQueriesSuspended) {
+          this.terminalCellMetricsRefreshPending = true;
+          return;
+        }
+        if (
+          columns !== this.terminalColumns ||
+          rows !== this.terminalRows
+        ) {
+          this.terminalCellMetricsRefreshPending = true;
+          return;
+        }
+        const cellSize = resolveTerminalCellSize(
+          cellPixels,
+          windowPixels,
+          columns,
+          rows,
+        );
+        if (cellSize === undefined) return;
+        const changed = this.kittyGraphicsManager.setCellSize(cellSize);
+        if (changed && this.altScreenActive) {
+          this.scheduleRender();
+        }
+      })
+      .catch(() => {
+        /* Pixel geometry is best-effort; retain the last known value. */
+      })
+      .finally(() => {
+        this.terminalCellMetricsInFlight = false;
+        if (
+          this.terminalCellMetricsRefreshPending &&
+          !this.isPaused &&
+          !this.terminalQueriesSuspended
+        ) {
+          this.terminalCellMetricsRefreshPending = false;
+          this.refreshTerminalCellMetrics();
+        }
+      });
+  }
+
+  /** Reopen terminal queries only after late handoff replies are quarantined. */
+  private resumeTerminalQueriesAfterHandoff(): void {
+    if (this.terminalQueryResumeTimer !== null) {
+      clearTimeout(this.terminalQueryResumeTimer);
+    }
+    this.terminalQueryResumeTimer = setTimeout(() => {
+      this.terminalQueryResumeTimer = null;
+      if (this.isUnmounted) return;
+      this.app?.querier.resume();
+      this.app?.scheduleXtversionProbe();
+      if (
+        this.terminalCellMetricsRefreshPending &&
+        !this.terminalCellMetricsInFlight
+      ) {
+        this.terminalCellMetricsRefreshPending = false;
+        this.refreshTerminalCellMetrics();
+      } else if (!this.kittyGraphicsSupported) {
+        this.scheduleRender();
+      }
+    }, TERMINAL_REPLY_QUARANTINE_MS);
+  }
+
+  private get terminalQueriesSuspended(): boolean {
+    return this.app?.querier.isSuspended ?? false;
   }
 
   /**
@@ -2424,6 +2576,10 @@ export default class Ink {
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
+    }
+    if (this.terminalQueryResumeTimer !== null) {
+      clearTimeout(this.terminalQueryResumeTimer);
+      this.terminalQueryResumeTimer = null;
     }
 
     // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler

--- a/src/ink/kitty-graphics.ts
+++ b/src/ink/kitty-graphics.ts
@@ -200,12 +200,6 @@ export class KittyGraphicsManager {
     }
   }
 
-  /** Forget terminal-side state after leaving the buffer that owned it. */
-  reset(): void {
-    this.images.clear()
-    this.placements.clear()
-  }
-
   /** Delete every image owned by this renderer and forget their ids. */
   deleteAll(): string {
     const output = [...this.images.values()]

--- a/src/ink/kitty-graphics.ts
+++ b/src/ink/kitty-graphics.ts
@@ -1,8 +1,13 @@
-import { randomInt } from 'node:crypto'
+import { createHash, randomInt } from 'node:crypto'
+import { deflateSync } from 'node:zlib'
 import type { DOMElement } from './dom.js'
-import type {
-  TerminalImagePlacement,
-  TerminalImageSource,
+import {
+  DEFAULT_TERMINAL_CELL_SIZE,
+  fitTerminalImageSource,
+  normalizeTerminalCellSize,
+  type TerminalCellSize,
+  type TerminalImagePlacement,
+  type TerminalImageSource,
 } from './terminal-image.js'
 
 const APC = '\u001b_G'
@@ -10,14 +15,26 @@ const ST = '\u001b\\'
 const BASE64_CHUNK_CELLS = 4096
 const ID_MIN = 0x40000000
 const ID_MAX_EXCLUSIVE = 0x7fffffff
+const PLACEMENT_ID_MAX_EXCLUSIVE = 0x40000000
 // Keep raster content behind terminal text and explicit panel backgrounds.
 const IMAGE_Z_INDEX = -0x80000000
 
-type PlacementState = {
+type PreparedKittyRgba = {
+  readonly data: Uint8Array
+  readonly width: number
+  readonly height: number
+}
+
+type ImageState = {
   readonly imageId: number
-  readonly placementId: number
-  source: TerminalImageSource | undefined
+  readonly payload: PreparedKittyRgba
   uploaded: boolean
+}
+
+type PlacementState = {
+  readonly placementId: number
+  readonly zIndex: number
+  image: ImageState
   placed: boolean
   x: number
   y: number
@@ -28,61 +45,98 @@ type PlacementState = {
 export interface KittyGraphicsManagerOptions {
   /** Deterministic seed used by protocol tests; production chooses a random range. */
   readonly firstImageId?: number
+  /** Physical pixels per cell; defaults to a conventional 8×16 cell. */
+  readonly cellSize?: TerminalCellSize
 }
 
 /**
  * Reconcile renderer image requests with Kitty image/placement state.
  *
- * One DOM node owns one image id and one placement id. Pixel changes replace
- * that image, geometry changes replace the placement without flicker, and
- * removed nodes release both placement and image data.
+ * Pixel content owns an image id while each DOM node owns a placement id.
+ * Equal immutable RGBA content is uploaded once and can back several nodes;
+ * geometry changes replace only that node's placement without flicker.
  */
 export class KittyGraphicsManager {
-  private readonly states = new Map<DOMElement, PlacementState>()
+  private readonly images = new Map<string, ImageState>()
+  private readonly placements = new Map<DOMElement, PlacementState>()
+  private readonly contentHashes = new WeakMap<Uint8Array, string>()
   private nextImageId: number
+  private nextPlacementId = 1
+  private cellSize: TerminalCellSize
 
   constructor(options: KittyGraphicsManagerOptions = {}) {
     this.nextImageId = normalizeFirstId(
       options.firstImageId ?? randomInt(ID_MIN, ID_MAX_EXCLUSIVE),
     )
+    this.cellSize = normalizeTerminalCellSize(
+      options.cellSize ?? DEFAULT_TERMINAL_CELL_SIZE,
+    )
+  }
+
+  /** Update the physical cell ratio used by future image variants. */
+  setCellSize(cellSize: TerminalCellSize): boolean {
+    const normalized = normalizeTerminalCellSize(cellSize)
+    if (
+      normalized.width === this.cellSize.width &&
+      normalized.height === this.cellSize.height
+    ) {
+      return false
+    }
+    this.cellSize = normalized
+    return true
   }
 
   reconcile(placements: readonly TerminalImagePlacement[]): string {
-    const desired = new Set<DOMElement>()
+    const desiredNodes = new Set<DOMElement>()
+    const desiredImages = new Set<ImageState>()
+    const desired: Array<{
+      readonly placement: TerminalImagePlacement
+      readonly image: ImageState
+    }> = []
     const output: string[] = []
 
     for (const placement of placements) {
-      if (desired.has(placement.node)) continue
-      desired.add(placement.node)
-      let state = this.states.get(placement.node)
+      if (desiredNodes.has(placement.node)) continue
+      desiredNodes.add(placement.node)
+      const image = this.imageFor(placement)
+      desiredImages.add(image)
+      desired.push({ placement, image })
+    }
+
+    const obsoletePlacements: Array<{
+      readonly image: ImageState
+      readonly placementId: number
+    }> = []
+
+    for (const { placement, image } of desired) {
+      let state = this.placements.get(placement.node)
       if (state === undefined) {
+        const placementId = this.allocatePlacementId()
         state = {
-          imageId: this.allocateImageId(),
-          placementId: 1,
-          source: undefined,
-          uploaded: false,
+          image,
+          placementId,
+          zIndex: IMAGE_Z_INDEX + placementId - 1,
           placed: false,
           x: -1,
           y: -1,
           columns: 0,
           rows: 0,
         }
-        this.states.set(placement.node, state)
+        this.placements.set(placement.node, state)
       }
 
-      if (
-        state.source?.data !== placement.source.data ||
-        state.source?.width !== placement.source.width ||
-        state.source?.height !== placement.source.height
-      ) {
-        state.source = placement.source
-        state.uploaded = false
+      if (state.image !== image) {
+        obsoletePlacements.push({
+          image: state.image,
+          placementId: state.placementId,
+        })
+        state.image = image
         state.placed = false
       }
 
-      if (!state.uploaded) {
-        output.push(transmitKittyRgba(state.imageId, placement.source))
-        state.uploaded = true
+      if (!image.uploaded) {
+        output.push(transmitPreparedKittyRgba(image.imageId, image.payload))
+        image.uploaded = true
       }
 
       const moved =
@@ -93,12 +147,13 @@ export class KittyGraphicsManager {
       if (!state.placed || moved) {
         output.push(
           kittyPlacement(
-            state.imageId,
+            image.imageId,
             state.placementId,
             placement.x,
             placement.y,
             placement.columns,
             placement.rows,
+            state.zIndex,
           ),
         )
         state.x = placement.x
@@ -109,10 +164,29 @@ export class KittyGraphicsManager {
       }
     }
 
-    for (const [node, state] of this.states) {
-      if (desired.has(node)) continue
-      output.push(deleteKittyImage(state.imageId))
-      this.states.delete(node)
+    for (const [node, state] of this.placements) {
+      if (desiredNodes.has(node)) continue
+      obsoletePlacements.push({
+        image: state.image,
+        placementId: state.placementId,
+      })
+      this.placements.delete(node)
+    }
+
+    for (const obsolete of obsoletePlacements) {
+      if (!desiredImages.has(obsolete.image)) continue
+      output.push(
+        deleteKittyPlacement(
+          obsolete.image.imageId,
+          obsolete.placementId,
+        ),
+      )
+    }
+
+    for (const [key, image] of this.images) {
+      if (desiredImages.has(image)) continue
+      output.push(deleteKittyImage(image.imageId))
+      this.images.delete(key)
     }
 
     return output.join('')
@@ -120,24 +194,63 @@ export class KittyGraphicsManager {
 
   /** A clear/screen swap invalidated terminal-side data; resend next frame. */
   invalidateAll(): void {
-    for (const state of this.states.values()) {
-      state.uploaded = false
+    for (const image of this.images.values()) image.uploaded = false
+    for (const state of this.placements.values()) {
       state.placed = false
     }
   }
 
   /** Forget terminal-side state after leaving the buffer that owned it. */
   reset(): void {
-    this.states.clear()
+    this.images.clear()
+    this.placements.clear()
   }
 
   /** Delete every image owned by this renderer and forget their ids. */
   deleteAll(): string {
-    const output = [...this.states.values()]
-      .map(state => deleteKittyImage(state.imageId))
+    const output = [...this.images.values()]
+      .map(image => deleteKittyImage(image.imageId))
       .join('')
-    this.states.clear()
+    this.images.clear()
+    this.placements.clear()
     return output
+  }
+
+  private imageFor(placement: TerminalImagePlacement): ImageState {
+    const digest = this.contentHash(placement.source.data)
+    const key = [
+      digest,
+      placement.source.width,
+      placement.source.height,
+      placement.columns,
+      placement.rows,
+      this.cellSize.width,
+      this.cellSize.height,
+    ].join(':')
+    const existing = this.images.get(key)
+    if (existing !== undefined) return existing
+
+    const fitted = fitTerminalImageSource(
+      placement.source,
+      placement.columns,
+      placement.rows,
+      this.cellSize,
+    )
+    const image: ImageState = {
+      imageId: this.allocateImageId(),
+      payload: prepareKittyRgba(fitted),
+      uploaded: false,
+    }
+    this.images.set(key, image)
+    return image
+  }
+
+  private contentHash(data: Uint8Array): string {
+    const existing = this.contentHashes.get(data)
+    if (existing !== undefined) return existing
+    const digest = createHash('sha256').update(data).digest('base64url')
+    this.contentHashes.set(data, digest)
+    return digest
   }
 
   private allocateImageId(): number {
@@ -146,17 +259,41 @@ export class KittyGraphicsManager {
     if (this.nextImageId >= ID_MAX_EXCLUSIVE) this.nextImageId = ID_MIN
     return id
   }
+
+  private allocatePlacementId(): number {
+    const id = this.nextPlacementId
+    this.nextPlacementId += 1
+    if (this.nextPlacementId >= PLACEMENT_ID_MAX_EXCLUSIVE) {
+      this.nextPlacementId = 1
+    }
+    return id
+  }
 }
 
-/** Direct RGBA transmission split into protocol-compliant base64 chunks. */
+/** Zlib-compressed direct RGBA split into protocol-compliant base64 chunks. */
 export function transmitKittyRgba(
   imageId: number,
   source: TerminalImageSource,
 ): string {
+  return transmitPreparedKittyRgba(imageId, prepareKittyRgba(source))
+}
+
+function prepareKittyRgba(source: TerminalImageSource): PreparedKittyRgba {
+  return {
+    data: deflateSync(source.data, { level: 1 }),
+    width: source.width,
+    height: source.height,
+  }
+}
+
+function transmitPreparedKittyRgba(
+  imageId: number,
+  payload: PreparedKittyRgba,
+): string {
   const encoded = Buffer.from(
-    source.data.buffer,
-    source.data.byteOffset,
-    source.data.byteLength,
+    payload.data.buffer,
+    payload.data.byteOffset,
+    payload.data.byteLength,
   ).toString('base64')
   const chunks: string[] = []
   for (let offset = 0; offset < encoded.length; offset += BASE64_CHUNK_CELLS) {
@@ -168,7 +305,7 @@ export function transmitKittyRgba(
       const more = index + 1 < chunks.length ? 1 : 0
       const control =
         index === 0
-          ? `a=t,t=d,f=32,s=${source.width},v=${source.height},i=${imageId},q=2,m=${more}`
+          ? `a=t,t=d,f=32,s=${payload.width},v=${payload.height},i=${imageId},o=z,q=2,m=${more}`
           : `m=${more},q=2`
       return kittyCommand(control, chunk)
     })
@@ -182,13 +319,21 @@ export function kittyPlacement(
   y: number,
   columns: number,
   rows: number,
+  zIndex = IMAGE_Z_INDEX,
 ): string {
   return (
     `\u001b[${y + 1};${x + 1}H` +
     kittyCommand(
-      `a=p,i=${imageId},p=${placementId},c=${columns},r=${rows},z=${IMAGE_Z_INDEX},C=1,q=2`,
+      `a=p,i=${imageId},p=${placementId},c=${columns},r=${rows},z=${zIndex},C=1,q=2`,
     )
   )
+}
+
+export function deleteKittyPlacement(
+  imageId: number,
+  placementId: number,
+): string {
+  return kittyCommand(`a=d,d=i,i=${imageId},p=${placementId},q=2`)
 }
 
 export function deleteKittyImage(imageId: number): string {

--- a/src/ink/parse-keypress.ts
+++ b/src/ink/parse-keypress.ts
@@ -158,6 +158,10 @@ const KITTY_GRAPHICS_RE = /^\x1b_G([^;]*);([^\x1b]*)\x1b\\$/
 // Ctrl+F3 = CSI 1;5 R, etc.) — plain CSI row;col R is genuinely ambiguous.
 // eslint-disable-next-line no-control-regex
 const CURSOR_POSITION_RE = /^\x1b\[\?(\d+);(\d+)R$/
+// XTWINOPS pixel-size replies: CSI 6;height;width t (cell) and
+// CSI 4;height;width t (text area).
+// eslint-disable-next-line no-control-regex
+const TERMINAL_PIXEL_SIZE_RE = /^\x1b\[([46]);(\d+);(\d+)t$/
 // OSC response: OSC code ; data (BEL|ST)
 // eslint-disable-next-line no-control-regex
 const OSC_RESPONSE_RE = /^\x1b\](\d+);(.*?)(?:\x07|\x1b\\)$/s
@@ -215,6 +219,13 @@ export type TerminalResponse =
   | { type: 'kittyGraphics'; imageId: number; status: string }
   /** DSR: cursor position report (answer to CSI 6 n) */
   | { type: 'cursorPosition'; row: number; col: number }
+  /** XTWINOPS: physical pixels for one cell or the terminal text area. */
+  | {
+      type: 'terminalPixelSize'
+      scope: 'cell' | 'window'
+      height: number
+      width: number
+    }
   /** OSC response: generic operating-system-command reply (e.g. OSC 11 bg color) */
   | { type: 'osc'; code: number; data: string }
   /** XTVERSION: terminal name/version string (answer to CSI > 0 q).
@@ -260,6 +271,15 @@ function parseTerminalResponse(s: string): TerminalResponse | null {
         type: 'cursorPosition',
         row: parseInt(m[1]!, 10),
         col: parseInt(m[2]!, 10),
+      }
+    }
+
+    if ((m = TERMINAL_PIXEL_SIZE_RE.exec(s))) {
+      return {
+        type: 'terminalPixelSize',
+        scope: m[1] === '6' ? 'cell' : 'window',
+        height: parseInt(m[2]!, 10),
+        width: parseInt(m[3]!, 10),
       }
     }
 

--- a/src/ink/terminal-image.ts
+++ b/src/ink/terminal-image.ts
@@ -29,10 +29,11 @@ export const DEFAULT_TERMINAL_CELL_SIZE: TerminalCellSize = Object.freeze({
 /**
  * Immutable decoded image data accepted by the host image primitive.
  *
- * The renderer deliberately keys uploads by buffer identity instead of
- * hashing every frame. Callers must not mutate or refill `data` after passing
- * it to `<Image>`; changed pixels require a new `Uint8Array` (and therefore a
- * new source snapshot).
+ * The renderer hashes `data` once per buffer and caches the digest by buffer
+ * identity, so an in-place rewrite of the same buffer is never detected.
+ * Callers must not mutate or refill `data` after passing it to `<Image>`;
+ * changed pixels require a new `Uint8Array` (and therefore a new source
+ * snapshot).
  */
 export interface TerminalImageSource {
   /** Immutable row-major sRGB pixels, four bytes per pixel in RGBA order. */

--- a/src/ink/terminal-image.ts
+++ b/src/ink/terminal-image.ts
@@ -14,6 +14,18 @@ export const TERMINAL_IMAGE_MAX_FRAME_BYTES = 16 * 1024 * 1024
 export const TERMINAL_IMAGE_MAX_CELLS = 128 * 128
 export const TERMINAL_IMAGE_MAX_PLACEMENTS = 64
 
+/** Pixel dimensions of one terminal cell. */
+export interface TerminalCellSize {
+  readonly width: number
+  readonly height: number
+}
+
+/** Conventional monospace cell used when XTWINOPS pixel queries are absent. */
+export const DEFAULT_TERMINAL_CELL_SIZE: TerminalCellSize = Object.freeze({
+  width: 8,
+  height: 16,
+})
+
 /**
  * Immutable decoded image data accepted by the host image primitive.
  *
@@ -37,6 +49,245 @@ export interface TerminalImagePlacement {
   readonly columns: number
   readonly rows: number
   readonly source: TerminalImageSource
+}
+
+/**
+ * Normalize terminal-reported cell pixels before they reach allocation math.
+ * The upper bound rejects corrupt or injected XTWINOPS replies; real terminal
+ * cells remain far below it, including HiDPI displays.
+ */
+export function normalizeTerminalCellSize(
+  value: TerminalCellSize | undefined,
+): TerminalCellSize {
+  return plausibleTerminalCellSize(value) ?? DEFAULT_TERMINAL_CELL_SIZE
+}
+
+/** Prefer a direct cell report, then derive it from text-area pixels. */
+export function resolveTerminalCellSize(
+  cell: TerminalCellSize | undefined,
+  window: TerminalCellSize | undefined,
+  columns: number,
+  rows: number,
+): TerminalCellSize | undefined {
+  const direct = plausibleTerminalCellSize(cell)
+  if (direct !== undefined) return direct
+  if (
+    window === undefined ||
+    !Number.isFinite(window.width) ||
+    !Number.isFinite(window.height) ||
+    columns <= 0 ||
+    rows <= 0
+  ) {
+    return undefined
+  }
+  return plausibleTerminalCellSize({
+    width: window.width / columns,
+    height: window.height / rows,
+  })
+}
+
+function plausibleTerminalCellSize(
+  value: TerminalCellSize | undefined,
+): TerminalCellSize | undefined {
+  if (
+    value === undefined ||
+    !Number.isFinite(value.width) ||
+    !Number.isFinite(value.height) ||
+    value.width < 1 ||
+    value.height < 1 ||
+    value.width > 512 ||
+    value.height > 512
+  ) {
+    return undefined
+  }
+  return { width: Math.round(value.width), height: Math.round(value.height) }
+}
+
+/**
+ * Prepare an RGBA raster that fits a laid-out cell rectangle without
+ * distortion. The transparent canvas has the terminal rectangle's physical
+ * aspect ratio; the host only downsamples source pixels and centers them
+ * inside it. Kitty can then scale that bounded canvas to the requested cells.
+ */
+export function fitTerminalImageSource(
+  source: TerminalImageSource,
+  columns: number,
+  rows: number,
+  cellSize: TerminalCellSize = DEFAULT_TERMINAL_CELL_SIZE,
+): TerminalImageSource {
+  const cell = normalizeTerminalCellSize(cellSize)
+  const safeColumns = Math.max(1, Math.floor(columns))
+  const safeRows = Math.max(1, Math.floor(rows))
+  const [boxWidth, boxHeight] = boundedPixelBox(
+    safeColumns * cell.width,
+    safeRows * cell.height,
+  )
+
+  // Kitty scales the raster to the requested cell rectangle, so its canvas
+  // must have that rectangle's exact physical aspect ratio. Rounding each
+  // side independently would distort tiny sources. Use the smallest integer
+  // multiple of the reduced ratio that contains the fitted source.
+  const requestedWidth = safeColumns * cell.width
+  const requestedHeight = safeRows * cell.height
+  const divisor = greatestCommonDivisor(requestedWidth, requestedHeight)
+  let ratioWidth = requestedWidth / divisor
+  let ratioHeight = requestedHeight / divisor
+  let maximumMultiple = Math.floor(
+    Math.min(boxWidth / ratioWidth, boxHeight / ratioHeight),
+  )
+
+  // Some coprime physical dimensions need more pixels than the allocation
+  // budget even at their smallest exact ratio. Only then use the nearest
+  // uniformly bounded raster ratio.
+  if (maximumMultiple < 1) {
+    const boundedDivisor = greatestCommonDivisor(boxWidth, boxHeight)
+    ratioWidth = boxWidth / boundedDivisor
+    ratioHeight = boxHeight / boundedDivisor
+    maximumMultiple = boundedDivisor
+  }
+
+  const multiple = Math.min(
+    maximumMultiple,
+    Math.max(
+      1,
+      Math.ceil(source.width / ratioWidth),
+      Math.ceil(source.height / ratioHeight),
+    ),
+  )
+  const canvasWidth = ratioWidth * multiple
+  const canvasHeight = ratioHeight * multiple
+
+  const canvasScale = Math.min(
+    1,
+    canvasWidth / source.width,
+    canvasHeight / source.height,
+  )
+  const fittedWidth = Math.max(
+    1,
+    Math.min(canvasWidth, Math.round(source.width * canvasScale)),
+  )
+  const fittedHeight = Math.max(
+    1,
+    Math.min(canvasHeight, Math.round(source.height * canvasScale)),
+  )
+
+  if (
+    fittedWidth === source.width &&
+    fittedHeight === source.height &&
+    canvasWidth === source.width &&
+    canvasHeight === source.height
+  ) {
+    return source
+  }
+
+  const content =
+    fittedWidth === source.width && fittedHeight === source.height
+      ? source.data
+      : resizeRgba(source, fittedWidth, fittedHeight)
+  if (canvasWidth === fittedWidth && canvasHeight === fittedHeight) {
+    return { data: content, width: fittedWidth, height: fittedHeight }
+  }
+
+  const data = new Uint8Array(canvasWidth * canvasHeight * 4)
+  const left = Math.floor((canvasWidth - fittedWidth) / 2)
+  const top = Math.floor((canvasHeight - fittedHeight) / 2)
+  const sourceStride = fittedWidth * 4
+  for (let row = 0; row < fittedHeight; row++) {
+    const sourceStart = row * sourceStride
+    const targetStart = ((top + row) * canvasWidth + left) * 4
+    data.set(content.subarray(sourceStart, sourceStart + sourceStride), targetStart)
+  }
+  return { data, width: canvasWidth, height: canvasHeight }
+}
+
+function greatestCommonDivisor(left: number, right: number): number {
+  while (right !== 0) {
+    const remainder = left % right
+    left = right
+    right = remainder
+  }
+  return left
+}
+
+function boundedPixelBox(width: number, height: number): readonly [number, number] {
+  const maxPixels = TERMINAL_IMAGE_MAX_BYTES / 4
+  const scale = Math.min(
+    1,
+    Math.sqrt(maxPixels / (width * height)),
+  )
+  return [
+    Math.max(1, Math.floor(width * scale)),
+    Math.max(1, Math.floor(height * scale)),
+  ]
+}
+
+/** Premultiplied-alpha bilinear resize avoids dark fringes at transparency. */
+function resizeRgba(
+  source: TerminalImageSource,
+  width: number,
+  height: number,
+): Uint8Array {
+  const output = new Uint8Array(width * height * 4)
+  const xScale = source.width / width
+  const yScale = source.height / height
+
+  for (let y = 0; y < height; y++) {
+    const sourceY = (y + 0.5) * yScale - 0.5
+    const rawY0 = Math.floor(sourceY)
+    const y0 = Math.max(0, Math.min(source.height - 1, rawY0))
+    const y1 = Math.max(0, Math.min(source.height - 1, rawY0 + 1))
+    const yWeight = sourceY - rawY0
+
+    for (let x = 0; x < width; x++) {
+      const sourceX = (x + 0.5) * xScale - 0.5
+      const rawX0 = Math.floor(sourceX)
+      const x0 = Math.max(0, Math.min(source.width - 1, rawX0))
+      const x1 = Math.max(0, Math.min(source.width - 1, rawX0 + 1))
+      const xWeight = sourceX - rawX0
+      const weight00 = (1 - xWeight) * (1 - yWeight)
+      const weight10 = xWeight * (1 - yWeight)
+      const weight01 = (1 - xWeight) * yWeight
+      const weight11 = xWeight * yWeight
+      const offset00 = (y0 * source.width + x0) * 4
+      const offset10 = (y0 * source.width + x1) * 4
+      const offset01 = (y1 * source.width + x0) * 4
+      const offset11 = (y1 * source.width + x1) * 4
+      const alpha00 = source.data[offset00 + 3]!
+      const alpha10 = source.data[offset10 + 3]!
+      const alpha01 = source.data[offset01 + 3]!
+      const alpha11 = source.data[offset11 + 3]!
+      const alpha =
+        alpha00 * weight00 +
+        alpha10 * weight10 +
+        alpha01 * weight01 +
+        alpha11 * weight11
+      const red =
+        source.data[offset00]! * alpha00 * weight00 +
+        source.data[offset10]! * alpha10 * weight10 +
+        source.data[offset01]! * alpha01 * weight01 +
+        source.data[offset11]! * alpha11 * weight11
+      const green =
+        source.data[offset00 + 1]! * alpha00 * weight00 +
+        source.data[offset10 + 1]! * alpha10 * weight10 +
+        source.data[offset01 + 1]! * alpha01 * weight01 +
+        source.data[offset11 + 1]! * alpha11 * weight11
+      const blue =
+        source.data[offset00 + 2]! * alpha00 * weight00 +
+        source.data[offset10 + 2]! * alpha10 * weight10 +
+        source.data[offset01 + 2]! * alpha01 * weight01 +
+        source.data[offset11 + 2]! * alpha11 * weight11
+
+      const target = (y * width + x) * 4
+      if (alpha > 0) {
+        output[target] = Math.round(red / alpha)
+        output[target + 1] = Math.round(green / alpha)
+        output[target + 2] = Math.round(blue / alpha)
+      }
+      output[target + 3] = Math.round(alpha)
+    }
+  }
+
+  return output
 }
 
 /** Validate an untrusted decoded source without copying its pixel buffer. */

--- a/src/ink/terminal-querier.ts
+++ b/src/ink/terminal-querier.ts
@@ -39,6 +39,10 @@ type Da1Response = Extract<TerminalResponse, { type: 'da1' }>
 type Da2Response = Extract<TerminalResponse, { type: 'da2' }>
 type KittyResponse = Extract<TerminalResponse, { type: 'kittyKeyboard' }>
 type KittyGraphicsResponse = Extract<TerminalResponse, { type: 'kittyGraphics' }>
+type TerminalPixelSizeResponse = Extract<
+  TerminalResponse,
+  { type: 'terminalPixelSize' }
+>
 type CursorPosResponse = Extract<TerminalResponse, { type: 'cursorPosition' }>
 type OscResponse = Extract<TerminalResponse, { type: 'osc' }>
 type XtversionResponse = Extract<TerminalResponse, { type: 'xtversion' }>
@@ -95,17 +99,37 @@ export function kittyKeyboard(): TerminalQuery<KittyResponse> {
 }
 
 /**
- * Query direct-data support for the Kitty graphics protocol with one 1×1
- * RGB pixel. The terminal echoes the caller-owned image id in its APC reply.
+ * Query direct-data and zlib support for the Kitty graphics protocol with one
+ * transparent 1×1 RGBA pixel. The terminal echoes the image id in its reply.
  */
 export function kittyGraphics(
   imageId: number,
 ): TerminalQuery<KittyGraphicsResponse> {
   const id = Number.isSafeInteger(imageId) && imageId > 0 ? imageId : 31
   return {
-    request: `\u001b_Gi=${id},s=1,v=1,a=q,t=d,f=24;AAAA\u001b\\`,
+    // One transparent RGBA pixel compressed with RFC 1950 zlib. Probe the
+    // same direct-data + compression path used by real renderer uploads.
+    request: `\u001b_Gi=${id},s=1,v=1,a=q,t=d,f=32,o=z;eAFjYGBgAAAABAAB\u001b\\`,
     match: (r): r is KittyGraphicsResponse =>
       r.type === 'kittyGraphics' && r.imageId === id,
+  }
+}
+
+/** XTWINOPS: query the physical pixel dimensions of one terminal cell. */
+export function terminalCellSizePixels(): TerminalQuery<TerminalPixelSizeResponse> {
+  return {
+    request: csi('16t'),
+    match: (r): r is TerminalPixelSizeResponse =>
+      r.type === 'terminalPixelSize' && r.scope === 'cell',
+  }
+}
+
+/** XTWINOPS: query the terminal text area's physical pixel dimensions. */
+export function terminalWindowSizePixels(): TerminalQuery<TerminalPixelSizeResponse> {
+  return {
+    request: csi('14t'),
+    match: (r): r is TerminalPixelSizeResponse =>
+      r.type === 'terminalPixelSize' && r.scope === 'window',
   }
 }
 
@@ -185,11 +209,17 @@ export class TerminalQuerier {
    * "no answer" keeps callers' .then() chains inert instead of pending.
    */
   private disposed = false
+  private suspended = false
 
   constructor(
     private stdout: NodeJS.WriteStream,
     private setRawMode?: (enabled: boolean) => void,
   ) {}
+
+  /** Whether terminal query I/O is paused for an external process handoff. */
+  get isSuspended(): boolean {
+    return this.suspended
+  }
 
   private holdRawMode(): () => void {
     this.setRawMode?.(true)
@@ -212,7 +242,7 @@ export class TerminalQuerier {
   send<T extends TerminalResponse>(
     query: TerminalQuery<T>,
   ): Promise<T | undefined> {
-    if (this.disposed) return Promise.resolve(undefined)
+    if (this.disposed || this.suspended) return Promise.resolve(undefined)
     return new Promise(resolve => {
       this.queue.push({
         kind: 'query',
@@ -234,7 +264,7 @@ export class TerminalQuerier {
    * Safe to call with no pending queries — still waits for a round-trip.
    */
   flush(): Promise<void> {
-    if (this.disposed) return Promise.resolve()
+    if (this.disposed || this.suspended) return Promise.resolve()
     return new Promise(resolve => {
       this.queue.push({
         kind: 'sentinel',
@@ -248,11 +278,8 @@ export class TerminalQuerier {
   /** Resolve and release all pending queries when their owning app unmounts. */
   dispose(): void {
     this.disposed = true
-    for (const pending of this.queue.splice(0)) {
-      if (pending.kind === 'query') pending.resolve(undefined)
-      else pending.resolve()
-      pending.releaseRawMode()
-    }
+    this.suspended = true
+    this.drainPending()
   }
 
   /**
@@ -275,6 +302,7 @@ export class TerminalQuerier {
    * @param r - the response parsed from stdin.
    */
   onResponse(r: TerminalResponse): void {
+    if (this.suspended) return
     const idx = this.queue.findIndex(p => p.kind === 'query' && p.match(r))
     if (idx !== -1) {
       const [q] = this.queue.splice(idx, 1)
@@ -293,6 +321,30 @@ export class TerminalQuerier {
         else p.resolve()
         p.releaseRawMode()
       }
+    }
+  }
+
+  /**
+   * Resolve outstanding queries before stdin is handed to another process.
+   * Their replies can no longer be routed reliably once the child owns the
+   * terminal; later queries remain available after the handoff.
+   */
+  suspend(): void {
+    if (this.disposed) return
+    this.suspended = true
+    this.drainPending()
+  }
+
+  /** Resume queries after the caller's terminal-reply quarantine has ended. */
+  resume(): void {
+    if (!this.disposed) this.suspended = false
+  }
+
+  private drainPending(): void {
+    for (const pending of this.queue.splice(0)) {
+      if (pending.kind === 'query') pending.resolve(undefined)
+      else pending.resolve()
+      pending.releaseRawMode()
     }
   }
 }


### PR DESCRIPTION
Depends on #688.
Closes #686.

## Summary

- preserve source aspect ratio from terminal-reported cell pixels, with bounded transparent letterboxing and premultiplied-alpha downsampling;
- compress direct RGBA with zlib, share immutable content uploads across nodes and remounts, and keep image resources separate from node-owned placements;
- refresh geometry across resize and font/DPI changes while coalescing bursts and rejecting stale reports;
- suspend, drain, quarantine, and resume terminal queries around external-editor handoff so late CSI/DA1 replies cannot poison a new batch;
- retain text fallback behavior for unsupported, inline, accessibility, and multiplexer sessions.

The public plugin/Image contract is unchanged. Attachment decoding, transcript projection, source cropping, and temporal payload caching stay out of this renderer-focused PR.

## Validation

- env TMPDIR=/tmp pnpm build
- pnpm smoke
- node --import tsx/esm scripts/verify-terminal-queries.tsx
- node --import tsx/esm scripts/verify-resize-reflow.tsx
- node --import tsx/esm scripts/repro-toolcards.tsx
- pnpm verify:package
- pnpm verify:bun-package
- git diff --check

## Stack note

Base branch is `nagi/kitty-graphics-image-base` (#688). Once #688 merges, this PR retargets to `main` without changing its commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Kitty terminal image rendering with centered, aspect-preserving images, transparent letterboxing, and higher-quality resizing.
  - Reuses shared image data efficiently and supports configurable terminal cell dimensions.
  - Added support for detecting terminal cell and window pixel sizes for more accurate image geometry.

- **Bug Fixes**
  - Improved terminal-query handling during screen transitions, interruptions, resizing, and shutdown.
  - Prevented stale or delayed terminal responses from affecting rendering.

- **Documentation**
  - Updated image rendering documentation to describe aspect-ratio preservation, centering, downsampling, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->