### PR TITLE
docs: dsh-tui-browser-use 候选子插件待审

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ sh install.sh
 - **生态组织**：[dsh-tui-ecosystem](https://github.com/dsh-tui-ecosystem)（社区插件与模板的家）
 - **模板仓库**：[plugin-template](https://github.com/dsh-tui-ecosystem/plugin-template)（从模板起步，5 分钟出一个插件）
 - **参考实现**：`dsh-working-activity`（实时工作状态行：TUI 槽位 + `activity/status` 会话事件双出口）
+- **候选子插件（待审）**：[dsh-tui-browser-use](https://github.com/FlameTN7/dsh-tui-browser-use)——为 agent 提供浏览器自动化能力（21 个 `browser_*` 工具，Playwright 驱动，含截图视觉理解）。该项目**可能**作为 dsh-tui 的子插件（Cordis）随 `dsh --profile dsh-tui` 组合加载，尚未正式收录；在此知会各位维护者，欢迎审阅其接缝使用与兼容性。
 
 ### 接缝稳定性参考
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -461,6 +461,12 @@ Want to build a plugin or extension for dsh-TUI? Join the ecosystem:
   (start from the template and ship a plugin in minutes)
 - **Reference implementation**: `dsh-working-activity` (live working-status
   line with dual outlets: TUI prompt slot + `activity/status` session events)
+- **Candidate sub-plugin (under review)**: [dsh-tui-browser-use](https://github.com/FlameTN7/dsh-tui-browser-use) —
+  browser automation for the agent (21 `browser_*` tools, Playwright-driven,
+  screenshot vision understanding). The project **may** be mounted as a dsh-tui
+  sub-plugin (Cordis) in the `dsh --profile dsh-tui` composition; it is not yet
+  officially listed. This notice is for maintainers: please review its seam
+  usage and compatibility.
 
 ### Seam stability reference
 


### PR DESCRIPTION
`dsh-tui-browser-use` 项目 （ https://github.com/FlameTN7/dsh-tui-browser-use ）可能作为 dsh-tui 的子插件存在——它向 agent 注册 21 个 `browser_*` 工具（Playwright 驱动，含截图视觉理解），随 `dsh --profile dsh-tui` 组合加载。目前**尚未正式收录**，仅在此登记候选状态，请各位审一下其接缝使用与兼容性，再决定是否/如何纳入生态列表。

本pr只是告知和提醒作用，无需merge，本pr希望对 https://github.com/FlameTN7/dsh-tui-browser-use 进行评审

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the pending-review `dsh-tui-browser-use` plugin.
  * Documented its browser automation, Playwright integration, and screenshot-vision capabilities.
  * Clarified that the plugin is under review and not officially listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->