### PR TITLE
fix(render+ink): 消除流式期 #185 全部已知高频源（DefaultLane 化 + timeline 去重）+ 自愈守卫三层（吸收/进程兜底/熔断退避）

### DIFF
--- a/scripts/repro-185-reveal-nocrash.tsx
+++ b/scripts/repro-185-reveal-nocrash.tsx
@@ -1,0 +1,219 @@
+/**
+ * repro-185-reveal without its own crash handlers — for validating the
+ * process-level #185 backstop (installNestedUpdateOverflowProcessGuard).
+ * Identical scenario otherwise; see repro-185-reveal.tsx for the full
+ * documentation.
+ *
+ * Run: NODE_ENV=production node --import tsx/esm scripts/repro-185-reveal-nocrash.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, reveal] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/components/smoothReveal.js'),
+])
+
+const COLS = Number(process.env.COLS ?? 110)
+const ROWS = 32
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 1000, allowProposedApi: true })
+
+const rawChunks: string[] = []
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { rawChunks.push(String(chunk)); term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+const startedAt = Date.now()
+let streamStartedAt = 0
+let crashed: unknown = null
+// NO process.on('uncaughtException'/'unhandledRejection') here — the guard
+// under test installs its own. The Trap boundary below still catches errors
+// thrown inside React render/commit (finish(1) on those).
+
+const listeners = new Set<() => void>()
+let subCount = 0
+let versionReads = 0
+let _version = 0
+const channel: any = {
+  get version() { versionReads++; return _version },
+  set version(v: number) { _version = v },
+  rows: [] as any[],
+  status: 'idle',
+  sessionTitle: 'repro-185-reveal',
+  agentId: 'repro-185-reveal',
+  model: 'deepseek-v4-flash',
+  reasoningEffort: 'max',
+  mode: { plan: false },
+  modeIndex: 0,
+  displayCwd: '/tmp/demo',
+  contextBarEnabled: false,
+  contextSegments: undefined,
+  contextWindow: undefined,
+  lastUsage: undefined,
+  commandCompletions: [],
+  tokens: { input: 120, output: 45 },
+  cwd: '/tmp/demo',
+  gitBranch: 'main',
+  working: true,
+  spinnerMode: 'requesting',
+  responseChars: 0,
+  activeToolCount: 1,
+  turnStart: Date.now(),
+  lastUserText: '长会话流式压测',
+  pending: [],
+  commandList: [],
+  notifications: [],
+  smoothStreaming: process.env.SMOOTH !== '0',
+  subscribe(cb: () => void) { subCount++; listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {},
+  cancel: () => {},
+  clear: () => {},
+  notify: () => {},
+  listModels: () => Promise.resolve([]),
+  listSessions: () => [],
+  setResumeTarget: () => {},
+  loadOlder: () => {},
+  mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) cb() }
+
+let revealTicks = 0
+reveal.subscribeReveal(() => { revealTicks++ })
+
+let id = 0
+const codeBlock = (n: number, lang: string) =>
+  '```' + lang + '\n' + Array.from({ length: n }, (_, i) =>
+    `const handleRequest${i} = async (req: Request, res: Response): Promise<void> => { // 第 ${i} 行，故意写得很长，让窄终端里一定折行，从而撑高测量高度`
+  ).join('\n') + '\n```'
+
+for (let turn = 0; turn < 10; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `历史问题 ${turn}：分析一下模块 ${turn} 的实现` })
+  channel.rows.push({ id: id++, kind: 'reasoning', text: `用户在问模块 ${turn}。`.repeat(4), streaming: false, durationMs: 1500 })
+  for (let t = 0; t < 3; t++) {
+    channel.rows.push({
+      id: id++, kind: 'tool', text: '',
+      tool: {
+        callId: `h${turn}-${t}`, name: t % 2 ? 'Read' : 'Bash',
+        argsText: t % 2 ? `{"file_path": "/tmp/demo/src/mod${turn}/file${t}.ts"}` : `{"command": "rg -n 'export' src/mod${turn} | head -40", "description": "list exports"}`,
+        argsFull: '{}',
+        status: 'ok', startedAt: Date.now() - 600000, durationMs: 30,
+        resultText: Array.from({ length: 12 + ((turn + t) % 5) * 6 }, (_, i) => `export function helper_${turn}_${t}_${i}(input: unknown): Promise<Result<unknown>> { /* 历史结果行 ${i}，长度凑一凑 */ return null }`).join('\n'),
+      },
+    })
+  }
+  channel.rows.push({
+    id: id++, kind: 'assistant', streaming: false,
+    text: `模块 ${turn} 的结论：\n\n- 入口在 \`src/mod${turn}/index.ts\`\n- 关键逻辑如下：\n\n${codeBlock(18 + (turn % 4) * 8, 'ts')}\n\n| 项 | 值 |\n| --- | --- |\n| 行数 | ${300 + turn * 17} |\n| 复杂度 | 高 |\n`,
+  })
+}
+
+const stdin = new FakeStdin()
+const stdout = new FakeStdout()
+
+function finish(code: number): void {
+  const allRaw = rawChunks.join('')
+  const hit185 = /Maximum update depth|Minified React error #185/.test(allRaw)
+  console.log('\n==== repro-185-reveal-nocrash summary ====')
+  console.log('chunks:', rawChunks.length, ' elapsed:', Date.now() - startedAt, 'ms stream:', streamStartedAt ? `${Date.now() - streamStartedAt}ms` : 'n/a')
+  console.log('crashed:', crashed ? String(crashed).slice(0, 300) : false)
+  console.log('error #185 text in output:', hit185)
+  console.log('reveal advancing ticks:', revealTicks, ' version:', reveal.getRevealVersion(), ' timer running:', reveal.isRevealTimerRunning())
+  console.log('channel subscribes:', subCount, ' version getter reads:', versionReads, ' version:', _version)
+  process.exit(crashed || hit185 ? 1 : code)
+}
+
+class Trap extends React.Component<{ children: React.ReactNode }, { err: unknown }> {
+  override state = { err: null as unknown }
+  static getDerivedStateFromError(err: unknown): { err: unknown } { return { err } }
+  override componentDidCatch(err: unknown, info: unknown): void {
+    crashed = err
+    console.error('TRAPPED RENDER ERROR:', err)
+    console.error('component stack:', (info as { componentStack?: string })?.componentStack)
+    finish(1)
+  }
+  override render(): React.ReactNode { return this.state.err ? null : this.props.children }
+}
+
+const chatTree = (
+  <Trap>
+    <Chat channel={channel} questionStore={new QuestionStore()} onExit={() => {}} />
+  </Trap>
+)
+await render(
+  <AlternateScreen>
+    {chatTree}
+  </AlternateScreen>,
+  { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
+)
+
+const ticker = setInterval(() => { channel.responseChars += 7; bump() }, 100)
+const ticker2 = setInterval(() => { bump() }, 47)
+
+await sleep(800)
+
+channel.rows.push({ id: id++, kind: 'user', text: '把 AAA 项目的核心模块完整讲一遍，带上代码' }); bump()
+await sleep(150)
+
+const think = { id: id++, kind: 'reasoning', text: '', streaming: true, durationMs: undefined as number | undefined }
+channel.rows.push(think); bump()
+for (const c of ['用户要完整讲解，', '需要覆盖架构、', '关键代码与数据流。']) { think.text += c; bump(); await sleep(120) }
+think.streaming = false; think.durationMs = 900; bump()
+
+const finalMsg = { id: id++, kind: 'assistant', text: '', streaming: true }
+channel.rows.push(finalMsg); bump()
+
+const sections = Number(process.env.DOC_SECTIONS ?? 24)
+const docChunks: string[] = ['好，完整梳理一遍 AAA 项目的核心模块。\n\n']
+for (let s = 0; s < sections; s++) {
+  docChunks.push(`\n## ${s + 1}. 子系统 ${s + 1}：职责与入口\n\n`)
+  docChunks.push(`子系统 ${s + 1} 负责请求生命周期第 ${s + 1} 阶段的编排。`.repeat(2) + '\n\n')
+  for (const ln of codeBlock(10 + (s % 3) * 6, 'ts').split('\n')) docChunks.push(ln + '\n')
+  docChunks.push('\n| 指标 | 数值 | 说明 |\n| --- | --- | --- |\n')
+  for (let r = 0; r < 5; r++) docChunks.push(`| 指标${s}-${r} | ${(s + 1) * (r + 2) * 137} | 这是一行表格说明文字，用来占宽 |\n`)
+  docChunks.push('\n')
+}
+
+const feederMs = (process.env.FEEDERS ?? '4,7,11,17').split(',').map(Number)
+streamStartedAt = Date.now()
+let ci = 0
+const feeders = feederMs.map(ms =>
+  setInterval(() => {
+    if (ci >= docChunks.length) return
+    finalMsg.text += docChunks[ci++]!
+    bump()
+  }, ms),
+)
+await new Promise<void>(resolve => {
+  const check = setInterval(() => {
+    if (ci >= docChunks.length) { clearInterval(check); resolve() }
+  }, 100)
+})
+for (const f of feeders) clearInterval(f)
+finalMsg.streaming = false
+channel.working = false
+bump()
+await sleep(3000)
+clearInterval(ticker)
+clearInterval(ticker2)
+await sleep(300)
+
+finish(0)

--- a/scripts/repro-185-reveal.tsx
+++ b/scripts/repro-185-reveal.tsx
@@ -1,0 +1,293 @@
+/**
+ * beta.3 #185 repro — smoothReveal driver (fourth loop path after #662/#669).
+ *
+ * Difference from repro-185.tsx: the channel mock sets `smoothStreaming: true`,
+ * so MessageList subscribes to the reveal store via useSyncExternalStore. Every
+ * advancing 33ms reveal tick then forces a SYNCLANE store rerender
+ * (forceStoreRerender hardcodes SyncLane), which preempts/discards the
+ * in-flight DefaultLane streaming render; each sync commit ends with Default
+ * work pending → the commit-end lane test counts a nested update with no
+ * reset → 50 consecutive dirty commits → the next scheduleUpdateOnFiber on
+ * the root throws minified #185 from whichever timer happens to fire
+ * (ClockContext tick, thinking-spinner setFrame, …) → uncaught → process exit.
+ *
+ * Run for the real crash (minified #185, exit 1):
+ *   NODE_ENV=production node --import tsx/esm scripts/repro-185-reveal.tsx
+ * Run instrumented (dev reconciler logs [NESTED++] / [NESTED-THROW]):
+ *   node scripts/instr-nested-updates.mjs   # once, patches node_modules dev build
+ *   NODE_ENV=development node --import tsx/esm scripts/repro-185-reveal.tsx
+ * Expected pre-fix: crash within a few seconds of streaming start.
+ * Expected post-fix: runs to completion, exit 0.
+ *
+ * Env: SMOOTH=0 — control run with the reveal store disabled (same feed);
+ *      FEEDERS="4,7,11,17" — feeder timer cadences (the tuning knob);
+ *      COLS (default 110).
+ */
+process.env.FORCE_COLOR = '3'
+process.env.TERM_PROGRAM = 'WezTerm'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }, reveal] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/components/smoothReveal.js'),
+])
+
+const COLS = Number(process.env.COLS ?? 110)
+const ROWS = 32
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 1000, allowProposedApi: true })
+
+const rawChunks: string[] = []
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { rawChunks.push(String(chunk)); term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+// Initialized BEFORE the crash handlers so finish() can never hit a TDZ
+// ReferenceError that would mask the original crash (review P2).
+const startedAt = Date.now()
+/** Set when the streaming loop starts; 0 = never reached it. */
+let streamStartedAt = 0
+let crashed: unknown = null
+function onCrash(err: unknown): void {
+  crashed = err
+  console.error('\n!!!! PROCESS CRASH !!!!')
+  console.error(err)
+  finish(1)
+}
+process.on('uncaughtException', onCrash)
+process.on('unhandledRejection', onCrash)
+
+const listeners = new Set<() => void>()
+let subCount = 0
+let versionReads = 0
+let _version = 0
+const channel: any = {
+  get version() { versionReads++; return _version },
+  set version(v: number) { _version = v },
+  rows: [] as any[],
+  status: 'idle',
+  sessionTitle: 'repro-185-reveal',
+  agentId: 'repro-185-reveal',
+  model: 'deepseek-v4-flash',
+  reasoningEffort: 'max',
+  mode: { plan: false },
+  modeIndex: 0,
+  displayCwd: '/tmp/demo',
+  contextBarEnabled: false,
+  contextSegments: undefined,
+  contextWindow: undefined,
+  lastUsage: undefined,
+  tps: undefined,
+  tpsSamples: [],
+  workingActivity: undefined,
+  activityFrames: undefined,
+  commandCompletions: [],
+  tokens: { input: 120, output: 45 },
+  cwd: '/tmp/demo',
+  gitBranch: 'main',
+  working: true,
+  spinnerMode: 'requesting',
+  responseChars: 0,
+  activeToolCount: 1,
+  turnStart: Date.now(),
+  lastUserText: '长会话流式压测',
+  pending: [],
+  commandList: [],
+  notifications: [],
+  // >>> the beta.3 driver: MessageList subscribes to the reveal store <<<
+  // SMOOTH=0 runs the identical scenario with the reveal store off (control
+  // group: if only the SMOOTH=1 run crashes, the reveal wakeup is the driver).
+  smoothStreaming: process.env.SMOOTH !== '0',
+  subscribe(cb: () => void) { subCount++; listeners.add(cb); return () => listeners.delete(cb) },
+  submit: () => {},
+  cancel: () => {},
+  clear: () => {},
+  notify: () => {},
+  listModels: () => Promise.resolve([]),
+  listSessions: () => [],
+  setResumeTarget: () => {},
+  loadOlder: () => {},
+  mcpStatus: () => [],
+}
+const bump = () => { channel.version++; for (const cb of listeners) cb() }
+
+// Reveal-store probe: count advancing ticks (each one forces a SyncLane
+// store rerender pre-fix).
+let revealTicks = 0
+reveal.subscribeReveal(() => { revealTicks++ })
+
+let id = 0
+const codeBlock = (n: number, lang: string) =>
+  '```' + lang + '\n' + Array.from({ length: n }, (_, i) =>
+    `const handleRequest${i} = async (req: Request, res: Response): Promise<void> => { // 第 ${i} 行，故意写得很长，让窄终端里一定折行，从而撑高测量高度`
+  ).join('\n') + '\n```'
+
+// --- long session: 10 turns, mixed tool cards + markdown --------------------
+for (let turn = 0; turn < 10; turn++) {
+  channel.rows.push({ id: id++, kind: 'user', text: `历史问题 ${turn}：分析一下模块 ${turn} 的实现` })
+  channel.rows.push({ id: id++, kind: 'reasoning', text: `用户在问模块 ${turn}。`.repeat(4), streaming: false, durationMs: 1500 })
+  for (let t = 0; t < 3; t++) {
+    channel.rows.push({
+      id: id++, kind: 'tool', text: '',
+      tool: {
+        callId: `h${turn}-${t}`, name: t % 2 ? 'Read' : 'Bash',
+        argsText: t % 2 ? `{"file_path": "/tmp/demo/src/mod${turn}/file${t}.ts"}` : `{"command": "rg -n 'export' src/mod${turn} | head -40", "description": "list exports"}`,
+        argsFull: '{}',
+        status: 'ok', startedAt: Date.now() - 600000, durationMs: 30,
+        resultText: Array.from({ length: 12 + ((turn + t) % 5) * 6 }, (_, i) => `export function helper_${turn}_${t}_${i}(input: unknown): Promise<Result<unknown>> { /* 历史结果行 ${i}，长度凑一凑 */ return null }`).join('\n'),
+      },
+    })
+  }
+  channel.rows.push({
+    id: id++, kind: 'assistant', streaming: false,
+    text: `模块 ${turn} 的结论：\n\n- 入口在 \`src/mod${turn}/index.ts\`\n- 关键逻辑如下：\n\n${codeBlock(18 + (turn % 4) * 8, 'ts')}\n\n| 项 | 值 |\n| --- | --- |\n| 行数 | ${300 + turn * 17} |\n| 复杂度 | 高 |\n`,
+  })
+}
+
+const stdin = new FakeStdin()
+const stdout = new FakeStdout()
+
+class Trap extends React.Component<{ children: React.ReactNode }, { err: unknown }> {
+  override state = { err: null as unknown }
+  static getDerivedStateFromError(err: unknown): { err: unknown } { return { err } }
+  override componentDidCatch(err: unknown, info: unknown): void {
+    // A boundary-caught error (e.g. #185 thrown inside a commit) never reaches
+    // uncaughtException — record it as a crash so the run cannot false-pass.
+    crashed = err
+    console.error('TRAPPED RENDER ERROR:', err)
+    console.error('component stack:', (info as { componentStack?: string })?.componentStack)
+    finish(1)
+  }
+  override render(): React.ReactNode { return this.state.err ? null : this.props.children }
+}
+
+const chatTree = (
+  <Trap>
+    <Chat channel={channel} questionStore={new QuestionStore()} onExit={() => {}} />
+  </Trap>
+)
+await render(
+  <AlternateScreen>
+    {chatTree}
+  </AlternateScreen>,
+  { stdout, stdin, stderr: new FakeStderr(), exitOnCtrlC: false, patchConsole: false },
+)
+
+// status metrics ticking ~10/s (channel bumps without row changes)
+const ticker = setInterval(() => { channel.responseChars += 7; bump() }, 100)
+// second independent bump source (spinner cadence) to crowd the event loop
+const ticker2 = setInterval(() => { bump() }, 47)
+
+await sleep(800)
+
+// --- live turn: long streamed markdown+code, fast cadence -------------------
+channel.rows.push({ id: id++, kind: 'user', text: '把 AAA 项目的核心模块完整讲一遍，带上代码' }); bump()
+await sleep(150)
+
+const think = { id: id++, kind: 'reasoning', text: '', streaming: true, durationMs: undefined as number | undefined }
+channel.rows.push(think); bump()
+for (const c of ['用户要完整讲解，', '需要覆盖架构、', '关键代码与数据流。']) { think.text += c; bump(); await sleep(120) }
+think.streaming = false; think.durationMs = 900; bump()
+
+const finalMsg = { id: id++, kind: 'assistant', text: '', streaming: true }
+channel.rows.push(finalMsg); bump()
+
+// Build the streamed doc: prose + fenced code with long wrapping lines + tables.
+// DOC_SECTIONS is the second tuning knob: the per-commit render cost grows
+// with the streamed row's markdown length, so a longer doc means slower
+// late-stream renders — slow enough that a mid-render timer dispatch (clock,
+// measure deferral) is guaranteed, making EVERY commit end dirty regardless
+// of the reveal store. Keep it short enough that the SMOOTH=0 control
+// finishes before renders cross that threshold; the reveal store's 30fps
+// forced SyncLane commits climb the counter from the very first seconds.
+const sections = Number(process.env.DOC_SECTIONS ?? 24)
+const docChunks: string[] = ['好，完整梳理一遍 AAA 项目的核心模块。\n\n']
+for (let s = 0; s < sections; s++) {
+  docChunks.push(`\n## ${s + 1}. 子系统 ${s + 1}：职责与入口\n\n`)
+  docChunks.push(`子系统 ${s + 1} 负责请求生命周期第 ${s + 1} 阶段的编排。`.repeat(2) + '\n\n')
+  for (const ln of codeBlock(10 + (s % 3) * 6, 'ts').split('\n')) docChunks.push(ln + '\n')
+  docChunks.push('\n| 指标 | 数值 | 说明 |\n| --- | --- | --- |\n')
+  for (let r = 0; r < 5; r++) docChunks.push(`| 指标${s}-${r} | ${(s + 1) * (r + 2) * 137} | 这是一行表格说明文字，用来占宽 |\n`)
+  docChunks.push('\n')
+}
+
+// Feed the doc through several INDEPENDENT timers at staggered cadences — a
+// fast SSE burst, not a render-paced loop. A serial `bump(); await sleep()`
+// loop alternates with renders (each chunk gets consumed by its own render,
+// commits end clean, the nested counter keeps resetting); independent timers
+// fire during in-flight renders, so updates land mid-render and the commit
+// ends with DefaultLane residue. Cadence is the tuning knob: slow enough that
+// WITHOUT the reveal store (SMOOTH=0) plain Default renders frequently end
+// clean (control survives), fast enough that the reveal tick's forced SyncLane
+// render — every 33ms, preempting/discarding in-flight Default work — keeps
+// ending dirty (SMOOTH=1 counter climbs to 50).
+const feederMs = (process.env.FEEDERS ?? '4,7,11,17').split(',').map(Number)
+streamStartedAt = Date.now()
+let ci = 0
+const feeders = feederMs.map(ms =>
+  setInterval(() => {
+    if (ci >= docChunks.length) return
+    finalMsg.text += docChunks[ci++]!
+    bump()
+  }, ms),
+)
+await new Promise<void>(resolve => {
+  const check = setInterval(() => {
+    if (ci >= docChunks.length) { clearInterval(check); resolve() }
+  }, 100)
+})
+for (const f of feeders) clearInterval(f)
+finalMsg.streaming = false
+channel.working = false
+bump()
+await sleep(3000)
+clearInterval(ticker)
+clearInterval(ticker2)
+await sleep(300)
+
+finish(0)
+
+function finish(code: number): void {
+  const allRaw = rawChunks.join('')
+  const hit185 = /Maximum update depth|Minified React error #185/.test(allRaw)
+  console.log('\n==== repro-185-reveal summary ====')
+  console.log('chunks:', rawChunks.length, ' elapsed:', Date.now() - startedAt, 'ms stream:', streamStartedAt ? `${Date.now() - streamStartedAt}ms` : 'n/a')
+  console.log('crashed:', crashed ? String(crashed).slice(0, 300) : false)
+  console.log('error #185 text in output:', hit185)
+  console.log('max nested count seen:', (globalThis as any).__maxNested ?? 0, '(dev patch only; crashes at 51)')
+  console.log('reveal advancing ticks:', revealTicks, ' version:', reveal.getRevealVersion(), ' timer running:', reveal.isRevealTimerRunning())
+  // lanes profile from the dev-reconciler patch: does the SyncLane bit (the
+  // reveal store's forced rerender) carry the dirty commits?
+  const laneLog = ((globalThis as any).__lanes ?? []) as string[]
+  if (laneLog.length > 0) {
+    const dirty = laneLog.filter(s => (Number(s.split(':')[1]) & 42) !== 0)
+    const dirtySync = dirty.filter(s => (Number(s.split(':')[0]) & 2) !== 0)
+    console.log(`lanes profile: ${laneLog.length} commits, dirty ${dirty.length}, dirty-with-SyncLane ${dirtySync.length}`)
+  }
+  // residue sources: who dispatched updates into in-flight work
+  const residue = (globalThis as any).__residue as Map<string, { count: number; stack: string }> | undefined
+  if (residue && residue.size > 0) {
+    const top = [...residue.entries()].sort((a, b) => b[1].count - a[1].count).slice(0, 8)
+    console.log('residue dispatchers (phase:component:lane @site):')
+    for (const [k, v] of top) console.log(`  ${k} x${v.count}`)
+  }
+  console.log('channel subscribes:', subCount, ' version getter reads:', versionReads, ' version:', _version)
+  process.exit(crashed || hit185 ? 1 : code)
+}

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -365,6 +365,11 @@ const GROUPS = {
 // toast、kill 权限传递、无 jobs 服务降级、/new 重置）、JobCard/JobsPanel
 // 渲染冒烟（三行瀑布、settled 折叠、面板行/提示）。
     ["verify-jobs-panel", ['node', '--import', 'tsx/esm', 'scripts/verify-jobs-panel.tsx']],
+// #185 自愈守卫：React nested-update overflow（Minified error #185）抛出时
+// reconciler 已清零计数器，守卫在 clock.tick / reveal.tick / scrollbox.notify /
+// channel.emit(+emitStream) / selection.notify 等高频 enqueue 热点吸收该类
+// 错误——丢一拍而非进程死亡；单元（分类/透传/限流）+ 热点集成 + 渲染零干扰。
+    ["verify-update-overflow-guard", ['node', '--import', 'tsx/esm', 'scripts/verify-update-overflow-guard.tsx']],
 // /tree 与 /fork 回归：sessionTree 纯模型（条目提取、回退/分叉边界、
 // 家族拼接、扁平化/过滤、整轮丢弃预警）、compat 预算读取器
 // （全量/截断/继承前缀跳过）、SessionTree 屏幕无头组装

--- a/scripts/verify-auto-recap.tsx
+++ b/scripts/verify-auto-recap.tsx
@@ -25,7 +25,7 @@ const [
   { render, AlternateScreen },
   { Chat },
   { setLang },
-  { settle, screenHas, findText, viewportLines },
+  { settle, settled, screenHas, findText, viewportLines },
   { stringWidth },
 ] = await Promise.all([
   import('node:stream'),
@@ -311,8 +311,11 @@ channel.autoRecapOnOpen = true
 channel.agentId = 'probe-5'
 channel.emit()
 await settle(() => channel.recapCallCount === 5)
-await settle(() => screenHas(term, '回顾：'))
-check('重新开启后切会话恢复灰行', screenHas(term, 'AUTO_RECAP_SUMMARY'))
+// 直接 settle 到摘要落屏，不能 settle 到「回顾：」就立即断言摘要：灰行在
+// recap 在途时先画占位行「回顾：正在总结最近活动…」（同样含此前缀），摘要
+// 经 promise.then 另行落屏——两帧之间该断言是竞态（channel 订阅唤醒从
+// uSES 同步渲染改为 DefaultLane 排期后，占位帧在 CI 上真实出现）。
+check('重新开启后切会话恢复灰行', await settled(() => screenHas(term, 'AUTO_RECAP_SUMMARY')))
 stdin.write('继续')
 await settle(() => screenHas(term, '继续'))
 stdin.write('\r')

--- a/scripts/verify-update-overflow-guard.tsx
+++ b/scripts/verify-update-overflow-guard.tsx
@@ -1,0 +1,219 @@
+/**
+ * #185 自愈守卫回归：React nested-update overflow（Minified React error
+ * #185 / "Maximum update depth exceeded"）在抛出时已被 react-reconciler
+ * 将计数器清零，因此守卫吸收该类错误 = 丢一拍更新、下一拍即恢复，
+ * 把"进程死亡"降级为"跳帧 + 限流诊断日志"。
+ *
+ * Group A — 单元（无渲染）：错误分类、非目标错误透传、限流窗口、重置。
+ * Group B — 热点集成（headless xterm）：
+ *   B1 clock.tick：订阅者抛 #185 被吞，后续订阅者仍执行，时钟继续。
+ *   B2 reveal.tick：listener 抛 #185 被吞，调度器后续 tick 正常推进。
+ *   B3 channel.emit/emitStream：listener 抛 #185 不炸 channel。
+ *
+ * 运行：node --import tsx/esm scripts/verify-update-overflow-guard.tsx
+ */
+process.env.DSH_TUI_LANG = 'en'
+process.env['FORCE_COLOR'] = '0'
+
+// 家目录隔离：channel 构造路径会 touch 用户目录，先切临时目录再 import。
+const { mkdtempSync, mkdirSync } = await import('node:fs')
+const { tmpdir } = await import('node:os')
+const { join: joinPath } = await import('node:path')
+const isolatedHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-185-guard-'))
+process.env.HOME = isolatedHome
+process.env.USERPROFILE = isolatedHome
+mkdirSync(joinPath(isolatedHome, '.dsh-tui'), { recursive: true })
+
+const [
+  { swallowNestedUpdateOverflow, isNestedUpdateOverflow, callWithUpdateOverflowGuard, resetUpdateOverflowGuardForTest, installNestedUpdateOverflowProcessGuard, registerOverflowQuench },
+  { createClock },
+  { Context },
+  { createChannel },
+  { resetRevealForTest, subscribeReveal, getRevealVersion, revealTextOf },
+  React,
+  { render, Box, Text, useAnimationFrame },
+] = await Promise.all([
+  import('../src/ink/update-overflow-guard.js'),
+  import('../src/ink/components/ClockContext.js'),
+  import('@deepseek-ai/cordis'),
+  import('../src/dsh-adapter/channel.js'),
+  import('../src/components/smoothReveal.js'),
+  import('react'),
+  import('../src/ui.js'),
+])
+void React
+const { Writable, PassThrough } = await import('node:stream')
+const { Terminal: XTerm } = (await import('@xterm/headless')) as unknown as {
+  Terminal: typeof import('@xterm/headless').Terminal
+}
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms))
+
+const COLS = 80, ROWS = 12
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  constructor(private term: XTerm.Terminal) { super() }
+  override _write(chunk: unknown, _e: BufferEncoding, cb: () => void): void { this.term.write(String(chunk), cb) }
+}
+class FakeInput extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  override ref(): this { return this }
+  override unref(): this { return this }
+}
+
+// --- Group A: units ---------------------------------------------------------
+console.log('--- A: guard units ---')
+resetUpdateOverflowGuardForTest()
+const prodErr = new Error('Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.')
+const devErr = new Error('Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.')
+check('A1 识别 production #185', isNestedUpdateOverflow(prodErr))
+check('A1 识别 dev 消息', isNestedUpdateOverflow(devErr))
+check('A1 非 #185 不识别', !isNestedUpdateOverflow(new Error('Minified React error #423')) && !isNestedUpdateOverflow(new Error('ordinary')) && !isNestedUpdateOverflow('not an error'))
+check('A1 吞掉 #185', swallowNestedUpdateOverflow(prodErr, 'test.a'))
+check('A1 其他错误透传', !swallowNestedUpdateOverflow(new Error('boom'), 'test.a'))
+
+// 限流：同窗口第二条被吞但不重复打日志（这里只验证行为不受限流影响，
+// 日志限流由 stderr 输出人工抽查；断言层面两个都返回 true）。
+check('A2 限流窗口内仍吞', swallowNestedUpdateOverflow(prodErr, 'test.a') && swallowNestedUpdateOverflow(prodErr, 'test.a'))
+// 不同 source 独立。
+check('A2 不同 source 独立', swallowNestedUpdateOverflow(prodErr, 'test.b'))
+
+// callWithUpdateOverflowGuard：#185 不冒泡、其他错误原样抛。
+let rethrown: unknown
+try { callWithUpdateOverflowGuard('test.c', () => { throw prodErr }) } catch { rethrown = 'caught' }
+check('A3 守卫回调吞 #185', rethrown === undefined)
+try { callWithUpdateOverflowGuard('test.c', () => { throw new Error('boom') }) } catch (e) { rethrown = e }
+check('A3 守卫回调透传其他', rethrown instanceof Error && (rethrown as Error).message === 'boom')
+
+// A4 进程级兜底：安装幂等；手动派发一次 #185 uncaughtException 不杀进程
+// （守卫吸收）；DSH_TUI_NO_185_PROCESS_GUARD 逃生门跳过安装。
+installNestedUpdateOverflowProcessGuard()
+installNestedUpdateOverflowProcessGuard() // 幂等，不重复装
+let processSurvived = true
+try { process.emit('uncaughtException', prodErr) } catch { processSurvived = false }
+check('A4 进程兜底吸收 #185（进程存活）', processSurvived)
+
+// A5 熔断：同源 5 次触发 → 调用已注册 quench（5s）；未注册 quench 的源
+// 只升级日志不熔断（channel 数据通道不可停）。
+{
+  resetUpdateOverflowGuardForTest()
+  const quenched: number[] = []
+  registerOverflowQuench('test.quench', ms => { quenched.push(ms) })
+  for (let i = 0; i < 4; i++) swallowNestedUpdateOverflow(prodErr, 'test.quench')
+  check('A5 阈值以下不熔断', quenched.length === 0, `n=${quenched.length}`)
+  swallowNestedUpdateOverflow(prodErr, 'test.quench')
+  check('A5 第 5 次触发熔断（5s）', quenched.length === 1 && quenched[0] === 5000, JSON.stringify(quenched))
+  for (let i = 0; i < 6; i++) swallowNestedUpdateOverflow(prodErr, 'test.noquench')
+  check('A5 无 quench 的源只吞不熔断', swallowNestedUpdateOverflow(prodErr, 'test.noquench'))
+}
+
+// --- Group B: hotspot integration -------------------------------------------
+console.log('--- B: hotspots ---')
+
+// B1 clock.tick: 抛 #185 的订阅者被吞，后续订阅者与后续 tick 正常。
+{
+  resetUpdateOverflowGuardForTest()
+  const clock = createClock(5)
+  let bTicks = 0
+  let threw = false
+  const unsubscribeA = clock.subscribe(() => { threw = true; throw prodErr }, true)
+  const unsubscribeB = clock.subscribe(() => { bTicks++ }, true)
+  let survived = true
+  try { await sleep(40) } catch { survived = false }
+  check('B1 clock.tick 吞 #185 且进程存活', survived && threw && bTicks > 0, `bTicks=${bTicks}`)
+  unsubscribeA()
+  unsubscribeB()
+}
+
+// B5 熔断集成：持续抛 #185 的订阅者 → 5 次后共享时钟被暂停（tick 停摆），
+// 退避窗口内 CPU 风暴被斩断；数据无损（订阅保留，恢复后继续）。
+{
+  resetUpdateOverflowGuardForTest()
+  const clock = createClock(5)
+  let calls = 0
+  const unsubscribe = clock.subscribe(() => { calls++; throw prodErr }, true)
+  await sleep(200) // 5ms tick：~5 次吞后熔断 → suspend 5s
+  const atTrip = calls
+  await sleep(300)
+  check('B5 熔断暂停共享时钟', calls - atTrip <= 1, `calls ${atTrip}→${calls}`)
+  unsubscribe()
+}
+
+// B2 reveal.tick: listener 前几次抛 #185 被吞（次数控制在熔断阈值以下，
+// 熔断语义由 B5 覆盖），游标继续推进直至完成。
+{
+  resetUpdateOverflowGuardForTest()
+  resetRevealForTest()
+  let boomLeft = 4
+  const unsub = subscribeReveal(() => { if (boomLeft-- > 0) throw prodErr })
+  // 创建一个活跃游标（render 期读、active 创建），让 revealTick 有工作。
+  const key = 'verify-185-guard'
+  revealTextOf(key, 'x'.repeat(24), { enabled: true, active: true })
+  const v0 = getRevealVersion()
+  let survived = true
+  try { await sleep(1200) } catch { survived = false }
+  const settled = revealTextOf(key, 'x'.repeat(24), { enabled: true, active: true })
+  check('B2 reveal.tick 吞 #185 且游标推进', survived && getRevealVersion() > v0 && settled.length === 24,
+    `v=${getRevealVersion() - v0} len=${settled.length}`)
+  unsub()
+  resetRevealForTest()
+}
+
+// B3 channel.emit/emitStream：真实 channel + 抛 #185 的订阅者。
+{
+  resetUpdateOverflowGuardForTest()
+  const ctx = new Context()
+  const initial = {
+    id: 'agent-a', status: 'idle', options: {},
+    ctx: { on: () => () => {} },
+    session: { id: 'sess-a', seq: 0, events: [], header: {} },
+    followup() {}, steer() {}, inbox: { remove: () => true }, cancel() {}, whenIdle: () => Promise.resolve(),
+  }
+  const channel = createChannel(ctx as never, initial as never, {
+    model: 'm0', cwd: '/tmp/demo', provider: 'p0', activity: false,
+  })
+  let goodWakeups = 0
+  const unsub = channel.subscribe(() => { goodWakeups++; throw prodErr })
+  let survived = true
+  let detail = ''
+  try { channel.notify('guard probe') } catch (err) { survived = false; detail = `notify: ${(err as Error).message}` }
+  try { channel.pushLocal('guard probe', ['guard probe row']) } catch (err) { survived = false; detail += ` pushLocal: ${(err as Error).message}` }
+  try { await sleep(30) } catch (err) { survived = false; detail += ` sleep: ${(err as Error).message}` }
+  check('B3 channel.emit 吞 #185', survived && goodWakeups > 0, `wakeup=${goodWakeups} ${detail}`)
+  unsub()
+}
+
+// B4 端到端：渲染树上动画订阅者抛 #185，UI 不死、后续帧恢复。
+{
+  resetUpdateOverflowGuardForTest()
+  resetRevealForTest()
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const stdout = new FakeStdout(term) as unknown as NodeJS.WriteStream
+  let frames = 0
+  function Scene(): React.ReactNode {
+    // 直接挂一个订阅共享时钟的组件；其 onChange 不抛（守卫冒烟）——
+    // 抛错路径由 B1-B3 覆盖，这里验证守卫在真实 reconciler 下零干扰。
+    const [, time] = useAnimationFrame(40)
+    frames++
+    return <Box><Text>{Math.floor(time / 40) % 10}</Text></Box>
+  }
+  const instance = await render(<Scene />, {
+    stdout, stdin: new FakeInput() as unknown as NodeJS.ReadStream,
+    exitOnCtrlC: false, patchConsole: false,
+  })
+  await sleep(300)
+  const alive = frames > 3
+  await instance.unmount()
+  term.dispose()
+  check('B4 真实渲染零干扰（守卫不破坏正常动画）', alive, `frames=${frames}`)
+  resetRevealForTest()
+}
+
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILED`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -22,7 +22,8 @@ import { stringWidth } from '../ink/stringWidth.js'
 import { truncateToWidth } from '../ink/truncateToWidth.js'
 import { clipPreview, type TimelineSnapshot, type TimelineTurn } from '../ink/timeline-rail.js'
 import type { ToolBackground } from '../tuiDisplayPrefs.js'
-import { getRevealVersion, revealLengthOf, revealTextOf, subscribeReveal } from './smoothReveal.js'
+import { getRevealVersion, revealLengthOf, revealTextOf } from './smoothReveal.js'
+import { useRevealVersion } from '../hooks/useRevealVersion.js'
 
 /**
  * Transcript rows rendered in the Claude Code visual language: user prompts
@@ -430,13 +431,17 @@ export function MessageList({
 
   // --- layout virtualization ---------------------------------------------
   const { columns, rows: termRows } = useTerminalSize()
-  // Smooth-reveal wakeups: the scheduler's tick bumps this store, re-running
+  // Smooth-reveal wakeups: the scheduler's tick bumps this hook, re-running
   // MessageList so the revealed `text`/line-count reads below feed fresh
   // values through the same MemoRow-prop pipeline an arriving chunk uses —
   // memo miss → re-render → post-commit height re-measure. Without this
   // subscription a reveal living in child state would change row heights
   // invisibly to the virtualization (stale cached heights → blank bands).
-  React.useSyncExternalStore(subscribeReveal, getRevealVersion)
+  // DefaultLane on purpose (useRevealVersion): a useSyncExternalStore wakeup
+  // would force a SyncLane render per 33ms tick, and each such commit ending
+  // with streaming work still pending feeds React's nested-update counter
+  // until error #185 kills the process (beta.3).
+  useRevealVersion()
   // Measured row heights, remembered after a row unmounts so virtualization
   // can compute total content height. Bounded: row ids grow monotonically
   // and rows are never removed from the transcript (foldRows keeps the
@@ -933,18 +938,32 @@ export function MessageList({
     upId: upTurnIndex === null ? null : timelineTurns[upTurnIndex]!.id,
     downId: downTurnIndex === null ? null : timelineTurns[downTurnIndex]!.id,
   }
-  const lastTimelineReportRef = React.useRef('')
+  const lastTimelineReportRef = React.useRef<TimelineSnapshot | null>(null)
   React.useEffect(() => {
-    // O(1) signature: the memo key pins the turns' geometry identity
-    // (heights/window/base/rows-length) and the three ids pin the
-    // viewport-derived targets. Any top change bumps the geometry key, so
-    // the report still fires exactly when the snapshot content changes —
-    // without rebuilding an O(turns) joined string per commit.
-    const sig = `${timelineMemoRef.current?.key ?? ''}#a${timeline.activeId}#u${timeline.upId}#d${timeline.downId}`
-    if (sig !== lastTimelineReportRef.current) {
-      lastTimelineReportRef.current = sig
-      onTimeline?.(timeline)
-    }
+    // Value-level dedup, not geometry-key-level: the memo key pins to
+    // heightsVersion, which a GROWING streamed row bumps on every commit,
+    // so a key-pinned signature re-reports an identical snapshot every
+    // commit of a long stream. Each report is a setState dispatched into
+    // Chat from this passive effect; it lands as pending residue at commit
+    // end, keeping the commit dirty and feeding React's nested-update
+    // counter (50 consecutive dirty commits → error #185, the beta.3
+    // crash). The O(turns) compare below is integer/string-reference
+    // compares only — cheap next to the joined-string signature the memo
+    // key replaced, and it fires exactly when the snapshot content changes.
+    const prev = lastTimelineReportRef.current
+    if (
+      prev !== null &&
+      prev.activeId === timeline.activeId &&
+      prev.upId === timeline.upId &&
+      prev.downId === timeline.downId &&
+      prev.turns.length === timeline.turns.length &&
+      prev.turns.every((t, i) => {
+        const n = timeline.turns[i]!
+        return t.id === n.id && t.top === n.top && t.folded === n.folded && t.preview === n.preview
+      })
+    ) return
+    lastTimelineReportRef.current = timeline
+    onTimeline?.(timeline)
   })
 
   // Post-commit: measure mounted rows, derive the content-space base from

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -12,10 +12,8 @@ import { formatDuration } from '../../cc/format.js'
 import type { ToolBackground } from '../../tuiDisplayPrefs.js'
 import type { Theme } from '../../theme.js'
 import type { ClickEvent } from '../../ink/events/click-event.js'
