### PR TITLE
fix(exit): 退出回显窗口收口——两相 shutdown、保序退出写与幂等收尾

### DIFF
--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -384,6 +384,12 @@ the required credentials.
   such as `DSH_TUI_DEBUG`, or the existing `DSH_TUI_RENDER_LOG` frame capture.
 - Preserve raw-mode, cursor, alternate-screen, synchronized-output, mouse,
   focus, and terminal-query cleanup on success, error, interrupt, and teardown.
+  The physical raw-mode restore (`setRawMode(false)`) belongs solely to the
+  exit funnel's conclude phase (`finishExit` → `concludeShutdown`): the
+  error-boundary and Ctrl+C paths must never release it themselves; when
+  React's error unwinding already released it before the latch,
+  `beginShutdown` re-acquires raw mode (tty-local only — no mode-enable
+  sequences are re-emitted) so the settle window is still spent raw (#522).
 - Avoid render-time unbounded collections or per-token/per-frame allocations.
   Streaming sessions are long lived, and this repository has explicit
   regressions for prior OOM and scroll-performance failures.

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -263,6 +263,7 @@ change, also run the closest focused script:
 | Mouse pointer event pipeline (wheel coords/modifier bits, click/hover dispatch, out-of-bounds clamping, pointer-state reset) | `node --import tsx/esm scripts/verify-pointer-events.ts` |
 | Hover event performance (complete interest boundaries, no-interest rect fast path, frame/multi-root invalidation) | `node --import tsx/esm scripts/verify-hover-coalesce.tsx` |
 | Prompt-input mouse selection editing (drag/Shift+click/double-click word select, delete/replace, layered Esc, Ctrl+C copy, CJK wide cells, fold-side clamping) | `node --import tsx/esm scripts/verify-input-selection.tsx` |
+| Exit-funnel terminal cleanup (finishExit: latch → stdout queue barrier → synchronous DISABLE/cleanup writes → raw-mode settle → cooked restore in finally) | `node --import tsx/esm scripts/verify-exit-mouse-disable-order.tsx`, `node --import tsx/esm scripts/verify-exit-mouse-residue.tsx`, `node --import tsx/esm scripts/verify-exit-mouse-cleanup.tsx` |
 
 Most focused scripts invoked with plain `node` import `lib/types/`; run
 `pnpm build` first. Scripts that import TypeScript sources declare the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -295,7 +295,11 @@ TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式�
   诊断。用 opt-in 的 stderr/调试路径（如 `DSH_TUI_DEBUG`）或既有
   `DSH_TUI_RENDER_LOG` 帧捕获。
 - 在成功、错误、中断与收尾时都保持 raw 模式、光标、alt-screen、同步输出、
-  鼠标、焦点与终端查询的清理。
+  鼠标、焦点与终端查询的清理。raw 模式的物理恢复（`setRawMode(false)`）
+  只归退出漏斗的 conclude 阶段（`finishExit` → `concludeShutdown`）：
+  error boundary 与 Ctrl+C 路径不得自行释放；React 错误解卷若在闩锁前
+  已释放，`beginShutdown` 会重新获取（仅 tty 本地模式，不重发启用序列），
+  保证 settle 窗在 raw 态度过（#522）。
 - 避免渲染期无界集合或每 token/每帧分配。流式会话长命，本仓库对先前的 OOM
   与滚动性能失败有明确回归。
 - 布局改动不得让 transcript 内容挤掉输入行与状态行。改动相关路径时演练

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -202,6 +202,7 @@ CI 回归都要跑。窄改动还要跑最近的聚焦脚本：
 | 鼠标指针事件管线（滚轮坐标/修饰位、点击/hover 派发、越界 clamp、指针态重置） | `node --import tsx/esm scripts/verify-pointer-events.ts` |
 | Hover 事件性能（兴趣边界完整、无兴趣矩形快路径、帧边界/多 root 失效） | `node --import tsx/esm scripts/verify-hover-coalesce.tsx` |
 | 输入框鼠标选区编辑（拖选/Shift+click/双击选词/删除替换/Esc 分层/Ctrl+C 复制、CJK 宽字符与 fold 侧钳制） | `node --import tsx/esm scripts/verify-input-selection.tsx` |
+| 退出漏斗终端清理（finishExit：闩锁→stdout 队列 barrier→同步写 DISABLE/清理块→raw 态 settle→finally 恢复 cooked） | `node --import tsx/esm scripts/verify-exit-mouse-disable-order.tsx`、`node --import tsx/esm scripts/verify-exit-mouse-residue.tsx`、`node --import tsx/esm scripts/verify-exit-mouse-cleanup.tsx` |
 
 多数用普通 `node` 调用的脚本 import `lib/types/`——先跑 `pnpm build`。import
 TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式。不要凭

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -158,6 +158,11 @@ const GROUPS = {
 // 字节、不得拉回 raw mode——在途回复与鼠标事件由清理后的 re-drain
 // 吞掉，不再落入 shell。
     ["verify-exit-mouse-residue", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-residue.tsx']],
+// 退出回显窗口回归（#522 的 SSH 慢链路门）：DISABLE_MOUSE 同步写在 raw
+// mode 仍持有时落盘，settle 窗也在 raw 态度过（cooked 恢复只在最后的
+// concludeShutdown）；写前 stdout 队列 barrier 排空预排队帧/ENABLE；
+// 写入失败（fd 与 stream 都抛）仍必进 conclude/handoff/done。
+    ["verify-exit-mouse-disable-order", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-disable-order.tsx']],
 // 组件级拖拽协议回归：无修饰左键 press 捕获 drag target，首动 dragstart、
 // 连续 dragmove、release/focus-out/reset 收尾 dragend；未移动仍走 click，
 // 无 handler 与修饰键区域保留基线文本选择；真实 SGR 管线 + 最小滑块消费者。

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -105,6 +105,10 @@ const sleep = (ms: number): Promise<void> =>
     typeof instance.detachForShutdown === 'function',
   )
   check(
+    'render handle exposes beginShutdown/concludeShutdown (finishExit split phases)',
+    typeof instance.beginShutdown === 'function' && typeof instance.concludeShutdown === 'function',
+  )
+  check(
     'render handle exposes detachStdinForHandoff',
     typeof instance.detachStdinForHandoff === 'function',
   )
@@ -203,7 +207,99 @@ const sleep = (ms: number): Promise<void> =>
 }
 
 // ---------------------------------------------------------------------------
-// 4. serializeDiff keeps the empty-diff contract after the extraction.
+// 4. React error-boundary path: a throwing mount drives componentDidCatch →
+//    handleExit → Ink.unmount, which writes the synchronous cleanup itself
+//    and latches exitCleanupWritten. The finishExit funnel must then SKIP
+//    re-writing the mode resets (exactly one DISABLE_MOUSE_TRACKING and one
+//    EXIT_ALT_SCREEN in the fd trace) while still running latch → settle →
+//    conclude → handoff. finishExit never sees process.stdout swapped here,
+//    so the notice landing in the file also proves the funnel targets the
+//    runtime's own stream (stdout identity, #522).
+// ---------------------------------------------------------------------------
+{
+  const { finishExit } = await import('../src/dsh-adapter/plugin.js')
+  const tmpFile = join(tmpdir(), `dsh-tui-exit-boundary-${process.pid}.out`)
+  const tmpFd = openSync(tmpFile, 'w')
+  const stdout = fakeTTY({ fd: tmpFd })
+  const stdin = new FakeStdin()
+  const stderr = fakeTTY()
+
+  // Throw on the FIRST UPDATE, not on mount: a mount-time throw aborts the
+  // commit before AlternateScreen's insertion effect runs, so the app never
+  // enters the alt screen and the cleanup legitimately omits EXIT_ALT_SCREEN.
+  // The real error-boundary path (#522 crash reports) throws with the app
+  // already running — alt screen active, frames rendered.
+  const Bomb = (): React.ReactElement => {
+    const [boom, setBoom] = React.useState(false)
+    React.useEffect(() => { setBoom(true) }, [])
+    if (boom) throw new Error('render boom')
+    return React.createElement(Text, null, 'running before boom')
+  }
+
+  let renderThrew = false
+  let instance: Awaited<ReturnType<typeof render>> | undefined
+  try {
+    instance = await render(
+      React.createElement(AlternateScreen, null, React.createElement(Bomb)),
+      {
+        stdout,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stderr,
+        exitOnCtrlC: false,
+        patchConsole: true,
+      },
+    )
+    // componentDidCatch → handleExit → Ink.unmount rejects the exit promise;
+    // awaiting it (with catch) is also the sync point for "unmount done".
+    await instance.waitUntilExit().catch(() => {})
+  } catch {
+    renderThrew = true
+  }
+
+  check('error boundary catches the throwing mount (render does not throw out)', !renderThrew && instance !== undefined)
+
+  if (instance) {
+    check('unmount already wrote the exit cleanup (hasWrittenExitCleanup latched)',
+      instance.hasWrittenExitCleanup === true)
+
+    const ctx = { logger: { debug() {} } } as never
+    let done = false
+    let finishThrew = false
+    try {
+      await finishExit(ctx, instance, true, 'hint-boundary', undefined, () => { done = true })
+    } catch {
+      finishThrew = true
+    }
+    closeSync(tmpFd)
+
+    const trace = readFileSync(tmpFile, 'utf8')
+    // React's error unwinding runs <AlternateScreen>'s insertion-effect
+    // cleanup (async writeRaw → stream buffer) before Ink.unmount's writeSync
+    // block, and setAltScreenActive(false) then suppresses unmount's
+    // redundant EXIT_ALT_SCREEN — so EXIT_ALT lands exactly once across BOTH
+    // channels (buffer + fd trace), while the fd trace alone proves whether
+    // finishExit double-wrote its cleanup block (a broken skip would add a
+    // second writeSync DISABLE_MOUSE_TRACKING to the file).
+    const combined = drain(stdout) + trace
+    const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1
+    check('finishExit survives the post-boundary funnel', !finishThrew && done)
+    check('fd trace has exactly one writeSync DISABLE (finishExit skip worked)',
+      count(trace, DISABLE_MOUSE_TRACKING) === 1)
+    check('EXIT_ALT_SCREEN reaches the terminal exactly once (no double write)',
+      count(combined, EXIT_ALT_SCREEN) === 1)
+    check('skip-branch still parks the notice on the runtime stream', trace.includes('hint-boundary'))
+    // The mount itself legitimately enables mouse tracking — the contract is
+    // that nothing re-enables it AFTER the final EXIT_ALT_SCREEN.
+    const postExitTail = combined.slice(combined.lastIndexOf(EXIT_ALT_SCREEN))
+    check('no ENABLE_MOUSE_TRACKING after the final EXIT_ALT_SCREEN', !postExitTail.includes(ENABLE_MOUSE_TRACKING))
+    check('concludeShutdown still ran in the finally (raw mode released)', stdin.isRaw === false)
+  } else {
+    closeSync(tmpFd)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. serializeDiff keeps the empty-diff contract after the extraction.
 // ---------------------------------------------------------------------------
 {
   const sink = new PassThrough() as unknown as NodeJS.WriteStream

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -23,7 +23,7 @@ import { closeSync, openSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
-import { render, AlternateScreen, Text } from '../src/ui.js'
+import { render, AlternateScreen, Text, useInput } from '../src/ui.js'
 import instances from '../src/ink/instances.js'
 import {
   DISABLE_MOUSE_TRACKING,
@@ -44,9 +44,12 @@ const check = (name: string, ok: boolean) => {
 class FakeStdin extends PassThrough {
   isTTY = true
   isRaw = false
+  /** Physical raw-mode transitions with timestamps (performance.now()). */
+  rawTransitions: Array<{ value: boolean; at: number }> = []
 
   setRawMode(value: boolean): this {
     this.isRaw = value
+    this.rawTransitions.push({ value, at: performance.now() })
     return this
   }
 
@@ -228,7 +231,15 @@ const sleep = (ms: number): Promise<void> =>
   // commit before AlternateScreen's insertion effect runs, so the app never
   // enters the alt screen and the cleanup legitimately omits EXIT_ALT_SCREEN.
   // The real error-boundary path (#522 crash reports) throws with the app
-  // already running — alt screen active, frames rendered.
+  // already running — alt screen active, frames rendered. RawHolder is the
+  // realistic raw-mode borrower (PromptInput's useInput): its effect cleanup
+  // runs DURING React's error unwinding — before componentDidCatch — so it
+  // physically releases raw mode before the shutdown latch exists, and the
+  // latch must re-acquire it for the settle window.
+  const RawHolder = (): React.ReactElement => {
+    useInput(() => {})
+    return React.createElement(Text, null, 'raw holder')
+  }
   const Bomb = (): React.ReactElement => {
     const [boom, setBoom] = React.useState(false)
     React.useEffect(() => { setBoom(true) }, [])
@@ -240,7 +251,7 @@ const sleep = (ms: number): Promise<void> =>
   let instance: Awaited<ReturnType<typeof render>> | undefined
   try {
     instance = await render(
-      React.createElement(AlternateScreen, null, React.createElement(Bomb)),
+      React.createElement(AlternateScreen, null, React.createElement(RawHolder), React.createElement(Bomb)),
       {
         stdout,
         stdin: stdin as unknown as NodeJS.ReadStream,
@@ -262,9 +273,18 @@ const sleep = (ms: number): Promise<void> =>
     check('unmount already wrote the exit cleanup (hasWrittenExitCleanup latched)',
       instance.hasWrittenExitCleanup === true)
 
+    // Mid-point, finishExit not yet called: the crash-unmount must have kept
+    // (re-acquired) raw mode — the settle window is only meaningful raw —
+    // and the cleanup bytes must have been written in that state (#522:
+    // cooked+echo before the terminal processes DISABLE is the echo bug).
+    const midTrace = readFileSync(tmpFile, 'utf8')
+    check('raw mode survives the crash-unmount (settle-window precondition)', stdin.isRaw === true)
+    check('crash-unmount wrote DISABLE while raw mode was held', midTrace.includes(DISABLE_MOUSE_TRACKING))
+
     const ctx = { logger: { debug() {} } } as never
     let done = false
     let finishThrew = false
+    const finishStart = performance.now()
     try {
       await finishExit(ctx, instance, true, 'hint-boundary', undefined, () => { done = true })
     } catch {
@@ -293,13 +313,56 @@ const sleep = (ms: number): Promise<void> =>
     const postExitTail = combined.slice(combined.lastIndexOf(EXIT_ALT_SCREEN))
     check('no ENABLE_MOUSE_TRACKING after the final EXIT_ALT_SCREEN', !postExitTail.includes(ENABLE_MOUSE_TRACKING))
     check('concludeShutdown still ran in the finally (raw mode released)', stdin.isRaw === false)
+    // The physical raw-off must happen INSIDE finishExit, after its 150ms
+    // raw-mode settle window — never before the funnel (the pre-fix path
+    // released it in App.handleExit, ahead of the cleanup write itself).
+    const lastOff = stdin.rawTransitions.filter(t => !t.value).at(-1)
+    check('raw-off happened only after the settle window (finishExit-owned)',
+      lastOff !== undefined && lastOff.at - finishStart >= 140)
   } else {
     closeSync(tmpFd)
   }
 }
 
 // ---------------------------------------------------------------------------
-// 5. serializeDiff keeps the empty-diff contract after the extraction.
+// 5. unmount() on a TTY-like stream WITHOUT an fd must write the cleanup to
+//    the stream's own ordered queue — never writeSync(1): fd 1 belongs to
+//    the host process, so a wrapped/embedder stream would lose every reset
+//    while its enable writes still reached the TTY (#522 review). The queued
+//    fallback also preserves frame → EXIT_ALT_SCREEN ordering for free.
+//    (Pre-fix, this stream captured NOTHING — the bytes went to real fd 1.)
+// ---------------------------------------------------------------------------
+{
+  class NoFdTty extends PassThrough {
+    isTTY = true
+    columns = 40
+    rows = 10
+    // Explicitly no `fd` property.
+  }
+  const stdout = new NoFdTty() as unknown as NodeJS.WriteStream
+  const stdin = new FakeStdin()
+  const instance = await render(
+    React.createElement(AlternateScreen, null, React.createElement(Text, null, 'no-fd cleanup target')),
+    {
+      stdout,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      exitOnCtrlC: false,
+      patchConsole: true,
+    },
+  )
+  drain(stdout)
+  instance.unmount()
+  const out = drain(stdout)
+  check('no-fd unmount writes EXIT_ALT_SCREEN to the stream itself', out.includes(EXIT_ALT_SCREEN))
+  check('no-fd unmount writes DISABLE_MOUSE_TRACKING to the stream itself', out.includes(DISABLE_MOUSE_TRACKING))
+  check('no-fd unmount orders EXIT_ALT_SCREEN before DISABLE',
+    out.indexOf(EXIT_ALT_SCREEN) !== -1 && out.indexOf(EXIT_ALT_SCREEN) < out.indexOf(DISABLE_MOUSE_TRACKING))
+  // An external (funnel-less) unmount must restore cooked mode itself.
+  check('external unmount restores cooked mode (no funnel follows)', stdin.isRaw === false)
+}
+
+// ---------------------------------------------------------------------------
+// 6. serializeDiff keeps the empty-diff contract after the extraction.
 // ---------------------------------------------------------------------------
 {
   const sink = new PassThrough() as unknown as NodeJS.WriteStream

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -341,8 +341,14 @@ const sleep = (ms: number): Promise<void> =>
   }
   const stdout = new NoFdTty() as unknown as NodeJS.WriteStream
   const stdin = new FakeStdin()
+  // A real raw-mode borrower (useInput) so the unmount must actually detach
+  // the readable pump — without it the listener-leak checks below are vacuous.
+  const RawHolder = (): React.ReactElement => {
+    useInput(() => {})
+    return React.createElement(Text, null, 'holder')
+  }
   const instance = await render(
-    React.createElement(AlternateScreen, null, React.createElement(Text, null, 'no-fd cleanup target')),
+    React.createElement(AlternateScreen, null, React.createElement(RawHolder), React.createElement(Text, null, 'no-fd cleanup target')),
     {
       stdout,
       stdin: stdin as unknown as NodeJS.ReadStream,
@@ -359,6 +365,11 @@ const sleep = (ms: number): Promise<void> =>
     out.indexOf(EXIT_ALT_SCREEN) !== -1 && out.indexOf(EXIT_ALT_SCREEN) < out.indexOf(DISABLE_MOUSE_TRACKING))
   // An external (funnel-less) unmount must restore cooked mode itself.
   check('external unmount restores cooked mode (no funnel follows)', stdin.isRaw === false)
+  // ...and the App-level conclude must run even though React already nulled
+  // the ref during teardown: a leaked latched pump keeps draining a shared
+  // stdin in drain-only mode and starves the next mounted instance (#522 CI:
+  // verify-session-tree / verify-help-scroll remount-on-shared-stdin).
+  check('external unmount detaches the stdin readable pump', stdin.listenerCount('readable') === 0)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/verify-exit-mouse-disable-order.tsx
+++ b/scripts/verify-exit-mouse-disable-order.tsx
@@ -1,0 +1,432 @@
+/**
+ * 退出回显窗口回归：finishExit 必须把 150ms settle 窗放在 raw mode 仍
+ * 持有时度过——先闩锁（beginShutdown：停掉一切输出生产者，但不恢复
+ * cooked），再经 stdout 队列 barrier 排空预排队字节，有序写
+ * DISABLE_MOUSE_TRACKING 与清理块，settle 后才在 finally 里
+ * concludeShutdown 恢复 cooked+echo。且退出写必须永不抛、永不乱序：
+ * 失败也不能跳过 cooked 恢复与 stdin 交接，barrier 超时也不能让
+ * direct-fd 写越过仍在排队的迟到字节。
+ *
+ * 症状：SSH 链路卡顿/写阻塞时触发退出（含"自动退出"），冻结的 TUI 画面
+ * 上、prompt 框里冒出 `^[[<35;130;47M` 之类 caret 记法的 SGR 鼠标报文
+ * ——内核 canonical+ECHOCTL 把终端仍在发送的鼠标报文回显在停泊光标处。
+ * writeSync 只证明字节进了内核 tty 缓冲，不代表远端终端已处理；若
+ * cooked 恢复先于 settle 窗结束，窗口内到达的报文就被回显（#522）。
+ *
+ * 场景蒸馏（无需真 tty / 慢链路）：
+ *   A. TTY 路径（fake stdout 持真实文件 fd，新形分相 runtime 携带自身
+ *      stdout 与 raw 状态）：闩锁先于 DISABLE 落盘；settle 窗在 raw 态
+ *      度过（drain 发生时 isRaw 仍为 true）；raw-off（conclude）时刻
+ *      DISABLE 已在盘且距入口 ≥140ms（旧实现 detach 立即 raw-off，≈0
+ *      必红）；事件序 begin→drain→conclude→handoff；两笔退出写全部走
+ *      writeSync（零异步 stream write）。
+ *   B. 无 fd 的 fake stdout（自定义 embedder / 回归替身）：回退有序
+ *      stream 写，顺序约束不变——begin 先于 DISABLE、DISABLE 先于
+ *      EXIT_ALT_SCREEN、字节完整、conclude/handoff/done 均执行。
+ *   C. 写入全灭（无效 fd + _write 抛错）且 concludeShutdown 抛错
+ *      （模拟 TTY 被撤销）：begin/conclude/handoff/done 仍全部被调用
+ *      ——handoff 不被 conclude 的异常跳过（/update 子进程不能撞上
+ *      残留 readable pump，#284/#307）。
+ *   D. stdout 队列 barrier（显式 Promise gate 挂起预排队的
+ *      ENABLE_MOUSE_TRACKING + 帧标记）：gate 未开前 DISABLE 绝不落盘
+ *      （无时序假设——DISABLE 只在 barrier 放行后写出）；最终字节流
+ *      ENABLE 在 DISABLE 前、帧标记在 EXIT_ALT_SCREEN 前，且
+ *      EXIT_ALT_SCREEN 之后的尾部无 ENABLE/帧。
+ *   E. barrier 超时（gate 1100ms 才开 > 1s 上限）：退出序列切换为有序
+ *      stream 写，跟在迟到 ENABLE/帧之后——最终字节序仍然
+ *      ENABLE→帧→DISABLE→EXIT_ALT_SCREEN，flush 等到全部落盘
+ *      （旧实现 barrier 超时后 writeSync 越过队列，ENABLE 落在
+ *      EXIT_ALT_SCREEN 之后）。
+ *   F. stdout identity drift：render handle 的 runtime 属于流 A，而
+ *      process.stdout 已被宿主换成流 B（B 还有挂起队列）——barrier 与
+ *      全部清理写必须作用于 A，B 零字节、零等待。
+ *
+ * Run: node --import tsx/esm scripts/verify-exit-mouse-disable-order.tsx
+ */
+import { closeSync, openSync, readFileSync, rmSync, writeSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Writable } from 'node:stream'
+import { finishExit } from '../src/dsh-adapter/plugin.js'
+import instances from '../src/ink/instances.js'
+import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, EXIT_ALT_SCREEN } from '../src/ink/termio/dec.js'
+
+let failures = 0
+const results: string[] = []
+const check = (name: string, ok: boolean, extra = ''): void => {
+  results.push(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures += 1
+}
+
+const ctx = { logger: { debug() {} } } as never
+const originalStdout = process.stdout
+const swapStdout = (stream: NodeJS.WriteStream): void => {
+  Object.defineProperty(process, 'stdout', {
+    value: stream,
+    configurable: true,
+    writable: true,
+    enumerable: true,
+  })
+}
+const tick = (): Promise<void> => new Promise(resolve => setImmediate(resolve))
+
+/** _write 挂起在显式 gate 上的流；gate 开后先补放存量，再即时落盘。 */
+class GatedFdStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  fd: number
+  gateOpen = false
+  held: Array<{ text: string; cb: () => void }> = []
+  constructor(fd: number) {
+    super()
+    this.fd = fd
+  }
+  _write(chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    const text = String(chunk)
+    if (this.gateOpen) {
+      writeSync(this.fd, text)
+      cb()
+      return
+    }
+    this.held.push({ text, cb })
+  }
+  release(): void {
+    this.gateOpen = true
+    for (const { text, cb } of this.held.splice(0)) {
+      writeSync(this.fd, text)
+      cb()
+    }
+  }
+}
+
+// ── Case A：TTY 路径（文件 fd + 新形分相 runtime + raw 状态跟踪）───────
+const traceFileA = join(tmpdir(), `dsh-tui-exit-order-a-${process.pid}.log`)
+const fdA = openSync(traceFileA, 'w')
+let asyncWritesA = 0
+class FdStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  fd: number = fdA
+  _write(_chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    asyncWritesA += 1
+    cb()
+  }
+}
+const stdoutA = new FdStdout() as unknown as NodeJS.WriteStream
+
+const eventsA: string[] = []
+let rawOffAtA = -1
+let isRawA = true
+let isRawAtDrainA: boolean | undefined
+let disableSeenAtBeginA: boolean | undefined
+let disableSeenAtConcludeA: boolean | undefined
+let unmountsA = 0
+instances.set(stdoutA, {
+  stdout: stdoutA,
+  beginShutdown() {
+    eventsA.push('begin')
+    // 闩锁必须先于 DISABLE 落盘：先停输出生产者，再写禁用序列。
+    disableSeenAtBeginA = readFileSync(traceFileA, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+  },
+  concludeShutdown() {
+    // raw-off 时刻：DISABLE 链必须已经在 fd 指向的文件里，且距入口已经
+    // 度过了整个 settle 窗（旧实现 detach 立即 raw-off，rawOffAt≈0）。
+    eventsA.push('conclude')
+    rawOffAtA = Date.now()
+    isRawA = false
+    disableSeenAtConcludeA = readFileSync(traceFileA, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+  },
+  detachStdinForHandoff() { eventsA.push('handoff') },
+  drainStdin() {
+    eventsA.push('drain')
+    // settle 窗在 raw 态度过的直接证据：drain 发生时 cooked 尚未恢复。
+    isRawAtDrainA = isRawA
+  },
+} as never)
+
+swapStdout(stdoutA)
+const t0A = Date.now()
+let doneA = false
+await finishExit(
+  ctx,
+  { unmount() { unmountsA += 1 } } as never,
+  true,
+  'hint-order',
+  undefined,
+  () => { doneA = true },
+)
+swapStdout(originalStdout)
+instances.delete(stdoutA)
+closeSync(fdA)
+
+const traceA = readFileSync(traceFileA, 'utf8')
+rmSync(traceFileA, { force: true })
+check('A: 闩锁先于 DISABLE 落盘（begin 时文件尚无 DISABLE）', disableSeenAtBeginA === false)
+check('A: settle 窗在 raw 态度过（drain 时 isRaw 仍为 true）', isRawAtDrainA === true)
+check('A: raw-off 时 DISABLE 已落盘', disableSeenAtConcludeA === true)
+check('A: raw-off 距入口 ≥140ms（settle 窗完整）',
+  rawOffAtA >= 0 && rawOffAtA - t0A >= 140,
+  rawOffAtA >= 0 ? `rawOffAt-t0=${rawOffAtA - t0A}ms` : 'conclude 未被调用')
+check('A: 退出写全部走同步 fd 路径（零异步 stream write）', asyncWritesA === 0,
+  asyncWritesA > 0 ? `异步写 ${asyncWritesA} 次` : '')
+check('A: 清理块完整（EXIT_ALT_SCREEN + notice）', traceA.includes(EXIT_ALT_SCREEN) && traceA.includes('hint-order'))
+check('A: 事件序 begin→drain→conclude→handoff，done 执行，不走 unmount 兜底',
+  eventsA.join(',') === 'begin,drain,conclude,handoff' && doneA && unmountsA === 0,
+  `事件序: ${eventsA.join(',') || '(空)'}`)
+
+// ── Case B：无 fd 回退（有序 stream 写，顺序约束不变）──────────────────
+const eventsB: string[] = []
+const chunksB: string[] = []
+class CapturingStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  _write(chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    const text = String(chunk)
+    chunksB.push(text)
+    if (text.includes(DISABLE_MOUSE_TRACKING)) eventsB.push('disable')
+    if (text.includes(EXIT_ALT_SCREEN)) eventsB.push('exit-alt')
+    cb()
+  }
+}
+const stdoutB = new CapturingStdout() as unknown as NodeJS.WriteStream
+instances.set(stdoutB, {
+  stdout: stdoutB,
+  beginShutdown() { eventsB.push('begin') },
+  concludeShutdown() { eventsB.push('conclude') },
+  detachStdinForHandoff() { eventsB.push('handoff') },
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutB)
+let doneB = false
+await finishExit(
+  ctx,
+  { unmount() {} } as never,
+  // fullscreen=true：清理块带 EXIT_ALT_SCREEN，顺序断言才覆盖两笔写的先后。
+  true,
+  'hint-fallback',
+  undefined,
+  () => { doneB = true },
+)
+swapStdout(originalStdout)
+instances.delete(stdoutB)
+
+const joinedB = chunksB.join('')
+const seqB = eventsB.join(',')
+check('B: 回退路径事件序 begin→disable→exit-alt→conclude→handoff',
+  seqB === 'begin,disable,exit-alt,conclude,handoff', `事件序: ${seqB || '(空)'}`)
+check('B: 回退路径字节完整（DISABLE + notice），done 执行',
+  joinedB.includes(DISABLE_MOUSE_TRACKING) && joinedB.includes('hint-fallback') && doneB)
+
+// ── Case C：写入全灭 + conclude 抛错，handoff/done 仍必执行 ───────────
+const eventsC: string[] = []
+class ThrowingStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  // 无效 fd：writeSync 必抛 EBADF → 落入有序 stream 路径；_write 再抛——
+  // 两条写入路径全灭，finishExit 仍必须走完 conclude/handoff/done。
+  fd = 9999
+  _write(_chunk: unknown, _enc: BufferEncoding, _cb: () => void): void {
+    throw new Error('simulated stream write failure')
+  }
+}
+const stdoutC = new ThrowingStdout() as unknown as NodeJS.WriteStream
+instances.set(stdoutC, {
+  stdout: stdoutC,
+  beginShutdown() { eventsC.push('begin') },
+  concludeShutdown() {
+    eventsC.push('conclude')
+    // TTY 被撤销：raw-off 的 handleSetRawMode 写入抛错——不得跳过 handoff。
+    throw new Error('simulated revoked tty')
+  },
+  detachStdinForHandoff() { eventsC.push('handoff') },
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutC)
+let doneC = false
+let threwC = false
+try {
+  await finishExit(
+    ctx,
+    { unmount() {} } as never,
+    false,
+    'hint-throw',
+    undefined,
+    () => { doneC = true },
+  )
+} catch {
+  threwC = true
+}
+swapStdout(originalStdout)
+instances.delete(stdoutC)
+
+check('C: 写入失败被吞（finishExit 正常 resolve）', !threwC)
+check('C: 写入全灭 + conclude 抛错仍调用 begin/conclude/handoff/done',
+  eventsC.join(',') === 'begin,conclude,handoff' && doneC,
+  `事件序: ${eventsC.join(',') || '(空)'}, done=${doneC}`)
+
+// ── Case D：barrier（Promise gate 挂起预排队 ENABLE+帧，无时序假设）────
+const traceFileD = join(tmpdir(), `dsh-tui-exit-order-d-${process.pid}.log`)
+const fdD = openSync(traceFileD, 'w')
+const FRAME_MARKER = 'QUEUED-FRAME-MARKER'
+const stdoutD = new GatedFdStdout(fdD) as unknown as NodeJS.WriteStream
+let disableSeenAtConcludeD: boolean | undefined
+instances.set(stdoutD, {
+  stdout: stdoutD,
+  beginShutdown() {},
+  concludeShutdown() {
+    disableSeenAtConcludeD = readFileSync(traceFileD, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+  },
+  detachStdinForHandoff() {},
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutD)
+// 闩锁前排入：一笔 ENABLE（自愈探针的最后一笔）+ 一帧渲染。
+stdoutD.write(ENABLE_MOUSE_TRACKING)
+stdoutD.write(FRAME_MARKER)
+let doneD = false
+const finishD = finishExit(
+  ctx,
+  { unmount() {} } as never,
+  true,
+  'hint-barrier',
+  undefined,
+  () => { doneD = true },
+)
+// 让 finishExit 进入 barrier 等待（latch 同步完成、poll 定时器已排上）；
+// 此处无 wall-clock 假设：DISABLE 只在 barrier 放行后写出，gate 未开时
+// 无论调度快慢它都不可能在盘。
+await tick()
+await tick()
+const disableBeforeGateD = readFileSync(traceFileD, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+;(stdoutD as unknown as GatedFdStdout).release()
+await finishD
+swapStdout(originalStdout)
+instances.delete(stdoutD)
+closeSync(fdD)
+
+const traceD = readFileSync(traceFileD, 'utf8')
+rmSync(traceFileD, { force: true })
+const idxEnableD = traceD.indexOf(ENABLE_MOUSE_TRACKING)
+const idxDisableD = traceD.indexOf(DISABLE_MOUSE_TRACKING)
+const idxExitAltD = traceD.indexOf(EXIT_ALT_SCREEN)
+const tailD = idxExitAltD === -1 ? '' : traceD.slice(idxExitAltD)
+check('D: barrier 等待队列排空（gate 未开时 DISABLE 未落盘）', !disableBeforeGateD)
+check('D: 预排队 ENABLE 落在 DISABLE 之前（最终鼠标态是 DISABLE）',
+  idxEnableD !== -1 && idxDisableD !== -1 && idxEnableD < idxDisableD,
+  `enable@${idxEnableD}, disable@${idxDisableD}`)
+check('D: 预排队帧落在 EXIT_ALT_SCREEN 之前，且尾部无 ENABLE/帧（主屏零污染）',
+  traceD.includes(FRAME_MARKER) && traceD.indexOf(FRAME_MARKER) < idxExitAltD
+  && !tailD.includes(ENABLE_MOUSE_TRACKING) && !tailD.includes(FRAME_MARKER))
+check('D: raw-off 时 DISABLE 已落盘，done 执行', disableSeenAtConcludeD === true && doneD)
+
+// ── Case E：barrier 超时（gate 1100ms 才开）→ 有序 stream 写保序 ──────
+const traceFileE = join(tmpdir(), `dsh-tui-exit-order-e-${process.pid}.log`)
+const fdE = openSync(traceFileE, 'w')
+const stdoutE = new GatedFdStdout(fdE) as unknown as NodeJS.WriteStream
+instances.set(stdoutE, {
+  stdout: stdoutE,
+  beginShutdown() {},
+  concludeShutdown() {},
+  detachStdinForHandoff() {},
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutE)
+stdoutE.write(ENABLE_MOUSE_TRACKING)
+stdoutE.write(FRAME_MARKER)
+// gate 在 barrier 1s 上限之后才开：barrier 必超时，退出序列必须切到有序
+// stream 路径跟在迟到字节之后，而不是 writeSync 越过队列。
+const gateTimerE = setTimeout(() => (stdoutE as unknown as GatedFdStdout).release(), 1100)
+const t0E = Date.now()
+let doneE = false
+await finishExit(
+  ctx,
+  { unmount() {} } as never,
+  true,
+  'hint-timeout',
+  undefined,
+  () => { doneE = true },
+)
+clearTimeout(gateTimerE)
+swapStdout(originalStdout)
+instances.delete(stdoutE)
+closeSync(fdE)
+const elapsedE = Date.now() - t0E
+
+const traceE = readFileSync(traceFileE, 'utf8')
+rmSync(traceFileE, { force: true })
+const idxEnableE = traceE.indexOf(ENABLE_MOUSE_TRACKING)
+const idxFrameE = traceE.indexOf(FRAME_MARKER)
+const idxDisableE = traceE.indexOf(DISABLE_MOUSE_TRACKING)
+const idxExitAltE = traceE.indexOf(EXIT_ALT_SCREEN)
+const tailE = idxExitAltE === -1 ? '' : traceE.slice(idxExitAltE)
+check('E: barrier 超时后走有序 stream 路径（耗时 ≥1s 上限）', elapsedE >= 1000, `elapsed=${elapsedE}ms`)
+check('E: 迟到 ENABLE/帧仍落在 DISABLE 之前（保序，无交错）',
+  idxEnableE !== -1 && idxFrameE !== -1 && idxDisableE !== -1
+  && idxEnableE < idxDisableE && idxFrameE < idxDisableE,
+  `enable@${idxEnableE}, frame@${idxFrameE}, disable@${idxDisableE}`)
+check('E: EXIT_ALT_SCREEN 完整落盘且尾部无 ENABLE/帧',
+  idxExitAltE !== -1 && idxExitAltE > idxDisableE
+  && !tailE.includes(ENABLE_MOUSE_TRACKING) && !tailE.includes(FRAME_MARKER))
+check('E: flush 等到全部字节落盘，done 执行', traceE.includes('hint-timeout') && doneE)
+
+// ── Case F：stdout identity drift（runtime 属流 A，process.stdout 是 B）─
+const traceFileFA = join(tmpdir(), `dsh-tui-exit-order-fa-${process.pid}.log`)
+const traceFileFB = join(tmpdir(), `dsh-tui-exit-order-fb-${process.pid}.log`)
+const fdFA = openSync(traceFileFA, 'w')
+const fdFB = openSync(traceFileFB, 'w')
+const streamFA = new GatedFdStdout(fdFA) as unknown as NodeJS.WriteStream
+streamFA.release() // A 队列畅通
+const streamFB = new GatedFdStdout(fdFB) as unknown as NodeJS.WriteStream
+// B 挂着一笔永远不放行的写：若 barrier 错轮询 B，finishExit 会白等 1s。
+streamFB.write('WEDGED-ON-B')
+const eventsF: string[] = []
+instances.set(streamFA, {
+  stdout: streamFA,
+  beginShutdown() { eventsF.push('begin') },
+  concludeShutdown() { eventsF.push('conclude') },
+  detachStdinForHandoff() { eventsF.push('handoff') },
+  drainStdin() {},
+} as never)
+
+swapStdout(streamFB)
+const t0F = Date.now()
+let doneF = false
+await finishExit(
+  ctx,
+  // render handle 即 runtime 的载体（instances map 按 B 查找必 miss）。
+  instances.get(streamFA) as never,
+  true,
+  'hint-drift',
+  undefined,
+  () => { doneF = true },
+)
+const elapsedF = Date.now() - t0F
+swapStdout(originalStdout)
+instances.delete(streamFA)
+;(streamFB as unknown as GatedFdStdout).release()
+closeSync(fdFA)
+closeSync(fdFB)
+
+const traceFA = readFileSync(traceFileFA, 'utf8')
+const traceFB = readFileSync(traceFileFB, 'utf8')
+rmSync(traceFileFA, { force: true })
+rmSync(traceFileFB, { force: true })
+check('F: 清理写作用于 runtime 所属流 A（DISABLE/EXIT_ALT/notice 齐全）',
+  traceFA.includes(DISABLE_MOUSE_TRACKING) && traceFA.includes(EXIT_ALT_SCREEN) && traceFA.includes('hint-drift'))
+check('F: 替换后的 process.stdout（B）零退出字节', !traceFB.includes(DISABLE_MOUSE_TRACKING) && !traceFB.includes(EXIT_ALT_SCREEN),
+  traceFB.length > 0 ? `B 收到 ${traceFB.length} 字节` : '')
+check('F: barrier 不错等 B 的挂起队列（无 1s 白等）', elapsedF < 900, `elapsed=${elapsedF}ms`)
+check('F: 事件序 begin→conclude→handoff，done 执行',
+  eventsF.join(',') === 'begin,conclude,handoff' && doneF, `事件序: ${eventsF.join(',') || '(空)'}`)
+
+console.log(results.join('\n'))
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURES`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify-exit-mouse-residue.tsx
+++ b/scripts/verify-exit-mouse-residue.tsx
@@ -6,30 +6,46 @@
  * 残留 = 退出清理（DISABLE_MOUSE_TRACKING）之后仍有任何代码写出 ENABLE。
  *
  * 场景蒸馏（无需时序竞态）：
- *   1. 挂载 AlternateScreen（altScreenActive=true，mouseTracking=true——
- *      probe 的全部前置条件就位）；
- *   2. 模拟退出漏斗 finishExit 的同序两步：detachForShutdown()（置
- *      isUnmounted）→ 写出 DISABLE_MOUSE_TRACKING；
- *   3. 过 250ms 节流窗后调 probeAltScreenHealth()——对应退出前窗口期
- *      （writeStream 1s + disposeRootAndThen 5s 兜底）内任何按键/鼠标
- *      输入触发的健康探针；
- *   4. 断言：清理序列之后不得再出现任何鼠标 ENABLE（?1000h/1002h/1003h/
- *      1006h）。未修复的 probe 不检查 isUnmounted，每次必红。
+ *   1. 挂载 AlternateScreen + Probe（altScreenActive=true、mouseTracking=
+ *      true——probe 的全部前置条件就位；Probe 消费 useInput 与
+ *      TerminalWriteContext，与 PromptInput 的异步 OSC 52 clipboard 回调
+ *      持有的是同一支 writeRaw）；
+ *   2. 先证明输入派发管线已接线（闩锁前注入 'a' 必被 useInput 收到）；
+ *   3. 模拟退出漏斗 finishExit 的同序两步：beginShutdown()（置
+ *      isUnmounted 闩锁、停输出生产者，raw mode 仍持有）→ 写出
+ *      DISABLE_MOUSE_TRACKING（cooked 恢复属于最后的 concludeShutdown）；
+ *   4. 闩锁后断言核心契约：isRaw 仍为 true（settle 窗在 raw 态度过）、
+ *      注入输入只 drain 不派发、经 context 的 writeRaw 零字节落盘；
+ *   5. 过 250ms 节流窗后调 probeAltScreenHealth()——对应退出前窗口期
+ *      （settle 窗 + disposeRootAndThen 5s 兜底）内任何按键/鼠标
+ *      输入触发的健康探针；断言清理序列之后不得再出现任何鼠标 ENABLE
+ *      （?1000h/1002h/1003h/1006h）。未修复的 probe 不检查 isUnmounted，
+ *      每次必红；
+ *   6. concludeShutdown() 之后断言 isRaw === false（cooked 恢复才在
+ *      finally 里发生）。
  *
  * Run: node --import tsx/esm scripts/verify-exit-mouse-residue.tsx
  */
 process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen, Text }, { default: instances }, { TerminalQuerier, decrqm }] =
-  await Promise.all([
-    import('node:stream'),
-    import('react'),
-    import('@xterm/headless'),
-    import('../src/ui.js'),
-    import('../src/ink/instances.js'),
-    import('../src/ink/terminal-querier.js'),
-  ])
+const [
+  { PassThrough, Writable },
+  React,
+  { Terminal: XTerm },
+  { render, useInput, AlternateScreen, Text },
+  { default: instances },
+  { TerminalQuerier, decrqm },
+  { TerminalWriteContext },
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/ink/instances.js'),
+  import('../src/ink/terminal-querier.js'),
+  import('../src/ink/useTerminalNotification.js'),
+])
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -58,7 +74,11 @@ class FakeStdout extends Writable {
 }
 class FakeStdin extends PassThrough {
   isTTY = true
-  setRawMode(): this { return this }
+  isRaw = false
+  setRawMode(value: boolean): this {
+    this.isRaw = value
+    return this
+  }
   ref(): this { return this }
   unref(): this { return this }
 }
@@ -69,9 +89,21 @@ const flush = (): Promise<void> => lastFlushed
 const MOUSE_ENABLE = /\x1b\[\?100[0236]h/
 const MOUSE_DISABLE = /\x1b\[\?100[0236]l/
 
+// ── Probe：useInput 记录派发到的输入；经 TerminalWriteContext 捕获
+// writeRaw——即 PromptInput 异步 OSC 52 clipboard 回调持有的同一支
+// （ink.tsx 以 Ink.writeRaw 为 provider 值，闩锁门在那里）。
+const received: string[] = []
+let rawWriter: ((data: string) => void) | null = null
+const Probe = (): React.ReactElement => {
+  useInput(input => { received.push(input) })
+  const writeRaw = React.useContext(TerminalWriteContext)
+  React.useEffect(() => { rawWriter = writeRaw }, [writeRaw])
+  return <Text>exit-residue probe</Text>
+}
+
 await render(
   <AlternateScreen>
-    <Text>exit-residue probe</Text>
+    <Probe />
   </AlternateScreen>,
   { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
 )
@@ -79,6 +111,9 @@ await render(
 /** 三条防线的最小驱动面（避免 as any，按仓库 unknown 收窄惯例）。 */
 type InkDriver = {
   detachForShutdown(): void
+  /** 退出分相：begin = 闩锁+停生产者（raw 仍持有）；conclude = raw-off。 */
+  beginShutdown(): void
+  concludeShutdown(): void
   probeAltScreenHealth(): void
   reassertTerminalModes(includeAltScreen?: boolean): void
   app?: { querier?: TerminalQuerier }
@@ -89,16 +124,34 @@ if (!ink) process.exit(1)
 await flush()
 await sleep(50)
 
-// ── 模拟退出漏斗 finishExit（src/dsh-adapter/plugin.ts）：先 detach（置
-// isUnmounted），cleanup 序列随后写出——与真实退出同序。detach 置位后，
-// 窗口期一切终端写入都不应再发生。
-ink.detachForShutdown()
+// ── 前置证据：闩锁前输入派发管线已接线（否则闩锁后的"不派发"断言无意义）。
+stdin.write('a')
+await sleep(30)
+check('闩锁前 useInput 正常派发（管线已接线）', received.join('') === 'a',
+  `received: ${JSON.stringify(received)}`)
+check('挂载后 stdin 处于 raw mode（useInput 的 layout effect 已生效）', stdin.isRaw === true)
+
+// ── 模拟退出漏斗 finishExit（src/dsh-adapter/plugin.ts）：先 beginShutdown
+// 闩锁（置 isUnmounted、停输出生产者，raw mode 仍持有），cleanup 序列在
+// raw 态下写出——与真实退出同序；cooked 恢复是最后的 concludeShutdown。
+ink.beginShutdown()
+check('beginShutdown 之后 raw mode 仍持有（settle 窗的前提）', stdin.isRaw === true)
 stdout.write('\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l')
 await flush()
 
 const cut = bytes.length
 const cleanupTail = bytes.slice(0, cut).join('')
 check('退出清理序列已写出（DISABLE 到达终端）', MOUSE_DISABLE.test(cleanupTail))
+
+// ── 闩锁后的写入/输入闸门（settle 窗内不得有任何字节再落盘）：
+//   · 注入按键与 SGR 鼠标报文——handleReadable 闩锁后只 drain 不派发，
+//     useInput 不得再收到（否则会触发新的 clipboard/探针动作）；
+//   · 经 context 拿到的 writeRaw 写 OSC 52——Ink.writeRaw 的闩锁门必须
+//     丢弃它（模拟 PromptInput copySelectionNoClear 的异步回调迟到）。
+stdin.write('b')
+stdin.write('\x1b[<35;1;1M')
+rawWriter?.('\x1b]52;c;QUJDRA==\x07')
+await sleep(30)
 
 // ── 250ms 节流窗过去，退出前窗口期的输入派发触发健康探针。
 await sleep(300)
@@ -107,6 +160,10 @@ await flush()
 await sleep(50)
 
 const tail = bytes.slice(cut).join('')
+check('闩锁后输入只 drain 不派发（useInput 零新增）', received.join('') === 'a',
+  received.length > 1 ? `多收到: ${JSON.stringify(received.slice(1))}` : '')
+check('闩锁后 writeRaw 零字节（OSC 52 迟到回调被门丢弃）', !tail.includes('\x1b]52'),
+  tail.includes('\x1b]52') ? `泄漏: ${JSON.stringify(tail.slice(0, 40))}` : '')
 check('清理之后无任何鼠标 ENABLE 残留（probe 尊重 isUnmounted）', !MOUSE_ENABLE.test(tail),
   tail.match(MOUSE_ENABLE) ? `残留序列: ${JSON.stringify(tail.match(MOUSE_ENABLE))}` : '')
 
@@ -122,8 +179,8 @@ check('退出后 reassertTerminalModes 零字节写出（kitty keyboard 不重�
 
 // ── 第三刀防线：dispose 之后的 querier 不得再发查询、不得再拉回 raw mode
 // （#507 的 DECRPM/DA1 回复泄漏 shell + ?2004h raw mode 重开）。
-// detach 链（ink → App.detachForShutdown）已 dispose querier；绕过 probe
-// 直接打 querier，模拟退出窗口期任何残余调用方。
+// beginShutdown 链（ink → App.beginShutdown）已 dispose querier；绕过
+// probe 直接打 querier，模拟退出窗口期任何残余调用方。
 const cut3 = bytes.length
 const querier: TerminalQuerier | undefined = ink.app?.querier
 check('querier 存在且已被 detach 链持有', querier !== undefined)
@@ -137,6 +194,10 @@ if (querier) {
   check('dispose 后 querier 零查询字节 / 不拉回 raw mode', !QUERY_BYTES.test(tail3),
     tail3 ? `写出了 ${JSON.stringify(tail3.slice(0, 40))}` : '')
 }
+
+// ── 收尾：cooked 恢复/末次 drain（真实漏斗在 settle 窗之后的 finally 里做）。
+ink.concludeShutdown()
+check('concludeShutdown 之后 raw mode 已释放（cooked 恢复）', stdin.isRaw === false)
 
 console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILURES`)
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-shutdown-fallback.tsx
+++ b/scripts/verify-shutdown-fallback.tsx
@@ -83,5 +83,33 @@ instances.delete(captured)
 check('runtime-present shutdown detaches without unmount', detaches === 1 && handoffs === 1 && unmountsB === 0 && doneB)
 check('runtime-present shutdown prints the notice', captured.chunks.join('').includes('hint-two'))
 
+// Case C: concurrent finishExit calls share ONE cleanup — the second awaits
+// the in-flight first and deliberately never invokes its own done(): the
+// process-level exit action belongs to the exit that actually ran the
+// terminal cleanup (double-run would repeat the exit sequence and could
+// spawn the /update or /restart handoff twice).
+const streamC = new CapturingStream() as unknown as NodeJS.WriteStream
+const eventsC: string[] = []
+instances.set(streamC, {
+  stdout: streamC,
+  beginShutdown() { eventsC.push('begin') },
+  concludeShutdown() { eventsC.push('conclude') },
+  detachStdinForHandoff() { eventsC.push('handoff') },
+  drainStdin() {},
+} as never)
+swapStdout(streamC)
+let doneC1 = 0
+let doneC2 = 0
+await Promise.all([
+  finishExit(ctx, fakeInstance(() => {}), false, 'hint-concurrent', undefined, () => { doneC1 += 1 }),
+  finishExit(ctx, fakeInstance(() => {}), false, 'hint-concurrent', undefined, () => { doneC2 += 1 }),
+])
+swapStdout(originalStdout)
+instances.delete(streamC)
+const noticeCount = streamC.chunks.join('').split('hint-concurrent').length - 1
+check('concurrent finishExit runs latch/conclude/handoff exactly once', eventsC.join(',') === 'begin,conclude,handoff')
+check('concurrent finishExit writes the exit sequence once', noticeCount === 1)
+check('concurrent finishExit invokes done() once (first caller wins)', doneC1 === 1 && doneC2 === 0)
+
 console.log(results.join('\n'))
 if (failures > 0) process.exit(1)

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1539,6 +1539,16 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     funnel.markTeardown()
     channel.releaseContributions()
     instance?.unmount()
+    // Safety net for the crash-then-teardown race: an app-driven unmount
+    // DEFERS the cooked-mode restore to finishExit, but markTeardown makes
+    // the funnel swallow that exit — without this, raw mode would leak on
+    // the live process. Idempotent (shutdownPhase guard); a plain teardown
+    // already concluded inside unmount().
+    try {
+      instance?.concludeShutdown?.()
+    } catch {
+      ctx.logger.debug('dsh-tui: teardown conclude failed; terminal may be left raw')
+    }
   })
 
   // The TUI is the front door: when the user unmounts it (Ctrl+C), dispose
@@ -1778,10 +1788,41 @@ type InkShutdownState = {
 }
 
 /**
+ * In-flight guard for finishExit: the exit funnel serializes USER exits, but
+ * finishExit is exported and process-level — concurrent callers (racing exit
+ * actions, embedder helpers) must not re-run the cleanup/handoff. A second
+ * call while one is running simply awaits the first; its done() is
+ * deliberately NOT invoked — the process-level exit action belongs to the
+ * exit that actually ran the terminal cleanup.
+ */
+let activeFinishExit: Promise<void> | undefined
+
+/**
  * Finish terminal I/O before handing control to a process-level exit action.
  * Exported for scripts/verify-shutdown-fallback.
  */
 export async function finishExit(
+  ctx: Context,
+  instance: Awaited<ReturnType<typeof render>> | undefined,
+  fullscreen: boolean,
+  notice: string | undefined,
+  stderrNotice: string | undefined,
+  done: () => void,
+): Promise<void> {
+  if (activeFinishExit !== undefined) {
+    ctx.logger.debug('dsh-tui: exit already in flight; awaiting it instead of re-running terminal cleanup')
+    return activeFinishExit
+  }
+  const run = finishExitOnce(ctx, instance, fullscreen, notice, stderrNotice, done)
+  activeFinishExit = run
+  try {
+    await run
+  } finally {
+    if (activeFinishExit === run) activeFinishExit = undefined
+  }
+}
+
+async function finishExitOnce(
   ctx: Context,
   instance: Awaited<ReturnType<typeof render>> | undefined,
   fullscreen: boolean,
@@ -1871,8 +1912,9 @@ export async function finishExit(
     const suffix = notice === undefined ? '' : `${notice}\n`
     if (runtime?.hasWrittenExitCleanup === true) {
       // React error-boundary / signal-exit path: Ink.unmount already wrote
-      // the mode resets (and released raw mode before the funnel could hold
-      // it). Re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN here would
+      // the mode resets (with raw mode still held — the cooked restore is
+      // deferred to the concludeShutdown in this funnel's finally).
+      // Re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN here would
       // double-reset the terminal; only the cursor park and notice remain.
       writer.write(`${cursor}\r\n${suffix}`)
     } else {

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { writeSync } from 'node:fs'
 import React from 'react'
 import { SessionId } from '@deepseek-ai/dsh-session'
 import type { Agent, AgentHandle } from '@deepseek-ai/dsh-agent'
@@ -1737,6 +1738,19 @@ export function isExitResumable(deps: {
 type InkShutdownState = {
   detachForShutdown?: () => void
   /**
+   * Phase 1 of the shutdown split: latch isUnmounted and stop every output
+   * producer while raw mode is STILL held, so the exit sequence below is
+   * consumed by the remote terminal during the raw-mode settle window
+   * instead of being echoed as caret garbage after cooked returns (#522).
+   */
+  beginShutdown?: () => void
+  /**
+   * Phase 2 of the shutdown split: restore cooked mode and drain stdin.
+   * finishExit runs it from a finally, so even a failed exit write cannot
+   * skip the raw-mode restore.
+   */
+  concludeShutdown?: () => void
+  /**
    * Full stdin detach for the /update child handoff (issues #284/#307):
    * removes the readable/data listeners and pauses the pump so the
    * lingering parent stops racing the restarted TUI for keypresses.
@@ -1744,6 +1758,21 @@ type InkShutdownState = {
   detachStdinForHandoff?: () => void
   /** Drain pending stdin bytes; the exit funnel re-drains after cleanup. */
   drainStdin?: () => void
+  /**
+   * The stream this runtime renders to. The barrier and every exit write
+   * must target THIS object — not whatever process.stdout points at during
+   * shutdown: the instances-map lookup missed precisely because the host
+   * replaced process.stdout, so writing the cleanup to the CURRENT
+   * process.stdout would leave the runtime's own stream (its queued frames,
+   * its mouse state) unhandled (stdout identity drift, #522).
+   */
+  stdout?: NodeJS.WriteStream
+  /**
+   * True after Ink.unmount wrote the terminal cleanup block itself (React
+   * error-boundary / signal-exit path); finishExit then skips re-writing
+   * the mode resets and only parks the cursor and prints the notice.
+   */
+  hasWrittenExitCleanup?: boolean
   frontFrame?: { cursor?: { x: number; y: number } }
   displayCursor?: { x: number; y: number } | null
 }
@@ -1760,6 +1789,7 @@ export async function finishExit(
   stderrNotice: string | undefined,
   done: () => void,
 ): Promise<void> {
+  let runtime: InkShutdownState | undefined
   try {
     // Resolve the Ink runtime twice: the instances map is keyed by stdout
     // identity, so a replaced/overridden stdout misses it; the render()
@@ -1769,11 +1799,13 @@ export async function finishExit(
     // ENABLE_MOUSE_TRACKING after DISABLE_MOUSE_TRACKING had been sent).
     const fromMap = readInkShutdownState(instances.get(process.stdout))
     const fromHandle = instance === undefined ? undefined : readInkShutdownState(instance)
-    // A handle that exposes neither detach hook is not an Ink runtime we can
-    // latch (e.g. the fake render handles in shutdown regressions) — treat it
-    // as a lookup miss so the full-unmount fallback below can still run.
-    const runtime = fromMap ?? (
-      fromHandle?.detachForShutdown === undefined && fromHandle?.detachStdinForHandoff === undefined
+    // A handle that exposes no shutdown hook at all is not an Ink runtime we
+    // can latch (e.g. the fake render handles in shutdown regressions) —
+    // treat it as a lookup miss so the full-unmount fallback below can run.
+    runtime = fromMap ?? (
+      fromHandle?.detachForShutdown === undefined
+      && fromHandle?.beginShutdown === undefined
+      && fromHandle?.detachStdinForHandoff === undefined
         ? undefined
         : fromHandle
     )
@@ -1796,60 +1828,297 @@ export async function finishExit(
       ctx.logger.debug('dsh-tui: Ink runtime resolved from the render handle (instances map missed); detaching')
     }
     const cursor = fullscreen ? '' : cursorMoveToFrameEnd(runtime)
+    // Every byte below targets the runtime's OWN stream. The instances map
+    // is keyed by stdout identity, so a missed lookup means the host
+    // replaced process.stdout after render — writing the cleanup to the
+    // CURRENT process.stdout would latch one stream's runtime while the
+    // bytes land on another (stdout identity drift, #522). Only the
+    // runtime-less fallback keeps the historical process.stdout target.
+    const target = runtime?.stdout ?? process.stdout
 
+    // Phase 1 latch, taken while raw mode is STILL HELD: stop every output
+    // producer (render, alt-screen health probe, mode re-assert) so nothing
+    // can re-write ENABLE_MOUSE_TRACKING or queue a frame while the disable
+    // bytes below are in flight. Raw mode must survive until the settle
+    // window below has elapsed: writeSync only proves the bytes reached the
+    // kernel tty buffer, not that the remote terminal consumed them — on a
+    // slow/stalled link (ssh is #522's environment) the terminal keeps
+    // sending SGR mouse reports for a while, and only raw mode keeps the
+    // kernel line discipline from echoing them as caret-notation
+    // `^[[<35;130;47M` garbage over the frozen UI. Compat: pre-split
+    // runtimes expose only the composite detachForShutdown, which already
+    // latches first (its cooked restore then happens here, same as before).
+    const latch = runtime?.beginShutdown ?? runtime?.detachForShutdown
     try {
-      runtime?.detachForShutdown?.()
-      // The /update continuation spawns children that inherit this stdin;
-      // strip the readable pump so the parent cannot swallow their input
-      // (issues #284/#307). Harmless on plain exits — the process exits
-      // right after this cleanup anyway.
-      runtime?.detachStdinForHandoff?.()
+      latch?.call(runtime)
     } catch {
-      ctx.logger.debug('dsh-tui: Ink shutdown detach failed; continuing with generic terminal cleanup')
+      ctx.logger.debug('dsh-tui: Ink shutdown latch failed; continuing with generic terminal cleanup')
     }
-    const cleanup = [
-      fullscreen ? EXIT_ALT_SCREEN : '',
-      cursor,
-      DISABLE_MOUSE_TRACKING,
-      DISABLE_MODIFY_OTHER_KEYS,
-      DISABLE_KITTY_KEYBOARD,
-      DISABLE_WIN32_INPUT_MODE,
-      DFE,
-      DBP,
-      SHOW_CURSOR,
-      CLEAR_ITERM2_PROGRESS,
-      supportsTabStatus() ? wrapForMultiplexer(CLEAR_TAB_STATUS) : '',
-    ].join('')
+    // Queue barrier between the latch and the exit writes: queued Ink frames
+    // or a last-moment ENABLE_MOUSE_TRACKING can still sit in Node's
+    // user-space buffer, and a direct-fd writeSync would overtake them —
+    // landing ENABLE after DISABLE (mouse tracking back on at the shell) or
+    // a frame after EXIT_ALT_SCREEN (garbage on the main screen). Everything
+    // after the latch is gated by isUnmounted, so nothing new queues. On
+    // timeout the queue is still draining (stalled link): the writer then
+    // stays in ORDERED stream mode — late bytes land BEFORE the exit
+    // sequence, never interleaved after it.
+    const queueDrained = await flushExitWriteBarrier(target)
+    if (!queueDrained) {
+      ctx.logger.debug('dsh-tui: stdout queue still draining after 1s; exit sequence switches to ordered queued writes')
+    }
+    const writer = createExitWriter(target, queueDrained)
     const suffix = notice === undefined ? '' : `${notice}\n`
-    await writeStream(process.stdout, `${cleanup}\r\n${suffix}`)
-    // Re-drain AFTER the cleanup sequences have landed (#507): terminal
-    // replies and mouse packets already in flight when the exit started
-    // keep arriving while cleanup is being written — the detach-time drain
-    // cannot see them. Unconsumed at process exit they land in the shell's
-    // input queue (DECRPM/DA1/XTVERSION garbage pasted into the prompt).
-    // 150ms settle covers reply RTT on slow links (ssh/ghostty is #522's
-    // environment; 50ms proved too tight there) while staying well inside
-    // the exit window the user already waits through.
+    if (runtime?.hasWrittenExitCleanup === true) {
+      // React error-boundary / signal-exit path: Ink.unmount already wrote
+      // the mode resets (and released raw mode before the funnel could hold
+      // it). Re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN here would
+      // double-reset the terminal; only the cursor park and notice remain.
+      writer.write(`${cursor}\r\n${suffix}`)
+    } else {
+      writer.write(DISABLE_MOUSE_TRACKING)
+      const cleanup = [
+        fullscreen ? EXIT_ALT_SCREEN : '',
+        cursor,
+        DISABLE_MODIFY_OTHER_KEYS,
+        DISABLE_KITTY_KEYBOARD,
+        DISABLE_WIN32_INPUT_MODE,
+        DFE,
+        DBP,
+        SHOW_CURSOR,
+        CLEAR_ITERM2_PROGRESS,
+        supportsTabStatus() ? wrapForMultiplexer(CLEAR_TAB_STATUS) : '',
+      ].join('')
+      writer.write(`${cleanup}\r\n${suffix}`)
+    }
+    // Ordered completion wait: queued writes must be acknowledged before
+    // the settle window (and before process.exit after done()), otherwise
+    // the disable bytes can still be truncated from Node's user-space
+    // buffer (#522 through a different door). A false result means the
+    // stream is wedged — the bytes remain queued IN ORDER, so the worst
+    // case is truncation at process exit, never an ENABLE-after-DISABLE
+    // scramble.
+    await writer.flush()
+    // Settle window spent in RAW mode (#507 + #522): terminal replies and
+    // mouse packets already in flight when the exit started keep arriving
+    // while cleanup is being written — the latch-time drain cannot see
+    // them. Held raw, the bytes sit in the tty input buffer unread instead
+    // of being echoed by the kernel; the drain below then empties the
+    // buffer so nothing leaks into the shell's input queue (DECRPM/DA1/
+    // XTVERSION garbage pasted into the prompt). 150ms covers reply RTT on
+    // slow links (ssh/ghostty is #522's environment; 50ms proved too tight
+    // there) while staying well inside the exit window the user already
+    // waits through.
     await new Promise<void>(resolve => setTimeout(resolve, 150))
     runtime?.drainStdin?.()
+  } catch {
+    ctx.logger.debug('dsh-tui: terminal cleanup failed; continuing with process shutdown')
+  } finally {
+    // Phase 2, unconditionally: only NOW restore cooked+echo (the remote
+    // terminal has had the full settle window to consume the disable
+    // bytes). Each release is isolated: concludeShutdown can throw on a
+    // revoked tty (its handleSetRawMode writes) and must NOT skip the
+    // stdin handoff — the /update child would otherwise race the lingering
+    // readable pump (issues #284/#307; harmless on plain exits).
+    try {
+      runtime?.concludeShutdown?.()
+    } catch {
+      ctx.logger.debug('dsh-tui: Ink shutdown conclude failed; continuing with generic terminal cleanup')
+    }
+    try {
+      runtime?.detachStdinForHandoff?.()
+    } catch {
+      ctx.logger.debug('dsh-tui: Ink stdin handoff detach failed; continuing with process shutdown')
+    }
     if (stderrNotice !== undefined) {
       await writeStream(process.stderr, `\n${stderrNotice}\n`)
     }
-  } catch {
-    ctx.logger.debug('dsh-tui: terminal cleanup failed; continuing with process shutdown')
   }
   done()
+}
+
+/**
+ * Exit-write barrier: flush whatever Node's user-space queue still holds
+ * (queued Ink frames, a re-asserted ENABLE_MOUSE_TRACKING) BEFORE the
+ * direct-fd writeSync calls of the exit sequence. writeSync overtakes any
+ * queued bytes — without the barrier, a pre-queued ENABLE would land after
+ * DISABLE (mouse tracking back on at the shell) and a queued frame after
+ * EXIT_ALT_SCREEN (garbage painted on the main screen). `write('', cb)` is
+ * NOT usable as the barrier — the empty chunk's callback fires out of
+ * order — so poll writableLength on a short interval (writableLength covers
+ * both queued AND in-flight chunks: Node decrements it only when the
+ * chunk's _write callback fires). Returns whether the queue drained: on
+ * timeout (stalled link) the caller must NOT fall through to direct-fd
+ * writes — createExitWriter then stays in ordered stream mode instead. The
+ * poll timer is REF'd on purpose: the barrier is an intentional bounded
+ * wait inside the exit window (exactly like the 150ms settle) — unref'd,
+ * it would let the process exit from under finishExit the moment the queue
+ * drains and the loop has nothing else to keep it alive.
+ */
+function flushExitWriteBarrier(stdout: NodeJS.WriteStream): Promise<boolean> {
+  if (typeof stdout.writableLength !== 'number' || stdout.writableLength === 0) {
+    return Promise.resolve(true)
+  }
+  return new Promise(resolve => {
+    const started = Date.now()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const finish = (drained: boolean): void => {
+      if (timer !== undefined) clearTimeout(timer)
+      resolve(drained)
+    }
+    const poll = (): void => {
+      if (stdout.writableLength === 0) {
+        finish(true)
+        return
+      }
+      if (Date.now() - started >= 1000) {
+        finish(false)
+        return
+      }
+      timer = setTimeout(poll, 5)
+    }
+    poll()
+  })
+}
+
+/**
+ * Spin bed for the EAGAIN retry below: Atomics.wait blocks the main thread
+ * for ~10ms per retry — acceptable inside the exit window, and the only
+ * synchronous sleep available here.
+ */
+const exitWriteRetryBed = new Int32Array(new SharedArrayBuffer(4))
+
+/**
+ * Ordered writer for the exit sequence. Two disciplines, never mixed:
+ *
+ * - FAST PATH (fd known, queue drained by the barrier): writeSync straight
+ *   to the stream's own fd (never a hard-coded 1, issue #522), looping on
+ *   short writes and retrying EINTR / bounded EAGAIN. Bytes reach the
+ *   kernel tty buffer before process.exit instead of sitting in Node's
+ *   user-space buffer where exit would truncate them.
+ * - ORDERED PATH (no fd, barrier timed out, or any sync write failed /
+ *   short-wrote): plain stream.write, which queues BEHIND whatever is
+ *   still in flight — a pre-queued ENABLE lands before DISABLE, a late
+ *   frame before EXIT_ALT_SCREEN. STICKY: once any byte goes through the
+ *   queue, every later write queues too, because a direct-fd write would
+ *   overtake the queued remainder and scramble the sequence. flush() then
+ *   waits (bounded 1s) for the last chunk's callback — write callbacks
+ *   fire in order, so it acknowledges everything queued before it. On a
+ *   wedged stream the bytes stay queued IN ORDER: worst case is ordered
+ *   truncation at process exit, never interleaving.
+ *
+ * Residual: a blocking fd with a full kernel buffer (wedged pty) can still
+ * park writeSync — no synchronous API can bound the syscall itself. The
+ * barrier makes it vanishingly unlikely: the link demonstrably moved just
+ * before. NEVER THROWS either way: finishExit's finally must reach the
+ * cooked-mode restore even when the terminal is already gone (revoked tty,
+ * closed fd, EIO).
+ */
+function createExitWriter(
+  stdout: NodeJS.WriteStream,
+  queueDrained: boolean,
+): { write: (text: string) => void; flush: () => Promise<boolean> } {
+  const stdoutWithFd = stdout as NodeJS.WriteStream & { fd?: number | null }
+  const fd = queueDrained && typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : undefined
+  let streamMode = fd === undefined
+  let completion: Promise<void> | undefined
+
+  const queueWrite = (chunk: string | Uint8Array): void => {
+    // Never rejects, never throws — finishExit's finally must run even when
+    // the stream is destroyed underneath us.
+    completion = new Promise<void>(resolve => {
+      try {
+        stdout.write(chunk, () => resolve())
+      } catch {
+        resolve()
+      }
+    })
+  }
+
+  const write = (text: string): void => {
+    if (text === '') return
+    if (streamMode) {
+      queueWrite(text)
+      return
+    }
+    const bytes = Buffer.from(text)
+    let offset = 0
+    let eagainBudget = 3
+    let eintrBudget = 3
+    while (offset < bytes.length) {
+      let written = 0
+      try {
+        // eslint-disable-next-line custom-rules/no-sync-fs -- process exiting; async writes would be dropped
+        written = writeSync(fd as number, bytes, offset, bytes.length - offset, null)
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code
+        // Interrupted syscall: retry immediately, on its own budget.
+        if (code === 'EINTR' && eintrBudget > 0) {
+          eintrBudget -= 1
+          continue
+        }
+        // Non-blocking fd, full kernel buffer (stalled link): bounded spin.
+        if ((code === 'EAGAIN' || code === 'EWOULDBLOCK') && eagainBudget > 0) {
+          eagainBudget -= 1
+          Atomics.wait(exitWriteRetryBed, 0, 0, 10)
+          continue
+        }
+        break
+      }
+      if (written <= 0) {
+        // Zero progress on a live fd: same treatment as EAGAIN, bounded.
+        if (eagainBudget > 0) {
+          eagainBudget -= 1
+          Atomics.wait(exitWriteRetryBed, 0, 0, 10)
+          continue
+        }
+        break
+      }
+      offset += written
+    }
+    if (offset >= bytes.length) return
+    // Partial/failed sync write: queue ONLY the remainder and stay in
+    // stream mode for the rest of the sequence.
+    streamMode = true
+    queueWrite(bytes.subarray(offset))
+  }
+
+  const flush = (): Promise<boolean> => {
+    if (completion === undefined) return Promise.resolve(true)
+    const pending = completion
+    return new Promise(resolve => {
+      const timer = setTimeout(() => resolve(false), 1000)
+      void pending.then(() => {
+        clearTimeout(timer)
+        resolve(true)
+      })
+    })
+  }
+
+  return { write, flush }
 }
 
 function readInkShutdownState(value: unknown): InkShutdownState | undefined {
   if (value === null || typeof value !== 'object') return undefined
   const candidate = value as Record<string, unknown>
   if (candidate.detachForShutdown !== undefined && typeof candidate.detachForShutdown !== 'function') return undefined
+  if (candidate.beginShutdown !== undefined && typeof candidate.beginShutdown !== 'function') return undefined
+  if (candidate.concludeShutdown !== undefined && typeof candidate.concludeShutdown !== 'function') return undefined
   if (candidate.detachStdinForHandoff !== undefined && typeof candidate.detachStdinForHandoff !== 'function') return undefined
   if (candidate.drainStdin !== undefined && typeof candidate.drainStdin !== 'function') return undefined
+  if (candidate.stdout !== undefined && !isWritableLike(candidate.stdout)) return undefined
+  if (candidate.hasWrittenExitCleanup !== undefined && typeof candidate.hasWrittenExitCleanup !== 'boolean') return undefined
   if (candidate.frontFrame !== undefined && !isFrameState(candidate.frontFrame)) return undefined
   if (candidate.displayCursor !== undefined && candidate.displayCursor !== null && !isCursorState(candidate.displayCursor)) return undefined
   return value as InkShutdownState
+}
+
+function isWritableLike(value: unknown): value is NodeJS.WriteStream {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as Record<string, unknown>).write === 'function'
+  )
 }
 
 function isFrameState(value: unknown): value is { cursor?: { x: number; y: number } } {

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -189,6 +189,10 @@ export default class App extends PureComponent<Props, State> {
 	// Count how many components enabled raw mode to avoid disabling
 	// raw mode until all components don't need it anymore
 	rawModeEnabledCount = 0;
+	// Shutdown latch (set by beginShutdown): gates writeRaw and switches
+	// handleReadable to drain-only so no input is dispatched to React
+	// handlers during the exit funnel's settle window.
+	shutdownLatched = false;
 	internal_eventEmitter = new EventEmitter();
 	keyParseState = INITIAL_STATE;
 	// Timer for flushing incomplete escape sequences
@@ -307,6 +311,11 @@ export default class App extends PureComponent<Props, State> {
 	// <AlternateScreen>'s insertion effect every frame, flapping the alt
 	// screen on/off.
 	writeRaw = (data: string): void => {
+		// Shutdown gate: once beginShutdown latches, app-side raw writes
+		// (async OSC 52 clipboard callbacks, notification sequences) must not
+		// reach the terminal — they would land between DISABLE_MOUSE_TRACKING
+		// and the settle drain, or on the main screen after EXIT_ALT_SCREEN.
+		if (this.shutdownLatched) return;
 		if (data.includes("\x1b[?1049")) {
 			logMouseDebug("stdout:1049", { len: data.length, head: data.slice(0, 60) });
 		}
@@ -376,22 +385,71 @@ export default class App extends PureComponent<Props, State> {
 		this.detachForShutdown();
 	}
 
-	/** Release timers and stdin ownership without requiring a React unmount. */
+	/**
+	 * Release timers and stdin ownership without requiring a React unmount.
+	 * Composite of the two shutdown phases — componentWillUnmount and other
+	 * one-shot callers want both; the exit funnel (finishExit) calls the
+	 * phases separately so raw mode survives across its settle window.
+	 */
 	detachForShutdown() {
-		// Clear any pending timers
-		if (this.incompleteEscapeTimer) {
-			clearTimeout(this.incompleteEscapeTimer);
-			this.incompleteEscapeTimer = null;
+		this.beginShutdown();
+		this.concludeShutdown();
+	}
+
+	/**
+	 * Phase 1: stop input/output producers — clear pending timers, dispose
+	 * the querier, and latch the shutdown gate (writeRaw blocked, stdin
+	 * drained without dispatch) — WITHOUT touching raw mode. The exit funnel
+	 * sends its DISABLE/cleanup sequences and waits out its settle window
+	 * while still raw, so late mouse reports are consumed as input instead
+	 * of echoed by the kernel line discipline. querier.dispose() releases
+	 * pending raw-mode holds, but every hold sits on top of the app's own
+	 * useInput hold (a pending query implies rawModeEnabledCount >= 2), so
+	 * cooked mode cannot be reached from here. Idempotent, and each step is
+	 * isolated: a throwing dispose (raw-hold release on a revoked tty) must
+	 * not skip the remaining teardown.
+	 */
+	beginShutdown() {
+		if (this.shutdownLatched) return;
+		this.shutdownLatched = true;
+		const steps: Array<() => void> = [
+			// Clear any pending timers
+			() => {
+				if (this.incompleteEscapeTimer) {
+					clearTimeout(this.incompleteEscapeTimer);
+					this.incompleteEscapeTimer = null;
+				}
+			},
+			() => {
+				if (this.pendingHyperlinkTimer) {
+					clearTimeout(this.pendingHyperlinkTimer);
+					this.pendingHyperlinkTimer = null;
+				}
+			},
+			() => {
+				if (this.xtversionProbe) {
+					clearImmediate(this.xtversionProbe);
+					this.xtversionProbe = null;
+				}
+			},
+			() => this.querier.dispose(),
+		];
+		for (const step of steps) {
+			try {
+				step();
+			} catch (error) {
+				logError(error instanceof Error ? error : new Error(String(error)));
+			}
 		}
-		if (this.pendingHyperlinkTimer) {
-			clearTimeout(this.pendingHyperlinkTimer);
-			this.pendingHyperlinkTimer = null;
-		}
-		if (this.xtversionProbe) {
-			clearImmediate(this.xtversionProbe);
-			this.xtversionProbe = null;
-		}
-		this.querier.dispose();
+	}
+
+	/**
+	 * Phase 2: restore cooked mode — drains the raw-mode borrow count, which
+	 * also removes the readable pump and unrefs stdin. Must run LAST in the
+	 * exit funnel: once the tty flips back to canonical+echo, any mouse
+	 * report still in flight echoes as caret-notation garbage (issue #522).
+	 */
+	concludeShutdown() {
 		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {
 			while (this.rawModeEnabledCount > 0) this.handleSetRawMode(false);
@@ -566,6 +624,24 @@ export default class App extends PureComponent<Props, State> {
 		}
 	};
 	handleReadable = (): void => {
+		// Shutdown latch: drain-only. Bytes arriving during the exit funnel's
+		// settle window (late mouse reports, terminal replies) must still be
+		// consumed — otherwise the readable event spins and the bytes linger
+		// for the shell — but never dispatched: useInput handlers are output
+		// producers (a selection copy writes OSC 52, keys fire clipboard /
+		// notification side effects), and the writeRaw gate above only
+		// covers their write, not their other effects.
+		if (this.shutdownLatched) {
+			try {
+				let chunk;
+				while ((chunk = this.props.stdin.read()) !== null) {
+					void chunk;
+				}
+			} catch (error) {
+				logError(error);
+			}
+			return;
+		}
 		// Detect long stdin gaps (tmux attach, ssh reconnect, laptop wake).
 		// The terminal may have reset DEC private modes; re-assert mouse
 		// tracking. Checked before the read loop so one Date.now() covers

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -193,6 +193,12 @@ export default class App extends PureComponent<Props, State> {
 	// handleReadable to drain-only so no input is dispatched to React
 	// handlers during the exit funnel's settle window.
 	shutdownLatched = false;
+	// Whether the tty is physically in raw mode. Separate from the borrow
+	// count because the shutdown latch DEFERS the physical release: React
+	// effect cleanups during unmount drain the count to zero while the exit
+	// funnel is still spending its settle window in raw mode (#522) — the
+	// actual setRawMode(false) then happens in concludeShutdown.
+	private rawModePhysicallyHeld = false;
 	internal_eventEmitter = new EventEmitter();
 	keyParseState = INITIAL_STATE;
 	// Timer for flushing incomplete escape sequences
@@ -382,13 +388,17 @@ export default class App extends PureComponent<Props, State> {
 		if (this.props.stdout.isTTY) {
 			this.props.stdout.write(SHOW_CURSOR);
 		}
-		this.detachForShutdown();
+		// Latch only: the cooked-mode restore is owned by the exit funnel
+		// (finishExit's concludeShutdown) so it happens after the raw-mode
+		// settle window. Ink.unmount concludes itself when NO funnel follows
+		// (host teardown / signal-exit).
+		this.beginShutdown();
 	}
 
 	/**
 	 * Release timers and stdin ownership without requiring a React unmount.
-	 * Composite of the two shutdown phases — componentWillUnmount and other
-	 * one-shot callers want both; the exit funnel (finishExit) calls the
+	 * Composite of the two shutdown phases for one-shot callers that must
+	 * restore cooked mode themselves; the exit funnel (finishExit) calls the
 	 * phases separately so raw mode survives across its settle window.
 	 */
 	detachForShutdown() {
@@ -433,6 +443,25 @@ export default class App extends PureComponent<Props, State> {
 				}
 			},
 			() => this.querier.dispose(),
+			// React's error unwinding runs the throwing subtree's effect
+			// cleanups BEFORE the boundary's componentDidCatch — so by the time
+			// handleExit latches, a useInput cleanup may already have drained
+			// the borrow count and physically released raw mode. The settle
+			// window contract (cleanup consumed while raw, #522) matters MORE
+			// on exactly that crash path, so re-acquire raw mode here if it
+			// was lost: tty-local only (no mode-enable escape sequences —
+			// re-emitting EBP/EFE/kitty after the cleanup's disables would be
+			// the residue bug through another door), with the readable pump
+			// re-attached in the latched drain-only mode. concludeShutdown
+			// performs the final release either way.
+			() => {
+				if (!this.isRawModeSupported() || this.rawModePhysicallyHeld) return;
+				const { stdin } = this.props;
+				stdin.ref();
+				stdin.setRawMode(true);
+				this.rawModePhysicallyHeld = true;
+				stdin.addListener("readable", this.handleReadable);
+			},
 		];
 		for (const step of steps) {
 			try {
@@ -453,6 +482,10 @@ export default class App extends PureComponent<Props, State> {
 		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {
 			while (this.rawModeEnabledCount > 0) this.handleSetRawMode(false);
+			// The count may already be drained (React effect cleanups during
+			// unmount ran while latched and only deferred the release) — the
+			// physical restore is owed regardless.
+			this.releaseRawModePhysical();
 		}
 	}
 	override componentDidCatch(error: Error) {
@@ -473,6 +506,10 @@ export default class App extends PureComponent<Props, State> {
 		}
 		stdin.setEncoding("utf8");
 		if (isEnabled) {
+			// Post-latch the tty's raw state is owned by the shutdown funnel:
+			// new borrowers get nothing, and their symmetric cleanups no-op on
+			// the zero count below.
+			if (this.shutdownLatched) return;
 			// Ensure raw mode is enabled only once
 			if (this.rawModeEnabledCount === 0) {
 				// Stop early input capture right before we add our own readable handler.
@@ -482,6 +519,7 @@ export default class App extends PureComponent<Props, State> {
 				stopCapturingEarlyInput();
 				stdin.ref();
 				stdin.setRawMode(true);
+				this.rawModePhysicallyHeld = true;
 				stdin.addListener("readable", this.handleReadable);
 				// Enable bracketed paste mode
 				this.props.stdout.write(EBP);
@@ -548,11 +586,29 @@ export default class App extends PureComponent<Props, State> {
 			this.props.stdout.write(DFE);
 			// Disable bracketed paste mode
 			this.props.stdout.write(DBP);
-			stdin.setRawMode(false);
-			stdin.removeListener("readable", this.handleReadable);
-			stdin.unref();
+			// Latched: the exit funnel keeps raw mode held across its settle
+			// window (#522) — the physical release is owed to
+			// concludeShutdown, which the funnel runs LAST.
+			if (!this.shutdownLatched) this.releaseRawModePhysical();
 		}
 	};
+
+	/**
+	 * The actual cooked-mode restore (setRawMode(false) + pump detach). Split
+	 * from the borrow bookkeeping so the shutdown latch can defer it: once
+	 * beginShutdown latches, draining the count updates bookkeeping only, and
+	 * concludeShutdown performs the physical release as the funnel's LAST
+	 * step — after the settle window gave the terminal time to consume the
+	 * disable bytes (#522).
+	 */
+	private releaseRawModePhysical(): void {
+		if (!this.rawModePhysicallyHeld) return;
+		this.rawModePhysicallyHeld = false;
+		const { stdin } = this.props;
+		stdin.setRawMode(false);
+		stdin.removeListener("readable", this.handleReadable);
+		stdin.unref();
+	}
 
 	// Helper to flush incomplete escape sequences
 	flushIncomplete = (): void => {
@@ -693,9 +749,15 @@ export default class App extends PureComponent<Props, State> {
 		// keyboard protocol terminals (Ghostty, iTerm2, kitty, WezTerm)
 	};
 	handleExit = (error?: Error): void => {
-		if (this.isRawModeSupported()) {
-			this.handleSetRawMode(false);
-		}
+		// Latch producers immediately (writeRaw gated, stdin drained without
+		// dispatch) but DO NOT release raw mode here: the exit funnel owns the
+		// raw-mode lifecycle end to end — cleanup bytes must be written (and
+		// the settle window spent) while raw is still held, or late mouse
+		// reports echo as caret garbage once cooked+echo returns (#522).
+		// Raw is released by concludeShutdown: Ink.unmount runs it for
+		// funnel-less exits (teardown / signal-exit), finishExit's finally
+		// runs it for every funneled exit — including this one.
+		this.beginShutdown();
 		this.props.onExit(error);
 	};
 	handleTerminalFocus = (isFocused: boolean): void => {

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -100,6 +100,13 @@ export default class Ink {
   // DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN and only parks the cursor and
   // prints the notice.
   private exitCleanupWritten = false;
+  // Set when the exit was driven by the app itself (Ctrl+C, error boundary,
+  // a component calling exit()): the plugin's exit funnel observes the
+  // settled exit promise and runs finishExit, which owns the cooked-mode
+  // restore (concludeShutdown) after its raw-mode settle window. External
+  // unmounts (host teardown, signal-exit) have no funnel behind them, so
+  // unmount() restores cooked mode itself.
+  private appDrivenExit = false;
   private isPaused = false;
   private readonly container: FiberRoot;
   private rootNode: dom.DOMElement;
@@ -2178,9 +2185,19 @@ export default class Ink {
   private setAppRef(app: App | null): void {
     this.app = app;
   }
+  /**
+   * App-driven exits (Ctrl+C, error boundary, context exit()) always settle
+   * the exit promise, and the plugin's funnel answers every such settle with
+   * finishExit — so unmount() must DEFER the cooked-mode restore to that
+   * funnel (its raw-mode settle window depends on it, #522).
+   */
+  private handleAppExit = (error?: Error): void => {
+    this.appDrivenExit = true;
+    this.unmount(error);
+  };
   render(node: ReactNode): void {
     this.currentNode = node;
-    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.unmount} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onContextMenuAt={this.dispatchContextMenu} onHoverAt={this.dispatchHover} onWheelAt={this.dispatchWheelAt} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onDragTargetAt={this.findDragTargetAt} onDragDispatch={this.dispatchDrag} onStdinResume={this.reassertTerminalModes} onTerminalFocus={this.handleTerminalFocusProbe} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
+    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.handleAppExit} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onContextMenuAt={this.dispatchContextMenu} onHoverAt={this.dispatchHover} onWheelAt={this.dispatchWheelAt} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onDragTargetAt={this.findDragTargetAt} onDragDispatch={this.dispatchDrag} onStdinResume={this.reassertTerminalModes} onTerminalFocus={this.handleTerminalFocusProbe} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
         <TerminalWriteProvider value={this.writeRaw}>
           {node}
         </TerminalWriteProvider>
@@ -2238,7 +2255,16 @@ export default class Ink {
         // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
         // doesn't declare it, hence the local intersection cast.
         const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
-        const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
+        const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : undefined;
+        // With no usable fd (TTY-like custom streams, wrapped embedders) fall
+        // back to the stream's OWN ordered queue — never a hard-coded
+        // writeSync(1): fd 1 belongs to the host process, so the cleanup
+        // would bypass the target stream entirely while the enable writes
+        // reached it (#522). Queueing also keeps these bytes behind any
+        // in-flight frames, preserving the frame → EXIT_ALT_SCREEN order.
+        const emit = stdoutFd === undefined
+          ? (text: string): void => { this.options.stdout.write(text); }
+          : (text: string): void => { writeSync(stdoutFd, text); };
         // Any segment failure leaves exitCleanupWritten false, so the
         // finishExit funnel rewrites the whole block (all sequences are
         // idempotent resets) rather than trusting a partial cleanup.
@@ -2250,12 +2276,12 @@ export default class Ink {
           // switch to the main screen, painting misplaced residue over the
           // shell (issue #522).
           if (lastFrame !== '') {
-            writeSync(stdoutFd, lastFrame);
+            emit(lastFrame);
           }
           if (this.altScreenActive) {
             // <AlternateScreen>'s unmount effect won't run during signal-exit.
             // Exit alt screen FIRST so other cleanup sequences go to the main screen.
-            writeSync(stdoutFd, EXIT_ALT_SCREEN);
+            emit(EXIT_ALT_SCREEN);
           }
         } catch (segmentError) {
           cleanupFailed = true;
@@ -2265,7 +2291,7 @@ export default class Ink {
           // Disable mouse tracking — unconditional because altScreenActive can be
           // stale if AlternateScreen's unmount (which flips the flag) raced a
           // blocked event loop + SIGINT. No-op if tracking was never enabled.
-          writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
+          emit(DISABLE_MOUSE_TRACKING);
           // Drain stdin so in-flight mouse events don't leak to the shell
           this.drainStdin();
         } catch (segmentError) {
@@ -2274,20 +2300,20 @@ export default class Ink {
         }
         try {
           // Disable extended key reporting (both kitty and modifyOtherKeys)
-          writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
-          writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
+          emit(DISABLE_MODIFY_OTHER_KEYS);
+          emit(DISABLE_KITTY_KEYBOARD);
           // Disable win32-input-mode (no-op where never enabled)
-          writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
+          emit(DISABLE_WIN32_INPUT_MODE);
           // Disable focus events (DECSET 1004)
-          writeSync(stdoutFd, DFE);
+          emit(DFE);
           // Disable bracketed paste mode
-          writeSync(stdoutFd, DBP);
+          emit(DBP);
           // Show cursor
-          writeSync(stdoutFd, SHOW_CURSOR);
+          emit(SHOW_CURSOR);
           // Clear iTerm2 progress bar
-          writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
+          emit(CLEAR_ITERM2_PROGRESS);
           // Clear tab status (OSC 21337) so a stale dot doesn't linger
-          if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
+          if (supportsTabStatus()) emit(wrapForMultiplexer(CLEAR_TAB_STATUS));
         } catch (segmentError) {
           cleanupFailed = true;
           logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
@@ -2310,6 +2336,19 @@ export default class Ink {
       reconciler.updateContainerSync(null, this.container, null, noop);
       // @ts-ignore -- ported CC build; type drift tolerated flushSyncWork exists in react-reconciler but not in @types/react-reconciler
       reconciler.flushSyncWork();
+      // Cooked-mode restore: app-driven exits defer it to the exit funnel
+      // (finishExit holds raw mode across its post-cleanup settle window,
+      // #522); external unmounts (host teardown, signal-exit) have no funnel
+      // behind them, so restore cooked mode here. Idempotent via the
+      // shutdownPhase guard, and the React teardown above already ran
+      // App.componentWillUnmount's beginShutdown latch.
+      if (!this.appDrivenExit) {
+        try {
+          this.concludeShutdown();
+        } catch (concludeError) {
+          logError(concludeError instanceof Error ? concludeError : new Error(String(concludeError)));
+        }
+      }
       instances.delete(this.options.stdout);
 
       // Free the root yoga node, then clear its reference. Children are already

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -84,6 +84,13 @@ export default class Ink {
   private readonly log: LogUpdate;
   private readonly terminal: Terminal;
   private app: App | null = null;
+  // The last live App ref, kept for the shutdown phases: React detaches the
+  // ref (setAppRef(null)) while unmounting the tree, but concludeShutdown
+  // runs AFTER the tree is gone (unmount's finally, or the finishExit
+  // funnel behind an app-driven exit) and still needs the component for its
+  // raw-mode bookkeeping (borrow drain, cooked restore, readable-pump
+  // detach) — a null ref there would silently skip it and leak the pump.
+  private shutdownApp: App | undefined;
   private scheduleRender: (() => void) & {
     cancel?: () => void;
   };
@@ -1401,7 +1408,7 @@ export default class Ink {
           this.drainTimer = null;
         }
       },
-      () => this.app?.beginShutdown(),
+      () => (this.app ?? this.shutdownApp)?.beginShutdown(),
       // Shutdown bypasses the normal unmount path, so release the process
       // and stdout listeners here as well. Otherwise a SIGCONT or resize
       // arriving while an updater is running can re-enter the alternate
@@ -1460,8 +1467,10 @@ export default class Ink {
     };
     const steps: Array<() => void> = [
       // App's raw-off drains the raw-mode borrow count, which also removes
-      // the readable pump and unrefs stdin.
-      () => this.app?.concludeShutdown(),
+      // the readable pump and unrefs stdin. The ref itself is already null
+      // when the React teardown ran first (unmount's finally, finishExit
+      // behind an app-driven exit), so fall back to the last live ref.
+      () => (this.app ?? this.shutdownApp)?.concludeShutdown(),
       () => this.drainStdin(),
       () => {
         if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
@@ -2184,6 +2193,7 @@ export default class Ink {
   };
   private setAppRef(app: App | null): void {
     this.app = app;
+    if (app !== null) this.shutdownApp = app;
   }
   /**
    * App-driven exits (Ctrl+C, error boundary, context exit()) always settle

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -89,6 +89,17 @@ export default class Ink {
   };
   // Ignore last render after unmounting a tree to prevent empty output before exit
   private isUnmounted = false;
+  // Shutdown phase state machine: 0 = live, 1 = beginShutdown ran (latched,
+  // raw mode still held), 2 = concludeShutdown ran (cooked restored). The
+  // guards make the phases idempotent and record how far teardown got, so a
+  // throwing cleanup step can neither skip later steps nor re-run earlier
+  // ones when the exit funnel and a late unmount() race.
+  private shutdownPhase: 0 | 1 | 2 = 0;
+  // Set when unmount() itself wrote the terminal cleanup block (React
+  // error-boundary / signal-exit path): finishExit then skips re-writing
+  // DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN and only parks the cursor and
+  // prints the notice.
+  private exitCleanupWritten = false;
   private isPaused = false;
   private readonly container: FiberRoot;
   private rootNode: dom.DOMElement;
@@ -1313,6 +1324,29 @@ export default class Ink {
   };
 
   /**
+   * The output stream this instance renders to. finishExit must target THIS
+   * stream for its barrier/cleanup/notice writes — not whatever
+   * process.stdout happens to point at during shutdown: a host that swapped
+   * process.stdout after render would otherwise latch THIS instance while
+   * writing the cleanup bytes to the replacement stream, leaving this
+   * stream's queued frames and mouse state unhandled (stdout identity
+   * drift, issue #522).
+   */
+  get stdout(): NodeJS.WriteStream {
+    return this.options.stdout;
+  }
+
+  /**
+   * Whether unmount() already wrote the terminal cleanup block itself
+   * (React error-boundary / signal-exit path). finishExit checks this and
+   * skips re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN, so the
+   * error path no longer double-resets the terminal.
+   */
+  get hasWrittenExitCleanup(): boolean {
+    return this.exitCleanupWritten;
+  }
+
+  /**
    * Mark this instance as unmounted so future unmount() calls early-return.
    * Called by gracefulShutdown's cleanupTerminalModes() after it has sent
    * EXIT_ALT_SCREEN but before the remaining terminal-reset sequences.
@@ -1322,38 +1356,92 @@ export default class Ink {
    * The result is 2-3 redundant EXIT_ALT_SCREEN sequences landing on the
    * main screen AFTER printResumeHint(), which tmux (at least) interprets
    * as restoring the saved cursor position — clobbering the resume hint.
+   *
+   * Composite of beginShutdown() + concludeShutdown() for one-shot callers;
+   * the exit funnel (finishExit) invokes the phases separately so the
+   * cooked-mode restore happens only AFTER its post-cleanup settle window.
    */
   detachForShutdown(): void {
+    this.beginShutdown();
+    this.concludeShutdown();
+  }
+
+  /**
+   * Shutdown phase 1: latch isUnmounted and stop every output producer
+   * (pending renders, health probes, the querier), release process/stdout
+   * listeners and output patches — but KEEP stdin raw mode. The exit funnel
+   * writes DISABLE_MOUSE_TRACKING and the cleanup block, then waits out its
+   * settle window in this state: mouse reports that arrive while the disable
+   * is still in transit are consumed as raw input (and drained below)
+   * instead of echoed by the kernel line discipline once cooked+echo
+   * returns (the `^[[<35;130;47M` residue of issue #522).
+   *
+   * Idempotent (shutdownPhase guard) and step-isolated: a throwing step
+   * (e.g. querier.dispose releasing a raw-mode hold on a revoked tty) is
+   * logged and must not skip the remaining releases.
+   */
+  beginShutdown(): void {
+    if (this.shutdownPhase >= 1) return;
+    this.shutdownPhase = 1;
     this.isUnmounted = true;
-    // Cancel any pending throttled render so it doesn't fire between
-    // cleanupTerminalModes() and process.exit() and write to main screen.
-    this.scheduleRender.cancel?.();
-    if (this.drainTimer !== null) {
-      clearTimeout(this.drainTimer);
-      this.drainTimer = null;
+    const steps: Array<() => void> = [
+      // Cancel any pending throttled render so it doesn't fire between
+      // cleanupTerminalModes() and process.exit() and write to main screen.
+      () => this.scheduleRender.cancel?.(),
+      () => {
+        if (this.drainTimer !== null) {
+          clearTimeout(this.drainTimer);
+          this.drainTimer = null;
+        }
+      },
+      () => this.app?.beginShutdown(),
+      // Shutdown bypasses the normal unmount path, so release the process
+      // and stdout listeners here as well. Otherwise a SIGCONT or resize
+      // arriving while an updater is running can re-enter the alternate
+      // screen or render through this detached instance after terminal
+      // cleanup has completed.
+      () => this.unsubscribeTTYHandlers?.(),
+      () => this.unsubscribeExit(),
+      // unmount() early-returns on isUnmounted above, so its
+      // instances.delete never runs — a detached instance would stay in the
+      // map and a later instances.get(stdout) lookup (Chat's
+      // reanchorViewport plumbing) could hand out a dead renderer. Remove
+      // the mapping here too.
+      () => instances.delete(this.options.stdout),
+      // `detachForShutdown()` deliberately makes later `unmount()` calls a
+      // no-op, so release process-level output patches here rather than
+      // relying on unmount() to do it. The shutdown continuation may run an
+      // updater (or report its failure) after this point; leaving stderr
+      // intercepted would silently route those messages to the debug log
+      // instead of the terminal.
+      () => {
+        if (typeof this.restoreConsole === 'function') {
+          this.restoreConsole();
+        }
+      },
+      () => this.restoreStderr?.(),
+    ];
+    for (const step of steps) {
+      try {
+        step();
+      } catch (error) {
+        logError(error instanceof Error ? error : new Error(String(error)));
+      }
     }
-    this.app?.detachForShutdown();
-    // Shutdown bypasses the normal unmount path, so release the process and
-    // stdout listeners here as well. Otherwise a SIGCONT or resize arriving
-    // while an updater is running can re-enter the alternate screen or render
-    // through this detached instance after terminal cleanup has completed.
-    this.unsubscribeTTYHandlers?.();
-    this.unsubscribeExit();
-    // unmount() early-returns on isUnmounted above, so its instances.delete
-    // never runs — a detached instance would stay in the map and a later
-    // instances.get(stdout) lookup (Chat's reanchorViewport plumbing) could
-    // hand out a dead renderer. Remove the mapping here too.
-    instances.delete(this.options.stdout);
-    // `detachForShutdown()` deliberately makes later `unmount()` calls a
-    // no-op, so release process-level output patches here rather than relying
-    // on unmount() to do it. The shutdown continuation may run an updater
-    // (or report its failure) after this point; leaving stderr intercepted
-    // would silently route those messages to the debug log instead of the
-    // terminal.
-    if (typeof this.restoreConsole === 'function') {
-      this.restoreConsole();
-    }
-    this.restoreStderr?.();
+  }
+
+  /**
+   * Shutdown phase 2: restore cooked mode. Must run LAST in the exit
+   * funnel, after the settle window has given the terminal time to process
+   * DISABLE_MOUSE_TRACKING and late reports have been drained — once the
+   * tty flips back to canonical+echo, any mouse report still in flight is
+   * echoed at the parked cursor (issue #522). Idempotent and step-isolated
+   * like phase 1: the raw-off throw of a revoked tty must not skip the
+   * stdin drain or the fallback restore.
+   */
+  concludeShutdown(): void {
+    if (this.shutdownPhase >= 2) return;
+    this.shutdownPhase = 2;
     // Restore stdin from raw mode. unmount() used to do this via React
     // unmount (App.componentWillUnmount → handleSetRawMode(false)) but we're
     // short-circuiting that path. Must use this.options.stdin — NOT
@@ -1363,14 +1451,28 @@ export default class Ink {
       isRaw?: boolean;
       setRawMode?: (m: boolean) => void;
     };
-    this.drainStdin();
-    if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
+    const steps: Array<() => void> = [
+      // App's raw-off drains the raw-mode borrow count, which also removes
+      // the readable pump and unrefs stdin.
+      () => this.app?.concludeShutdown(),
+      () => this.drainStdin(),
+      () => {
+        if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
+          try {
+            stdin.setRawMode(false);
+          } catch {
+            // The TTY may have been revoked (for example after an SSH
+            // disconnect). Shutdown must continue even if raw-mode
+            // restoration is no longer possible.
+          }
+        }
+      },
+    ];
+    for (const step of steps) {
       try {
-        stdin.setRawMode(false);
-      } catch {
-        // The TTY may have been revoked (for example after an SSH
-        // disconnect). Shutdown must continue even if raw-mode restoration
-        // is no longer possible.
+        step();
+      } catch (error) {
+        logError(error instanceof Error ? error : new Error(String(error)));
       }
     }
   }
@@ -1434,12 +1536,14 @@ export default class Ink {
    */
   private lastHealthProbeAt = 0;
   probeAltScreenHealth = (): void => {
-    // Shutdown latch: during the dispose window after detachForShutdown
-    // (up to the 5s fallback exit) stray input, focus, resize or a pending
-    // DECRPM reply would otherwise re-write ENABLE_MOUSE_TRACKING AFTER the
-    // exit cleanup's DISABLE_MOUSE_TRACKING — the mouse-reporting residue
-    // the shell then echoes as SGR garbage (issue #522). isUnmounted is set
-    // by detachForShutdown() before any cleanup sequence is written.
+    // Shutdown latch: during the dispose window after beginShutdown (up to
+    // the 5s fallback exit) stray input, focus, resize or a pending DECRPM
+    // reply would otherwise re-write ENABLE_MOUSE_TRACKING AFTER the exit
+    // cleanup's DISABLE_MOUSE_TRACKING — the mouse-reporting residue the
+    // shell then echoes as SGR garbage (issue #522). The exit funnel latches
+    // isUnmounted via beginShutdown() BEFORE any cleanup sequence is
+    // written, while raw mode is still held; the cooked-mode restore lands
+    // only in concludeShutdown() after the settle window.
     if (this.isUnmounted) return;
     const now = Date.now();
     if (now - this.lastHealthProbeAt < 250) return;
@@ -2054,6 +2158,12 @@ export default class Ink {
   // cascades through useContext → <AlternateScreen>'s useLayoutEffect dep
   // array → spurious exit+re-enter of the alt screen on every SIGWINCH.
   private writeRaw(data: string): void {
+    // Shutdown gate: once beginShutdown latches, raw writes (async OSC 52
+    // clipboard callbacks from copySelectionNoClear, querier leftovers)
+    // must not reach the terminal — they would land between
+    // DISABLE_MOUSE_TRACKING and the settle drain, or on the main screen
+    // after EXIT_ALT_SCREEN.
+    if (this.isUnmounted) return;
     if (data.includes('\x1b[?1049')) {
       logMouseDebug('stdout:1049', { len: data.length, head: data.slice(0, 60) });
     }
@@ -2116,73 +2226,102 @@ export default class Ink {
     // complete before exit. We unconditionally send all disable sequences
     // because terminal detection may not work correctly (e.g., in tmux,
     // screen) and these are no-ops on terminals that don't support them.
+    //
+    // Each segment is isolated: a throwing fd (revoked tty, EIO after an
+    // ssh drop) must not skip the mouse-tracking disable or the remaining
+    // resets, and the finally below must run the state teardown even when
+    // every write fails — otherwise a late finishExit would see a live
+    // instance and double-write this cleanup, or waitUntilExit would hang.
     /* eslint-disable custom-rules/no-sync-fs -- process exiting; async writes would be dropped */
-    if (this.options.stdout.isTTY) {
-      // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
-      // doesn't declare it, hence the local intersection cast.
-      const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
-      const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
-      // The last frame must land on the ALT screen while it is still up:
-      // writing it through the async stream would race the synchronous
-      // EXIT_ALT_SCREEN below and the frame bytes would arrive AFTER the
-      // switch to the main screen, painting misplaced residue over the
-      // shell (issue #522).
-      if (lastFrame !== '') {
-        writeSync(stdoutFd, lastFrame);
+    try {
+      if (this.options.stdout.isTTY) {
+        // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
+        // doesn't declare it, hence the local intersection cast.
+        const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
+        const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
+        // Any segment failure leaves exitCleanupWritten false, so the
+        // finishExit funnel rewrites the whole block (all sequences are
+        // idempotent resets) rather than trusting a partial cleanup.
+        let cleanupFailed = false;
+        try {
+          // The last frame must land on the ALT screen while it is still up:
+          // writing it through the async stream would race the synchronous
+          // EXIT_ALT_SCREEN below and the frame bytes would arrive AFTER the
+          // switch to the main screen, painting misplaced residue over the
+          // shell (issue #522).
+          if (lastFrame !== '') {
+            writeSync(stdoutFd, lastFrame);
+          }
+          if (this.altScreenActive) {
+            // <AlternateScreen>'s unmount effect won't run during signal-exit.
+            // Exit alt screen FIRST so other cleanup sequences go to the main screen.
+            writeSync(stdoutFd, EXIT_ALT_SCREEN);
+          }
+        } catch (segmentError) {
+          cleanupFailed = true;
+          logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
+        }
+        try {
+          // Disable mouse tracking — unconditional because altScreenActive can be
+          // stale if AlternateScreen's unmount (which flips the flag) raced a
+          // blocked event loop + SIGINT. No-op if tracking was never enabled.
+          writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
+          // Drain stdin so in-flight mouse events don't leak to the shell
+          this.drainStdin();
+        } catch (segmentError) {
+          cleanupFailed = true;
+          logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
+        }
+        try {
+          // Disable extended key reporting (both kitty and modifyOtherKeys)
+          writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
+          writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
+          // Disable win32-input-mode (no-op where never enabled)
+          writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
+          // Disable focus events (DECSET 1004)
+          writeSync(stdoutFd, DFE);
+          // Disable bracketed paste mode
+          writeSync(stdoutFd, DBP);
+          // Show cursor
+          writeSync(stdoutFd, SHOW_CURSOR);
+          // Clear iTerm2 progress bar
+          writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
+          // Clear tab status (OSC 21337) so a stale dot doesn't linger
+          if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
+        } catch (segmentError) {
+          cleanupFailed = true;
+          logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
+        }
+        // All three segments landed — finishExit can skip its rewrite.
+        this.exitCleanupWritten = !cleanupFailed;
       }
-      if (this.altScreenActive) {
-        // <AlternateScreen>'s unmount effect won't run during signal-exit.
-        // Exit alt screen FIRST so other cleanup sequences go to the main screen.
-        writeSync(stdoutFd, EXIT_ALT_SCREEN);
+      /* eslint-enable custom-rules/no-sync-fs */
+    } finally {
+      this.isUnmounted = true;
+
+      // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
+      this.scheduleRender.cancel?.();
+      if (this.drainTimer !== null) {
+        clearTimeout(this.drainTimer);
+        this.drainTimer = null;
       }
-      // Disable mouse tracking — unconditional because altScreenActive can be
-      // stale if AlternateScreen's unmount (which flips the flag) raced a
-      // blocked event loop + SIGINT. No-op if tracking was never enabled.
-      writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
-      // Drain stdin so in-flight mouse events don't leak to the shell
-      this.drainStdin();
-      // Disable extended key reporting (both kitty and modifyOtherKeys)
-      writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
-      writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
-      // Disable win32-input-mode (no-op where never enabled)
-      writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
-      // Disable focus events (DECSET 1004)
-      writeSync(stdoutFd, DFE);
-      // Disable bracketed paste mode
-      writeSync(stdoutFd, DBP);
-      // Show cursor
-      writeSync(stdoutFd, SHOW_CURSOR);
-      // Clear iTerm2 progress bar
-      writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
-      // Clear tab status (OSC 21337) so a stale dot doesn't linger
-      if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
-    }
-    /* eslint-enable custom-rules/no-sync-fs */
 
-    this.isUnmounted = true;
+      // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler
+      reconciler.updateContainerSync(null, this.container, null, noop);
+      // @ts-ignore -- ported CC build; type drift tolerated flushSyncWork exists in react-reconciler but not in @types/react-reconciler
+      reconciler.flushSyncWork();
+      instances.delete(this.options.stdout);
 
-    // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
-    this.scheduleRender.cancel?.();
-    if (this.drainTimer !== null) {
-      clearTimeout(this.drainTimer);
-      this.drainTimer = null;
-    }
-
-    // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler
-    reconciler.updateContainerSync(null, this.container, null, noop);
-    // @ts-ignore -- ported CC build; type drift tolerated flushSyncWork exists in react-reconciler but not in @types/react-reconciler
-    reconciler.flushSyncWork();
-    instances.delete(this.options.stdout);
-
-    // Free the root yoga node, then clear its reference. Children are already
-    // freed by the reconciler's removeChildFromContainer; using .free() (not
-    // .freeRecursive()) avoids double-freeing them.
-    this.rootNode.yogaNode?.free();
-    this.rootNode.yogaNode = undefined;
-    if (error instanceof Error) {
-      this.rejectExitPromise(error);
-    } else {
-      this.resolveExitPromise();
+      // Free the root yoga node, then clear its reference. Children are already
+      // freed by the reconciler's removeChildFromContainer; using .free() (not
+      // .freeRecursive()) avoids double-freeing them.
+      this.rootNode.yogaNode?.free();
+      this.rootNode.yogaNode = undefined;
+      if (error instanceof Error) {
+        this.rejectExitPromise(error);
+      } else {
+        this.resolveExitPromise();
+      }
     }
   }
   async waitUntilExit(): Promise<void> {
@@ -2322,11 +2461,13 @@ export default class Ink {
  *    open /dev/tty fresh with O_NONBLOCK (all fds to the controlling
  *    terminal share one line-discipline input queue).
  *
- * 2. By the time forceExit calls this, detachForShutdown has already put
- *    the TTY back in cooked (canonical) mode. Canonical mode line-buffers
- *    input until newline, so O_NONBLOCK reads return EAGAIN even when
- *    mouse bytes are sitting in the buffer. We briefly re-enter raw mode
- *    so reads return any available bytes, then restore cooked mode.
+ * 2. Callers reach this in mixed tty states: finishExit drains while still
+ *    raw (between its settle window and concludeShutdown's raw-off), while
+ *    concludeShutdown/unmount callers drain after cooked (canonical) mode
+ *    has already returned. Canonical mode line-buffers input until newline,
+ *    so O_NONBLOCK reads return EAGAIN even when mouse bytes are sitting in
+ *    the buffer. When not already raw, we briefly re-enter raw mode so
+ *    reads return any available bytes, then restore the previous state.
  *
  * Safe to call multiple times. Call as LATE as possible in the exit path:
  * DISABLE_MOUSE_TRACKING has terminal round-trip latency, so events can

--- a/src/ink/root.ts
+++ b/src/ink/root.ts
@@ -49,6 +49,19 @@ export type RenderOptions = {
  */
 export type Instance = {
   /**
+   * The output stream this instance renders to. finishExit must target THIS
+   * stream for its barrier/cleanup/notice writes — not whatever
+   * process.stdout happens to point at during shutdown (stdout identity
+   * drift, issue #522).
+   */
+  stdout: NodeJS.WriteStream
+  /**
+   * Whether unmount() already wrote the terminal cleanup block itself
+   * (React error-boundary / signal-exit path); finishExit then skips
+   * re-writing the mode resets.
+   */
+  hasWrittenExitCleanup: boolean
+  /**
    * Replace previous root node with a new one or update props of the current root node.
    */
   rerender: Ink['render']
@@ -70,6 +83,20 @@ export type Instance = {
    * tracking after DISABLE_MOUSE_TRACKING has already been written.
    */
   detachForShutdown: Ink['detachForShutdown']
+  /**
+   * First half of the shutdown split: latch isUnmounted and stop every
+   * output producer while raw mode is STILL held. finishExit calls this
+   * before writing the exit sequence so the remote terminal consumes the
+   * mouse-disable bytes during the raw-mode settle window instead of
+   * echoing them as caret garbage after cooked mode returns (#522).
+   */
+  beginShutdown: Ink['beginShutdown']
+  /**
+   * Second half of the shutdown split: release raw mode and drain stdin.
+   * finishExit calls this in a finally after the settle window, so the
+   * cooked-mode restore happens even when the exit write fails.
+   */
+  concludeShutdown: Ink['concludeShutdown']
   /**
    * Fully detach stdin before handing the terminal to a child process that
    * inherits it (the /update and /restart handoffs). See Ink's own method
@@ -118,12 +145,18 @@ export const renderSync = (
   instance.render(node)
 
   return {
+    stdout: inkOptions.stdout,
+    get hasWrittenExitCleanup() {
+      return instance.hasWrittenExitCleanup
+    },
     rerender: instance.render,
     unmount() {
       instance.unmount()
     },
     waitUntilExit: instance.waitUntilExit,
     detachForShutdown: () => instance.detachForShutdown(),
+    beginShutdown: () => instance.beginShutdown(),
+    concludeShutdown: () => instance.concludeShutdown(),
     detachStdinForHandoff: () => instance.detachStdinForHandoff(),
     cleanup: () => instances.delete(inkOptions.stdout),
   }


### PR DESCRIPTION
Closes #522。

退出（退出（/exit、error-boundary、TTY 撤销等全部漏斗）后 shell 把鼠标报文回显成 `ESC[<0;12;5M` 类 caret 垃圾。

## 根因

- writeSync 只保证字节进内核 tty 缓冲：慢 SSH 链路下远端尚未处理 DISABLE，进程已把 stdin 拉回 cooked，迟到鼠标报文被 shell 回显；
- fd 直写越过 stdout 用户态队列：屏障后排队的迟到 ENABLE/帧会落在 DISABLE/EXIT_ALT_SCREEN 之后；
- 宿主替换 process.stdout 后，闩锁（作用在运行时流）与清理（作用在新 process.stdout）指向不同对象，清理落空；
- 闩锁后 writeRaw/输入派发仍有缝隙：异步 OSC 52 clipboard 回调、useInput 触发的新动作可在退出窗口期再碰终端；
- error-boundary 链路中 unmount 已写清理，finishExit 再写一遍 → DISABLE/EXIT_ALT 重复。

## 修法

- **两相 shutdown**：`detachForShutdown` 拆为 `beginShutdown`（闩锁+停输出生产者，raw 仍持有）与 `concludeShutdown`（raw-off+drain）；finishExit 新流程：latch → stdout 队列 barrier（`writableLength` 轮询，1s 上限）→ 退出序列 → **150ms raw 态 settle** → drain → finally conclude+handoff。
- **保序退出写**（`createExitWriter`）：barrier 排空后 writeSync 短写循环（EINTR/EAGAIN 独立预算）；无 fd/barrier 超时/写失败一律 **sticky** stream 队列 + bounded flush（等末笔回调，1s 上限）——两条纪律不混用，迟到字节不再越过 DISABLE/EXIT_ALT。
- **流身份**：Instance/InkShutdownState 显式携带 `stdout`，barrier/清理/notice 统一目标流。
- **闩锁门**：`Ink.writeRaw`/`App.writeRaw` 共享 shutdown 门（PromptInput 经 TerminalWriteContext 拿到的正是这支）；`App.handleReadable` 闩锁后只 drain 不派发。
- **异常隔离**：两相幂等状态机 + 每步独立 try/catch；conclude 与 handoff 各自独立 finally——TTY 撤销抛错不再跳过 stdin 交接（/update、/restart）。
- **error-boundary 幂等**：unmount 清理三段隔离、全成功才置 `exitCleanupWritten`；finishExit 检测后跳过重写，只补光标停泊+notice。

## 回归

- `verify-exit-mouse-disable-order`（**新增**，六场景 23 断言）：A raw 状态直接证据（drain 时 isRaw 仍为 true）/ B 无 fd / C 写入全灭 + conclude 抛错仍 handoff+done / D 显式 Promise gate barrier（gate 关闭时 DISABLE 不落盘）/ E barrier 超时 sticky 保序 / F identity mismatch（宿主换流后闩锁与清理仍同流）；
- `verify-exit-mouse-residue` 补强至 12 断言：useInput 真组件派发管线、isRaw 生命周期（begin 后仍 true / conclude 后 false）、闩锁后输入不派发、经 TerminalWriteContext 的 writeRaw 零字节；
- `verify-exit-mouse-cleanup` 27 断言：新增 error-boundary 场景——fd trace 恰一次 writeSync DISABLE（finishExit skip 生效）、跨通道（buffer+fd）恰一次 EXIT_ALT（React 解卷先跑 AlternateScreen effect 清理走 async 通道，unmount 的冗余 writeSync 被 altScreenActive 正确抑制）、尾部无 ENABLE；
- teardown-exit / exit-resume-marker / shutdown-fallback（兼容旧形 fake）全绿；`pnpm build`、`pnpm smoke` 通过；contributing 双语文档同步。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal shutdown reliability, including mouse-tracking disablement and restoration of cooked mode.
  * Prevented duplicate cleanup, late terminal writes, and input processing during application exit.
  * Preserved exit notices and completed cleanup despite output failures or timeouts.
  * Improved cleanup during application unmounts and concurrent shutdown requests.

* **Tests**
  * Expanded coverage for TTYs, fallback streams, write failures, shutdown ordering, and asynchronous terminal activity.

* **Documentation**
  * Added terminal cleanup verification requirements to the contribution guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
