### PR TITLE
perf: 消除 CPU 空转（render 热路径 / O(n) 扫描 / stdout 背压 / 后台轮询）

### DIFF
--- a/scripts/repro-slow-stdout.tsx
+++ b/scripts/repro-slow-stdout.tsx
@@ -1,0 +1,147 @@
+/**
+ * Slow-stdout reproduction: a stream that rejects writes (returns false,
+ * holds the callback, never drains on its own) must NOT put the renderer
+ * into a fixed ~4ms re-probe loop, must not accumulate an unbounded write
+ * backlog, and must resume on the stream's own `drain` event. Teardown
+ * must clear the drain listener and the fallback timer.
+ *
+ *   A. Backpressured window: bounded write count (fallback backoff, not a
+ *      4ms busy loop) and bounded backlog (frames coalesce, no growth).
+ *   B. `drain` event resumes writes.
+ *   C. unmount clears the drain listener and timers.
+ *
+ * Run via `node --import tsx/esm scripts/repro-slow-stdout.tsx`.
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { render }, { Text }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/ui.js'),
+])
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** An animated node so renders keep coming while we watch the gate. */
+function Animated(): React.ReactNode {
+  const [tick, setTick] = React.useState(0)
+  React.useEffect(() => {
+    const timer = setInterval(() => setTick(t => t + 1), 100)
+    return () => clearInterval(timer)
+  }, [])
+  return React.createElement(Text, null, `tick ${tick} `.repeat(40))
+}
+
+class SlowStdout extends Writable {
+  columns = 100
+  rows = 24
+  isTTY = true
+  writes = 0
+  heldCallbacks: Array<() => void> = []
+  term!: { write(chunk: string, cb: () => void): void }
+  override _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    this.writes += 1
+    // Hold the callback: the stream never flushes on its own (SSH-like
+    // saturated pipe). The internal buffer grows until write() returns
+    // false, which is exactly the state the backpressure gate must handle.
+    // When a held callback eventually fires (the B-phase flush), the bytes
+    // reach the simulated terminal — so the final-content assertion is real.
+    this.heldCallbacks.push(() => {
+      callback()
+      this.term.write(String(chunk), () => {})
+    })
+  }
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+
+const stdout = new SlowStdout()
+const stdin = new FakeStdin()
+const term = new (await import('@xterm/headless')).Terminal({ cols: 100, rows: 24, scrollback: 100, allowProposedApi: true })
+stdout.term = term
+const instance = await render(
+  React.createElement(Animated),
+  { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+)
+for (const value of instances.values()) instances.set(process.stdout, value)
+const ink = instances.get(stdout) ?? instances.values().next().value
+
+// Let the first paint land and the write buffer saturate (the held
+// callbacks make writableLength climb past the 8192 gate). Wait until the
+// ink instance actually reports backpressure before measuring anything.
+let saturated = false
+for (let i = 0; i < 100 && !saturated; i++) {
+  await sleep(50)
+  saturated = (ink as { backpressured?: boolean }).backpressured === true
+}
+check('saturation: the renderer reports backpressure', saturated, '')
+stdout.writes = 0
+
+// ── A. Backpressured window: bounded wakeups, bounded backlog ─────────────
+const startLength = (stdout as unknown as { writableLength: number }).writableLength
+await sleep(1500)
+const writesInWindow = stdout.writes
+// Fallback ladder 250+500+1000ms ⇒ ≤ ~5 re-probes in 1.5s. A 4ms busy loop
+// would be ~375. Allow slack for boundary effects.
+check('A1: backpressured renderer does not busy-poll at 4ms',
+  writesInWindow <= 8,
+  `writes=${writesInWindow} over 1.5s`)
+const endLength = (stdout as unknown as { writableLength: number }).writableLength
+check('A2: write backlog stays bounded while backpressured',
+  endLength - startLength <= 8192,
+  `backlog delta=${endLength - startLength} bytes (≤ one frame)`)
+// A second window must not keep growing the backlog: the gate holds it at
+// the saturation level instead of stacking a frame per render.
+const startLength2 = endLength
+await sleep(1500)
+const endLength2 = (stdout as unknown as { writableLength: number }).writableLength
+check('A3: backlog plateaus (no infinite growth)',
+  endLength2 <= startLength2 + 1024,
+  `second-window delta=${endLength2 - startLength2} bytes`)
+
+// ── B. The stream's own drain resumes painting ────────────────────────────
+stdout.writes = 0
+// Flush the held chunk (the drain that a real stream would emit after the
+// buffer empties) then signal drain explicitly.
+for (const cb of stdout.heldCallbacks) cb()
+if (process.env.SLOW_DEBUG === '1') console.error('[slow] B-phase flush done')
+stdout.heldCallbacks = []
+stdout.emit('drain')
+await sleep(400)
+check('B: drain event resumes frame writes', stdout.writes > 0, `writes=${stdout.writes} after drain`)
+// The coalesced frames must have painted the LATEST content: a skipped
+// frame's delta is re-computed against the last-written baseline, so the
+// terminal holds the final state, not a stale one.
+const buffer = term.buffer.active
+const screenText = Array.from({ length: 24 }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+check('B2: final terminal content is complete (no lost frames)',
+  /tick \d+/.test(screenText) && screenText.includes('tick'),
+  screenText.slice(0, 60).replace(/\n/g, '|'))
+
+// ── C. Teardown clears listener + timers ──────────────────────────────────
+instance.unmount()
+instances.delete(stdout)
+await sleep(50)
+check('C1: unmount removes the drain listener',
+  stdout.listenerCount('drain') === 0,
+  `drain listeners=${stdout.listenerCount('drain')}`)
+const drainTimerCleared =
+  (ink as { drainTimer?: unknown }).drainTimer === null ||
+  (ink as { drainTimer?: unknown }).drainTimer === undefined
+check('C2: unmount clears the fallback timer', drainTimerCleared, '')
+stdout.destroy()
+
+console.log(failed === 0 ? 'repro-slow-stdout: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-grants-watch.ts
+++ b/scripts/verify-grants-watch.ts
@@ -1,0 +1,116 @@
+/**
+ * Grants-file watcher regression: the fallback GrantStore must notify on
+ * file changes (event-driven, not a 50ms poll), stop polling once the last
+ * subscriber unsubscribes, and fall back to a slow bounded poll when
+ * fs.watch cannot watch the file (e.g. it does not exist yet).
+ *
+ *   A. Live file: a write notifies subscribers promptly; an unchanged file
+ *      notifies nothing; unsubscribe stops the watcher (later writes do
+ *      not notify).
+ *   B. Missing file: fs.watch fails → slow fallback poll still picks up a
+ *      subsequently created file.
+ *
+ * Run via `node --import tsx/esm scripts/verify-grants-watch.mjs`.
+ */
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { sleep } from './lib/term-test.mjs'
+const { readGrantStore, EXTENSION_GRANTS_FILE } = await import('../src/dsh-adapter/grants.js')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+// ── A. Live file: event-driven notify + cleanup ───────────────────────────
+{
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const file = join(dir, EXTENSION_GRANTS_FILE)
+  writeFileSync(file, JSON.stringify({ grants: { live: [] } }))
+  const store = readGrantStore(dir)
+  let notified = 0
+  const stop = store.onChange?.(() => { notified += 1 })
+  check('A0: onChange seam exists', typeof stop === 'function')
+  await sleep(300) // settle: any initial watcher chatter must not notify
+  const baseline = notified
+  // A write that does not change the content must not notify (signature
+  // dedupe), and the watcher must be quiet while the file is static.
+  writeFileSync(file, JSON.stringify({ grants: { live: [] } }))
+  await sleep(300)
+  check('A1: unchanged file content notifies nothing', notified === baseline, `notified=${notified}`)
+  // A real change notifies promptly (fs.watch + 50ms debounce ≪ 250ms).
+  writeFileSync(file, JSON.stringify({
+    grants: { live: [{ name: 'session.input.intercept', scope: 'tui/input' }] },
+  }))
+  await sleep(250)
+  check('A2: a change notifies within a bounded delay', notified === baseline + 1, `notified=${notified}`)
+  // Revocation semantics stay live: allows() reads the file fresh.
+  check('A3: allows() reads the fresh file',
+    store.allows({ componentId: 'live' }, 'session.input.intercept', 'tui/input') === true)
+  // Unsubscribe stops the watcher: later writes must not notify.
+  stop?.()
+  notified = 0
+  writeFileSync(file, JSON.stringify({ grants: { live: [] } }))
+  await sleep(300)
+  check('A4: unsubscribe stops the watcher', notified === 0, `notified=${notified}`)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// ── B. Missing file: slow fallback poll picks up creation ─────────────────
+{
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const file = join(dir, EXTENSION_GRANTS_FILE)
+  const store = readGrantStore(dir)
+  let notified = 0
+  const stop = store.onChange?.(() => { notified += 1 })
+  check('B0: onChange seam exists on a missing file', typeof stop === 'function')
+  await sleep(300)
+  // fs.watch on a nonexistent path errors → the 2s fallback poll arms.
+  // Create the file: the poll must pick it up (allow up to ~2.8s for the
+  // first poll tick + debounce).
+  writeFileSync(file, JSON.stringify({ grants: { late: ['commands.invoke'] } }))
+  await sleep(2800)
+  check('B1: fallback poll picks up a created file', notified >= 1, `notified=${notified}`)
+  // Cleanup: the fallback poll must stop with the last subscriber.
+  notified = 0
+  stop?.()
+  writeFileSync(file, JSON.stringify({ grants: { late: [] } }))
+  await sleep(2500)
+  check('B2: fallback poll stops after unsubscribe', notified === 0, `notified=${notified}`)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// ── C. Atomic replace (temp file + rename) must still notify ─────────────
+// The common editor/writer pattern swaps the inode; a watcher pinned to the
+// old FILE would go silent. The directory watcher must see the rename.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const file = join(dir, EXTENSION_GRANTS_FILE)
+  writeFileSync(file, JSON.stringify({ grants: { atomic: [] } }))
+  const store = readGrantStore(dir)
+  let notified = 0
+  const stop = store.onChange?.(() => { notified += 1 })
+  await sleep(300)
+  const tmp = `${file}.tmp`
+  writeFileSync(tmp, JSON.stringify({ grants: { atomic: [{ name: 'commands.invoke', scope: 'root.command' }] } }))
+  renameSync(tmp, file)
+  await sleep(250)
+  check('C1: atomic replace notifies subscribers',
+    notified >= 1, `notified=${notified}`)
+  check('C2: allows() sees the replaced file',
+    store.allows({ componentId: 'atomic' }, 'commands.invoke', 'root.command') === true)
+  // delete/recreate: the directory watcher must also survive removal.
+  rmSync(file)
+  await sleep(250)
+  const afterDelete = notified
+  writeFileSync(file, JSON.stringify({ grants: { atomic: [] } }))
+  await sleep(250)
+  check('C3: delete/recreate notifies again', notified > afterDelete, `notified=${notified}`)
+  stop?.()
+  rmSync(dir, { recursive: true, force: true })
+}
+
+console.log(failed === 0 ? 'verify-grants-watch: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-idle-wakeups.tsx
+++ b/scripts/verify-idle-wakeups.tsx
@@ -1,0 +1,304 @@
+/**
+ * Idle-wakeup regression: static UI states must not hold animation clocks
+ * or periodic timers. Asserts, per component, that a quiet window produces
+ * ZERO frames (no renderer commits) in the static state and a non-zero
+ * frame count in the corresponding live state.
+ *
+ *   A. Chat idle (working=false, activity off): no frames after settle.
+ *   B. Chat working with the mini-wake enabled: frames while wide, no
+ *      frames on a narrow terminal (width gate) or with the wake disabled.
+ *   C. ActivityLine done: no frames; live phase: frames.
+ *   D. JobsPanel all-settled: no frames; with a running job: frames.
+ *   E. GoalTodoPanel paused/blocked: no frames; active: frames.
+ *
+ * Run via `node --import tsx/esm scripts/verify-idle-wakeups.tsx`.
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { Box }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/dsh-adapter/questions.js'),
+    import('../src/ui.js'),
+  ])
+const { ActivityLine } = await import('../src/components/ActivityLine.js')
+const { JobsPanel } = await import('../src/components/JobsPanel.js')
+const { GoalTodoPanel } = await import('../src/components/GoalTodoPanel.js')
+const { AgentView } = await import('../src/screens/AgentView.js')
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** Mount a React node in a headless terminal; counts painted frames. */
+async function mountProbe(cols: number, rows: number, node: React.ReactNode): Promise<{
+  countFrames: (windowMs: number) => Promise<number>
+  unmount: () => void
+}> {
+  const term = new XTerm({ cols, rows, scrollback: 100, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  let frames = 0
+  const causes: string[] = []
+  const instance = await render(node, {
+    stdout: stdout as never,
+    stdin: stdin as never,
+    stderr: stdout as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+    onFrame: () => { frames += 1 },
+  })
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  // Settle the initial paint (and any one-shot intro animations, plus the
+  // MessageList measure cascade / paint-expansion hold).
+  await sleep(900)
+  const countFrames = async (windowMs: number): Promise<number> => {
+    frames = 0
+    await sleep(windowMs)
+    return frames
+  }
+  const frameLog = (): void => {
+    // eslint-disable-next-line no-console
+    console.error(`[probe] frames=${frames}`)
+  }
+  const unmount = (): void => {
+    instance.unmount()
+    instances.delete(stdout)
+    term.dispose()
+  }
+  return { countFrames, unmount }
+}
+
+function makeChannel(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  // 40 rows: past the LogoHeader intro threshold (rows.length > 30 skips
+  // the ~3.4s whale animation), so the idle probe measures the steady state.
+  const rows = Array.from({ length: 40 }, (_, i) => ({
+    id: i,
+    kind: (i % 3 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    text: `row ${i}`,
+  }))
+  return {
+    version: 0,
+    rows,
+    status: 'idle',
+    sessionTitle: 'idle probe',
+    agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    tokens: { input: 600, output: 120 },
+    cwd: 'C:/code/demo',
+    displayCwd: 'C:/code/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    turnStart: Date.now() - 60_000,
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: true,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: true, shortcutHint: false,
+    },
+    activityFrames: [],
+    loadedContext: undefined,
+    goal: undefined,
+    todos: [],
+    traceEvents: () => [],
+    trajectory: () => ({ nodes: [], counts: { rows: 0, errors: 0 } }),
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => {},
+    clear: (): void => {},
+    notify: (): void => {},
+    ...overrides,
+  }
+}
+
+const chatNode = (channel: Record<string, unknown>): React.ReactNode =>
+  React.createElement(Chat, {
+    channel: channel as never,
+    questionStore: new QuestionStore() as never,
+    onExit: () => {},
+    fullscreen: false,
+    trajectorySeen: true,
+  })
+
+// ── A. Idle Chat: no periodic Chat-level renders ──────────────────────────
+{
+  const probe = await mountProbe(120, 30, chatNode(makeChannel()))
+  const frames = await probe.countFrames(1500)
+  check('A: idle Chat produces no periodic frames', frames === 0, `frames=${frames} over 1.5s`)
+  probe.unmount()
+}
+
+// ── B. MiniWake clock gating (wide/narrow/disabled) ───────────────────────
+{
+  // Wide + working + wake enabled: the 120ms wake clock ticks → frames.
+  const wide = await mountProbe(120, 30, chatNode(makeChannel({ working: true })))
+  const wideFrames = await wide.countFrames(1000)
+  check('B1: working Chat with wake enabled renders periodically',
+    wideFrames > 0, `frames=${wideFrames} over 1s`)
+  wide.unmount()
+
+  // The working spinner is a separate, legitimate animation (~17fps); the
+  // wake clock adds its own 120ms ticks on top. The gate assertions below
+  // therefore compare against the enabled baseline: when the wake is gated
+  // off (narrow terminal / disabled status-bar field), the frame rate must
+  // drop back to the spinner-only level.
+  // Narrow (<84 cols): miniWakeWidth()=0 → wake clock off despite working.
+  const narrow = await mountProbe(80, 30, chatNode(makeChannel({ working: true })))
+  const narrowFrames = await narrow.countFrames(1000)
+  check('B2: narrow terminal stops the wake clock',
+    narrowFrames > 0 && narrowFrames < wideFrames,
+    `frames=${narrowFrames} vs enabled=${wideFrames}`)
+  narrow.unmount()
+
+  // Wake disabled in the status bar: same gate, no clock.
+  const disabled = await mountProbe(120, 30, chatNode(makeChannel({
+    working: true,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: false, shortcutHint: false,
+    },
+  })))
+  const disabledFrames = await disabled.countFrames(1000)
+  check('B3: wake-disabled status bar stops the clock',
+    disabledFrames > 0 && disabledFrames < wideFrames,
+    `frames=${disabledFrames} vs enabled=${wideFrames}`)
+  disabled.unmount()
+}
+
+// ── C. ActivityLine static-done branch ────────────────────────────────────
+{
+  const done = {
+    phase: 'done' as const, line: '3 tools · thought 2s worked 1s', toolCount: 3, turnElapsedMs: 4000,
+  }
+  const doneProbe = await mountProbe(100, 20, React.createElement(ActivityLine, { activity: done }))
+  const doneFrames = await doneProbe.countFrames(1000)
+  check('C1: ActivityLine(done) holds no animation clock', doneFrames === 0, `frames=${doneFrames}`)
+  doneProbe.unmount()
+
+  const live = {
+    phase: 'thinking' as const, line: 'thinking · total 3s', toolCount: 0, turnElapsedMs: 3000,
+  }
+  const liveProbe = await mountProbe(100, 20, React.createElement(ActivityLine, { activity: live }))
+  const liveFrames = await liveProbe.countFrames(1000)
+  check('C2: ActivityLine(live) animates', liveFrames > 0, `frames=${liveFrames}`)
+  liveProbe.unmount()
+}
+
+// ── D. JobsPanel settled vs live ──────────────────────────────────────────
+{
+  const settledJobs = [
+    { id: 'j1', kind: 'shell', label: 'done job', status: 'completed' as const, startedAt: Date.now() - 5000, finishedAt: Date.now() - 1000, outputLines: [], command: undefined, detail: undefined, lastOutputAt: undefined, exitCode: 0 },
+  ]
+  const settledProbe = await mountProbe(100, 24, React.createElement(JobsPanel, {
+    jobs: settledJobs, onClose: () => {}, onKill: () => {},
+  }))
+  const settledFrames = await settledProbe.countFrames(1000)
+  check('D1: all-settled JobsPanel holds no clock', settledFrames === 0, `frames=${settledFrames}`)
+  settledProbe.unmount()
+
+  const emptyProbe = await mountProbe(100, 24, React.createElement(JobsPanel, {
+    jobs: [], onClose: () => {}, onKill: () => {},
+  }))
+  const emptyFrames = await emptyProbe.countFrames(1000)
+  check('D2: empty JobsPanel holds no clock', emptyFrames === 0, `frames=${emptyFrames}`)
+  emptyProbe.unmount()
+
+  const runningJobs = [
+    { id: 'j2', kind: 'shell', label: 'live job', status: 'running' as const, startedAt: Date.now() - 2000, finishedAt: undefined, outputLines: [], command: undefined, detail: undefined, lastOutputAt: Date.now() - 100, exitCode: undefined },
+  ]
+  const liveProbe = await mountProbe(100, 24, React.createElement(JobsPanel, {
+    jobs: runningJobs, onClose: () => {}, onKill: () => {},
+  }))
+  const liveFrames = await liveProbe.countFrames(1500)
+  check('D3: running job ticks the clock', liveFrames > 0, `frames=${liveFrames}`)
+  liveProbe.unmount()
+}
+
+// ── E. GoalTodoPanel paused/blocked vs active ─────────────────────────────
+{
+  const goalBase = {
+    id: 'g1', objective: 'build the thing', roundsStarted: 1, maxGoalRounds: 4,
+    phase: 'paused' as const, blockedReason: undefined,
+  }
+  const channel = (phase: 'paused' | 'blocked' | 'active'): Record<string, unknown> => {
+    const base = makeChannel()
+    base.goal = { ...goalBase, phase }
+    base.todos = [{ id: 't1', content: 'step one', status: 'pending' }]
+    return base
+  }
+  const pausedProbe = await mountProbe(100, 24, React.createElement(GoalTodoPanel, { channel: channel('paused') as never }))
+  const pausedFrames = await pausedProbe.countFrames(1200)
+  check('E1: paused goal holds no elapsed clock', pausedFrames === 0, `frames=${pausedFrames}`)
+  pausedProbe.unmount()
+
+  const blockedProbe = await mountProbe(100, 24, React.createElement(GoalTodoPanel, { channel: channel('blocked') as never }))
+  const blockedFrames = await blockedProbe.countFrames(1200)
+  check('E2: blocked goal holds no elapsed clock', blockedFrames === 0, `frames=${blockedFrames}`)
+  blockedProbe.unmount()
+
+  const activeProbe = await mountProbe(100, 24, React.createElement(GoalTodoPanel, { channel: channel('active') as never }))
+  const activeFrames = await activeProbe.countFrames(1500)
+  check('E3: active goal ticks the elapsed clock', activeFrames > 0, `frames=${activeFrames}`)
+  activeProbe.unmount()
+}
+
+// ── F. AgentView static list: bucket-boundary clock, not a 1s poll ────────
+{
+  const agentViewChannel = makeChannel()
+  agentViewChannel.agentViewRows = () => [
+    { id: 's1', status: 'completed', title: 'done session', summary: '', cwd: '/tmp', createdAt: Date.now() - 3600_000, updatedAt: Date.now() - 3600_000, current: false, needsInput: false },
+    { id: 's2', status: 'stopped', title: 'old session', summary: '', cwd: '/tmp', createdAt: Date.now() - 7200_000, updatedAt: Date.now() - 7200_000, current: false, needsInput: false },
+  ]
+  agentViewChannel.subscribeAgentView = () => () => {}
+  const probe = await mountProbe(120, 30, React.createElement(AgentView, {
+    channel: agentViewChannel as never,
+    home: '/home',
+    approval: null,
+    onApprove: () => {},
+    onClose: () => {},
+  }))
+  // Rows aged 1-2h: the next display bucket (minute/half-hour boundary) is
+  // minutes away, so a 2s window must contain NO clock-driven frames — a
+  // 1s polling clock would produce 1-2.
+  const frames = await probe.countFrames(2000)
+  check('F: static AgentView list holds no 1s clock', frames === 0, `frames=${frames} over 2s`)
+  probe.unmount()
+}
+
+console.log(failed === 0 ? 'verify-idle-wakeups: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -43,7 +43,11 @@ const commandService = {
     if (registered.has(descriptor.name)) throw new Error(`duplicate command: ${descriptor.name}`)
     registered.set(descriptor.name, descriptor)
     fire('commands/change')
-    return () => { registered.delete(descriptor.name) }
+    // Real dsh-commands emits commands/change on unregister too (the effect
+    // disposer tears the layer down and notifyChange() fires); the menu
+    // merge must hear about a disposed handler or it keeps listing skills
+    // whose dispatch command no longer exists.
+    return () => { registered.delete(descriptor.name); fire('commands/change') }
   },
 }
 
@@ -441,6 +445,60 @@ fire('skills/change')
     'current agent B returns a fresh /skills snapshot',
     freshSkills?.some(skill => skill.name === 'fresh') === true,
   )
+}
+
+// ---- an observation that NEVER completes retries a bounded number of
+// times with backoff, then stops polling and keeps last-good until the
+// next skills/change (the provider's own invalidation). Without the cap a
+// broken provider would keep an 800ms re-read loop alive forever.
+{
+  // Establish a last-good command set first (complete observation).
+  let snapshotCalls = 0
+  let incomplete = false
+  ctx.get = (name) => {
+    if (name === 'commands') return { list: () => [{ name: 'plan', description: 'Toggle plan mode' }] }
+    if (name === 'skills') {
+      return {
+        snapshot: async () => {
+          snapshotCalls += 1
+          return incomplete ? { skills: [], complete: false } : {
+            skills: [{ name: 'kept-skill', description: 'Kept', invocation: { modelInvocable: true, userInvocable: true } }],
+            complete: true,
+          }
+        },
+      }
+    }
+    return undefined
+  }
+  ctx.logger = { warn() {} }
+  fire('skills/change')
+  check('retry ladder: last-good established',
+    await settled(() => channel.commandList.some(command => command.name === 'kept-skill')))
+  const callsAfterGood = snapshotCalls
+  incomplete = true
+  fire('skills/change')
+  // Each skills/change fires BOTH consumers (the menu merge AND the
+  // command registration), so one change costs two snapshot reads; the
+  // registration ladder then retries 800+1600+3200ms (3 re-reads). The
+  // bound: 2 (change) + 3 (ladder) = 5 extra snapshot calls max.
+  await sleep(6800)
+  const callsAfterRetries = snapshotCalls
+  check('retry ladder: incomplete observation retries a bounded number of times',
+    callsAfterRetries <= callsAfterGood + 5,
+    `snapshot calls=${callsAfterRetries} after ladder (good=${callsAfterGood})`)
+  // A further window must see ZERO additional retries: the ladder is
+  // exhausted and last-good is preserved.
+  await sleep(1500)
+  check('retry ladder: retries stop after the cap',
+    snapshotCalls === callsAfterRetries,
+    `snapshot calls=${snapshotCalls}`)
+  check('retry ladder: last-good skills survive the exhausted ladder',
+    channel.commandList.some(command => command.name === 'kept-skill'))
+  // Recovery: the provider's own skills/change re-enters and completes.
+  incomplete = false
+  fire('skills/change')
+  check('retry ladder: a later skills/change recovers',
+    await settled(() => channel.commandList.some(command => command.name === 'kept-skill')))
 }
 
 console.log(failed === 0 ? 'ALL PASS' : `${failed} FAILED`)

--- a/scripts/verify-trajectory-cache.tsx
+++ b/scripts/verify-trajectory-cache.tsx
@@ -1,0 +1,244 @@
+/**
+ * Trajectory cache regression: Chat renders must not reach the session
+ * event getter, and the legacy `traceEvents()`-only fallback must fold by
+ * snapshot identity (one getter call per snapshot, not per render).
+ *
+ *   A. A channel providing `trajectory()`: `traceEvents` is never called
+ *      during render, across many version bumps.
+ *   B. A legacy stub providing only `traceEvents()`: repeated renders with
+ *      an unchanged snapshot call the getter exactly once; a NEW snapshot
+ *      (appended event) costs exactly one more call; the folded build
+ *      grows incrementally.
+ *
+ * Run via `node --import tsx/esm scripts/verify-trajectory-cache.tsx`.
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/dsh-adapter/questions.js'),
+  ])
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** A minimal session event log: one turn with a user + assistant message. */
+const makeEvents = (): Record<string, unknown>[] => [
+  { type: 'turn/start', seq: 1, time: 1000, data: { turn: 1 } },
+  {
+    type: 'user/message', seq: 2, time: 1100,
+    data: { turn: 1, content: [{ type: 'text', text: 'hello' }], source: { kind: 'user' } },
+  },
+  {
+    type: 'assistant/message', seq: 3, time: 1200,
+    data: { turn: 1, content: [{ type: 'text', text: 'hi there' }] },
+  },
+  { type: 'turn/end', seq: 4, time: 1300, data: { turn: 1, reason: { kind: 'completed' } } },
+]
+
+function makeChannel(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    version: 0,
+    rows: [],
+    status: 'idle',
+    sessionTitle: 'cache probe',
+    agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    tokens: { input: 600, output: 120 },
+    cwd: 'C:/code/demo',
+    displayCwd: 'C:/code/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    turnStart: Date.now() - 60_000,
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: true,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: true, shortcutHint: false,
+    },
+    activityFrames: [],
+    loadedContext: undefined,
+    goal: undefined,
+    todos: [],
+    traceEvents: () => [],
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => {},
+    clear: (): void => {},
+    notify: (): void => {},
+    ...overrides,
+  }
+}
+
+function makeHarness(cols: number, rows: number): {
+  stdout: Writable
+  stdin: PassThrough
+  term: XTerm
+  screen: () => string
+  dispose: () => void
+} {
+  const term = new XTerm({ cols, rows, scrollback: 200, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const screen = (): string => {
+    const buffer = term.buffer.active
+    return Array.from({ length: rows }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+  }
+  return { stdout, stdin, term, screen, dispose: () => { term.dispose() } }
+}
+
+// ── A. Real trajectory seam: renders never touch the event getter ─────────
+{
+  const { stdout, stdin, dispose } = makeHarness(100, 24)
+  let traceCalls = 0
+  let build = { nodes: [] as unknown[], counts: { rows: 0, errors: 0 } }
+  const listeners = new Set<() => void>()
+  const events = makeEvents()
+  const channel = makeChannel({
+    traceEvents: () => {
+      traceCalls += 1
+      return events
+    },
+    trajectory: () => build,
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  })
+  const publish = (): void => {
+    channel.version = Number(channel.version) + 1
+    for (const listener of listeners) listener()
+  }
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+  )
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  await sleep(200)
+  const callsAfterMount = traceCalls
+  // Ten idle version bumps (the streaming-cadence wakeup pattern): renders
+  // must not re-read events through the getter.
+  for (let i = 0; i < 10; i++) {
+    publish()
+    await sleep(20)
+  }
+  check('A1: trajectory seam renders never call traceEvents',
+    traceCalls === callsAfterMount,
+    `traceCalls=${traceCalls} after mount+10 bumps`)
+  // A session append changes the build: the channel folds it at event time
+  // (exercised through extendTrajectory directly), and a render reads the
+  // new build without touching the getter.
+  build = { nodes: [{ seq: 5 } as never], counts: { rows: 1, errors: 0 } }
+  publish()
+  await sleep(50)
+  check('A2: appended build is read without traceEvents',
+    traceCalls === callsAfterMount,
+    `traceCalls=${traceCalls}`)
+  instance.unmount()
+  instances.delete(process.stdout)
+  dispose()
+}
+
+// ── B. Legacy fallback: snapshot-identity cached fold ─────────────────────
+{
+  const { stdout, stdin, dispose } = makeHarness(100, 24)
+  let events = makeEvents()
+  let traceCalls = 0
+  const listeners = new Set<() => void>()
+  const channel = makeChannel({
+    // Working + trajectory-enabled + wide terminal: the status-line wake
+    // clock ticks at 120ms, re-rendering Chat WITHOUT version bumps — the
+    // perfect "idle render" source for the fallback probe.
+    working: true,
+    traceEvents: () => {
+      traceCalls += 1
+      return events
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  })
+  const publish = (): void => {
+    channel.version = Number(channel.version) + 1
+    for (const listener of listeners) listener()
+  }
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+  )
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  await sleep(150)
+  const afterMount = traceCalls
+  check('B1: legacy fallback folds once at mount',
+    afterMount >= 1 && afterMount <= 2,
+    `traceCalls=${afterMount}`)
+  // Wake-clock renders (unchanged channel version): the version gate must
+  // keep the getter silent — no per-render re-reads on an idle render.
+  await sleep(600)
+  check('B2: unchanged version renders never call traceEvents',
+    traceCalls === afterMount,
+    `traceCalls=${traceCalls} after ~5 wake ticks`)
+  // One appended event → one new snapshot → exactly one more getter call,
+  // and the fold extends the previous build (incremental path).
+  const appended = events
+  events = [...appended, { type: 'turn/start', seq: 5, time: 2000, data: { turn: 2 } }]
+  publish()
+  await sleep(50)
+  check('B3: one appended event costs exactly one getter call',
+    traceCalls === afterMount + 1,
+    `traceCalls=${traceCalls}`)
+  instance.unmount()
+  instances.delete(process.stdout)
+  dispose()
+}
+
+console.log(failed === 0 ? 'verify-trajectory-cache: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-working-activity.mjs
+++ b/scripts/verify-working-activity.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { settled } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 const testHome = mkdtempSync(join(tmpdir(), 'dsh-tui-activity-home-'))
 process.env.HOME = testHome
@@ -196,6 +196,78 @@ sessionEvent()(agent.session, {
   data: { turn: 'minimal-turn', step: 'step-1', chunk: { type: 'text-delta', text: 'hi' } },
 })
 assert.match(minimalChannel.workingActivity.line, /思考中|Thinking/)
+
+// ── the 500ms tick retires once the turn is done and the line is stable ───
+// (P1-4): a live phase holds the tick; a done summary keeps it only through
+// the completed-tool fragment window (~3s), then the timer stops and an
+// idle conversation emits nothing.
+{
+  const fresh = makeAgent('agent-3', 'session-3')
+  const tickChannel = createChannel(ctx, fresh, {
+    model: 'test-model', provider: 'test-provider', cwd: testHome, activity: true,
+  })
+  let emits = 0
+  const unsubscribe = tickChannel.subscribe(() => { emits += 1 })
+  // Run a full turn to completion.
+  handlers.get('agent/status')({ agent: fresh, status: 'running' })
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/start', seq: 0, time: Date.now(), data: { turn: 'tick-turn' },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 1, time: Date.now(),
+    data: { turn: 'tick-turn', step: 'step-1', chunk: { type: 'text-delta', text: 'hi' } },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/end', seq: 2, time: Date.now(),
+    data: { turn: 'tick-turn', reason: { kind: 'completed' } },
+  })
+  handlers.get('agent/status')({ agent: fresh, status: 'idle' })
+  assert.equal(tickChannel.workingActivity?.phase, 'done')
+  // The done summary carries a short-lived fragment; after it stabilizes
+  // (~3s window + 4s grace) the tick must stop: no further emits.
+  const emitsAtDone = emits
+  await settled(() => emits > emitsAtDone || tickChannel.workingActivity?.phase === 'done')
+  await sleep(5500)
+  const emitsAfterIdle = emits
+  await sleep(2000)
+  assert.equal(emits, emitsAfterIdle, 'no activity emits while the done line is stable')
+  unsubscribe()
+}
+
+// ── streaming revive bumps rowsStreamingVersion (P2-7) ────────────────────
+// A reconnect replay that revives a previously sealed assistant row flips
+// `streaming` IN PLACE — invisible to rows identity/length, so the
+// transcript filter cache must hear about it via the version counter.
+{
+  const fresh = makeAgent('agent-4', 'session-4')
+  const reviveChannel = createChannel(ctx, fresh, {
+    model: 'test-model', provider: 'test-provider', cwd: testHome, activity: false,
+  })
+  const before = reviveChannel.rowsStreamingVersion
+  // Stream a step, then seal it with an assistant/message.
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/start', seq: 0, time: Date.now(), data: { turn: 1, step: 1 },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 1, time: Date.now(),
+    data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: 'hello' } },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/message', seq: 2, time: Date.now(),
+    data: { turn: 1, step: 1, message: { content: [{ type: 'text', text: 'hello' }] } },
+  })
+  assert.ok(reviveChannel.rowsStreamingVersion > before, 'settle bumps rowsStreamingVersion')
+  const settledVersion = reviveChannel.rowsStreamingVersion
+  // A reconnect replay of the same step's chunk revives the sealed row.
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 3, time: Date.now(),
+    data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: 'hello' } },
+  })
+  assert.ok(
+    reviveChannel.rowsStreamingVersion > settledVersion,
+    'revive of a sealed row bumps rowsStreamingVersion',
+  )
+}
 
 for (const dispose of effects.reverse()) dispose()
 rmSync(testHome, { recursive: true, force: true })