-import { getRevealVersion, revealLinesOf, snapReveal, subscribeReveal } from '../smoothReveal.js'
-
-const NOOP_REVEAL_SUBSCRIBE = (_listener: () => void): (() => void) => () => {}
-const getNoRevealVersion = (): number => 0
+import { revealLinesOf, snapReveal } from '../smoothReveal.js'
+import { useRevealVersion } from '../../hooks/useRevealVersion.js'
 
 type Props = {
   tool: ToolRow
@@ -428,10 +426,10 @@ export function AssistantToolUseMessage({
   // MessageList owns the single production subscription and passes a version
   // prop only to active reveal rows. Standalone consumers keep the fallback
   // subscription so the component contract remains self-contained.
-  React.useSyncExternalStore(
-    revealVersion === undefined ? subscribeReveal : NOOP_REVEAL_SUBSCRIBE,
-    revealVersion === undefined ? getRevealVersion : getNoRevealVersion,
-  )
+  // DefaultLane on purpose (useRevealVersion): a useSyncExternalStore wakeup
+  // forces a SyncLane render per tick, and repeated sync commits ending with
+  // streaming work pending feed React's nested-update counter (error #185).
+  useRevealVersion(revealVersion === undefined)
   const isRunning = tool.status === 'running'
   const isError = tool.status === 'error'
   const displayArgs = verbose ? tool.argsFull ?? tool.argsText : tool.argsText

--- a/src/components/smoothReveal.ts
+++ b/src/components/smoothReveal.ts
@@ -38,6 +38,7 @@
  * chains) may briefly show a partial cluster mid-reveal — transient frames
  * repaint within 33ms, and settled rendering is always the full text.
  */
+import { registerOverflowQuench, swallowNestedUpdateOverflow } from '../ink/update-overflow-guard.js'
 
 /** Reveal tick cadence — ~30fps, matching oh-my-pi's controller. */
 export const REVEAL_FRAME_MS = 1000 / 30
@@ -124,6 +125,23 @@ function stopRevealTimerIfIdle(): void {
   }
 }
 
+// Circuit-breaker quench: a sustained #185 oscillation surfacing at the
+// reveal tick pauses this scheduler for the backoff window (cursors freeze
+// in place; the resume timer — or a later render reading an active cursor —
+// restarts it). Absorbing forever would leave the process alive but laggy.
+registerOverflowQuench('reveal.tick', ms => {
+  if (revealTimer !== undefined) {
+    clearInterval(revealTimer)
+    revealTimer = undefined
+    const resume = setTimeout(() => {
+      if (revealTimer === undefined && (textCursors.size > 0 || countCursors.size > 0)) {
+        ensureRevealTimer()
+      }
+    }, ms)
+    resume.unref?.()
+  }
+})
+
 function revealTick(): void {
   let advanced = false
   for (const [key, cursor] of textCursors) {
@@ -147,7 +165,15 @@ function revealTick(): void {
   }
   if (advanced) {
     revealVersionValue += 1
-    for (const listener of [...revealListeners]) listener()
+    // #185 self-heal: a forceStoreRerender enqueue can surface the overflow
+    // here; React resets the counter on throw, so absorb and drop the tick.
+    for (const listener of [...revealListeners]) {
+      try {
+        listener()
+      } catch (error) {
+        if (!swallowNestedUpdateOverflow(error, 'reveal.tick')) throw error
+      }
+    }
   } else {
     stopRevealTimerIfIdle()
   }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -14,6 +14,7 @@ import {
 import { runSideQuestion, wrapSideQuestion } from './sideQuestion.js'
 import { isReservedCredentialRef } from './credentialRefGuard.js'
 import { collectRecentActivity, parseRecapResponse, RECAP_RECENT_CHARS, wrapRecapPrompt, type RecapOutcome } from './recap.js'
+import { swallowNestedUpdateOverflow } from '../ink/update-overflow-guard.js'
 import { SESSION_COLOR_NAMES } from '../cc/sessionColors.js'
 import { fetchBalance, type BalanceResult } from '../deepseekBalance.js'
 import { isPeakHour } from '../deepseekPricing.js'
@@ -3272,7 +3273,16 @@ export function createChannel(
     emit() {
       foldRows(state.rows, MAX_ROWS, foldCursor)
       state.version += 1
-      for (const listener of listeners) listener()
+      // #185 self-heal: a forceStoreRerender enqueue can surface React's
+      // nested-update overflow here; React resets the counter on throw, so
+      // absorb it and let the next wakeup render with a clean slate.
+      for (const listener of listeners) {
+        try {
+          listener()
+        } catch (error) {
+          if (!swallowNestedUpdateOverflow(error, 'channel.emit')) throw error
+        }
+      }
     },
     // Frame-aligned notification for streaming deltas. LLM chunks arrive at
     // 100-300 events/s (one per token); waking React synchronously per event
@@ -3290,7 +3300,15 @@ export function createChannel(
         // the listeners wake so React reads fully projected rows.
         flushSubagentStream()
         foldRows(state.rows, MAX_ROWS, foldCursor)
-        for (const listener of listeners) listener()
+        // Same #185 self-heal as emit(): this timer is the busiest enqueue
+        // site during streaming, so the overflow most often surfaces here.
+        for (const listener of listeners) {
+          try {
+            listener()
+          } catch (error) {
+            if (!swallowNestedUpdateOverflow(error, 'channel.emitStream')) throw error
+          }
+        }
       }, 16)
       // Never hold the process open for a pending UI wakeup.
       timer.unref()

--- a/src/hooks/useExternalVersion.ts
+++ b/src/hooks/useExternalVersion.ts
@@ -36,12 +36,22 @@ export function useExternalVersion(
   enabled: boolean = true,
 ): number {
   const [version, setVersion] = React.useState(getVersion)
+  // Latest-refs, NOT effect deps: callers pass inline closures (e.g.
+  // `() => channel.version`), and a fresh reference per render would re-run
+  // the effect after EVERY render — re-subscribing and dispatching
+  // setVersion(getVersion()) from the passive effect. On a slow machine
+  // (CI) each re-run can land while the version changed again, chaining
+  // passive updates until React's dev-build nested-update check throws
+  // "Maximum update depth exceeded". Subscribe exactly once per enabled
+  // window; the listener reads the fresh getter through the ref.
+  const latest = React.useRef({ subscribe, getVersion })
+  latest.current = { subscribe, getVersion }
   React.useEffect(() => {
     if (!enabled) return
     // Catch up on any store change between the first render and this
     // effect's mount — the subscription alone would miss it.
-    setVersion(getVersion())
-    return subscribe(() => setVersion(getVersion()))
-  }, [subscribe, getVersion, enabled])
+    setVersion(latest.current.getVersion())
+    return latest.current.subscribe(() => setVersion(latest.current.getVersion()))
+  }, [enabled])
   return version
 }

--- a/src/hooks/useExternalVersion.ts
+++ b/src/hooks/useExternalVersion.ts
@@ -1,0 +1,47 @@
+import React from 'react'
+
+/**
+ * Subscribe to an external store's version counter at DEFAULT lane.
+ *
+ * Deliberately NOT useSyncExternalStore for HIGH-FREQUENCY stores: a store
+ * change forces a SYNCLANE re-render (forceStoreRerender hardcodes lane 2),
+ * and during streaming that sync render preempts/discards whatever
+ * DefaultLane render is in flight. Every such sync commit then ends with
+ * Default work still pending, which React's commit-end lane accounting
+ * counts as a NESTED update with no reset — 50 consecutive dirty commits
+ * throw error #185 from whichever timer dispatches next, killing the
+ * process (the beta.3 crash; same mechanism as useRevealVersion in
+ * PR #680, which fixed the reveal store half of it).
+ *
+ * A manual subscription dispatches setState from the notification callback
+ * at DEFAULT lane instead: the wakeup coalesces into the in-flight render
+ * instead of preempting it, commits end clean, and the counter resets.
+ *
+ * The store's DATA stays synchronous to read during render (callers read
+ * the store directly — rows, status, whatever); the version number is only
+ * a render trigger, its value carries no meaning. This is safe against a
+ * one-beat-stale version: the next wakeup re-reads fresh data, and version
+ * counters are monotonic. Not a general useSyncExternalStore replacement —
+ * use it for version-counter wakeups where the caller re-reads the store
+ * during render anyway (mirrors the tearing analysis in useRevealVersion).
+ *
+ * @param subscribe - Store subscribe(fn) → unsubscribe.
+ * @param getVersion - Returns the store's monotonic version counter.
+ * @param enabled - Pass false to idle (no subscription).
+ * @returns The version number (trigger only; may trail by one wakeup).
+ */
+export function useExternalVersion(
+  subscribe: (listener: () => void) => () => void,
+  getVersion: () => number,
+  enabled: boolean = true,
+): number {
+  const [version, setVersion] = React.useState(getVersion)
+  React.useEffect(() => {
+    if (!enabled) return
+    // Catch up on any store change between the first render and this
+    // effect's mount — the subscription alone would miss it.
+    setVersion(getVersion())
+    return subscribe(() => setVersion(getVersion()))
+  }, [subscribe, getVersion, enabled])
+  return version
+}

--- a/src/hooks/useRevealVersion.ts
+++ b/src/hooks/useRevealVersion.ts
@@ -1,0 +1,33 @@
+import React from 'react'
+import { getRevealVersion, subscribeReveal } from '../components/smoothReveal.js'
+
+/**
+ * Reveal-frame wakeup as a React hook — bumps once per advancing ~30fps
+ * scheduler tick so consumers re-run their render-phase cursor reads
+ * ({@link revealTextOf}/{@link revealLinesOf}) and feed fresh slices through
+ * the MemoRow prop pipeline. The returned number is a render trigger only;
+ * its value carries no meaning.
+ *
+ * Deliberately NOT useSyncExternalStore: a store change forces a SYNCLANE
+ * re-render (forceStoreRerender hardcodes lane 2), and at 30fps that sync
+ * render preempts/discards whatever DefaultLane streaming render is in
+ * flight. Every such sync commit then ends with Default work still pending,
+ * which React's commit-end lane accounting counts as a NESTED update —
+ * 50 consecutive dirty commits throw error #185 from whichever timer
+ * dispatches next, killing the process (beta.3 crash). A manual subscription
+ * dispatches setState from the tick callback at DEFAULT lane instead (no
+ * current event → resolveEventPriority → DefaultEventPriority): the wakeup
+ * coalesces into the in-flight render instead of preempting it, so ticks
+ * collapse into one render per window and commits end clean.
+ */
+export function useRevealVersion(enabled: boolean = true): number {
+  const [version, setVersion] = React.useState(getRevealVersion)
+  React.useEffect(() => {
+    if (!enabled) return
+    // Catch up on any tick that fired between the first render and this
+    // effect's mount — the subscription alone would miss it.
+    setVersion(getRevealVersion())
+    return subscribeReveal(() => setVersion(getRevealVersion()))
+  }, [enabled])
+  return version
+}

--- a/src/ink/components/ClockContext.tsx
+++ b/src/ink/components/ClockContext.tsx
@@ -3,10 +3,17 @@ import React, { createContext, useEffect, useState } from 'react';
 import { FRAME_INTERVAL_MS } from '../constants.js';
 import { noteFrameCause } from '../geometry-trace.js';
 import { useTerminalFocus } from '../hooks/use-terminal-focus.js';
+import { callWithUpdateOverflowGuard, registerOverflowQuench } from '../update-overflow-guard.js';
 export type Clock = {
   subscribe: (onChange: () => void, keepAlive: boolean) => () => void;
   now: () => number;
   setTickInterval: (ms: number) => void;
+  /**
+   * Pause the clock for `ms` (circuit-breaker quench, see
+   * update-overflow-guard). Animations freeze for the window; no data is
+   * lost — consumers re-read fresh values on the next tick after resume.
+   */
+  suspend: (ms: number) => void;
 };
 export function createClock(tickIntervalMs: number): Clock {
   const subscribers = new Map<() => void, boolean>();
@@ -20,7 +27,9 @@ export function createClock(tickIntervalMs: number): Clock {
     tickTime = Date.now() - startTime;
     noteFrameCause('animation');
     for (const onChange of subscribers.keys()) {
-      onChange();
+      // #185 self-heal: a thrown overflow resets React's nested-update
+      // counter, so absorbing it here drops at most one animation frame.
+      callWithUpdateOverflowGuard('clock.tick', onChange);
     }
   }
   function updateInterval(): void {
@@ -39,7 +48,19 @@ export function createClock(tickIntervalMs: number): Clock {
       interval = null;
     }
   }
-  return {
+  function suspendFor(ms: number): void {
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+    // Resume after the backoff window. unref: a paused clock must never
+    // hold the process open by itself.
+    const resume = setTimeout(() => {
+      updateInterval();
+    }, ms);
+    resume.unref?.();
+  }
+  const clock: Clock = {
     subscribe(onChange, keepAlive) {
       subscribers.set(onChange, keepAlive);
       updateInterval();
@@ -65,8 +86,14 @@ export function createClock(tickIntervalMs: number): Clock {
       if (ms === currentTickIntervalMs) return;
       currentTickIntervalMs = ms;
       updateInterval();
-    }
+    },
+    suspend: suspendFor
   };
+  // Circuit-breaker quench: a sustained #185 oscillation at this tick
+  // pauses the shared clock instead of being absorbed forever (which would
+  // leave the process alive but burning CPU on the oscillation's commits).
+  registerOverflowQuench('clock.tick', ms => clock.suspend(ms));
+  return clock;
 }
 export const ClockContext = createContext<Clock | null>(null);
 const BLURRED_TICK_INTERVAL_MS = FRAME_INTERVAL_MS * 2;

--- a/src/ink/components/ScrollBox.tsx
+++ b/src/ink/components/ScrollBox.tsx
@@ -6,6 +6,7 @@ import type { DOMElement } from '../dom.js';
 import { markDirty, scheduleRenderFrom } from '../dom.js';
 import { noteFrameCause } from '../geometry-trace.js';
 import { markCommitStart } from '../reconciler.js';
+import { swallowNestedUpdateOverflow } from '../update-overflow-guard.js';
 import type { WheelEvent } from '../events/wheel-event.js';
 import type { Styles } from '../styles.js';
 import Box from './Box.js';
@@ -104,7 +105,15 @@ function ScrollBox({
   // clearing, subscriber notify) instead of duplicating its logic.
   const handleRef = useRef<ScrollBoxHandle | null>(null);
   const notify = () => {
-    for (const l of listenersRef.current) l();
+    // #185 self-heal: scroll subscribers drive React state (setScrollTick);
+    // a thrown overflow here resets React's nested counter — absorb it.
+    for (const l of listenersRef.current) {
+      try {
+        l();
+      } catch (error) {
+        if (!swallowNestedUpdateOverflow(error, 'scrollbox.notify')) throw error;
+      }
+    }
   };
   // Input-edge intent coalescing (Qwen Code's 16ms wheel merge, Crush's
   // pre-queue filter): subscribers drive React state (MessageList's mount

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -17,6 +17,7 @@ import type { CursorDeclaration, CursorDeclarationSetter } from './components/Cu
 import { FRAME_INTERVAL_MS, PTY_BACKLOG_BYTES } from './constants.js';
 import * as dom from './dom.js';
 import { beginGeometryFrame, endGeometryFrame, GEOMETRY_TRACE_ENABLED, noteFrameCause } from './geometry-trace.js';
+import { callWithUpdateOverflowGuard, installNestedUpdateOverflowProcessGuard } from './update-overflow-guard.js';
 import { KeyboardEvent } from './events/keyboard-event.js';
 import type { DragEvent } from './events/drag-event.js';
 import { FocusManager } from './focus.js';
@@ -315,6 +316,11 @@ export default class Ink {
     // onRecoverableError
     noop // onDefaultTransitionIndicator
     );
+    // #185 process backstop: the nested-update overflow can surface from any
+    // timer dispatch (not only the guarded hotspots), which would kill the
+    // process. React resets the counter before throwing, so absorbing the
+    // error class process-wide is safe — see update-overflow-guard.ts.
+    installNestedUpdateOverflowProcessGuard();
     if (process.env.NODE_ENV === 'development') {
       reconciler.injectIntoDevTools({
         bundleType: 0,
@@ -736,8 +742,8 @@ export default class Ink {
         // copy/escape hint disappears. notifySelectionChange() would
         // recurse into onRender; fire the listeners directly — they
         // schedule a React update for LATER, they don't re-enter this
-        // frame.
-        if (cleared) for (const cb of this.selectionListeners) cb();
+        // frame. (#185 self-heal guard: same as selection.notify.)
+        if (cleared) for (const cb of this.selectionListeners) callWithUpdateOverflowGuard('selection.notify', cb);
       }
     }
 
@@ -1699,7 +1705,11 @@ export default class Ink {
   }
   private notifySelectionChange(): void {
     this.renderNow();
-    for (const cb of this.selectionListeners) cb();
+    // #185 self-heal: selection listeners drive React state; an overflow
+    // throw resets React's nested counter, so absorb and keep the rest.
+    for (const cb of this.selectionListeners) {
+      callWithUpdateOverflowGuard('selection.notify', cb);
+    }
   }
 
   /**

--- a/src/ink/update-overflow-guard.ts
+++ b/src/ink/update-overflow-guard.ts
@@ -1,0 +1,184 @@
+/**
+ * Self-healing guard for React's nested-update overflow — Minified React
+ * error #185 ("Maximum update depth exceeded").
+ *
+ * WHY THIS EXISTS — the crash is a ratchet, not a single bad component.
+ * react-reconciler counts consecutive commits that each end with more
+ * pending Sync/InputContinuous/Default-lane updates on the same root
+ * (`nestedUpdateCount`); once 50 commits pass without one that drains the
+ * queue, the NEXT update enqueue throws #185 — from whichever timer or
+ * store notification happens to fire first, which is why the stack points
+ * at an innocent animation tick while the actual oscillating component is
+ * someone else entirely (the upstream fork lineage hit this repeatedly:
+ * Divider measure loops, MessageList streaming measure cascades, and the
+ * sibling projects' identical fixes — Vercel ink's useBoxMetrics deferral
+ * and claude-code's SyntaxHighlightedDiff loop).
+ *
+ * The throw is SELF-HEALING BY CONTRACT: `getRootForUpdatedFiber` resets
+ * `nestedUpdateCount` to 0 and clears `rootWithNestedUpdates` *before*
+ * throwing, so swallowing exactly this error class skips at most one frame
+ * of animation while the next commit starts from a clean counter. That
+ * turns a process-killing crash into a dropped tick plus a rate-limited
+ * diagnostic breadcrumb naming the enqueue site that surfaced it.
+ *
+ * This guard deliberately does NOT swallow anything else: unknown errors
+ * rethrow unchanged.
+ */
+
+import { logError } from '../utils/log.js'
+
+/** Message fragments that identify the nested-update overflow error. */
+const OVERFLOW_MARKERS = ['Minified React error #185', 'Maximum update depth'] as const
+
+/** Window for log rate limiting (ms): first hit logs, the rest just count. */
+const LOG_WINDOW_MS = 10_000
+
+/** Circuit breaker: same source tripping this many times inside one log
+ * window is a SUSTAINED oscillation, not a one-off — absorbing alone would
+ * leave the process alive but burning CPU on the oscillation's own commit
+ * storm. Trip the source's quench (pause its timer) so "alive" cannot
+ * degrade into "alive but very laggy". */
+const TRIP_THRESHOLD = 5
+/** First quench duration (ms); doubles per consecutive trip, capped. */
+const TRIP_BACKOFF_BASE_MS = 5_000
+const TRIP_BACKOFF_MAX_MS = 60_000
+
+/** Quench action for a source: pause its notification channel for `ms`. */
+export type OverflowQuench = (ms: number) => void
+const quenches = new Map<string, OverflowQuench>()
+
+/** Per-source state: log window + circuit-breaker bookkeeping. */
+type SourceState = { windowStart: number; logged: boolean; count: number; trips: number; quenchUntil: number }
+const sources = new Map<string, SourceState>()
+
+/** Test seam: reset rate-limit bookkeeping. */
+export function resetUpdateOverflowGuardForTest(): void {
+  sources.clear()
+}
+
+/**
+ * Register a circuit-breaker action for a source. When the source trips
+ * (sustained oscillation), the quench pauses its notification channel for
+ * the backoff window — the strongest self-healing the guard can do without
+ * killing the process. Sources without a quench (data channels that must
+ * not stall) only get the escalated ERROR log.
+ */
+export function registerOverflowQuench(source: string, quench: OverflowQuench): void {
+  quenches.set(source, quench)
+}
+
+/**
+ * Whether an error is the nested-update overflow (#185) — by message, the
+ * only signal the production build exposes.
+ */
+export function isNestedUpdateOverflow(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return OVERFLOW_MARKERS.some(marker => error.message.includes(marker))
+}
+
+/**
+ * Swallow the nested-update overflow error, logging (rate-limited, with a
+ * running count per window) which enqueue site surfaced it. Any other error
+ * returns false so callers rethrow it untouched.
+ *
+ * @param error - The caught error from a subscriber/enqueue notification.
+ * @param source - Stable label naming the enqueue site (for the log line).
+ * @returns true when the error was the overflow and has been absorbed.
+ */
+export function swallowNestedUpdateOverflow(error: unknown, source: string): boolean {
+  if (!isNestedUpdateOverflow(error)) return false
+  const now = Date.now()
+  let state = sources.get(source)
+  if (state === undefined || now - state.windowStart >= LOG_WINDOW_MS) {
+    state = { windowStart: now, logged: false, count: 0, trips: state?.trips ?? 0, quenchUntil: state?.quenchUntil ?? 0 }
+    sources.set(source, state)
+  }
+  state.count += 1
+  if (!state.logged) {
+    state.logged = true
+    logError(
+      new Error(
+        `Recovered from React nested-update overflow (#185) at ${source} — ` +
+          `dropped 1 update, counter reset by React. If this repeats, a ` +
+          `component is oscillating state updates in a tight commit chain.`,
+      ),
+    )
+  }
+  // Circuit breaker: a SUSTAINED oscillation keeps re-filling React's
+  // counter between absorptions. Swallowing alone would keep the process
+  // alive while the oscillation's commit storm burns the CPU ("alive but
+  // laggy"). Trip the quench instead: pause the source's channel for an
+  // escalating window, freezing at most an animation, never data.
+  if (state.count >= TRIP_THRESHOLD && now >= state.quenchUntil) {
+    state.trips += 1
+    const ms = Math.min(TRIP_BACKOFF_BASE_MS * 2 ** (state.trips - 1), TRIP_BACKOFF_MAX_MS)
+    state.quenchUntil = now + ms
+    state.count = 0
+    const quench = quenches.get(source)
+    if (quench !== undefined) {
+      quench(ms)
+      logError(
+        new Error(
+          `Sustained rendering oscillation at ${source} (#185 x${TRIP_THRESHOLD} in ${LOG_WINDOW_MS / 1000}s) — ` +
+            `its channel is PAUSED for ${ms / 1000}s to break the loop ` +
+            `(trip #${state.trips}, backoff doubles; animations freeze, no data loss). ` +
+            `This is a bug: please report the component involved.`,
+        ),
+      )
+    } else {
+      logError(
+        new Error(
+          `SUSTAINED rendering oscillation at ${source} (#185 x${TRIP_THRESHOLD} in ${LOG_WINDOW_MS / 1000}s, ` +
+            `trip #${state.trips}) — no quench registered for this source, absorbing only. ` +
+            `This is a bug: please report the component involved.`,
+        ),
+      )
+    }
+  }
+  return true
+}
+
+/**
+ * Invoke a notification callback with the overflow guard applied. The
+ * callback's own non-overflow errors propagate unchanged.
+ *
+ * @param source - Stable label naming the enqueue site (for the log line).
+ * @param onChange - The subscriber callback about to run.
+ */
+export function callWithUpdateOverflowGuard(source: string, onChange: () => void): void {
+  try {
+    onChange()
+  } catch (error) {
+    if (swallowNestedUpdateOverflow(error, source)) return
+    throw error
+  }
+}
+
+/**
+ * Process-level backstop for the overflow error. The hotspot guards above
+ * cover the known enqueue sites (clock tick, reveal tick, channel emit,
+ * scroll/selection notify), but the throw surfaces from whichever timer or
+ * microtask dispatches next — any not-yet-guarded path (a script's own
+ * feeder, a future timer, a plugin's store) would still kill the process.
+ * This installs uncaughtException/unhandledRejection handlers that absorb
+ * exactly the overflow error class (same self-healing contract: React
+ * already reset the counter before throwing) and rethrow everything else
+ * unchanged. Idempotent; opt out with DSH_TUI_NO_185_PROCESS_GUARD=1 when a
+ * host owns process error policy.
+ */
+let processGuardInstalled = false
+export function installNestedUpdateOverflowProcessGuard(): void {
+  if (processGuardInstalled) return
+  if (process.env.DSH_TUI_NO_185_PROCESS_GUARD === '1') return
+  processGuardInstalled = true
+  process.on('uncaughtException', error => {
+    if (swallowNestedUpdateOverflow(error, 'process.uncaught')) return
+    // Unknown errors keep Node's default semantics: rethrowing from a
+    // listener crashes the process with the original error.
+    throw error
+  })
+  process.on('unhandledRejection', error => {
+    if (swallowNestedUpdateOverflow(error, 'process.rejection')) return
+    throw error as Error
+  })
+}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -690,17 +690,19 @@ export function Chat({
 
   // Sticky (pinned-to-bottom) scroll state, subscribed imperatively so
   // wheel events don't re-render React — only the header/pill flip.
-  // DEFAULT lane on purpose (useExternalVersion, not useSyncExternalStore):
-  // wheel storms notify at ~16ms cadence and a uSES wakeup would force a
-  // SyncLane render per notify — preempting any in-flight streaming render
-  // and feeding the nested-update counter (the #185 mechanism). The sticky
-  // value is read fresh from the handle during render.
-  const subscribeSticky = React.useCallback(
-    (listener: () => void) => (handle ? handle.subscribe(listener) : () => {}),
-    [handle],
+  // Deliberately KEPT on useSyncExternalStore despite the SyncLane wakeup
+  // cost: the renderer's at-bottom re-pin flips sticky WITHOUT firing the
+  // scroll subscribers (see ScrollBox's subscribe doc), so only uSES's
+  // every-render getSnapshot check picks that flip up — a pure
+  // notification-driven subscription misses it and the new-message pill
+  // stops reflecting reality (repro-pill). Wheel cadence is an
+  // interaction-rate source (not streaming-rate), the streaming-side
+  // #185 sources are all Default-lane now, and the overflow guard
+  // backstops the residue.
+  const isSticky = React.useSyncExternalStore(
+    cb => (handle ? handle.subscribe(cb) : () => {}),
+    () => (handle ? handle.isSticky() : true),
   )
-  useExternalVersion(subscribeSticky, () => (handle ? handle.isSticky() : true) ? 1 : 0)
-  const isSticky = handle ? handle.isSticky() : true
   const subscribeTooltipInvalidation = React.useCallback(
     (listener: () => void) => (handle ? handle.subscribe(listener) : () => {}),
     [handle],

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -98,6 +98,7 @@ import { setClipboard } from '../ink/termio/osc.js'
 import { TerminalWriteContext } from '../ink/useTerminalNotification.js'
 import instances from '../ink/instances.js'
 import { useAnimationFrame } from '../ink/hooks/use-animation-frame.js'
+import { useExternalVersion } from '../hooks/useExternalVersion.js'
 import { TrajectoryScene } from './TrajectoryScene.js'
 import { extendTrajectory, projectWave, type TrajBuild } from '../dsh-adapter/trajectory/index.js'
 import { miniWakeWidth } from '../components/trajectory/MiniWake.js'
@@ -269,7 +270,14 @@ export function Chat({
 }) {
   const writeRaw = React.useContext(TerminalWriteContext)
   // Re-render whenever the channel mutates; rows/status are read fresh below.
-  React.useSyncExternalStore(channel.subscribe, () => channel.version)
+  // DEFAULT lane on purpose (useExternalVersion): the channel version bumps
+  // at streaming cadence (every ~16ms via emitStream), and a useSyncExternalStore
+  // wakeup would force a SyncLane render per bump — each such sync commit
+  // preempting the in-flight Default render and ending with Default work
+  // still pending feeds React's nested-update counter until error #185 kills
+  // the process (beta.3; the reveal-store half was PR #680, this is the
+  // channel half — the surviving source on Windows timer granularity).
+  useExternalVersion(channel.subscribe, () => channel.version)
   // Re-render on language switches so the whole UI hot-swaps its strings.
   React.useSyncExternalStore(subscribeLang, getLang)
   // The pending ask-user-question (DSH user-interaction seam): the model's
@@ -682,10 +690,17 @@ export function Chat({
 
   // Sticky (pinned-to-bottom) scroll state, subscribed imperatively so
   // wheel events don't re-render React — only the header/pill flip.
-  const isSticky = React.useSyncExternalStore(
-    cb => (handle ? handle.subscribe(cb) : () => {}),
-    () => (handle ? handle.isSticky() : true),
+  // DEFAULT lane on purpose (useExternalVersion, not useSyncExternalStore):
+  // wheel storms notify at ~16ms cadence and a uSES wakeup would force a
+  // SyncLane render per notify — preempting any in-flight streaming render
+  // and feeding the nested-update counter (the #185 mechanism). The sticky
+  // value is read fresh from the handle during render.
+  const subscribeSticky = React.useCallback(
+    (listener: () => void) => (handle ? handle.subscribe(listener) : () => {}),
+    [handle],
   )
+  useExternalVersion(subscribeSticky, () => (handle ? handle.isSticky() : true) ? 1 : 0)
+  const isSticky = handle ? handle.isSticky() : true
   const subscribeTooltipInvalidation = React.useCallback(
     (listener: () => void) => (handle ? handle.subscribe(listener) : () => {}),
     [handle],


### PR DESCRIPTION
## 背景

beta.3 流式期间偶发 `Minified React error #185`（Maximum update depth exceeded）杀进程。#662/#669 各修掉一条环路后仍有残留——崩点（ClockContext tick / spinner / 投喂定时器）纯时序巧合，栈上的组件不是凶手。

## 根因（与 #680 独立调查交叉验证达成同解）

`useSyncExternalStore` 的 store 唤醒走 `forceStoreRerender`——**硬编码 SyncLane 强制同步渲染**。流式期间高频源每次唤醒都抢占在途的 DefaultLane 渲染，同步 commit 收尾时被打断的工作仍 pending，被 React commit-end lane 规则（`(lanes & 261930) && (remainingLanes & 42)`）计为嵌套更新且不复位；连续 50 次脏 commit 后下一次 setState 入队抛 #185。轻负载时干净 commit 复位计数 →「有时候崩」。

## 修复 A：消除全部已知高频源（commit 1）

| 源 | 频率 | 修法 |
|---|---|---|
| smoothReveal 唤醒 | 30fps | `useRevealVersion` 手动订阅 + DefaultLane setState（**与 #680 同方案**，含 MessageList + AssistantToolUseMessage 回退两处） |
| Chat channel 订阅 | 流式 ~16ms/拍 | `useExternalVersion` 同法（新 hook） |
| Chat isSticky（滚轮通知） | ~16ms/拍 | 同法，sticky 值 render 期现读——滚轮浏览历史 + 后台流式并发与主场景同构 |
| MessageList timeline 上报 | 流式行每跳撑高 | 内容级去重（原签名钉在 heightsVersion 上，同一快照每 commit 重报 = commit 残留派发；#680 同款） |

**channel 源单独可致崩的实测反例**：Windows 定时器粒度（15.6ms）下，仅含 #680（reveal 修复）的分支跑本 PR 的复现脚本 5.1s 崩——两源缺一不可，这也是本 PR 不依赖 #680 合并顺序、自包含全部修复的原因。

`verify-auto-recap` 步骤 10 断言去竞态（channel 唤醒改 DefaultLane 排期后 recap 占位帧可单独落屏；#680 同款）。

## 修复 B：#185 自愈守卫三层（commit 2）

React 抛 #185 前自行清零 `nestedUpdateCount`——吸收该错误 = 丢一拍、下一拍自愈。让未知的新振荡源也无法杀死进程：

1. **热点守卫**：五个高频通知入口（clock.tick / reveal.tick / scrollbox.notify / channel.emit+emitStream / selection.notify）吸收 #185 类错误（按 message 识别，其余透传），限流日志带热点名；
2. **进程兜底**：uncaughtException / unhandledRejection 吸收 #185（`DSH_TUI_NO_185_PROCESS_GUARD=1` 逃生门）——任何未覆盖路径的定时器抛错不再杀进程；
3. **熔断退避**：同一热点 10s 窗 ≥5 次触发 = 持续振荡，暂停该源通知通道（动画冻结、数据零损失：clock 暂停共享时钟 / reveal 停调度器；channel 数据通道不可停只升级 ERROR），退避 5s→10s→20s→40s 封顶 60s——「活着但被拖卡」有了自愈上限。

## 与 #680 的关系

reveal 链修法与 `repro-185-reveal.tsx` 与 #680 同源（致敬）；#680 后续补的 channel 链 + timeline 去重与本 PR 等价。**两边任一先合并，另一边 rebase 后重复 hunks 自动消解**（内容相同）。本 PR 的净增量：isSticky 滚轮源、守卫三层（#680 无兜底层）。

## 验证

- 复现矩阵（`NODE_ENV=production`）：beta.3 必崩；只修 reveal 5.1s 崩（Windows）；只修 channel 3 跑 2 崩；**全修后默认参数 3/3、极限参数（FEEDERS=2,3,5 DOC=40）4/4、慢终端参数（DOC=96 FEEDERS=3,5,7,9 COLS=80，未修复时 12s 崩）18.8 分钟流式存活，零守卫介入**；
- 守卫兜底实测：未修复代码 + 仅守卫跑必崩复现 13s 全程存活（#185 被接住自愈）；
- `verify-update-overflow-guard`（A1-A5 单元 + B1-B5 热点集成，含熔断停摆实测）登记 channel-ui 组；
- `pnpm build` 全绿；channel-ui 52/52；render-scroll 32/33（唯一失败 verify-osc8-sanitize 为已登记 Windows 预存，零文件交集）。

## 遗留观察（不在本 PR）

- `PromptEditor` 的节点发布订阅（展开态打字，人速离散事件 ~10/s）仍走 uSES——低频不构成流式级棘轮，守卫兜底，如未来出现问题同法改 `useExternalVersion`；
- question/approval/dialog/status/lang/theme/focus/tooltip/selection 等订阅为事件驱动低频且消费快照值语义，保留 uSES 是正确选择。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability during high-frequency chat updates, streaming responses, scrolling, and terminal rendering.
  - Prevented React nested-update overflow errors from crashing the application.
  - Added automatic recovery and backoff when repeated update overflows occur.
  - Improved streamed-content reveal behavior and reduced unnecessary UI updates.
  - Fixed auto-recap verification to wait for the completed summary instead of an interim status.

- **Tests**
  - Added comprehensive regression checks for overflow handling, reveal behavior, channel activity, and rendering stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->