### PR TITLE
fix(scroll): 已在底部时向下滚轮不打断 sticky，消除「↓ 回到底部」提示栏闪烁

### DIFF
--- a/scripts/verify-scroll.mjs
+++ b/scripts/verify-scroll.mjs
@@ -94,6 +94,14 @@ async function run() {
   scrollHandle.scrollTo(36)
   check('bottom scroll landed at maxScroll', await settled(() => frameLog.at(-1)?.scrollTop === 36 && frameLog.at(-1)?.scrollHeight === 60), JSON.stringify(frameLog.at(-1)))
 
+  // ---- wheel-down at the bottom must not break stickiness (pill-flash
+  // regression): the renderer re-pins sticky, then a wheel-down cannot move
+  // the viewport — scrollBy must keep isSticky() true synchronously so Chat's
+  // "back to bottom" pill never flickers on.
+  check('sticky re-pinned at bottom', await settled(() => scrollHandle.isSticky() === true))
+  scrollHandle.scrollBy(5)
+  check('wheel-down at bottom keeps sticky (no pill flash)', scrollHandle.isSticky() === true)
+
   // ---- shrink frame: 20 rows → content collapses to the viewport height
   // (24; the content wrapper flexGrows to at least the viewport), so
   // maxScroll = 0. scrollTo(36) landed on the exact bottom, which re-pins

--- a/src/ink/components/ScrollBox.tsx
+++ b/src/ink/components/ScrollBox.tsx
@@ -190,13 +190,28 @@ function ScrollBox({
     scrollBy(dy: number) {
       const el = domRef.current;
       if (!el) return;
-      el.stickyScroll = false;
       // Wheel input cancels any in-flight anchor seek — user override.
       el.scrollAnchor = undefined;
+      const delta = Math.floor(dy);
+      const viewportH = el.scrollViewportHeight ?? 0;
+      const maxScroll = Math.max(0, (el.scrollHeight ?? 0) - viewportH);
+      const projectedTop = (el.scrollTop ?? 0) + (el.pendingScrollDelta ?? 0);
+      // Wheel-down while already pinned at the bottom can't move the viewport;
+      // breaking stickiness here surfaces a transient stickyScroll=false to
+      // React subscribers before the renderer re-pins a frame later, flashing
+      // Chat's "back to bottom" pill. Keep sticky, drop the no-op delta.
+      if (delta >= 0 && projectedTop >= maxScroll) {
+        if (el.stickyScroll === false) {
+          el.stickyScroll = true;
+          scrollMutated(el);
+        }
+        return;
+      }
+      el.stickyScroll = false;
       // Accumulate in pendingScrollDelta; renderer drains it at a capped
       // rate so fast flicks show intermediate frames. Pure accumulator:
       // scroll-up followed by scroll-down naturally cancels.
-      el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy);
+      el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + delta;
       scrollMutated(el);
     },
     scrollToBottom() {


### PR DESCRIPTION
Fixes #708

## 问题

已在底部（新会话、内容不满一屏）时向下滚动，偶发闪出蓝底「↓ 回到底部（Enter/End）」提示栏，视口并未移动。

## 根因

`ScrollBox.scrollBy` 无条件 `stickyScroll=false`，即便当前已在底部、该滚轮增量无法移动视口。瞬时 `false` 经 `notifyCoalesced` 通知 `Chat` 的 `isSticky`，`showPill=!isSticky` 翻真 → 提示栏出现；一帧后渲染器 at-bottom re-pin 才复位。`notifyCoalesced` 的 microtask/`setTimeout` 两路径造成「每段滚动首个事件才闪」的偶发性。

## 改动

- `src/ink/components/ScrollBox.tsx`：`scrollBy` 增守卫——向下滚轮（`delta>=0`）且投影位置已达 `maxScroll` 时视作无操作，保持 sticky、丢弃无效增量；渲染器 re-pin 仍作兜底。
- `scripts/verify-scroll.mjs`：新增同步断言，底部向下滚轮后 `isSticky()` 恒为 `true`（未修复则同步读到瞬时 `false`，断言失败）。

## 验证

- `node scripts/run-ci-group.mjs render-scroll`：scroll/pill 相关全绿（`verify-scroll`、`verify-back-to-bottom`、`repro-pill`、`repro-user-drag-wheel-render` 等）。
- 组内 `repro-askpanel`、`verify-askpanel-layout` 为既有失败（clean tree 同样红），与本改动无关。

## 备注

#646 的 `fix(scroll)` 亦覆盖此 case，但夹带在大体量 feature PR 内；本 PR 为一处外科式修复。