--- a/src/components/ActivityLine.tsx
+++ b/src/components/ActivityLine.tsx
@@ -46,16 +46,18 @@ export function ActivityLine({
   warnDanger?: boolean
   suffix?: string
 }): React.ReactNode {
-  // 60ms frames: the shimmer sweep advances one column per frame (3.3× the
-  // ported 200ms cadence — the slow crawl read as lag).
-  const [, time] = useAnimationFrame(60)
+  // Static branch stays static: the done summary renders a fixed line, so it
+  // must not subscribe to the animation clock (a null interval unsubscribes).
+  // The live branch drives the shimmer sweep + frame rotation at 60ms.
+  const animate = activity.phase !== 'done'
+  const [, time] = useAnimationFrame(animate ? 60 : null)
   const [themeName] = useTheme()
   const theme = getTheme(themeName)
   const preset = React.useMemo(
     () => resolvePreset(activityFrames),
     [activityFrames],
   )
-  const frameIndex = Math.floor(time / preset.intervalMs) % preset.frames.length
+  const frameIndex = animate ? Math.floor(time / preset.intervalMs) % preset.frames.length : 0
   const frame = preset.frames[frameIndex] ?? '·'
   const color =
     activity.phase === 'done' || activity.phase === 'tool'

--- a/src/components/GoalTodoPanel.tsx
+++ b/src/components/GoalTodoPanel.tsx
@@ -134,16 +134,27 @@ export function GoalTodoPanel({
   // render (idempotent lazy ref init) so a fresh mount with a live goal
   // starts counting immediately.
   const startRef = React.useRef<{ id: string; at: number } | undefined>(undefined)
-  if (goal !== undefined && startRef.current?.id !== goal.id) {
-    startRef.current = { id: goal.id, at: Date.now() }
+  const phaseRef = React.useRef<ChannelGoal['phase'] | undefined>(undefined)
+  if (goal !== undefined) {
+    if (startRef.current?.id !== goal.id) {
+      startRef.current = { id: goal.id, at: Date.now() }
+    } else if (phaseRef.current !== undefined && phaseRef.current !== 'active' && goal.phase === 'active') {
+      // Resume from paused/blocked: re-base the elapsed clock so the count
+      // restarts at the moment the goal becomes active again (frozen time
+      // does not silently accrue while paused).
+      startRef.current = { id: goal.id, at: Date.now() }
+    }
+    phaseRef.current = goal.phase
   }
   const [now, setNow] = React.useState(() => Date.now())
   // Hover tint for the clickable todo fold header (mouse affordance).
   const [headerHovered, setHeaderHovered] = React.useState(false)
   React.useEffect(() => {
-    // Tick only while the goal is open; a complete goal freezes the last
-    // elapsed reading instead of counting past the finish line.
-    if (goal === undefined || goal.phase === 'complete') return
+    // Tick only while the goal is actively running: a complete goal freezes
+    // the last elapsed reading instead of counting past the finish line, and
+    // paused/blocked goals are static — no periodic wakeup for a frozen
+    // timer (resume re-bases via the phaseRef transition above).
+    if (goal === undefined || goal.phase !== 'active') return
     const timer = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(timer)
   }, [goal])

--- a/src/components/JobsPanel.tsx
+++ b/src/components/JobsPanel.tsx
@@ -123,8 +123,14 @@ export function JobsPanel({ jobs, onClose, onKill }: JobsPanelProps): React.Reac
   const [focusIndex, setFocusIndex] = React.useState(0)
   const scrollRef = React.useRef<ScrollBoxHandle | null>(null)
   const { rows } = useTerminalSize()
-  // 1s tick keeps live durations counting while the panel is open.
-  const [clockRef] = useAnimationFrame(1000)
+  // 1s tick keeps live durations counting while the panel is open — but only
+  // while a live job exists to count: an empty or all-settled panel is a
+  // static render and must not hold a clock subscription.
+  const liveCount = jobs.reduce(
+    (count, job) => count + (job.status === 'running' || job.status === 'stopping' ? 1 : 0),
+    0,
+  )
+  const [clockRef] = useAnimationFrame(liveCount > 0 ? 1000 : null)
 
   const focus = Math.min(focusIndex, Math.max(0, jobs.length - 1))
 

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -215,6 +215,8 @@ export function MessageList({
   onLoadOlder,
   thinkingVisible = true,
   historyPaintEnabled = true,
+  streamingVersion,
+  rowsGeneration,
   registerRowRef,
   scrollHandle,
   forceMountRowId,
@@ -266,6 +268,24 @@ export function MessageList({
    * seconds of lex/highlight/layout before first paint).
    */
   historyPaintEnabled?: boolean
+  /**
+   * Channel-owned counter that bumps exactly when an existing row's
+   * `streaming` flag flips IN PLACE (turn settle, revive). The filter cache
+   * keys on it so a settle that changes the empty-assistant filter boundary
+   * rebuilds without scanning every row per render. Absent on embedders
+   * that pass no channel metadata — they fall back to the allocation-free
+   * bit scan.
+   */
+  streamingVersion?: number
+  /**
+   * Transcript generation from the channel: bumped whenever the transcript
+   * is cleared and row ids restart at 0 (clear, session swap, loadOlder
+   * prepend, rewind/new/model/workspace switch). All per-row-id caches
+   * (heights, layout signatures, painted-once marks, timeline previews,
+   * header base) must be dropped on a generation change — ids alone cannot
+   * distinguish a fresh transcript from a previous one.
+   */
+  rowsGeneration?: number
   /** Transcript search: register each row's DOM element for scroll-to-match. */
   registerRowRef?: (rowId: number, el: DOMElement | null) => void
   /** Scroll viewport the list virtualizes against. */
@@ -337,6 +357,8 @@ export function MessageList({
      * in place, rows identity/length unchanged) changes empty-assistant
      * filtering below, so the cache must rebuild on any bit change. */
     streamBits: Uint8Array
+    /** The streamingVersion the bits were captured at (-1 = scanned). */
+    streamVersion: number
   } | null>(null)
   /** Generation counter for the visibleRows cache (timeline memo key). */
   const visGenRef = React.useRef(0)
@@ -345,12 +367,22 @@ export function MessageList({
   // settle) are invisible to the rows-identity/length key above, but an
   // assistant row that settles with EMPTY text crosses the empty-assistant
   // filter boundary (visible-while-streaming → filtered-when-settled).
-  // Allocation-free scan; rebuild only when a bit actually flipped.
-  let streamBitsSame = visibleCache !== null && visibleCache.streamBits.length === rows.length
-  if (streamBitsSame) {
-    const bits = visibleCache!.streamBits
-    for (let i = 0; i < rows.length; i++) {
-      if (bits[i] !== (rows[i]!.streaming === true ? 1 : 0)) { streamBitsSame = false; break }
+  // The channel owns a version counter that bumps exactly on such in-place
+  // flips, so the cache key can skip the O(rows) scan per render; hosts
+  // that pass no seam fall back to the allocation-free scan.
+  let streamBitsSame = false
+  if (visibleCache !== null && visibleCache.streamBits.length === rows.length) {
+    if (streamingVersion !== undefined) {
+      streamBitsSame = visibleCache.streamVersion === streamingVersion
+    } else {
+      const bits = visibleCache.streamBits
+      streamBitsSame = true
+      for (let i = 0; i < rows.length; i++) {
+        if (bits[i] !== (rows[i]!.streaming === true ? 1 : 0)) {
+          streamBitsSame = false
+          break
+        }
+      }
     }
   }
   if (
@@ -417,6 +449,7 @@ export function MessageList({
       out,
       margins,
       streamBits,
+      streamVersion: streamingVersion ?? -1,
     }
     visGenRef.current++
   }
@@ -517,6 +550,12 @@ export function MessageList({
     heightsVersionRef.current++
     baseRef.current = null
   }
+
+  // A transcript generation change (clear / session swap / loadOlder /
+  // rewind / new) reuses row ids from 0: every per-row-id cache belongs to
+  // the PREVIOUS transcript and must be dropped wholesale, or a fresh
+  // session would inherit stale heights, painted-once marks and previews.
+  const lastRowsGeneration = React.useRef(rowsGeneration)
 
   // --- layout signature: stale-height invalidation ------------------------
   // heightsRef entries outlive the commits that measured them, but many
@@ -866,33 +905,45 @@ export function MessageList({
   let upTurnIndex: number | null = null
   let downTurnIndex: number | null = null
   const timelineMemoRef = React.useRef<{ key: string; turns: TimelineTurn[] } | null>(null)
+  const timelineListRef = React.useRef<{
+    key: string
+    turns: Array<{ id: number; preview: string }>
+  } | null>(null)
+  const timelineTopsRef = React.useRef<{ key: string; tops: Map<number, number> } | null>(null)
+  // A transcript generation change (clear / session swap / loadOlder /
+  // rewind / new) reuses row ids from 0: every per-row-id cache belongs to
+  // the PREVIOUS transcript and must be dropped wholesale, or a fresh
+  // session would inherit stale heights, painted-once marks and previews.
+  // Placed after every cache ref it touches is declared.
+  if (lastRowsGeneration.current !== rowsGeneration) {
+    lastRowsGeneration.current = rowsGeneration
+    heightsRef.current.clear()
+    heightsVersionRef.current++
+    sigRef.current.clear()
+    paintedOnceRef.current = new Set()
+    paintedBaseRef.current = undefined
+    baseRef.current = null
+    previewCacheRef.current.clear()
+    timelineMemoRef.current = null
+    timelineListRef.current = null
+    timelineTopsRef.current = null
+    paintEdgeRef.current = -1
+    lastStartRef.current = -1
+  }
+
   {
-    // Split into (a) a GEOMETRY-memoized turns list and (b) a per-frame
-    // allocation-free target scan. Before the split this block rebuilt on
-    // EVERY scroll tick: an 800-object turns array, an 800-entry
-    // measuredTops Map, and the report effect's turns.map().join('|')
-    // signature — several hundred KB of churn per second of scrolling on a
-    // tool-heavy session.
-    //
-    // (a) turns/tops/folded change ONLY when geometry changes: row heights
-    // (heightsVersion — bumped at every heightsRef mutation), the visible
-    // window's content (visGen — bumped when the visibleRows cache
-    // rebuilds), the measured header base, or the rows array growing. Key
-    // on those; previews stay in their own id-keyed cache.
-    const memo = timelineMemoRef.current
-    const memoKey = `${visGenRef.current}:${heightsVersionRef.current}:${base}:${rows.length}:${columns}`
-    if (memo === null || memo.key !== memoKey) {
+    // Split into THREE caches so a scroll tick or a streaming commit does not
+    // rebuild the whole timeline: (a) the turns LIST (id + preview) keyed on
+    // the visibleRows cache generation — user rows never leave the list, so
+    // visGen is its only input; (b) the measured Tops map keyed on geometry
+    // (visGen + heightsVersion + base); (c) the merged array keyed on the
+    // tops key. A streaming commit bumps heightsVersion (growing row) but
+    // NOT visGen, so the O(rows) walk of (a) runs only when the fold window
+    // actually moves; the per-frame target scan below stays allocation-free.
+    const listKey = `${visGenRef.current}`
+    if (timelineListRef.current === null || timelineListRef.current.key !== listKey) {
       const previewCache = previewCacheRef.current
       if (previewCache.size > 2000) previewCache.clear()
-      // Measured tops for turns INSIDE the fold window (user rows are never
-      // filtered by the thinking toggle, so a user row absent from
-      // visibleRows is exactly a folded one).
-      const measuredTops = new Map<number, number>()
-      for (let i = 0; i < visibleRows.length; i++) {
-        const row = visibleRows[i]!
-        if (row.kind !== 'user') continue
-        measuredTops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
-      }
       // Walk ALL rows (not the fold window): the rail must cover the whole
       // conversation — a tool-heavy session packs 300 rows into a handful
       // of turns, and window-only turns made the rail show "2-3 nodes".
@@ -900,7 +951,7 @@ export function MessageList({
       // until revealed (they are all ABOVE the viewport, so active/down
       // over measured turns is unaffected; ▲ may name a folded turn — its
       // click goes through the reveal path, not scrollTo).
-      const turns: TimelineTurn[] = []
+      const turns: Array<{ id: number; preview: string }> = []
       for (const row of rows) {
         if (row.kind !== 'user') continue
         let cached = previewCache.get(row.id)
@@ -908,14 +959,37 @@ export function MessageList({
           cached = { len: row.text.length, preview: clipPreview(row.text) }
           previewCache.set(row.id, cached)
         }
-        const textTop = measuredTops.get(row.id)
+        turns.push({ id: row.id, preview: cached.preview })
+      }
+      timelineListRef.current = { key: listKey, turns }
+    }
+    const topsKey = `${visGenRef.current}:${heightsVersionRef.current}:${base}`
+    if (timelineTopsRef.current === null || timelineTopsRef.current.key !== topsKey) {
+      // Measured tops for turns INSIDE the fold window (user rows are never
+      // filtered by the thinking toggle, so a user row absent from
+      // visibleRows is exactly a folded one).
+      const tops = new Map<number, number>()
+      for (let i = 0; i < visibleRows.length; i++) {
+        const row = visibleRows[i]!
+        if (row.kind !== 'user') continue
+        tops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
+      }
+      timelineTopsRef.current = { key: topsKey, tops }
+    }
+    const memo = timelineMemoRef.current
+    if (memo === null || memo.key !== topsKey) {
+      const tops = timelineTopsRef.current!.tops
+      const list = timelineListRef.current!.turns
+      const turns: TimelineTurn[] = []
+      for (const entry of list) {
+        const textTop = tops.get(entry.id)
         if (textTop !== undefined) {
-          turns.push({ id: row.id, top: textTop, preview: cached.preview })
+          turns.push({ id: entry.id, top: textTop, preview: entry.preview })
         } else {
-          turns.push({ id: row.id, top: -1, preview: cached.preview, folded: true })
+          turns.push({ id: entry.id, top: -1, preview: entry.preview, folded: true })
         }
       }
-      timelineMemoRef.current = { key: memoKey, turns }
+      timelineMemoRef.current = { key: topsKey, turns }
     }
     timelineTurns = timelineMemoRef.current!.turns
     // (b) per-frame target scan — pure integer comparisons over the

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -87,6 +87,7 @@ import type { SpinnerMode } from '../components/Spinner/spinnerMode.js'
 import { ActivityTracker, type ActivityState } from 'dsh-working-activity/status'
 import type { TrackerConfig } from 'dsh-working-activity/status'
 import { featureOn } from 'dsh-working-activity/config'
+import { emptyTrajectory, extendTrajectory, extendTrajectoryEvents, type TrajBuild } from './trajectory/index.js'
 import { setMinimalMode } from '../minimalMode.js'
 import { readActivityConfig } from '../activityPrefs.js'
 import { attachSessionToWorkspace } from './workspace.js'
@@ -1247,6 +1248,23 @@ export interface Channel {
    * time; agent swaps (/resume /rewind /new) are reflected immediately.
    */
   traceEvents(): readonly SessionEvent[]
+  /**
+   * The session trajectory projection, folded incrementally by the channel
+   * as session events arrive — never on the render path. The returned build
+   * is stable between event batches (screens may read it during render);
+   * agent swaps (/resume /rewind /new) rebuild it from the new session's
+   * log. Headless/stub channels that do not provide the seam fall back to
+   * the same module-level empty build.
+   */
+  trajectory(): TrajBuild
+  /**
+   * Counter bumped exactly when an existing transcript row's `streaming`
+   * flag flips in place (turn settle, revive). MessageList keys its filter
+   * cache on it; new rows bump `rows.length` instead.
+   */
+  rowsStreamingVersion: number
+  /** Transcript generation (see the ChannelState field). */
+  rowsGeneration: number
 }
 
 /** @internal */
@@ -1349,6 +1367,22 @@ export interface ChannelState {
   tpsSamples: { tps: number; at: number }[]
   /** Latest working-activity snapshot (see the public Channel type). */
   workingActivity: ActivityStatus | undefined
+  /** Incremental trajectory projection (see the public Channel type). */
+  trajectory: () => TrajBuild
+  /**
+   * Counter bumped exactly when an existing row's `streaming` flag flips in
+   * place (turn settle, revive) — the transcript list's filter cache keys on
+   * it so settles invalidate without an O(rows) scan per render.
+   */
+  rowsStreamingVersion: number
+  /**
+   * Transcript generation: bumped whenever the transcript is cleared and
+   * row ids restart at 0 (clear, session swap, loadOlder prepend, rewind,
+   * new, workspace/model switch). MessageList keys its height/painted/
+   * signature caches on it so a fresh transcript never reuses a previous
+   * one's per-id state.
+   */
+  rowsGeneration: number
   /** Working-activity indicator preset (see the public Channel type). */
   activityFrames: string | undefined
   /** Raw cordis.yml pins `/reload` must respect (see the public Channel type). */
@@ -2654,6 +2688,7 @@ export function createChannel(
     lastReasoningRow = undefined
     toolCards.clear()
     nextRowId = 0
+    state.rowsGeneration += 1
     state.rows.length = 0
     resetSubagentProjection()
     resetJobProjection()
@@ -3382,6 +3417,7 @@ export function createChannel(
     lastReasoningRow = undefined
     toolCards.clear()
     nextRowId = 0
+    state.rowsGeneration += 1
     state.rows.length = 0
     state.todos = []
     state.pending = []
@@ -3541,6 +3577,7 @@ export function createChannel(
     lastReasoningRow = undefined
     toolCards.clear()
     nextRowId = 0
+    state.rowsGeneration += 1
     state.rows.length = 0
     state.todos = []
     state.pending = []
@@ -3656,6 +3693,9 @@ export function createChannel(
     mode: sessionModes[0]!,
     modeIndex: 0,
     workingActivity: undefined,
+    trajectory: () => trajectoryBuild,
+    rowsStreamingVersion: 0,
+    rowsGeneration: 0,
     activityFrames: options.activityFrames,
     configuredProvider: options.configuredProvider,
     configuredModel: options.configuredModel,
@@ -4993,6 +5033,7 @@ export function createChannel(
       lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       resetSubagentProjection()
       resetJobProjection()
@@ -5186,6 +5227,7 @@ export function createChannel(
       assistantRowsByStep.clear()
       lastTextDelta.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       resetSubagentProjection()
       resetJobProjection()
@@ -5382,6 +5424,7 @@ export function createChannel(
       lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       resetSubagentProjection()
       resetJobProjection()
@@ -5465,6 +5508,7 @@ export function createChannel(
     clear() {
       state.rows.length = 0
       nextRowId = 0
+      state.rowsGeneration += 1
       streaming = undefined
       reasoning = undefined
       toolCards.clear()
@@ -6458,6 +6502,7 @@ export function createChannel(
       lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       state.todos = []
       state.pending = []
@@ -7156,6 +7201,23 @@ export function createChannel(
   const skillCommandsRefused = new Set<string>()
   /** Pending re-read after an incomplete catalog observation. */
   let skillCommandsRetry: ReturnType<typeof setTimeout> | undefined
+  /**
+   * Bounded retry ladder for `complete:false` observations: a provider still
+   * warming its watcher re-reads a few times with exponential backoff, then
+   * gives up and keeps the last-good command set until the next
+   * `skills/change` (the provider's own invalidation) or an explicit
+   * refresh. Without the cap a provider that NEVER completes keeps an
+   * 800ms retry loop alive forever, re-snapshotting the catalog each time.
+   */
+  let skillRetryAttempts = 0
+  let skillRetryDelayMs = SKILL_COMMAND_RETRY_MS
+  const MAX_SKILL_RETRY_ATTEMPTS = 3
+  /**
+   * Refresh generation: bumped by releaseContributions (and rebinds) so an
+   * in-flight snapshot resolving afterwards is recognized as stale and
+   * never re-registers commands against a released channel.
+   */
+  let skillCommandSeq = 0
 
   /**
    * Publish every user-invocable skill as a slash command (issue #86).
@@ -7178,6 +7240,10 @@ export function createChannel(
   const refreshSkillCommands = async (): Promise<void> => {
     if (commandService === undefined) return
     const target = agent
+    // Generation snapshot: only release/rebind bump skillCommandSeq, so
+    // concurrent refreshes share one generation and all land (last write
+    // wins); a released/rebound channel invalidates every in-flight read.
+    const token = skillCommandSeq
     const registry = skillRegistryFor(target)
     if (registry === undefined) return
     let observation
@@ -7187,15 +7253,48 @@ export function createChannel(
       ctx.logger.warn('skill commands: catalog read failed: %o', error)
       return
     }
-    if (target !== agent) return
+    if (token !== skillCommandSeq || target !== agent) return
     // A provider still warming its watcher reports an incomplete observation;
-    // re-read once so a cold start cannot leave the menu permanently short.
-    if (!observation.complete && skillCommandsRetry === undefined) {
-      skillCommandsRetry = setTimeout(() => {
-        skillCommandsRetry = undefined
-        void refreshSkillCommands()
-      }, SKILL_COMMAND_RETRY_MS)
+    // re-read a bounded number of times with exponential backoff so a cold
+    // start cannot leave the menu permanently short, while a provider that
+    // NEVER completes stops retrying (the next skills/change re-enters and
+    // the last-good command set stays in place). The partial observation
+    // still reconciles below — registering the visible subset is idempotent
+    // (same names/descriptions dispose nothing) and keeps a warm start as
+    // complete as the provider can make it.
+    if (!observation.complete) {
+      // Incomplete (provider failure/rescan mid-flight): NOT authoritative —
+      // neither the menu merge (refreshCommandList) nor the command registry
+      // may reconcile against it. In particular the registry must KEEP every
+      // currently registered handler: refreshCommandList only restores the
+      // last-good MENU entries, not disposed command handlers, so disposing
+      // here would leave the menu pointing at handlers that no longer exist.
+      if (skillCommandsRetry === undefined && skillRetryAttempts < MAX_SKILL_RETRY_ATTEMPTS) {
+        skillRetryAttempts += 1
+        skillCommandsRetry = setTimeout(() => {
+          skillCommandsRetry = undefined
+          void refreshSkillCommands()
+        }, skillRetryDelayMs)
+        skillCommandsRetry.unref?.()
+        skillRetryDelayMs *= 2
+        ctx.logger.warn(
+          `skill command merge: incomplete catalog observation (%d/%d attempts), retrying in %dms`,
+          skillRetryAttempts,
+          MAX_SKILL_RETRY_ATTEMPTS,
+          skillRetryDelayMs / 2,
+        )
+      } else {
+        ctx.logger.warn(
+          'skill command merge: incomplete catalog observation, retries exhausted — keeping last-good skills until skills/change',
+        )
+      }
+      return
     }
+    // Complete observation: the catalog is authoritative, so reset the
+    // retry ladder (a later transient failure starts back at the base
+    // delay with a fresh attempt budget).
+    skillRetryAttempts = 0
+    skillRetryDelayMs = SKILL_COMMAND_RETRY_MS
     const wanted = new Map<string, string>(
       observation.skills
         .filter(skill => isUserInvocable(skill))
@@ -7299,6 +7398,9 @@ export function createChannel(
   })
   /** See {@link Channel.releaseContributions}. */
   const releaseSkillCommands = (): void => {
+    // Invalidate any in-flight refresh (its token no longer matches), then
+    // cancel the retry ladder and dispose the registered handlers.
+    skillCommandSeq += 1
     if (skillCommandsRetry !== undefined) clearTimeout(skillCommandsRetry)
     skillCommandsRetry = undefined
     for (const entry of skillCommands.values()) entry.dispose()
@@ -7310,6 +7412,17 @@ export function createChannel(
   void refreshSkillCommands()
 
   let nextRowId = 0
+
+  /**
+   * Bump the rows-streaming version: the transcript list keys its filter
+   * cache on this counter, which changes ONLY when an existing row's
+   * `streaming` flag flips in place (turn settle, revive). New rows change
+   * rows.length instead, so they need no bump. Declared before
+   * renderEvent/replayEvents — the boot replay settles rows and calls this.
+   */
+  const markStreamingChanged = (): void => {
+    state.rowsStreamingVersion += 1
+  }
   /** The leaf's bash executor (dsh-bash-local in the example leaf) — the DSH
  *  execution seam for local `!` commands and the git status breadcrumb. The
  *  service registers under `ctx.shell` (ShellExecutor; dsh-bash-local and
@@ -7510,6 +7623,7 @@ ${output}
       : [...state.rows].reverse().find(row => row.kind === 'assistant' && row.seq === seq)
     if (existing !== undefined) {
       existing.streaming = true
+      markStreamingChanged()
       streaming = existing
       return existing
     }
@@ -7538,6 +7652,7 @@ ${output}
       ) {
         reasoning = lastReasoningRow.row
         reasoning.streaming = true
+        markStreamingChanged()
         const sealedIdx = sealedReasoning.indexOf(reasoning)
         if (sealedIdx !== -1) sealedReasoning.splice(sealedIdx, 1)
         reasoningStart = Date.now() - (reasoning.durationMs ?? 0)
@@ -7571,12 +7686,14 @@ ${output}
     const duration = Math.max(0, Date.now() - reasoningStart)
     reasoning.durationMs = duration
     reasoning.streaming = false
+    markStreamingChanged()
     sealedReasoning.push(reasoning)
     reasoning = undefined
     logForDebugging(`thinking: folded at ${where} (${duration}ms)`)
   }
 
   const settleStreaming = (): void => {
+    const flipped = streaming !== undefined || sealedReasoning.length > 0 || reasoning !== undefined
     if (streaming !== undefined) streaming.streaming = false
     streaming = undefined
     const folded = sealedReasoning.length + (reasoning !== undefined ? 1 : 0)
@@ -7587,6 +7704,7 @@ ${output}
       reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
     }
     reasoning = undefined
+    if (flipped) markStreamingChanged()
     if (folded > 0) logForDebugging(`thinking: folded ${folded} reasoning row(s) at turn settle`)
   }
 
@@ -7795,7 +7913,13 @@ ${output}
             const row = assistantRowsByStep.get(key) ?? ensureStreaming(event.seq)
             assistantRowsByStep.set(key, row)
             streaming = row
-            row.streaming = true
+            // Revive of a previously sealed row (reconnect replay): the
+            // in-place streaming flip is invisible to rows identity/length,
+            // so the transcript list's filter cache must hear about it.
+            if (row.streaming !== true) {
+              row.streaming = true
+              markStreamingChanged()
+            }
             const before = row.text.length
             appendTextDelta(row, chunk.text)
             state.responseChars += Math.max(0, row.text.length - before)
@@ -7877,6 +8001,7 @@ ${output}
           row.time = event.time
           if (text) row.text = text
           row.streaming = false
+          markStreamingChanged()
           // Live settles keep the smooth-reveal cursor alive (a one-shot
           // non-streaming delivery still paints as a flow); replayed
           // settles must not — the transcript would typewrite on open.
@@ -7892,7 +8017,10 @@ ${output}
           // (/settings opt-in) keeps the block expanded until turn settle
           // — settleStreaming folds the sealed rows then.
           reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
-          if (state.thinkingFold === 'preview') reasoning.streaming = false
+          if (state.thinkingFold === 'preview') {
+            reasoning.streaming = false
+            markStreamingChanged()
+          }
           sealedReasoning.push(reasoning)
           logForDebugging(`thinking: step sealed (${reasoning.durationMs}ms), expanded until turn/end`)
         }
@@ -8292,11 +8420,64 @@ ${output}
     return new ActivityTracker(prefs.config, Date.now, prefs.customActions)
   })()
   let activityTickTimer: NodeJS.Timeout | undefined
+  /**
+   * Wall-clock since the done line last changed. The done summary keeps a
+   * short-lived completed-tool fragment (~3s, upstream DONE_FRAGMENT_MS),
+   * so the tick retires only once the line has been STABLE for a grace
+   * window — then it stops until a live phase returns (updateWorkingActivity
+   * re-arms it). An idle conversation therefore holds no 500ms wakeup.
+   */
+  const ACTIVITY_DONE_STABLE_MS = 4000
+  let activityDoneStableSince: number | undefined
 
   const stopActivityTick = (): void => {
     if (activityTickTimer === undefined) return
     clearInterval(activityTickTimer)
     activityTickTimer = undefined
+  }
+
+  /**
+   * Create the 500ms activity tick if it is not running. `activity: false`
+   * never creates it (the projection is not read then). Live phases
+   * (waiting/thinking/tool) emit every tick so turnElapsedMs stays current;
+   * settled phases emit only when the line actually changes.
+   */
+  const ensureActivityTick = (): void => {
+    if (options.activity === false || activityTickTimer !== undefined) return
+    activityTickTimer = setInterval(() => {
+      const previous = state.workingActivity
+      const rendered = updateWorkingActivity('activity tick')
+      if (rendered === undefined) return
+      if (rendered.phase === 'done') {
+        // Retire once the done line has been stable past the fragment
+        // window — no more React updates, timer or tracker work needed.
+        if (previous !== undefined && previous.line === rendered.line) {
+          activityDoneStableSince ??= Date.now()
+          if (Date.now() - activityDoneStableSince >= ACTIVITY_DONE_STABLE_MS) {
+            stopActivityTick()
+            return
+          }
+        } else {
+          activityDoneStableSince = undefined
+        }
+      } else {
+        activityDoneStableSince = undefined
+      }
+      // Live phases deliberately wake at 500 ms even when the formatted line
+      // has not crossed its next whole-second boundary: turnElapsedMs remains
+      // a current state value, while line changes cover phrase rotation and
+      // the short-lived completed-tool summary.
+      if (
+        rendered.phase === 'waiting' ||
+        rendered.phase === 'thinking' ||
+        rendered.phase === 'tool' ||
+        previous?.phase !== rendered.phase ||
+        previous.line !== rendered.line
+      ) {
+        state.emit()
+      }
+    }, 500)
+    activityTickTimer.unref()
   }
 
   /** Render the current tracker into the TUI-only projection. */
@@ -8321,7 +8502,18 @@ ${output}
   ): ActivityStatus | undefined => {
     try {
       update?.()
-      return renderWorkingActivity()
+      const rendered = renderWorkingActivity()
+      // Live phases need the 500ms tick to keep turnElapsedMs/phrase
+      // rotation current — (re)arm it whenever an event or status change
+      // brings the tracker back to a live phase (a done/idle phase lets
+      // the tick retire itself, see maybeRetireActivityTick).
+      if (
+        rendered !== undefined &&
+        (rendered.phase === 'waiting' || rendered.phase === 'thinking' || rendered.phase === 'tool')
+      ) {
+        ensureActivityTick()
+      }
+      return rendered
     } catch (error: unknown) {
       if (!activityFailureReported) {
         activityFailureReported = true
@@ -8351,11 +8543,45 @@ ${output}
     updateSpinnerMode()
   }
 
+  // ── trajectory projection (channel-owned, event-driven) ───────────────────
+  // The session trajectory is folded HERE — at event time — so Chat renders
+  // never touch the session event getter (hosts without a snapshot cache pay
+  // an O(n) copy per render otherwise). The fold is incremental: identical
+  // prefix (object identity at the previous last index) → tail-only consume;
+  // anything else (session swap, rewind fork, /new) rebuilds from scratch.
+  // bindAgent resets the build explicitly so a swap can never extend a stale
+  // projection.
+  let trajectoryBuild: TrajBuild = emptyTrajectory()
+  /**
+   * Fold ONE newly observed main-session event into the trajectory build —
+   * incrementally, from the event the observer already holds. The session
+   * getter (`agent.session.events`) is O(n) on hosts that rebuild a frozen
+   * snapshot per append, so it must stay off the token-rate path: a full
+   * fold happens only in bindAgent (once per agent swap, where O(n) is
+   * the correct cost).
+   */
+  const foldTrajectoryEvent = (event: SessionEvent): void => {
+    trajectoryBuild = extendTrajectoryEvents(trajectoryBuild, [event])
+  }
+
   const bindAgent = (): void => {
     agentBindingGeneration += 1
     state.agentBindingGeneration = agentBindingGeneration
     for (const dispose of agentSubscriptions) dispose()
     stopActivityTick()
+    // A new agent starts with a fresh skill-retry budget (an old ladder's
+    // attempt counter must not shorten the new agent's retries). In-flight
+    // refreshes from the previous agent are already stale via the
+    // `target !== agent` check — the refresh generation is NOT bumped here
+    // because the boot-time refresh resolves AFTER this first bindAgent.
+    skillRetryAttempts = 0
+    skillRetryDelayMs = SKILL_COMMAND_RETRY_MS
+    // The trajectory build belongs to ONE bound agent's session log. A
+    // replacement (rewind/resume/new/workspace/model-switch) must never
+    // extend the previous session's projection — reset and fold the new
+    // session's full log once here (O(n) once per swap, never per event).
+    trajectoryBuild = emptyTrajectory()
+    trajectoryBuild = extendTrajectory(trajectoryBuild, agent.session.events)
     // Cancel state and deferred interrupt delivery belong to one bound agent.
     // A replacement must neither inherit the old latch nor receive its queued
     // microtask after the session identity changes.
@@ -8364,26 +8590,8 @@ ${output}
     const prefs = activityPrefsSnapshot()
     activityTracker = new ActivityTracker(prefs.config, Date.now, prefs.customActions)
     activityFailureReported = false
+    activityDoneStableSince = undefined
     updateWorkingActivity('agent bind', () => activityTracker.onAgentStatus(agent.status))
-    activityTickTimer = setInterval(() => {
-      const previous = state.workingActivity
-      const rendered = updateWorkingActivity('activity tick')
-      if (rendered === undefined) return
-      // Live phases deliberately wake at 500 ms even when the formatted line
-      // has not crossed its next whole-second boundary: turnElapsedMs remains
-      // a current state value, while line changes cover phrase rotation and
-      // the short-lived completed-tool summary.
-      if (
-        rendered.phase === 'waiting' ||
-        rendered.phase === 'thinking' ||
-        rendered.phase === 'tool' ||
-        previous?.phase !== rendered.phase ||
-        previous.line !== rendered.line
-      ) {
-        state.emit()
-      }
-    }, 500)
-    activityTickTimer.unref()
     // Re-couple the channel-owned model selection to the new agent's
     // assembly/request waterfalls, then re-apply the persisted effort when
     // this agent's route offers it (dsh-agent installModelSelection).
@@ -8520,6 +8728,12 @@ ${output}
           }
         }
         renderEvent(event)
+        // Fold the trajectory incrementally here — at EVENT time, not render
+        // time: Chat renders must never touch the session getter, and the
+        // token-rate path must not re-read the O(n) session snapshot. The
+        // observer already holds the event, so the fold consumes it directly
+        // (chunks are pure timing updates, O(1) with no state copy).
+        foldTrajectoryEvent(event)
         // Streaming deltas (one event per token) take the frame-aligned
         // path; every other event keeps synchronous notification.
         if (event.type === 'assistant/chunk') state.emitStream()

--- a/src/dsh-adapter/grants.ts
+++ b/src/dsh-adapter/grants.ts
@@ -1,7 +1,7 @@
 /** Live, scoped plugin grant evaluation. */
 
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync, watch as watchFile } from 'node:fs'
+import { dirname, join } from 'node:path'
 import type { PermissionRegistry } from '../plugin-spec/types.js'
 import { normalizePermissionScope, permissionScopeCovers } from '../plugin-spec/permission-scope.js'
 import { loadSpecData } from '../plugin-spec/registry.js'
@@ -198,12 +198,16 @@ export function readGrantStore(dir: string = DATA_DIR, registry?: PermissionRegi
       table: missing
         ? { grants: new Map(), denies: new Map(), corrupt: false }
         : parseTable(text),
-      signature: text,
+      // The existence bit is part of the signature: a missing file and an
+      // existing empty file both read as '' but are different states.
+      signature: `${missing ? 'M' : 'E'}:${text}`,
     }
   }
   const listeners = new Set<() => void>()
   let watching = false
   let watchTimer: ReturnType<typeof setInterval> | undefined
+  let watcher: ReturnType<typeof watchFile> | undefined
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let signature = readCurrent().signature
   const changed = (): void => {
     const next = readCurrent().signature
@@ -218,23 +222,74 @@ export function readGrantStore(dir: string = DATA_DIR, registry?: PermissionRegi
       }
     }
   }
+  // Debounced file-change notification: fs.watch can fire several events per
+  // write (rename+change on atomic replace), so coalesce them into one read.
+  const scheduleCheck = (): void => {
+    if (debounceTimer !== undefined) return
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined
+      changed()
+    }, 50)
+  }
+  const startWatching = (): void => {
+    // Prefer fs.watch on the PARENT DIRECTORY, not the file itself: the
+    // common atomic-replace write (temp file + rename) swaps the inode the
+    // file watcher holds, after which the old watcher goes silent. A
+    // directory watcher sees the rename/create/delete and the debounce
+    // re-reads the (possibly new) file. A poll fallback covers filesystems
+    // and edge cases where the watcher cannot be established. Both stop
+    // when the last listener unsubscribes; the fallback deliberately polls
+    // at a low frequency — the synchronous per-operation read remains the
+    // authorization source of truth, so this loop only needs to release
+    // grant-owned subscriptions promptly after a revocation, not keep them
+    // perfectly current.
+    let watchingFailed = false
+    try {
+      watcher = watchFile(dirname(file), { persistent: false }, () => scheduleCheck())
+      watcher.on('error', () => {
+        watchingFailed = true
+        watcher?.close()
+        watcher = undefined
+        if (listeners.size > 0 && watchTimer === undefined) {
+          watchTimer = setInterval(changed, 2000)
+          watchTimer.unref?.()
+        }
+      })
+      // fs.watch on some platforms silently misses events (or refuses to
+      // watch a not-yet-existing directory); a first error already re-arms
+      // the fallback above, and the watcher stays authoritative while
+      // healthy.
+    } catch {
+      watchingFailed = true
+      watcher = undefined
+    }
+    if (watchingFailed && watchTimer === undefined) {
+      watchTimer = setInterval(changed, 2000)
+      watchTimer.unref?.()
+    }
+  }
   const onChange = (listener: () => void): (() => void) => {
     listeners.add(listener)
     if (!watching) {
       watching = true
-      // A small unref'ed poll is deterministic across filesystems and
-      // timestamp granularities. The synchronous read on every operation
-      // remains the authorization source of truth; this loop only releases
-      // grant-owned subscriptions promptly after a revocation.
-      watchTimer = setInterval(changed, 50)
-      watchTimer.unref?.()
+      startWatching()
     }
     return () => {
       listeners.delete(listener)
       if (watching && listeners.size === 0) {
         watching = false
-        if (watchTimer !== undefined) clearInterval(watchTimer)
-        watchTimer = undefined
+        if (debounceTimer !== undefined) {
+          clearTimeout(debounceTimer)
+          debounceTimer = undefined
+        }
+        if (watchTimer !== undefined) {
+          clearInterval(watchTimer)
+          watchTimer = undefined
+        }
+        if (watcher !== undefined) {
+          watcher.close()
+          watcher = undefined
+        }
       }
     }
   }

--- a/src/dsh-adapter/trajectory/index.ts
+++ b/src/dsh-adapter/trajectory/index.ts
@@ -13,6 +13,7 @@ export {
   buildTrajectory,
   emptyTrajectory,
   extendTrajectory,
+  extendTrajectoryEvents,
   type StepTiming,
   type TrajBuild,
 } from './projection.js'

--- a/src/dsh-adapter/trajectory/projection.ts
+++ b/src/dsh-adapter/trajectory/projection.ts
@@ -76,6 +76,13 @@ export interface StepTiming {
 export interface TrajBuild {
   /** The snapshot this build consumed; identity-compared on the next append. */
   readonly source: readonly RawTrajEvent[]
+  /**
+   * Monotonic content revision: bumps by one per consumed event (including
+   * events that only CLOSE or mutate existing nodes in place — the node
+   * array identity and length do not change then, so consumers must key
+   * their memos on this, not on `nodes`).
+   */
+  readonly revision: number
   /** The ledger, in log order, after burst folding. */
   readonly nodes: TrajNode[]
   /** Per-step timing keyed `${turn}:${step}`, for the hotspot aggregate. */
@@ -721,7 +728,7 @@ function consume(state: FoldState, nodes: TrajNode[], timing: Map<string, StepTi
 /** An empty build, used as the identity element and for empty sessions. */
 export function emptyTrajectory(): TrajBuild {
   const state = newState()
-  return { source: [], nodes: [], timing: new Map(), counts: state.counts, state }
+  return { source: [], revision: 0, nodes: [], timing: new Map(), counts: state.counts, state }
 }
 
 /**
@@ -750,14 +757,50 @@ export function extendTrajectory(
       consume(state, nodes, timing, raw[index]!)
     }
     syncRowCount(state, nodes)
-    return { source: raw, nodes, timing, counts: state.counts, state }
+    return { source: raw, nodes, timing, counts: state.counts, state, revision: previous.revision + (raw.length - previous.source.length) }
   }
   const nodes: TrajNode[] = []
   const timing = new Map<string, StepTiming>()
   const state = newState()
   for (const event of raw) consume(state, nodes, timing, event)
   syncRowCount(state, nodes)
-  return { source: raw, nodes, timing, counts: state.counts, state }
+  return { source: raw, nodes, timing, counts: state.counts, state, revision: raw.length }
+}
+
+/**
+ * Incrementally fold a batch of NEW events into a previous build WITHOUT
+ * re-reading the session snapshot — the caller (the channel's event
+ * observer) already holds the appended events, so the O(n) snapshot getter
+ * stays off the token-rate hot path.
+ *
+ * No prefix-identity check: the caller guarantees `appended` continues the
+ * log the build consumed. `source` keeps the last known snapshot reference
+ * (stale by design — nothing re-validates against it on this path; a full
+ * rebuild via {@link extendTrajectory} after a session swap starts from
+ * `emptyTrajectory`).
+ *
+ * Chunk-only batches (pure timing updates) reuse the shared fold state
+ * without cloning the bracket maps — the token-rate path pays O(1).
+ */
+export function extendTrajectoryEvents(
+  previous: TrajBuild,
+  appended: readonly SessionEvent[],
+): TrajBuild {
+  if (appended.length === 0) return previous
+  const nodes = previous.nodes
+  const timing = previous.timing
+  const pureTiming = appended.every(event => (event as { type: string }).type === 'assistant/chunk')
+  const state = pureTiming ? previous.state : cloneState(previous.state)
+  for (const event of appended) consume(state, nodes, timing, event)
+  syncRowCount(state, nodes)
+  return {
+    source: previous.source,
+    nodes,
+    timing,
+    counts: state.counts,
+    state,
+    revision: previous.revision + appended.length,
+  }
 }
 
 /**

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -561,6 +561,16 @@ export default class App extends PureComponent<Props, State> {
 			stdin.setRawMode(false);
 			stdin.removeListener("readable", this.handleReadable);
 			stdin.unref();
+			// Raw mode fully released: no more input can reach the parser, so
+			// an incomplete escape sequence can never complete. Cancel its
+			// timer and reset the parse state — otherwise the timer re-arms
+			// forever on the leftover readableLength (no reader attached) and
+			// a partial paste/escape corrupts the next raw session.
+			if (this.incompleteEscapeTimer) {
+				clearTimeout(this.incompleteEscapeTimer);
+				this.incompleteEscapeTimer = null;
+			}
+			this.keyParseState = { ...INITIAL_STATE };
 		}
 	};
 
@@ -571,6 +581,14 @@ export default class App extends PureComponent<Props, State> {
 
 		// Only proceed if we have incomplete sequences
 		if (!this.keyParseState.incomplete) return;
+
+		// Raw mode released while a sequence was incomplete: the parser is
+		// dead (no readable listener, no further input), so the sequence can
+		// never complete — drop it instead of re-arming forever.
+		if (this.rawModeEnabledCount === 0) {
+			this.keyParseState = { ...INITIAL_STATE };
+			return;
+		}
 
 		// Fullscreen: if stdin has data waiting, it's almost certainly the
 		// continuation of the buffered sequence (e.g. `[<64;74;16M` after a

--- a/src/ink/constants.ts
+++ b/src/ink/constants.ts
@@ -2,6 +2,17 @@
 export const FRAME_INTERVAL_MS = 16
 
 /**
+ * Backoff ladder for the scroll-drain re-probe while stdout is
+ * backpressured: the stream's own 'drain' event is the fast path; this
+ * bounded fallback (250ms → 500ms → 1s) covers streams that never emit it.
+ * Deliberately far from a busy loop — each fire re-checks the backlog, so a
+ * drained stream resumes at the normal quarter-interval cadence on the next
+ * cycle.
+ */
+export const DRAIN_BACKOFF_BASE_MS = 250
+export const DRAIN_BACKOFF_MAX_MS = 1000
+
+/**
  * In-flight pty gate threshold (bytes) for scroll-drain frames — Grok
  * Build's Presenter in_flight gate. While stdout holds more unflushed
  * output than this, drain frames hold off instead of stacking latency

--- a/src/ink/geometry-trace.ts
+++ b/src/ink/geometry-trace.ts
@@ -27,6 +27,7 @@ export type FrameCause =
   | 'resize'
   | 'reanchor'
   | 'immediate'
+  | 'backpressure'
 
 export const GEOMETRY_TRACE_ENABLED = process.env.DSH_TUI_GEOMETRY_TRACE !== undefined &&
   process.env.DSH_TUI_GEOMETRY_TRACE !== ''

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -11,10 +11,11 @@ import { getYogaCounters } from '../native-ts/yoga-layout/index.js';
 import { logForDebugging } from '../utils/debug.js';
 import { logError } from '../utils/log.js';
 import { format } from 'util';
+import type { Writable } from 'stream';
 import { colorize } from './colorize.js';
 import App from './components/App.js';
 import type { CursorDeclaration, CursorDeclarationSetter } from './components/CursorDeclarationContext.js';
-import { FRAME_INTERVAL_MS, PTY_BACKLOG_BYTES } from './constants.js';
+import { DRAIN_BACKOFF_BASE_MS, DRAIN_BACKOFF_MAX_MS, FRAME_INTERVAL_MS, PTY_BACKLOG_BYTES } from './constants.js';
 import * as dom from './dom.js';
 import { beginGeometryFrame, endGeometryFrame, GEOMETRY_TRACE_ENABLED, noteFrameCause } from './geometry-trace.js';
 import { callWithUpdateOverflowGuard, installNestedUpdateOverflowProcessGuard } from './update-overflow-guard.js';
@@ -103,11 +104,20 @@ export default class Ink {
   private readonly unsubscribeTTYHandlers?: () => void;
   private terminalColumns: number;
   private terminalRows: number;
+  /** Columns the Yoga root was last constrained with (see onComputeLayout). */
+  private lastLayoutColumns = -1;
   private currentNode: ReactNode = null;
   private frontFrame: Frame;
   private backFrame: Frame;
   private lastPoolResetTime = performance.now();
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  /** True while the stream holds unflushed output above the backlog gate;
+   *  frame writes are skipped (coalesced) until the stream drains. */
+  private backpressured = false;
+  /** The pending stdout 'drain' listener (one per stream). */
+  private drainListener: (() => void) | null = null;
+  /** Fallback re-probe delay while backpressured (bounded backoff). */
+  private drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
   // Every scheduled microtask carries the generation that created it. Immediate
   // renders invalidate older trailing work before it can append an old frame.
   private renderGeneration = 0;
@@ -295,8 +305,23 @@ export default class Ink {
       }
       if (this.rootNode.yogaNode) {
         const t0 = performance.now();
-        this.rootNode.yogaNode.setWidth(this.terminalColumns);
-        this.rootNode.yogaNode.calculateLayout(this.terminalColumns);
+        const root = this.rootNode.yogaNode;
+        // setWidth marks the WHOLE tree dirty — calling it with an unchanged
+        // value would force a full layout pass on every commit (idle commits
+        // included). Only touch the constraint when the terminal width
+        // actually changed; handleResize re-renders with the new size, so
+        // the first commit after a resize still re-constrains.
+        if (this.lastLayoutColumns !== this.terminalColumns) {
+          this.lastLayoutColumns = this.terminalColumns;
+          root.setWidth(this.terminalColumns);
+        }
+        // Clean-tree early bail: every style/text mutation marks its node
+        // dirty (the engine's own dirty-skip depends on it), so a fully
+        // clean tree with unchanged constraints has nothing to recompute —
+        // skip the layout walk (and its round pass) entirely.
+        if (root.isDirty()) {
+          root.calculateLayout(this.terminalColumns);
+        }
         const ms = performance.now() - t0;
         recordYogaMs(ms);
         const c = getYogaCounters();
@@ -393,6 +418,8 @@ export default class Ink {
     this.renderGeneration++;
     this.pendingRenderGeneration = null;
     this.scheduleRender.cancel?.();
+    this.detachDrainListener();
+    this.backpressured = false;
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
@@ -564,7 +591,14 @@ export default class Ink {
     this.renderGeneration++;
     this.pendingRenderGeneration = null;
     this.scheduleRender.cancel?.();
-    if (this.drainTimer !== null) {
+    // A fresh frame is being produced right now — any pending drain-wait
+    // (listener or timer) is obsolete; this render re-arms what it needs.
+    // EXCEPT while backpressured: the drain event may already have been
+    // emitted before the listener attached (a one-shot signal), and the
+    // backing-off re-probe is then the ONLY recovery path — cancelling it
+    // here on every animation render would deadlock the writer.
+    this.detachDrainListener();
+    if (this.drainTimer !== null && !this.backpressured) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
     }
@@ -582,11 +616,16 @@ export default class Ink {
    *    (DECSTBM + ~10 patches); scroll throughput is unchanged.
    *  - IN-FLIGHT GATE: while stdout still holds unflushed bytes above
    *    PTY_BACKLOG_BYTES (slow ConPTY round trip, ssh link), queue nothing
-   *    further — re-probe at quarter interval instead. Grok's equivalent
-   *    (in_flight_target + writer ack) exists to keep latency bounded
-   *    under exactly this backpressure; without it each stacked frame adds
-   *    its full render+write to the input→paint latency, which reads as
-   *    sticky, laggy scrolling on Windows terminals.
+   *    further — wait for the stream's OWN drain event instead of
+   *    re-probing at quarter interval (a 250Hz busy loop that never
+   *    advances while the terminal stays saturated). A bounded fallback
+   *    timer (backing off 250ms → 1s) covers streams that never emit
+   *    drain; each fire re-checks the backlog and either resumes or
+   *    re-arms. Grok's equivalent (in_flight_target + writer ack) exists
+   *    to keep latency bounded under exactly this backpressure; without it
+   *    each stacked frame adds its full render+write to the
+   *    input→paint latency, which reads as sticky, laggy scrolling on
+   *    Windows terminals.
    *
    * The gate holds only DRAIN frames; React-driven renders (keystrokes,
    * streaming) still render via the normal throttle — user-visible updates
@@ -594,19 +633,69 @@ export default class Ink {
    */
   private scheduleDrain(): void {
     if (this.drainTimer !== null) return;
-    const stdout = this.options.stdout;
+    const stdout = this.options.stdout as Writable & { writableLength?: number };
     const backlog =
-      typeof (stdout as { writableLength?: number }).writableLength === 'number'
-        ? (stdout as { writableLength: number }).writableLength
+      typeof stdout.writableLength === 'number'
+        ? stdout.writableLength
         : 0;
-    if (backlog > PTY_BACKLOG_BYTES) {
-      this.drainTimer = setTimeout(() => {
-        this.drainTimer = null;
-        this.scheduleDrain();
-      }, FRAME_INTERVAL_MS >> 2);
+    // Fast path only when the writer is NOT backpressured: write() === false
+    // is the authoritative signal (a stream with a small high-water mark can
+    // reject writes while writableLength is still under the threshold), and
+    // the backlog check is an additional bound, never a way to override a
+    // rejected write into a 4ms retry loop.
+    if (!this.backpressured && backlog <= PTY_BACKLOG_BYTES) {
+      this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
       return;
     }
-    this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
+    // Backpressure path: wait for the stream's own drain event (fires once
+    // the buffered bytes flush after a rejected write); a bounded, backing-
+    // off re-probe covers streams that never emit it. The re-probe
+    // OPTIMISTICALLY clears the flag at the slow cadence (250ms→1s) — the
+    // write result re-asserts the true state — so a stream that silently
+    // recovered resumes painting without ever busy-looping. Never a fixed
+    // 4ms poll while backpressured.
+    this.backpressured = true;
+    this.attachDrainListener();
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      if (this.isUnmounted) return;
+      const nowBacklog =
+        typeof stdout.writableLength === 'number'
+          ? stdout.writableLength
+          : 0;
+      if (nowBacklog <= PTY_BACKLOG_BYTES) {
+        // The stream looks drained (or never reports a backlog): try a
+        // frame; the write result re-asserts the gate.
+        this.backpressured = false;
+      }
+      this.scheduleDrain();
+    }, this.drainBackoffMs);
+    this.drainBackoffMs = Math.min(DRAIN_BACKOFF_MAX_MS, this.drainBackoffMs * 2);
+  }
+
+  /** Arm the one-per-stream 'drain' listener; a no-op when already armed. */
+  private attachDrainListener(): void {
+    if (this.drainListener !== null) return;
+    const stdout = this.options.stdout;
+    const handler = (): void => {
+      this.drainListener = null;
+      stdout.removeListener('drain', handler);
+      if (this.isUnmounted || this.isPaused) return;
+      // The stream drained: clear the gate so this render actually writes
+      // (the write result re-asserts the true backpressure state).
+      this.backpressured = false;
+      this.renderNow();
+    };
+    this.drainListener = handler;
+    stdout.once('drain', handler);
+  }
+
+  /** Cancel the drain listener; keeps the timer handling intact. */
+  private detachDrainListener(): void {
+    if (this.drainListener !== null) {
+      this.options.stdout.removeListener('drain', this.drainListener);
+      this.drainListener = null;
+    }
   }
 
   onRender() {
@@ -617,7 +706,10 @@ export default class Ink {
     // Entering a render cancels any pending drain tick — this render will
     // handle the drain (and re-schedule below if needed). Prevents a
     // wheel-event-triggered render AND a drain-timer render both firing.
-    if (this.drainTimer !== null) {
+    // While backpressured this render SKIPS its write (see the gate below),
+    // so it does not handle the drain — keep the backing-off re-probe
+    // armed or the writer deadlocks (drain may already have been emitted).
+    if (this.drainTimer !== null && !this.backpressured) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
     }
@@ -888,9 +980,10 @@ export default class Ink {
     // implementation deviates from xterm and garbles scrolling content.
     isDecstbmSafe());
     const diffMs = performance.now() - tDiff;
-    // Swap buffers
-    this.backFrame = this.frontFrame;
-    this.frontFrame = frame;
+    // NOTE: frontFrame/backFrame are NOT swapped here — the candidate frame
+    // may be skipped by the backpressure gate below, and the diff engine
+    // must keep comparing against the last frame the terminal actually
+    // received. The swap happens in the write-success branch.
 
     // Periodically reset char/hyperlink pools to prevent unbounded growth
     // during long sessions. 5 minutes is infrequent enough that the O(cells)
@@ -919,7 +1012,14 @@ export default class Ink {
     const optimized = optimize(diff);
     const optimizeMs = performance.now() - tOptimize;
     const hasDiff = optimized.length > 0;
-    if (this.altScreenActive && hasDiff) {
+    // Backpressure gate, computed BEFORE the optimized patch list is built:
+    // write() === false is the authoritative signal (a stream with a small
+    // high-water mark can reject writes while writableLength is still below
+    // the threshold); the backlog check is an additional bound only.
+    const stdout = this.options.stdout as Writable & { writableLength?: number };
+    const backlog = typeof stdout.writableLength === 'number' ? stdout.writableLength : 0;
+    const writing = !this.backpressured && backlog <= PTY_BACKLOG_BYTES;
+    if (this.altScreenActive && hasDiff && writing) {
       // Prepend CSI H to anchor the physical cursor to (0,0) so
       // log-update's relative moves compute from a known spot (self-healing
       // against out-of-band cursor drift, see the ALT_SCREEN_ANCHOR_CURSOR
@@ -1042,19 +1142,48 @@ export default class Ink {
       }
     }
     const tWrite = performance.now();
-    writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
-    const writeMs = performance.now() - tWrite;
-    // One frame reached the terminal. Components holding a widened mount
-    // window until its content is actually flushed (MessageList's paint
-    // expansion hold) key off this tick — a commit can be superseded before
-    // its frame flushes, so "mounted" alone must never unlock tightening.
-    noteTerminalFlush();
+    // Skip THIS write while backpressured (see the gate above) and wait for
+    // the stream's own drain. The diff engine compares against frontFrame —
+    // the last frame the terminal ACTUALLY received — so a skipped frame
+    // coalesces into the next write instead of being lost (and its erase/
+    // cursor patches never reach the terminal, so needsEraseBeforePaint and
+    // displayCursor stay truthful).
+    let writeMs = 0;
+    if (writing) {
+      const flushed = writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
+      writeMs = performance.now() - tWrite;
+      this.backpressured = !flushed;
+      if (flushed && this.drainBackoffMs !== DRAIN_BACKOFF_BASE_MS) {
+        this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
+      }
+      // One frame reached the terminal. Components holding a widened mount
+      // window until its content is actually flushed (MessageList's paint
+      // expansion hold) key off this tick — a commit can be superseded before
+      // its frame flushes, so "mounted" alone must never unlock tightening.
+      noteTerminalFlush();
 
-    // Update blit safety for the NEXT frame. The frame just rendered
-    // becomes frontFrame (= next frame's prevScreen). If we applied the
-    // selection overlay, that buffer has inverted cells. selActive/hlActive
-    // are only ever true in alt-screen; in main-screen this is false→false.
-    this.prevFrameContaminated = selActive || hlActive;
+      // The terminal now holds `frame`: it becomes the diff baseline for
+      // every later pass. Swap AFTER a successful write — a skipped frame
+      // must never advance the baseline or the delta against it would be
+      // lost forever.
+      this.backFrame = this.frontFrame;
+      this.frontFrame = frame;
+
+      // Update blit safety for the NEXT frame. The frame just rendered
+      // becomes frontFrame (= next frame's prevScreen). If we applied the
+      // selection overlay, that buffer has inverted cells. selActive/hlActive
+      // are only ever true in alt-screen; in main-screen this is false→false.
+      this.prevFrameContaminated = selActive || hlActive;
+    } else {
+      // Skipped write: the frame never reached the terminal, so the cursor
+      // park target (displayCursor, set above) and the contamination flag
+      // must stay at their last-WRITTEN values — displayCursor was already
+      // updated for this frame, so roll it back; the next written frame
+      // recomputes both fresh from the same baseline.
+      this.displayCursor = parked;
+      this.backpressured = true;
+      noteFrameCause('backpressure');
+    }
 
     // A ScrollBox has pendingScrollDelta left to drain — schedule the next
     // frame via scheduleDrain (cadence + pty backpressure gate, see there).
@@ -1064,7 +1193,7 @@ export default class Ink {
     // → leadingEdge fires IMMEDIATELY → double render ~0.1ms apart → jank.
     // If a wheel event or immediate render arrives first, renderNow cancels
     // this timer — no double.
-    if (frame.scrollDrainPending) {
+    if (frame.scrollDrainPending || this.backpressured) {
       noteFrameCause('scroll-drain');
       this.scheduleDrain();
     }
@@ -1336,6 +1465,7 @@ export default class Ink {
     // Cancel any pending throttled render so it doesn't fire between
     // cleanupTerminalModes() and process.exit() and write to main screen.
     this.scheduleRender.cancel?.();
+    this.detachDrainListener();
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
@@ -2336,6 +2466,11 @@ export default class Ink {
 
     // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
     this.scheduleRender.cancel?.();
+    // The final renderNow() above may have re-armed the backpressure wait
+    // (a backpressured final frame re-attaches the drain listener): release
+    // it unconditionally so a stdout that never drains cannot hold the
+    // renderer (and its stream listener) past unmount.
+    this.detachDrainListener();
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;

--- a/src/ink/layout/node.ts
+++ b/src/ink/layout/node.ts
@@ -127,6 +127,8 @@ export type LayoutNode = {
   setMeasureFunc(fn: LayoutMeasureFunc): void
   unsetMeasureFunc(): void
   markDirty(): void
+  /** Whether this node or its subtree needs re-layout (clean-tree fast path). */
+  isDirty(): boolean
 
   // Layout reading (post-layout)
   getComputedLeft(): number

--- a/src/ink/layout/yoga.ts
+++ b/src/ink/layout/yoga.ts
@@ -87,6 +87,10 @@ export class YogaLayoutNode implements LayoutNode {
 
   // Layout
 
+  isDirty(): boolean {
+    return this.yoga.isDirty()
+  }
+
   calculateLayout(width?: number, _height?: number): void {
     this.yoga.calculateLayout(width, undefined, Direction.LTR)
   }

--- a/src/ink/terminal.ts
+++ b/src/ink/terminal.ts
@@ -471,15 +471,18 @@ export function serializeDiff(
  * @param terminal - the terminal to write to.
  * @param diff - the frame diff patches to render.
  * @param skipSyncMarkers - when true, omit the BSU/ESU wrapping.
+ * @returns `false` when the underlying stream reported backpressure
+ *   (`stdout.write()` returned false) — callers gate scroll-drain and
+ *   backlog handling on this.
  */
 export function writeDiffToTerminal(
   terminal: Terminal,
   diff: Diff,
   skipSyncMarkers = false,
-): void {
+): boolean {
   const buffer = serializeDiff(terminal, diff, skipSyncMarkers)
   if (buffer === '') {
-    return
+    return true
   }
-  terminal.stdout.write(buffer)
+  return terminal.stdout.write(buffer)
 }

--- a/src/screens/AgentView.tsx
+++ b/src/screens/AgentView.tsx
@@ -69,6 +69,44 @@ function statusLabel(status: AgentViewStatus): string {
   }
 }
 
+/** Safety cap for the bucket-boundary wake (local midnight). */
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * The next wall-clock instant at which {@link formatWhen} would render a
+ * DIFFERENT label for a row last touched at `at` — the display-bucket
+ * boundary: "now" flips at 45s, minutes at each half-minute, hours at each
+ * half-hour, days at each half-day, and the date form at the next local
+ * midnight. A view whose rows all fall in the same bucket can sleep until
+ * the nearest of these instead of re-rendering every second.
+ */
+function nextWhenBoundaryAt(at: number, now: number): number {
+  const age = Math.max(0, now - at)
+  const ageSec = age / 1000
+  if (ageSec < 45) return now + (45_000 - age)
+  const minutes = ageSec / 60
+  if (minutes < 60) {
+    // The label shows round(minutes); it changes when the age crosses a
+    // half-minute mark (k + 0.5 minutes).
+    const displayed = Math.round(minutes)
+    return now + Math.max(1, ((displayed + 0.5) * 60_000) - age)
+  }
+  const hours = minutes / 60
+  if (hours < 24) {
+    const displayed = Math.round(hours)
+    return now + Math.max(1, ((displayed + 0.5) * 3_600_000) - age)
+  }
+  const days = hours / 24
+  if (days <= 7) {
+    const displayed = Math.round(days)
+    return now + Math.max(1, ((displayed + 0.5) * 86_400_000) - age)
+  }
+  // Date form: the label changes at the next local midnight.
+  const midnight = new Date(now)
+  midnight.setHours(24, 0, 0, 0)
+  return midnight.getTime()
+}
+
 /** A thrown value's message, for a notification that has to say something. */
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -233,16 +271,37 @@ export function AgentView({
   const stopArmRef = React.useRef<{ id: string; deadline: number } | null>(null)
 
   // One clock per render pass: every relative time on screen must agree.
+  // Scheduled at the NEXT display-bucket boundary instead of a fixed 1s
+  // interval — `formatWhen` only changes at 45s / minute / hour / day / local
+  // midnight boundaries, so a static list wakes at most once per bucket
+  // (sub-second buckets cannot occur). The wake re-arms itself: `now` is in
+  // the deps, so the effect recomputes the next boundary after every tick
+  // (and on every rows change).
   React.useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(timer)
-  }, [])
+    if (agentRows.length === 0) return
+    const nowMs = Date.now()
+    let boundaryAt = Infinity
+    for (const row of agentRows) {
+      const next = nextWhenBoundaryAt(row.updatedAt, nowMs)
+      if (next < boundaryAt) boundaryAt = next
+    }
+    if (!Number.isFinite(boundaryAt)) return
+    // nextWhenBoundaryAt returns an ABSOLUTE timestamp; setTimeout wants a
+    // relative delay. Cap the target at one day so an anomalous value can
+    // never stall the clock entirely.
+    const target = Math.min(boundaryAt, nowMs + DAY_MS)
+    const delay = Math.max(0, target - nowMs)
+    const timer = setTimeout(() => setNow(Date.now()), delay)
+    return () => clearTimeout(timer)
+  }, [agentRows, now])
 
   // CC parity: working rows animate their glyph (the `·✢*✶✻✽` cycle). The
   // shared clock only runs while at least one row is working and pauses
-  // otherwise, so an idle view costs no extra ticks.
+  // otherwise, so an idle view costs no extra ticks. The ref is attached to
+  // the list container so the viewport gate pauses the clock when the list
+  // is out of view (peek panel covering, narrow split).
   const workingCount = agentRows.filter(row => row.status === 'working').length
-  const [, spinnerTime] = useAnimationFrame(workingCount > 0 ? 120 : null)
+  const [spinnerViewportRef, spinnerTime] = useAnimationFrame(workingCount > 0 ? 120 : null)
   const spinnerFrame = Math.floor(spinnerTime / 120)
 
   // The delete arm expires after its window without an explicit keystroke;
@@ -630,7 +689,7 @@ export function AgentView({
 
       <Box flexGrow={1} flexShrink={1}>
         {!soloPreview && (
-          <Box flexDirection="column" width={listWidth} height={listHeight} flexShrink={0}>
+          <Box ref={spinnerViewportRef} flexDirection="column" width={listWidth} height={listHeight} flexShrink={0}>
             {agentRows.length === 0 && (
               <Text dimColor italic>{` ${truncateWidth(t('agentview-none'), listWidth - 2)}`}</Text>
             )}

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -102,7 +102,7 @@ import { useAnimationFrame } from '../ink/hooks/use-animation-frame.js'
 import { useExternalVersion } from '../hooks/useExternalVersion.js'
 import { TrajectoryScene } from './TrajectoryScene.js'
 import { AgentView } from './AgentView.js'
-import { extendTrajectory, projectWave, type TrajBuild } from '../dsh-adapter/trajectory/index.js'
+import { extendTrajectory, emptyTrajectory, projectWave, type TrajBuild } from '../dsh-adapter/trajectory/index.js'
 import { miniWakeWidth } from '../components/trajectory/MiniWake.js'
 import { readTrajectorySeen, writeTrajectorySeen } from '../trajectoryPrefs.js'
 import type { SessionEvent } from '../dsh-adapter/types.js'
@@ -118,8 +118,15 @@ import {
   type WorkspaceFlowInput,
 } from './chatOverlay.js'
 
-/** Shared empty snapshot for hosts whose channel has no event log. */
+/** Shared empty snapshot for channels without an event log (legacy stubs). */
 const NO_EVENTS: readonly SessionEvent[] = []
+/** Shared empty build for channels that provide neither seam (stable
+ *  identity keeps stub renders churn-free). */
+const EMPTY_TRAJECTORY = emptyTrajectory()
+/** Shared no-op unsubscribe for stub channels without an agent-view feed. */
+const EMPTY_SUBSCRIBE = (): (() => void) => () => {}
+/** Shared empty agent-view rows for stub channels (see EMPTY_TRAJECTORY). */
+const EMPTY_AGENT_VIEW_ROWS: readonly never[] = []
 
 const PERMISSION_RESULT_CELLS = 200
 
@@ -293,8 +300,15 @@ export function Chat({
   React.useSyncExternalStore(subscribeLang, getLang)
   // The pending ask-user-question (DSH user-interaction seam): the model's
   // `ask_user_question` tool parks here until the panel is answered.
+  // useSyncExternalStore re-subscribes whenever the subscribe function
+  // identity changes, so these bindings are stable per store instance
+  // (useCallback) instead of fresh closures per render.
+  const subscribeQuestions = React.useCallback(
+    (listener: () => void) => questionStore.subscribe(listener),
+    [questionStore],
+  )
   const questionSnapshot = React.useSyncExternalStore(
-    listener => questionStore.subscribe(listener),
+    subscribeQuestions,
     () => questionStore.getSnapshot(),
   )
   // The pending tool-approval ask (DSH approval seam): the permission layer
@@ -302,8 +316,12 @@ export function Chat({
   // questionnaire since it gates a tool about to run. Hosts that pass no
   // approvalStore share one inert instance that never holds an ask.
   const approvals = approvalStore ?? (fallbackApprovalStore ??= new ApprovalStore())
+  const subscribeApprovals = React.useCallback(
+    (listener: () => void) => approvals.subscribe(listener),
+    [approvals],
+  )
   const approvalSnapshot = React.useSyncExternalStore(
-    listener => approvals.subscribe(listener),
+    subscribeApprovals,
     () => approvals.getSnapshot(),
   )
   // The pending managed plugin dialog (tuiDialogs seam): a plugin's
@@ -312,15 +330,23 @@ export function Chat({
   // plugin's question) and above the questionnaire. Hosts without the
   // extensions row share one inert store that never holds a dialog.
   const dialogs = extensionDialogs ?? (fallbackDialogStore ??= new TuiDialogStore())
+  const subscribeDialogs = React.useCallback(
+    (listener: () => void) => dialogs.subscribe(listener),
+    [dialogs],
+  )
   const dialogSnapshot = React.useSyncExternalStore(
-    listener => dialogs.subscribe(listener),
+    subscribeDialogs,
     () => dialogs.getSnapshot(),
   )
   // Plugin status-line contributions (tuiStatus seam): keyed texts joined
   // into one line above the prompt.
   const statusContributions = extensionStatus ?? (fallbackStatusStore ??= new TuiStatusStore())
+  const subscribeStatus = React.useCallback(
+    (listener: () => void) => statusContributions.subscribe(listener),
+    [statusContributions],
+  )
   const statusEntries = React.useSyncExternalStore(
-    listener => statusContributions.subscribe(listener),
+    subscribeStatus,
     () => statusContributions.getSnapshot(),
   )
   // Shortcut handler failures surface as toasts (the registry also logs
@@ -457,10 +483,13 @@ export function Chat({
   /** Live agent-view rows: the prompt footer's "← N agents" hint reads the
    *  needs-input count from here (cached snapshot in the channel). The
    *  `?.()` fallbacks keep pre-agent-view test stubs (channel facades in
-   *  scripts/*) rendering — the real channel always provides the seams. */
-  const EMPTY_AGENT_VIEW_ROWS: readonly never[] = []
+   *  scripts/*) rendering — the real channel always provides the seams. The
+   *  fallbacks are module-level constants: useSyncExternalStore must see a
+   *  stable subscribe/getSnapshot identity or it re-subscribes (and
+   *  snapshot-compares) on every render.
+   */
   const agentViewRows = React.useSyncExternalStore(
-    listener => channel.subscribeAgentView?.(listener) ?? (() => {}),
+    channel.subscribeAgentView ?? EMPTY_SUBSCRIBE,
     () => channel.agentViewRows?.() ?? EMPTY_AGENT_VIEW_ROWS,
   )
   const backgroundAgentsNeedingInput = agentViewRows.filter(
@@ -590,8 +619,39 @@ export function Chat({
   }, [autoRecapSessionId])
   // The user starts a new message → the auto recap has served its purpose
   // (catching them up) and bows out. A newer user row is the signal; the
-  // assistant's own streamed rows don't count.
-  const lastUserRowId = channel.rows.filter(row => row.kind === 'user').at(-1)?.id ?? -1
+  // assistant's own streamed rows don't count. `lastUserRowId` is tracked
+  // amortized O(1) per render: user rows are only ever APPENDED to the tail
+  // (folds keep the newest), so only rows appended past the last scan can
+  // hold a newer user row, and a session swap (agentId change) rescans the
+  // new session's rows exactly once.
+  const lastUserRowStateRef = React.useRef<{ agentId: string; scanned: number; id: number }>({
+    agentId: '',
+    scanned: 0,
+    id: -1,
+  })
+  const lastUserRowState = lastUserRowStateRef.current
+  let lastUserRowId = lastUserRowState.id
+  if (lastUserRowState.agentId !== channel.agentId) {
+    lastUserRowId = -1
+    for (let index = channel.rows.length - 1; index >= 0; index--) {
+      if (channel.rows[index]?.kind === 'user') {
+        lastUserRowId = channel.rows[index]!.id
+        break
+      }
+    }
+    lastUserRowStateRef.current = {
+      agentId: channel.agentId,
+      scanned: channel.rows.length,
+      id: lastUserRowId,
+    }
+  } else if (channel.rows.length > lastUserRowState.scanned) {
+    for (let index = lastUserRowState.scanned; index < channel.rows.length; index++) {
+      const row = channel.rows[index]
+      if (row?.kind === 'user' && row.id > lastUserRowId) lastUserRowId = row.id
+    }
+    lastUserRowState.scanned = channel.rows.length
+    lastUserRowState.id = lastUserRowId
+  }
   React.useEffect(() => {
     if (
       recap !== null &&
@@ -687,7 +747,7 @@ export function Chat({
 
   /** Open the scene, mark failures seen, and retire the key hint for good. */
   const openScene = React.useCallback(() => {
-    seenFailuresRef.current = trajectoryRef.current?.counts.errors ?? 0
+    seenFailuresRef.current = trajectoryRef.current.counts.errors
     setTrajectorySeen(previous => {
       if (!previous) writeTrajectorySeen()
       return true
@@ -802,6 +862,24 @@ export function Chat({
     (listener: () => void) => (handle ? handle.subscribe(listener) : () => {}),
     [handle],
   )
+  // The sticky header pins the turn owning the viewport top row
+  // (timeline.activeId, reported by MessageList) — scrolled up to an old
+  // turn, it carries THAT turn's prompt, not the latest one. The lookup is
+  // memoized: a user row's text is immutable after creation, so the result
+  // can only change when the anchor id or the session changes (row ids
+  // restart at 0 on a swap). Declared BEFORE the screen-swap early returns
+  // (scene/browser/agent-view): a hook placed after them would drop from
+  // the hook list while a replacement screen is up, and React would throw
+  // "Rendered fewer hooks than expected" on the way back.
+  const anchorUserRowId = timeline.activeId
+  const anchorUserText = React.useMemo(
+    () =>
+      anchorUserRowId === null
+        ? null
+        : channel.rows.find(row => row.id === anchorUserRowId)?.text ?? null,
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [anchorUserRowId, channel.agentId],
+  )
 
   // "N new messages" pill: new rows whose top edge is still BELOW the
   // viewport bottom. The count decrements as the user scrolls down through
@@ -836,10 +914,13 @@ export function Chat({
   // Live view into the prompt's text for the Ctrl+C rule (clears text when
   // non-empty; the double-press exit only arms on an empty input).
   const promptControllerRef = React.useRef<PromptController | null>(null)
-  // Publish the external-injection controller (dsh.nvim etc.) every render so
-  // the adapter-owned socket can append to the prompt and submit. `submit`
+  // Publish the external-injection controller (dsh.nvim etc.) so the
+  // adapter-owned socket can append to the prompt and submit. `submit`
   // mirrors an Enter press: `channel.submit` routes through the DSH inbox
   // (queued after the current turn while working), then the input is cleared.
+  // Mounted once per channel: every closure reads the LIVE prompt controller
+  // through the ref at call time, so the published value never goes stale —
+  // re-running this effect on every commit would churn the ref for nothing.
   React.useEffect(() => {
     if (!injectControllerRef) return
     injectControllerRef.current = {
@@ -862,7 +943,10 @@ export function Chat({
     return () => {
       injectControllerRef.current = null
     }
-  })
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- the ref and
+    // channel identities are stable for the life of the mount; the closures
+    // read live state through refs, so no per-render refresh is needed.
+  }, [channel, injectControllerRef])
   const requestExit = () => {
     if (exitPendingRef.current) {
       onExit()
@@ -2210,22 +2294,45 @@ export function Chat({
   }
 
   /**
-   * The session's trajectory projection, folded here rather than inside the
-   * scene.
+   * The session's trajectory projection, folded incrementally by the channel
+   * at EVENT time — never here. Render reads the ready build (a stable
+   * channel-owned object), so no render touches the session event getter.
    *
-   * Two things fall out of owning it at this level: the status-line chip can
-   * show live counters without a second fold, and opening the scene is
-   * instant because the build is already warm. The fold is incremental — it
-   * consumes only events appended since the last render — so an idle
-   * conversation pays nothing for it.
+   * Legacy/headless channels that only provide `traceEvents()` (test stubs,
+   * bare embeds) fall back to a snapshot-identity-cached fold here: the
+   * getter is called at most ONCE per event-snapshot identity, and the
+   * fold itself is incremental, so the fallback stays O(1) per render on an
+   * unchanged snapshot. Real channels provide `trajectory()` and never hit
+   * this path.
    */
-  const trajectoryRef = React.useRef<TrajBuild | null>(null)
-  trajectoryRef.current = extendTrajectory(
-    trajectoryRef.current,
-    // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: headless hosts render Chat with a partial channel
-    channel.traceEvents?.() ?? NO_EVENTS,
-  )
-  const trajectory = trajectoryRef.current
+  const trajectoryFallbackRef = React.useRef<{
+    version: number
+    events: readonly SessionEvent[]
+    build: TrajBuild
+  } | null>(null)
+  const trajectory = channel.trajectory
+    ? channel.trajectory()
+    : (() => {
+        const cached = trajectoryFallbackRef.current
+        // Version gate: the getter is consulted only when the channel
+        // version moved (the stub's own change signal); renders triggered
+        // by anything else (animation ticks, local state) pay nothing.
+        if (cached !== null && cached.version === channel.version) return cached.build
+        const events = channel.traceEvents?.() ?? NO_EVENTS
+        if (cached !== null && cached.events === events) {
+          // Same snapshot, new version (a notify without session events):
+          // reuse the build — the fold stays incremental.
+          trajectoryFallbackRef.current = { version: channel.version, events, build: cached.build }
+          return cached.build
+        }
+        const build = extendTrajectory(cached?.build ?? null, events)
+        trajectoryFallbackRef.current = { version: channel.version, events, build }
+        return build
+      })()
+  // Mirrors the current build for callbacks defined before `trajectory` is in
+  // scope (openScene) without re-creating them per render.
+  const trajectoryRef = React.useRef(trajectory)
+  trajectoryRef.current = trajectory
 
   /**
    * The status-line wake.
@@ -2249,11 +2356,32 @@ export function Chat({
         // rather than as short. It simply grows as the session does.
         : projectWave(trajectory.nodes, Math.min(wakeWidth, trajectory.nodes.length), 'sequence'),
     // The node array is mutated in place by the incremental fold, so its
-    // length is the honest dependency; its identity never changes.
+    // identity never changes and its length misses in-place closes (a
+    // tool/result only flips an existing node's status). The build's
+    // monotonic revision covers every consumed event — including closes.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [trajectory.nodes, trajectory.counts.rows, wakeWidth],
+    [trajectory.nodes, trajectory.counts.rows, trajectory.revision, wakeWidth],
   )
-  const [wakeTickRef, wakeTime] = useAnimationFrame(channel.working ? 120 : null)
+  // The mini-wake clock runs ONLY while the strip can actually be seen: the
+  // main chat surface is rendered (no replacement screen owns the viewport —
+  // a swapped-out screen leaves the wake ref's element unmounted and the
+  // viewport hook's isVisible stale at its last value), the terminal is wide
+  // enough for a strip (miniWakeWidth > 0), the trajectory chrome is enabled,
+  // and a turn is actually working. All four are read every render, so the
+  // animation unsubscribes the moment any condition drops.
+  const mainSurfaceRendered =
+    !sceneOpen &&
+    channel.pluginScene === undefined &&
+    !agentViewOpen &&
+    !browserOpen &&
+    !treeOpen &&
+    !settingsOpen &&
+    subagentDetailId === null &&
+    !jobsPanelOpen &&
+    !subagentDashboardOpen
+  const wakeTickActive =
+    channel.working && wakeWidth > 0 && mainSurfaceRendered && channel.statusBar?.trajectory === true
+  const [wakeTickRef, wakeTime] = useAnimationFrame(wakeTickActive ? 120 : null)
   /**
    * The key hint beside the strip retires itself once the trajectory has been
    * opened — teaching belongs in the first minute, not on every frame forever.
@@ -2277,8 +2405,14 @@ export function Chat({
       if (row?.kind === 'tool' && row.tool?.status === 'error') return row.id
     }
     return null
+    // The newest failed tool row can only change when the trajectory's error
+    // count grows or the session swaps — NOT on every channel version bump.
+    // Keying on those (instead of channel.version) keeps the reverse scan
+    // off the streaming frame path: an idle/long session re-renders without
+    // touching rows at all, and a streaming session scans only when an error
+    // actually lands.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [channel.rows, channel.version, unreadFailures])
+  }, [trajectory.counts.errors, channel.agentId, unreadFailures])
 
   // Row seeking under layout virtualization: a mounted row seeks directly;
   // an unmounted one is force-mounted first, then sought by the completion
@@ -3370,16 +3504,6 @@ export function Chat({
   }) && !(overlay.kind === 'permission'
     && (approvalSnapshot !== null || questionSnapshot !== null || dialogSnapshot !== null))
 
-  // The sticky header pins the turn owning the viewport top row
-  // (timeline.activeId, reported by MessageList) — scrolled up to an old
-  // turn, it carries THAT turn's prompt, not the latest one.
-  // channel.rows is a live in-place array, so the lookup is per-render.
-  const anchorUserRowId = timeline.activeId
-  const anchorUserText =
-    anchorUserRowId === null
-      ? null
-      : channel.rows.find(row => row.id === anchorUserRowId)?.text ?? null
-
   return (
     <Box ref={wakeTickRef} flexDirection="column" flexGrow={1} width="100%">
       {!isSticky && anchorUserText && (
@@ -3431,6 +3555,8 @@ export function Chat({
         )}
         <MessageList
           rows={channel.rows}
+          streamingVersion={channel.rowsStreamingVersion}
+          rowsGeneration={channel.rowsGeneration}
           failureHintRowId={failureHintRowId}
           failureHint={t('traj-hint-failure', { key: `${modLabel}t` })}
           expanded={expanded}

--- a/src/screens/TrajectoryScene.tsx
+++ b/src/screens/TrajectoryScene.tsx
@@ -106,15 +106,17 @@ export function TrajectoryScene({
   const { rows: filtered, indexes } = React.useMemo(
     () => applyQuery(nodes, query),
     // `nodes` is mutated in place by the incremental fold, so its length is
-    // the honest dependency — the array identity never changes.
+    // NOT an honest dependency alone — an in-place close (tool/result,
+    // step/end) changes status/duration without touching length. The
+    // build's monotonic revision covers every consumed event.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [nodes, nodes.length, query],
+    [nodes, nodes.length, build.revision, query],
   )
 
   const agg = React.useMemo(
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     () => aggregate(build, sort),
-    [build, nodes.length, sort],
+    [build, nodes.length, build.revision, sort],
   )
 
   // ── arrival + alert detection ────────────────────────────────────────────
@@ -147,7 +149,7 @@ export function TrajectoryScene({
   const band = React.useMemo(
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     () => projectWave(nodes, bandWidth, projection),
-    [nodes, nodes.length, bandWidth, projection],
+    [nodes, nodes.length, build.revision, bandWidth, projection],
   )
   const matchColumns = React.useMemo(() => {
     if (query.empty) return undefined


### PR DESCRIPTION
## 动机

dsh-TUI 在会话静置、长会话渲染与慢终端背压下有可测量的 CPU 空转（issue #712）。本 PR 消除 render 热路径上的 session 事件触达、静态 UI 状态的无意义动画/timer、长会话的 O(n) 扫描、stdout 背压忙轮询与无终止条件的后台重试。

## 改动概览

**A. trajectory 移出 render 热路径（`channel.ts` / `projection.ts` / `Chat.tsx` / `TrajectoryScene.tsx`）**
- Chat render 不再调用 `channel.traceEvents()`；channel 在 `session/event` 时增量折叠，新增 `extendTrajectoryEvents` 直接消费新增事件（纯 chunk 批次 O(1)，不复制 O(n) snapshot），bindAgent 时一次性全量重建；
- `TrajBuild.revision` 单调递增（含原地 close 的节点），wave/查询/detail memo 全部接入，修复 running 状态不刷新问题；
- 旧式 stub（仅 `traceEvents()`）回退按 snapshot identity + version 双门控缓存。

**B. 静态状态不再持有时钟（`ActivityLine` / `JobsPanel` / `GoalTodoPanel` / `AgentView` / `Chat` / `channel.ts`）**
- `ActivityLine(done)`、全 settled/空 `JobsPanel`、paused/blocked `GoalTodoPanel` 不订阅动画/计时时钟；paused/blocked 冻结 elapsed，resume 重设基准；
- `AgentView` 1s 轮询改为显示桶边界 one-shot 调度（相对延迟 + 自续）；
- MiniWake 时钟仅在主 Chat 可见、宽度 ≥84、功能开启且 working 时运行（不依赖已卸载元素遗留的 `isVisible`）；
- 真实 channel 的 activity tick：`activity:false` 不创建；done 行稳定（片段窗口 + 4s 宽限）后销毁，live phase 事件驱动重建。

**C. 长会话 O(n) 扫描消除（`MessageList` / `Chat` / `channel.ts`）**
- streaming 位翻转走 `rowsStreamingVersion`（6 处翻转点统一，含 revive 路径），过滤缓存不再每 render 全量扫描；
- `failureHintRowId` / `lastUserRowId` / sticky anchor 元数据化，流式帧不再扫描 rows；
- timeline 三级缓存（列表/几何 tops/合并）拆分；
- `rowsGeneration` 纳入 MessageList 高度/painted/签名缓存键（clear/swap/rewind/new 后 id 复用不再串台）；
- injectController effect 固定依赖，不再每 commit cleanup/reinstall。

**D. stdout 背压与渲染生命周期（`ink.tsx` / `terminal.ts` / `App.tsx`）**
- `write() === false` 为权威背压信号：跳过写入并合并到下一帧（diff 基线仍是终端实际收到的帧），drain 事件 + 250ms→1s 退避恢复；修复 drain 单次信号丢失 + fallback 被渲染取消导致的写者死锁；
- `frontFrame` 仅在实际写入成功后推进；`needsEraseBeforePaint` 不被空转消费；resize/unmount 重置背压并 detach drain listener；
- incomplete escape timer 随 raw mode 释放取消并重置解析状态。

**E. 后台轮询与重试有界（`grants.ts` / `channel.ts`）**
- grants 改 `fs.watch`（父目录，原子替换/删除重建仍通知）+ debounce，无订阅即停，低频 fallback；signature 含存在位；
- skill `complete:false` 重试 3 次指数退避后停止（last-good 保留，`skills/change` 恢复）；incomplete 观察不再 dispose 有效 handler；release/rebind 以 generation 使在途刷新失效。

**F. Yoga 无效 commit 成本（`ink.tsx` / `layout/*`）**
- 仅尺寸实际变化时 `setWidth`；树完全干净（`isDirty()` 为 false）时跳过整轮 layout+round。

## 验证

- `pnpm build`（compile + verify:boundary/contract/patch-surface/plugin-*/approval-visibility 等 290 项）通过；
- `pnpm verify:package`、`pnpm smoke` 通过；
- 新增回归：`verify-trajectory-cache.tsx`（render 零 getter、fallback identity 缓存）、`verify-idle-wakeups.tsx`（各静态态零帧、MiniWake 门控、AgentView 无 1s 轮询）、`repro-slow-stdout.tsx`（无 4ms 忙轮询、backlog 有界、drain 后终端内容完整、unmount 清理）、`verify-grants-watch.ts`（事件通知、atomic replace、无订阅停止）；
- 扩展：`verify-working-activity.mjs`（done 稳定后 timer 停止、revive 版本递增）、`verify-skill-commands.mjs`（有界重试、mock dispose 对齐真实 dsh-commands 契约）；
- 既有回归全量通过：trace-scene/projection、jobs-panel、goal-todo、compact(-switch)、resize-temporal/reflow、pointer-events、hover-coalesce、copy-on-select、agent-view、session-browser、submit、win32-protocol/input、scroll、resticky、askpanel、toolcards、plan-review-scroll、drag-protocol、input-selection、ctrl-t-scope、channel-goal-todo、tips 等；
- `verify-queue.mjs` 一项失败为基线既有问题（f7db6057 复现），非本次引入。

## 风险与说明

- Yoga clean-tree early bail 依赖引擎 markDirty 完备性（与引擎既有 dirty-skip 同一不变量），改动集中在 `onComputeLayout` 一处，可单点回退；
- `AgentView` 相对时间从 1s 实时刷新改为桶边界刷新（显示值在边界前不变）；GoalTodoPanel paused/blocked 冻结 elapsed 且 resume 重设基准；
- 上游 `dsh-working-activity` 的 `lang.js` statSync 热点与 `tickMs` 无法关闭为上游限制，已记录于 https://github.com/ccch1mneyyy/working-activity/issues/14，本 PR 不做 workaround。

Closes #712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary redraws and layout work during scrolling, streaming, and inactive views.
  * Improved terminal rendering under heavy output, including safer recovery when output becomes saturated.
  * Reduced background timers and animation activity when content is idle or settled.

* **Bug Fixes**
  * Improved live transcript updates, trajectory rendering, timestamps, and elapsed-time tracking.
  * Improved grant-file change detection, including atomic updates and delete/recreate scenarios.
  * Prevented incomplete terminal input from lingering after shutdown.

* **Reliability**
  * Added regression coverage for rendering, caching, file watching, command discovery, and activity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->