### PR TITLE
fix(streaming): 恢复 revealVersion 传参——#676 误删致 #669 订阅收敛失效

### DIFF
--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1451,6 +1451,7 @@ function TranscriptRow({
             toolBackground={toolBackground}
             smoothReveal={smoothStreaming}
             fresh={fresh}
+            revealVersion={revealVersion}
             foldTerminalCommand={foldTerminalCommand}
             onClick={foldOnClick}
             onOpenFile={onOpenFile}


### PR DESCRIPTION
#676 合并时删掉了 MessageList 渲染处向 AssistantToolUseMessage 传 `revealVersion` 的一行（git 考古：#669/e72ed5b 引入整套收敛管道并传参，#676/a9fad30 只删了传参，上游计算/传递/解构全部悬空）。

后果：每张工具卡回退到逐卡全局订阅（`useSyncExternalStore` 走 `subscribeReveal` 回退分支）——一个 revealTick 同步唤醒全部订阅卡，正是 #669 要修的 React #185 崩溃模式回归。组件内注释「MessageList owns the single production subscription」也随之失实。

修复：恢复传参一行，死管道复活。

验证：`verify-smooth-reveal` 全过；`repro-185` 无 in-render/in-commit setState 源。

Closes #682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smooth-reveal updates for tool-related messages, helping active content display more reliably as it becomes available.
  * Reduced unnecessary refreshes during streaming, providing a smoother and more consistent message display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->