### PR TITLE
feat(ui): 页边距 pageMargin 设置 + 内容列/全幅出血排版

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -48,6 +48,10 @@ const GROUPS = {
 // （thinking ticker 跟随已到达文本而展开体吃切片、工具卡行级揭示、
 // result 落定即全显）。
     ["verify-smooth-reveal", ['node', '--import', 'tsx/esm', 'scripts/verify-smooth-reveal.tsx']],
+// 根级页边距（PageMargin）契约：无内缩终端（裸 WSL/tmux/SSH）下文字贴边。
+// 左右 2 列上下 1 行内缩 + TerminalSize 收敛成内容区尺寸 + inset 坐标
+// 补偿，对照组保证无 PageMargin 时既有「全宽」契约不变。
+    ["verify-page-margin", ['node', '--import', 'tsx/esm', 'scripts/verify-page-margin.tsx']],
 // 滚动/pill/内联模式回归：新消息 pill 计数递减、Ctrl+C 交互、
 // 内联 scrollback 第三方终端适配。曾因 mock channel 缺新字段而
 // 静默冻结（render 期 TypeError 被 ink 吞掉），不在 CI 里烂了

--- a/scripts/verify-page-margin.tsx
+++ b/scripts/verify-page-margin.tsx
@@ -1,0 +1,277 @@
+/**
+ * verify-page-margin — 根级页边距（PageMargin）契约：
+ * 一些终端（Windows Terminal 的 PowerShell profile 等）自带内缩 padding，
+ * 另一些（裸 WSL/tmux/SSH）完全没有——文字直接贴屏幕四边。PageMargin
+ * 在根布局加一圈小边距（左右 2 列、上下 1 行），同时把 TerminalSize
+ * 收敛成内容区尺寸、经 PageInsetContext 报告内容区相对屏幕原点的偏移。
+ *
+ * 断言（headless xterm 40×12，fullscreen：AlternateScreen > PageMargin）：
+ *   1. 内容区尺寸：useTerminalSize() 报告 36×10（40-2×2, 12-2×1）；
+ *   2. inset：PageInsetContext 报告 {x:2, y:1}；
+ *   3. 顶/底边距：第 0 行与最后一行全空；
+ *   4. 左边距：内容起始于第 2 列（两格前导空格）；
+ *   5. 左右边距对称：E 行从第 2 列到第 37 列，第 38/39 列空白；
+ *   6. 档位切换（模块级 store → useSyncExternalStore 即时重布局）：
+ *      roomy 32x8/inset 4,2/上下各两行空，none 40x12/无内缩/END 贴底；
+ *   7. 自定义规格：`NxM` 解析/边界/规范化单元检查，3x1 与单值 5（→5x1）
+ *      实时重布局，非法值回退 normal；
+ *   8. 出血契约：页面级分割线（bleed）自第 0 列画满整个终端、文本仍在
+ *      第 2 列；Chat 冒烟里滚动轨贴 98/99 列（右缘），转录文本不越
+ *      内容列（0/1 列恒空白）；
+ *   9. 对照组（无 PageMargin）：内容仍全宽、inset=0 —— 既有 verify
+ *      直接挂 Chat 的「全宽」契约不变。
+ *
+ * 运行：node --import tsx/esm scripts/verify-page-margin.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen, Box, Text }, { PageMargin, PageInsetContext }, { useTerminalSize }, { settle, sleep }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/PageMargin.js'),
+  import('../src/ink/hooks/use-terminal-size.js'),
+  import('./lib/term-test.mjs'),
+])
+
+const COLS = 40, ROWS = 12
+let failed = 0
+function check(name: string, ok: boolean, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStderr extends Writable { isTTY = true; _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() } }
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdin = new FakeStdin(), stdout = new FakeStdout(), stderr = new FakeStderr()
+
+/** 探针：报告内容区尺寸、inset，并画一条顶到底的可测布局。 */
+function Probe() {
+  const size = useTerminalSize()
+  const inset = React.useContext(PageInsetContext)
+  return (
+    <Box flexDirection="column" flexGrow={1} width="100%">
+      <Text>{`size=${size.columns}x${size.rows} inset=${inset.x},${inset.y}`}</Text>
+      <Text>{`|${'E'.repeat(Math.max(0, size.columns - 2))}|`}</Text>
+      <Box flexGrow={1} />
+      <Text>{'END'}</Text>
+    </Box>
+  )
+}
+
+function screenLines(): string[] {
+  const buffer = term.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '')
+}
+
+const inst = await render(
+  <AlternateScreen>
+    <PageMargin>
+      <Probe />
+    </PageMargin>
+  </AlternateScreen>,
+  { stdout: stdout as any, stdin: stdin as any, stderr: stderr as any, exitOnCtrlC: false, patchConsole: false },
+)
+
+// 等首帧画出探针行再断言（渲染经节流 + xterm 异步解析）。
+await settle(() => screenLines().some(line => line.includes('size=36x10')))
+
+const lines = screenLines()
+check('内容区尺寸报告 36x10（终端 40x12 扣除页边距）', lines.some(l => l.includes('size=36x10 inset=2,1')))
+check('inset 报告 {x:2, y:1}', lines.some(l => l.includes('inset=2,1')))
+const topBlank = lines[0]?.trim() === ''
+const bottomBlank = lines[ROWS - 1]?.trim() === ''
+check('顶行空白（上行边距）', topBlank, JSON.stringify(lines[0]))
+check('底行空白（下行边距）', bottomBlank, JSON.stringify(lines[ROWS - 1]))
+const sizeRow = lines.findIndex(l => l.includes('size='))
+const edgeRow = lines.findIndex(l => l.trimStart().startsWith('|'))
+const endRow = lines.findIndex(l => l.trimStart().startsWith('END'))
+check('size 行从第 2 列开始', sizeRow >= 0 && lines[sizeRow]!.startsWith('  '), JSON.stringify(lines[sizeRow]))
+check('边距内 E 行从第 2 列开始', edgeRow >= 0 && lines[edgeRow]!.startsWith('  |'), JSON.stringify(lines[edgeRow]))
+// E 行 = 2 空格 + 36 内容列。帧切换时渲染器会把旧行残留单元格清成
+// 空格（xterm buffer 中显示为 " "，translateToString 不减），所以长度
+// 断言统一先 trimEnd 再量。
+check('右列对称：E 行止于第 37 列（38/39 列空白）', edgeRow >= 0 && lines[edgeRow]!.startsWith('  |') && lines[edgeRow]!.trimEnd().length === 38 && lines[edgeRow]!.trimEnd().endsWith('|'), `len=${lines[edgeRow]?.trimEnd().length}`)
+check('END 停在内容区底行（第 10 行，0-based）', endRow === ROWS - 2 && lines[endRow]!.startsWith('  '), JSON.stringify(lines[endRow]))
+
+// ── 档位切换：模块级 store 驱动 PageMargin 即时重布局（/settings 实机路径）──
+const { applyPageMargin } = await import('../src/tuiDisplayPrefs.js')
+applyPageMargin('roomy')
+await settle(() => screenLines().some(l => l.includes('size=32x8 inset=4,2')))
+const roomy = screenLines()
+check('roomy：内容区 32x8（40-2×4, 12-2×2）', roomy.some(l => l.includes('size=32x8 inset=4,2')))
+check('roomy：顶部两行空白', (roomy[0]?.trim() ?? 'x') === '' && (roomy[1]?.trim() ?? 'x') === '', JSON.stringify(roomy.slice(0, 3)))
+check('roomy：底部两行空白', (roomy[ROWS - 1]?.trim() ?? 'x') === '' && (roomy[ROWS - 2]?.trim() ?? 'x') === '', JSON.stringify(roomy.slice(-3)))
+const roomyEdge = roomy.findIndex(l => l.trimStart().startsWith('|'))
+check('roomy：内容起始第 4 列且止于第 35 列', roomyEdge >= 0 && roomy[roomyEdge]!.startsWith('    |') && roomy[roomyEdge]!.trimEnd().length === 36, `len=${roomy[roomyEdge]?.trimEnd().length}`)
+applyPageMargin('none')
+await settle(() => screenLines().some(l => l.includes('size=40x12 inset=0,0')))
+const none = screenLines()
+check('none：内容区 40x12（无内缩）', none.some(l => l.includes('size=40x12 inset=0,0')))
+check('none：首行即内容（无顶部边距）', none[0]!.includes('size=40x12'), JSON.stringify(none[0]))
+check('none：END 贴最后一行', none[ROWS - 1]!.trim() === 'END', JSON.stringify(none[ROWS - 1]))
+
+// ── 自定义规格：NxM（预设之外手动填数值）──
+const { parsePageMarginSpec, normalizePageMargin } = await import('../src/tuiDisplayPrefs.js')
+check('单元：parsePageMarginSpec("2,1") → "2x1"', parsePageMarginSpec('2,1') === '2x1')
+check('单元：parsePageMarginSpec("3x1") → "3x1"', parsePageMarginSpec('3x1') === '3x1')
+check('单元：parsePageMarginSpec("9x9") 超界 → undefined', parsePageMarginSpec('9x9') === undefined)
+check('单元：normalizePageMargin("5") 规范化为 "5x1"', normalizePageMargin('5') === '5x1')
+check('单元：normalizePageMargin("abc") 回退 normal', normalizePageMargin('abc') === 'normal')
+applyPageMargin('3x1')
+await settle(() => screenLines().some(l => l.includes('size=34x10 inset=3,1')))
+const custom = screenLines()
+const customEdge = custom.findIndex(l => l.trimStart().startsWith('|'))
+check('自定义 3x1：内容区 34x10（40-2×3, 12-2×1）', custom.some(l => l.includes('size=34x10 inset=3,1')))
+check('自定义 3x1：内容起始第 3 列且止于第 36 列', customEdge >= 0 && custom[customEdge]!.startsWith('   |') && custom[customEdge]!.trimEnd().length === 37, `len=${custom[customEdge]?.trimEnd().length}`)
+applyPageMargin('5')
+await settle(() => screenLines().some(l => l.includes('size=30x10 inset=5,1')))
+check('自定义 5（单值 → 5x1）：内容区 30x10', screenLines().some(l => l.includes('size=30x10 inset=5,1')))
+applyPageMargin('abc')
+await settle(() => screenLines().some(l => l.includes('size=36x10 inset=2,1')))
+check('自定义非法值回退正常档（36x10）', screenLines().some(l => l.includes('size=36x10 inset=2,1')))
+applyPageMargin('normal')
+await settle(() => screenLines().some(l => l.includes('size=36x10 inset=2,1')))
+check('恢复 normal：内容区回到 36x10', screenLines().some(l => l.includes('size=36x10 inset=2,1')))
+
+// ── 出血（full-bleed）契约：结构线直通终端边缘，文本留在内容列 ──
+// 页面级分割线从第 0 列画到最后一列；文本行仍从内容列开始。
+const { Divider } = await import('../src/components/design-system/Divider.js')
+function BleedProbe() {
+  return (
+    <Box flexDirection="column" flexGrow={1} width="100%">
+      <Text>{'line-content'}</Text>
+      <Divider bleed />
+      <Text>{'tail'}</Text>
+    </Box>
+  )
+}
+const termB = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+const stdoutB = new (class extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { termB.write(String(chunk), cb) }
+})()
+const stdinB = new FakeStdin(), stderrB = new FakeStderr()
+inst.unmount()
+await sleep(150)
+const instB = await render(
+  <AlternateScreen>
+    <PageMargin>
+      <BleedProbe />
+    </PageMargin>
+  </AlternateScreen>,
+  { stdout: stdoutB as any, stdin: stdinB as any, stderr: stderrB as any, exitOnCtrlC: false, patchConsole: false },
+)
+function linesB(): string[] {
+  const buffer = termB.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '')
+}
+await settle(() => linesB().some(l => l.trimStart() === '─'.repeat(COLS)))
+const linesBNow = linesB()
+check('分割线出血：─ 行自第 0 列画满 40 列', linesBNow.some(l => l.trimStart() === '─'.repeat(COLS) && l.trimEnd() === '─'.repeat(COLS)))
+check('分割线出血：文本行仍在第 2 列（内容留边距）', linesBNow.some(l => l.includes('line-content') && l.startsWith('  ')), JSON.stringify(linesBNow.find(l => l.includes('line-content'))))
+check('分割线出血：行高仍占 1 行（flow 不塌）', linesBNow.filter(l => l.trimStart() === '─'.repeat(COLS)).length >= 1)
+
+// ── Chat 冒烟：滚动轨贴右缘（98/99 列），转录文本不越内容列 ──
+const { Chat } = await import('../src/screens/Chat.js')
+const { QuestionStore } = await import('../src/dsh-adapter/questions.js')
+const { LOCAL_COMMANDS, completeCommands } = await import('../src/commands.js')
+const CHAT_COLS = 100, CHAT_ROWS = 40
+const termC = new XTerm({ cols: CHAT_COLS, rows: CHAT_ROWS, scrollback: 0, allowProposedApi: true })
+const stdoutC = new (class extends Writable {
+  columns = CHAT_COLS; rows = CHAT_ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { termC.write(String(chunk), cb) }
+})()
+const stdinC = new FakeStdin(), stderrC = new FakeStderr()
+const chatRows: any[] = []
+for (let turn = 1; turn <= 8; turn++) {
+  chatRows.push({ id: turn * 2 - 1, kind: 'user', text: `问题 ${turn}` })
+  chatRows.push({ id: turn * 2, kind: 'assistant', text: Array.from({ length: 8 }, (_, i) => `回复 ${turn} 第 ${i + 1} 行`).join('\n') })
+}
+const chatListeners = new Set<() => void>()
+const channel: any = {
+  version: 0, rows: chatRows, status: 'idle', sessionTitle: 'probe', agentId: 'probe',
+  model: 'deepseek-v4-flash', provider: 'deepseek', reasoningEffort: 'max', effortLevels: [],
+  tokens: { input: 0, output: 0 }, cwd: '/tmp/demo', displayCwd: '/tmp/demo', gitBranch: 'main',
+  working: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0, turnStart: 0,
+  pending: [], commandList: LOCAL_COMMANDS, notifications: [], mode: { plan: false, sandbox: undefined },
+  activityFrames: 'claude', agentPreset: undefined, subagents: [], lastUserText: '问题 8',
+  scrollGutter: 'timeline',
+  subscribe(cb: () => void) { chatListeners.add(cb); return () => chatListeners.delete(cb) as unknown as void },
+  submit: () => {}, cancel: () => {}, clear: () => {}, notify: () => {},
+  listModels: () => Promise.resolve([]), listSessions: () => Promise.resolve([]),
+  deleteSession: () => Promise.resolve(true), renameSessionTo: () => Promise.resolve(true),
+  setResumeTarget: () => {}, loadOlder: () => {}, mcpStatus: () => [], pushLocal: () => {},
+  commandCompletions: (input: string) => completeCommands(input),
+}
+instB.unmount()
+await sleep(150)
+const instC = await render(
+  <AlternateScreen>
+    <PageMargin>
+      <Chat channel={channel} questionStore={new QuestionStore()} fullscreen />
+    </PageMargin>
+  </AlternateScreen>,
+  { stdout: stdoutC as any, stdin: stdinC as any, stderr: stderrC as any, exitOnCtrlC: false, patchConsole: false },
+)
+function cellAtC(y: number, col: number): string {
+  const line = termC.buffer.active.getLine(termC.buffer.active.baseY + y)
+  return line?.getCell(col)?.getChars() ?? ''
+}
+function linesC(): string[] {
+  return Array.from({ length: CHAT_ROWS }, (_, y) => termC.buffer.active.getLine(termC.buffer.active.baseY + y)?.translateToString(true) ?? '')
+}
+await settle(() => linesC().some(l => l.trimStart().startsWith('❯')))
+await sleep(250)
+const railRows = Array.from({ length: CHAT_ROWS }, (_, y) => cellAtC(y, 98) !== '' || cellAtC(y, 99) !== '')
+const promptRow = linesC().findIndex(l => l.trimStart().startsWith('❯'))
+const promptCol = promptRow >= 0 ? linesC()[promptRow]!.indexOf('❯') : -1
+check('Chat：提示符 ❯ 在第 2 列', promptCol === 2, `col=${promptCol}`)
+check('Chat：滚动轨在 98/99 列（贴终端右缘）', railRows.some(Boolean))
+check('Chat：右缘 98/99 列只有滚动轨占用（无其他内容越界）',
+  Array.from({ length: CHAT_ROWS }, (_, y) => (cellAtC(y, 98) === '' && cellAtC(y, 99) === '') || railRows[y]!).every(Boolean))
+check('Chat：左缘 0/1 列恒空白（文本不越界）',
+  Array.from({ length: CHAT_ROWS }, (_, y) => cellAtC(y, 0) === '' && cellAtC(y, 1) === '').every(Boolean))
+
+// 对照组：无 PageMargin 的树 —— 尺寸不收敛、inset=0（verify 直挂契约不变）。
+// 先卸载带边距的应用再挂对照组：同一进程并存两个 Ink 实例时，第二个实例
+// 的 alt-screen 状态探测（instances.size !== 1）落空、按 inline 路径写帧
+// 会丢首行——真机只有一个实例，测试里先后串行即可。
+instC.unmount()
+await sleep(150)
+const term2 = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+const stdout2 = new (class extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term2.write(String(chunk), cb) }
+})()
+const stdin2 = new FakeStdin(), stderr2 = new FakeStderr()
+await render(
+  <AlternateScreen>
+    <Probe />
+  </AlternateScreen>,
+  { stdout: stdout2 as any, stdin: stdin2 as any, stderr: stderr2 as any, exitOnCtrlC: false, patchConsole: false },
+)
+function screenLines2(): string[] {
+  const buffer = term2.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '')
+}
+await settle(() => screenLines2().some(line => line.includes('size=40x12')))
+const plain = screenLines2()
+check('对照组：无页边距时尺寸仍为 40x12', plain.some(l => l.includes('size=40x12 inset=0,0')))
+check('对照组：内容全宽（E 行止于第 39 列）', plain.some(l => l.trimStart().startsWith('|') && l.trimEnd().endsWith('|') && l.trimEnd().length === COLS))
+
+console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILED`)
+process.exit(failed === 0 ? 0 : 1)

--- a/src/components/PageMargin.tsx
+++ b/src/components/PageMargin.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { Box } from '../ui.js'
+import {
+  TerminalSizeContext,
+  type TerminalSize,
+} from '../ink/components/TerminalSizeContext.js'
+import { useTerminalSize } from '../ink/hooks/use-terminal-size.js'
+import {
+  getPageMarginSetting,
+  resolvePageMargin,
+  subscribePageMargin,
+  type PageMarginSetting,
+} from '../tuiDisplayPrefs.js'
+
+/**
+ * 整页边距（页边距 / page margin）：有些终端（Windows Terminal 的
+ * PowerShell 等 profile 默认 8px padding、GUI 终端）自带内缩，另一些
+ * （裸 WSL、tmux、SSH、部分嵌入宿主）完全没有——文字直接贴着屏幕四边，
+ * 观感压抑。TUI 无法读取终端的 padding，所以在根布局自备一层小"页边距"。
+ * 设置（`dsh-tui.pageMargin`）可以是预设名 none / slim / normal（默认，
+ * 左右 2 列、上下 1 行）/ roomy，或自定义 `NxM`（左右各 N 列 × 上下各 M
+ * 行，如 3x1）——解析与几何见 tuiDisplayPrefs。
+ *
+ * 实现策略（三层）：
+ *
+ * 1. 布局层：`PageMargin` 渲染一个 `paddingX/Y` 的根盒，所有屏幕
+ *    （Chat 及其中所有 early-return 屏幕）自动内缩；
+ * 2. 尺寸层：嵌套覆盖 `TerminalSizeContext`，向内报告的 columns/rows
+ *    已扣除边距，因此所有用 `useTerminalSize()` 做内容宽度/高度数学的
+ *    组件（换行宽度、虚拟化、输入区预算、表格布局……）无需各自知道
+ *    边距存在——它们拿到的就是内容区尺寸；
+ * 3. 坐标层：`PageInsetContext` 报告内容区相对屏幕原点的偏移，供少数
+ *    以「屏幕坐标」做 absolute 定位的浮层（Tooltip、SessionBrowser
+ *    右键菜单）补偿——它们的锚点来自指针事件（屏幕坐标），而 absolute
+ *    盒子相对的是内缩后的内容区原点。
+ *
+ * 模式来源是 tuiDisplayPrefs 的模块级 store（applyPageMargin），不是
+ * props：`.PageMargin` 位于 Chat 之上，/settings 的更改如果只走 channel
+ * 的版本 bump 无法驱动它（那只重渲染 Chat 以下）。store 由 plugin 的
+ * applyDisplay 镜像写入，模式变化时本组件重渲染并重布局。
+ *
+ * 注意：`PageMargin` 必须在「所有以屏幕原点为参照的组件之外」读取
+ * TerminalSizeContext（它读到的就是真实终端尺寸）；AlternateScreen 等
+ * 需要真实 rows 的组件放在它的外侧。verify 脚本直接挂载
+ * `<AlternateScreen><Chat/></AlternateScreen>`（不经 plugin.ts 的树），
+ * 因此测试默认无页边距——组件契约仍是「全宽可用」。
+ */
+
+/** 内容区相对屏幕原点的偏移（屏幕坐标 → 内容坐标的换算量）。 */
+export type PageInset = { readonly x: number; readonly y: number }
+
+/** 嵌套安全的 inset（若未来出现嵌套 PageMargin 会累加）。 */
+export const PageInsetContext = React.createContext<PageInset>({ x: 0, y: 0 })
+
+/**
+ * 内容区相对屏幕原点的偏移。供"出血"（full-bleed）chrome 使用：页面级
+ * 分割线、右侧滚动轨这类结构性元素直通终端边缘，而内容（文本、卡片）
+ * 保持页边距内缩——常规排版设计的做法（内容列留边距、横线/滚动轨出血
+ * 到版面边缘）。无 PageMargin 时恒为 {x:0, y:0}。
+ */
+export function usePageInset(): PageInset {
+  return React.useContext(PageInsetContext)
+}
+
+/**
+ * 根级页边距容器：给整棵 UI 加一圈可配置的小边距，并把「终端尺寸」收敛
+ * 成「内容区尺寸」下传（见文件头三层策略）。flexGrow={1} 让它撑满
+ * AlternateScreen 的定高盒（inline 无定高父级时为内容自然高，与现状
+ * 一致）。
+ */
+export function PageMargin({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactNode {
+  const setting: PageMarginSetting = React.useSyncExternalStore(
+    subscribePageMargin,
+    getPageMarginSetting,
+  )
+  const { x, y } = resolvePageMargin(setting)
+  const size = useTerminalSize()
+  const parentInset = React.useContext(PageInsetContext)
+  const inner: TerminalSize = {
+    columns: Math.max(1, size.columns - 2 * x),
+    rows: Math.max(1, size.rows - 2 * y),
+  }
+  const inset: PageInset = {
+    x: parentInset.x + x,
+    y: parentInset.y + y,
+  }
+  return (
+    <PageInsetContext.Provider value={inset}>
+      <TerminalSizeContext.Provider value={inner}>
+        <Box
+          flexDirection="column"
+          flexGrow={1}
+          width="100%"
+          paddingX={x}
+          paddingY={y}
+        >
+          {/* 内容盒：ink 的百分比宽度按父盒「全宽」（含 padding）解析——
+              直接 padding 的盒子里 width="100%" 会始终宽出 2·inset×（滚动轨
+              曾被推到 x=100 出屏）。给子树一个确定数值宽的内容盒，% 就回到
+              真实内容宽。 */}
+          <Box flexDirection="column" flexGrow={1} width={inner.columns}>
+            {children}
+          </Box>
+        </Box>
+      </TerminalSizeContext.Provider>
+    </PageInsetContext.Provider>
+  )
+}

--- a/src/components/PromptEditor.tsx
+++ b/src/components/PromptEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Box, Text } from '../ui.js'
+import { Box, Text, useTerminalSize } from '../ui.js'
+import { usePageInset } from './PageMargin.js'
 import type { Color } from '../ink/styles.js'
 import type { Theme } from '../theme.js'
 
@@ -50,13 +51,20 @@ function snapshot(): EditorNode {
 export function PromptEditorLayer(): React.ReactNode {
   const node = React.useSyncExternalStore(subscribe, snapshot)
   if (node === null) return null
+  // Full-bleed cover: under PageMargin the Chat root box starts at the
+  // content origin, so the editor must extend into the page margins up to
+  // the terminal edges — the editor is a whole-screen surface, and the
+  // margin strips must be covered rather than letting the transcript
+  // bleed through.
+  const inset = usePageInset()
+  const size = useTerminalSize()
   return (
     <Box
       position="absolute"
-      top={0}
-      left={0}
-      width="100%"
-      height="100%"
+      top={-inset.y}
+      left={-inset.x}
+      width={size.columns + 2 * inset.x}
+      height={size.rows + 2 * inset.y}
       flexDirection="column"
       flexShrink={0}
       overflow="hidden"

--- a/src/components/ScrollbarGutter.tsx
+++ b/src/components/ScrollbarGutter.tsx
@@ -156,7 +156,9 @@ export function ScrollbarGutter({
     <NoSelect>
       {/* Raw ink-box (not the themed Box): onWheel is a host-level prop
           (same as ScrollBox's viewport) — wheel over the gutter scrolls
-          the transcript, the gutter has no scroll of its own. */}
+          the transcript, the gutter has no scroll of its own. The row
+          above extends past the page margin (Chat), so this track
+          naturally lands at the terminal's right edge. */}
       <ink-box
         onWheel={e => {
           if (e.deltaY !== 0) handle.scrollBy(e.deltaY)

--- a/src/components/TimelineRail.tsx
+++ b/src/components/TimelineRail.tsx
@@ -286,7 +286,9 @@ export function TimelineRail({
     <NoSelect>
       {/* Raw ink-box (not the themed Box): onWheel is a host-level prop
           (same as ScrollBox's viewport) — wheel over the rail scrolls the
-          transcript, the rail has no scroll of its own. */}
+          transcript, the rail has no scroll of its own. The row above
+          extends past the page margin (Chat), so this gutter naturally
+          lands at the terminal's right edge. */}
       <ink-box
         onWheel={e => {
           if (e.deltaY !== 0) handle.scrollBy(e.deltaY)

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,6 +4,7 @@ import { Box, Text, useTerminalSize } from '../ui.js'
 import { useTerminalFocus } from '../ink/hooks/use-terminal-focus.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { getGraphemeSegmenter } from '../utils/intl.js'
+import { PageInsetContext } from './PageMargin.js'
 import type { PointerEvent } from '../ink/events/pointer-event.js'
 
 /**
@@ -215,11 +216,23 @@ export function TooltipLayer({
   const height = lines.length + 2
   // Prefer resting on the row ABOVE the anchor; when there is no room
   // (anchor at the top of the screen), drop below it, clamped on-screen.
+  // The anchor coordinates are SCREEN coordinates (pointer events) while
+  // the absolute box is placed relative to the content-area origin — under
+  // PageMargin (root page inset) the offset must be added back, and the
+  // clamp bounds run over the inset content area.
+  const inset = React.useContext(PageInsetContext)
   const topAbove = tooltip.anchorRow - height
-  const top = topAbove >= 0
-    ? topAbove
-    : Math.max(0, Math.min(tooltip.anchorRow + 1, rows - height))
-  const left = Math.max(0, Math.min(tooltip.anchorCol, columns - width))
+  const top = Math.max(
+    inset.y,
+    Math.min(
+      topAbove >= 0 ? topAbove : tooltip.anchorRow + 1,
+      inset.y + Math.max(0, rows - height),
+    ),
+  )
+  const left = Math.max(
+    inset.x,
+    Math.min(tooltip.anchorCol, inset.x + Math.max(0, columns - width)),
+  )
   return (
     <Box
       position="absolute"

--- a/src/components/design-system/Divider.tsx
+++ b/src/components/design-system/Divider.tsx
@@ -5,6 +5,7 @@ import type { DOMElement } from '../../ink/dom.js'
 import measureElement from '../../ink/measure-element.js'
 import { stringWidth } from '../../ink/stringWidth.js'
 import { useTerminalSize } from '../../ink/hooks/use-terminal-size.js'
+import { usePageInset } from '../PageMargin.js'
 import type { Theme } from '../../theme.js'
 
 type DividerProps = {
@@ -37,6 +38,15 @@ type DividerProps = {
    * May contain ANSI codes (e.g., chalk-styled text).
    */
   title?: string
+
+  /**
+   * Full-bleed: extend the rule into the page margins to the terminal
+   * edges (page-level structural hairline — the page-margin convention:
+   * TEXT stays inside the content column, structural lines bleed). Use for
+   * screen-level dividers only; dividers inside cards, panels, or the
+   * transcript stay at content width. No-op outside PageMargin.
+   */
+  bleed?: boolean
 }
 
 // Upper bound on distinct measurements applied per terminal-width
@@ -73,8 +83,16 @@ export function Divider({
   char = '─',
   padding = 0,
   title,
+  bleed = false,
 }: DividerProps): React.ReactNode {
   const { columns } = useTerminalSize()
+  const inset = usePageInset()
+  // Full-bleed: the rule spans the terminal columns, shifted left by the
+  // page inset via a negative margin (the box reaches into the margin
+  // area; the parent does not clip). `columns` here is the CONTENT width
+  // (PageMargin narrows TerminalSizeContext), so +2·inset.x = terminal.
+  const bleedX = bleed ? inset.x : 0
+  const bleedWidth = columns + 2 * bleedX
   const [measuredWidth, setMeasuredWidth] = useState<number | null>(null)
   const boxRef = useRef<DOMElement | null>(null)
   // Measurement feedback guard: the rule width rendered from
@@ -114,8 +132,9 @@ export function Divider({
     applied.push(w)
     setMeasuredWidth(w)
   })
-  const available = measuredWidth ?? columns
-  const lineWidth = Math.max(0, Math.min(available, width ?? columns) - padding)
+  const available = measuredWidth ?? bleedWidth
+  const target = bleed ? bleedWidth : (width ?? columns)
+  const lineWidth = Math.max(0, Math.min(available, target) - padding)
   const titleWidth = title ? stringWidth(title) : 0
 
   let text: string
@@ -136,7 +155,14 @@ export function Divider({
   }
 
   return (
-    <Box ref={boxRef}>
+    <Box
+      ref={boxRef}
+      {...(bleed
+        ? { width: bleedWidth, marginLeft: -bleedX }
+        : width !== undefined
+          ? { width }
+          : {})}
+    >
       <Text dimColor={!color} color={color} wrap="truncate-end">
         {text}
       </Text>

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -79,7 +79,7 @@ import { getLang, LANGS, t, tOr, type Lang } from '../i18n.js'
 import { AUTO_THEME_NAME } from '../theme.js'
 import { listThemeCatalog } from '../themeCatalog.js'
 import { modeDisplayName, resolveSessionModes, type SessionModeSpec } from '../sessionModes.js'
-import { normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
+import { normalizePageMargin, normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type PageMarginSetting, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import { SubagentActivityStore, type SubagentState } from './subagents.js'
 export type { SubagentState } from './subagents.js'
 import { BackgroundJobStore, formatJobDuration, type BackgroundJobState, type BackgroundJobStatus, type JobsRuntime } from './jobs.js'
@@ -865,6 +865,12 @@ export interface Channel {
    *  `dsh-tui.scrollGutter`: turn timeline / proportional scrollbar /
    *  nothing). */
   readonly scrollGutter: ScrollGutterMode
+  /** Root page inset (settings `dsh-tui.pageMargin`): a preset name
+   *  (`none` / `slim` / `normal` (default) / `roomy`) or a custom `NxM`
+   *  spec (columns per side × rows top/bottom) inset the whole UI from the
+   *  terminal edges — terminals without their own viewport padding (bare
+   *  WSL, tmux, SSH) otherwise hug the screen border. */
+  readonly pageMargin: PageMarginSetting
   /** Terminal-card header folding (settings `dsh-tui.foldTerminalCommand`):
    *  collapse a multi-line command title to its first line + count hint. */
   readonly foldTerminalCommand: boolean
@@ -1365,6 +1371,8 @@ export interface ChannelState {
   toolBackground: ToolBackground
   /** Transcript gutter mode (see the public Channel type). */
   scrollGutter: ScrollGutterMode
+  /** Root page inset setting (see the public Channel type). */
+  pageMargin: PageMarginSetting
   /** Terminal-card header folding (see the public Channel type). */
   foldTerminalCommand: boolean
   /** Session-name chip on the prompt border (see the public Channel type). */
@@ -1383,6 +1391,8 @@ export interface ChannelState {
   setToolBackground(background: ToolBackground): void
   /** Apply a transcript gutter mode change. */
   setScrollGutter(mode: ScrollGutterMode): void
+  /** Apply a root page-inset setting change (drives the PageMargin box). */
+  setPageMargin(setting: PageMarginSetting): void
   /** Apply a terminal-card header folding change. */
   setFoldTerminalCommand(enabled: boolean): void
   /** Apply a prompt session-name chip change. */
@@ -1962,6 +1972,8 @@ export function createChannel(
     toolBackground?: ToolBackground
     /** Transcript gutter mode; default `timeline` (settings `dsh-tui.scrollGutter`). */
     scrollGutter?: ScrollGutterMode
+    /** Root page inset setting; default `normal` (settings `dsh-tui.pageMargin`). */
+    pageMargin?: PageMarginSetting
     /** Terminal-card header folding; default off (settings
      *  `dsh-tui.foldTerminalCommand`). */
     foldTerminalCommand?: boolean
@@ -3666,6 +3678,7 @@ export function createChannel(
     thinkingFold: options.thinkingFold ?? 'preview',
     toolBackground: normalizeToolBackground(options.toolBackground),
     scrollGutter: normalizeScrollGutter(options.scrollGutter),
+    pageMargin: normalizePageMargin(options.pageMargin),
     foldTerminalCommand: options.foldTerminalCommand === true,
     promptSessionLabel: options.promptSessionLabel === true,
     expandEditor: options.expandEditor !== false,
@@ -5533,6 +5546,12 @@ export function createChannel(
       const normalized = normalizeScrollGutter(mode)
       if (normalized === state.scrollGutter) return
       state.scrollGutter = normalized
+      state.emit()
+    },
+    setPageMargin(setting) {
+      const normalized = normalizePageMargin(setting)
+      if (normalized === state.pageMargin) return
+      state.pageMargin = normalized
       state.emit()
     },
     setFoldTerminalCommand(enabled) {

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -9,7 +9,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
 import type { SessionModeSpec } from '../sessionModes.js'
-import { DEFAULT_STATUS_BAR, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
+import { DEFAULT_STATUS_BAR, normalizePageMargin, type PageMarginSetting, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import { SHORTCUT_ACTIONS, type ShortcutActionId } from '../utils/keymap.js'
 
 export const name = 'dsh-tui'
@@ -93,6 +93,12 @@ export interface Config {
    *  `dsh-tui.scrollGutter`): `timeline` turn rail (default), `scrollbar`
    *  proportional thumb, or `hidden`. */
   scrollGutter?: ScrollGutterMode
+  /** Root page inset (settings `dsh-tui.pageMargin`): a preset name
+   *  (`none` / `slim` / `normal` (default) / `roomy`) or a custom `NxM`
+   *  spec (columns per side × rows top/bottom) that insets the whole UI
+   *  from the terminal edges. Terminals without their own viewport padding
+   *  (bare WSL, tmux, SSH) otherwise hug the screen border. */
+  pageMargin?: PageMarginSetting
   /** Terminal-card header folding (settings `dsh-tui.foldTerminalCommand`):
    *  `true` collapses a multi-line command title to its first line plus a
    *  `+N lines` hint; Ctrl+O / clicking the card expands it. Default off —
@@ -147,6 +153,13 @@ export const Config: Schema<Config> = Schema.object({
   thinkingFold: Schema.union(['preview', 'full']).default('preview'),
   toolBackground: Schema.union(['none', 'subtle', 'strong']).default('none'),
   scrollGutter: Schema.union(['timeline', 'scrollbar', 'hidden']).default('timeline'),
+  // Preset names AND custom `NxM` specs must survive validation (a custom
+  // spec is not a fixed union member); junk is normalized to `normal` by
+  // the transform, so every parsed config carries a valid setting.
+  pageMargin: Schema.transform(
+    Schema.string().default('normal'),
+    value => normalizePageMargin(value),
+  ),
   foldTerminalCommand: Schema.boolean().default(false),
   promptSessionLabel: Schema.boolean().default(false),
   expandEditor: Schema.boolean().default(true),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -28,7 +28,7 @@ import { clearResumeTarget, resumeTargetFromArgv, writeResumeTarget } from '../s
 import { resolveSessionCwd } from '../utils/workspaceRoot.js'
 import { beginRestartAttempt, checkForTuiUpdate, installedTuiVersion, isBootDeadlockTarget, isStandaloneRuntime, isVersionNewer, logRestartEvent, resolveDshProfileName, resolveTuiUpdateTarget, restartTui, updateTuiAndRestart, writeHandoffNotice } from '../update.js'
 import { getLang, isLang, resolveStartupLang, setLang, t, writeLangPref } from '../i18n.js'
-import { DEFAULT_STATUS_BAR, normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
+import { DEFAULT_PAGE_MARGIN, DEFAULT_STATUS_BAR, applyPageMargin, isPageMarginMode, normalizePageMargin, normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, parsePageMarginSpec, type PageMarginSetting, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../tuiDisplayPrefs.js'
 import {
   draftComboConflicts,
   effectiveComboString,
@@ -52,6 +52,7 @@ import { createLocalWorkspaceRuntime, getHostWorkspaceRuntime } from './workspac
 import { getHostSettingsSections, getLocalSettingsSectionsHost, type TuiSettingsField, type TuiSettingsSectionsRuntime } from './settings-sections.js'
 import { withHostRootCapability } from './host-access.js'
 import { render, ThemeProvider, AlternateScreen } from '../ui.js'
+import { PageMargin } from '../components/PageMargin.js'
 import instances from '../ink/instances.js'
 import { cursorMove, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE } from '../ink/termio/csi.js'
 import { DBP, DFE, DISABLE_MOUSE_TRACKING, EXIT_ALT_SCREEN, SHOW_CURSOR } from '../ink/termio/dec.js'
@@ -530,6 +531,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     thinkingFold: config.thinkingFold,
     toolBackground: config.toolBackground,
     scrollGutter: config.scrollGutter,
+    pageMargin: config.pageMargin,
     foldTerminalCommand: config.foldTerminalCommand,
     promptSessionLabel: config.promptSessionLabel,
     expandEditor: config.expandEditor,
@@ -537,6 +539,11 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     statusBar: config.statusBar,
     handle,
   })
+  // Root page-margin store: the PageMargin inset box sits ABOVE Chat, so
+  // the channel version bump (which re-renders everything below Chat)
+  // cannot drive it. Seed the store from config before the tree mounts;
+  // applyDisplay below mirrors every settings change into it live.
+  applyPageMargin(config.pageMargin)
   // Plugin toasts ride the channel's own notification surface: the runtime
   // already sanitized/rate-limited the delivery, the sink only forwards.
   // Without the extensions row (tuiToast absent) plugin toasts are dropped
@@ -589,6 +596,13 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
         thinkingFold: Schema.union(['preview', 'full']).default('preview'),
         toolBackground: Schema.union(['none', 'subtle', 'strong']).default('none'),
         scrollGutter: Schema.union(['timeline', 'scrollbar', 'hidden']).default('timeline'),
+        // Preset names AND custom `NxM` specs (the settings field's parse
+        // gate keeps junk out of the user layer; the transform normalizes
+        // whatever survives — cordis.yml junk included).
+        pageMargin: Schema.transform(
+          Schema.string().default('normal'),
+          value => normalizePageMargin(value),
+        ),
         // No default on purpose (same rule as `fullscreen` below): a schema
         // default here would come back from scope.get()/watch() and shadow
         // an explicit cordis.yml `foldTerminalCommand: true` while the
@@ -651,6 +665,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       thinkingFold?: 'preview' | 'full'
       toolBackground?: ToolBackground
       scrollGutter?: ScrollGutterMode
+      pageMargin?: PageMarginSetting
       foldTerminalCommand?: boolean
       promptSessionLabel?: boolean
       expandEditor?: boolean
@@ -693,6 +708,12 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       channel.setThinkingFold(value.thinkingFold ?? config.thinkingFold ?? 'preview')
       channel.setToolBackground(normalizeToolBackground(value.toolBackground ?? config.toolBackground))
       channel.setScrollGutter(normalizeScrollGutter(value.scrollGutter ?? config.scrollGutter))
+      // Page margin: the channel carries the mode (tests observe it), the
+      // module store drives the actual inset box above Chat — keep both in
+      // lockstep so a live /settings edit re-lays out immediately.
+      const pageMargin = normalizePageMargin(value.pageMargin ?? config.pageMargin)
+      channel.setPageMargin(pageMargin)
+      applyPageMargin(pageMargin)
       channel.setFoldTerminalCommand(value.foldTerminalCommand ?? config.foldTerminalCommand ?? false)
       channel.setPromptSessionLabel(value.promptSessionLabel ?? config.promptSessionLabel ?? false)
       channel.setExpandEditor(value.expandEditor ?? config.expandEditor ?? true)
@@ -957,6 +978,25 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
             { value: 'scrollbar', label: 'Scrollbar', descriptions: { zh: '滚动条' } },
             { value: 'hidden', label: 'Hidden', descriptions: { zh: '隐藏' } },
           ],
+        },
+        {
+          path: ['pageMargin'],
+          label: 'Page margin',
+          descriptions: { zh: '页边距' },
+          hint: 'Inset the whole UI from the terminal edges. Type a preset (none / slim / normal / roomy) or a custom spec `NxM`: N columns per side, M rows top/bottom (e.g. 3x1, max 8x4; a bare `N` keeps rows at 1). Empty resets to the default `normal`. Applies immediately.',
+          hintDescriptions: { zh: '让整个界面相对终端四边内缩。输入预设名（none / slim / normal / roomy）或自定义 `NxM`：左右各 N 列、上下各 M 行（如 3x1，上限 8x4；只填 N 则上下保持 1 行）。清空恢复默认 normal。立即生效。' },
+          kind: 'text',
+          placeholder: 'normal',
+          format(value: unknown): string {
+            return String(value ?? config.pageMargin ?? DEFAULT_PAGE_MARGIN)
+          },
+          parse(text: string) {
+            const draft = text.trim().toLowerCase()
+            if (draft === '') return { kind: 'clear' }
+            if (isPageMarginMode(draft)) return { kind: 'set', value: draft }
+            const spec = parsePageMarginSpec(draft)
+            return spec === undefined ? undefined : { kind: 'set', value: spec }
+          },
         },
         {
           path: ['foldTerminalCommand'],
@@ -1474,9 +1514,17 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
   // tracking), which turns on in-app text selection (copy-on-select via
   // useCopyOnSelect), wheel scroll, and click/hover hit-testing. Inline
   // mode leaves the mouse to the terminal emulator's native selection.
+  // PageMargin keeps the whole UI inset from the terminal edges (some
+  // terminals — bare WSL/tmux/SSH — have no own padding, so text touches
+  // the screen border). It must sit INSIDE AlternateScreen: the alt-screen
+  // box sizes itself to the real terminal rows, while PageMargin reports
+  // content-box dimensions to everything below it.
+  const marginChildren = bootedFullscreen
+    ? React.createElement(AlternateScreen, null, React.createElement(PageMargin, null, chat))
+    : React.createElement(PageMargin, null, chat)
   const tree = React.createElement(ThemeProvider, {
     themeHost,
-    children: bootedFullscreen ? React.createElement(AlternateScreen, null, chat) : chat,
+    children: marginChildren,
   })
   instance = await render(tree, { exitOnCtrlC: false })
   const isRecompose = lastBootedFullscreen !== undefined

--- a/src/screens/AgentView.tsx
+++ b/src/screens/AgentView.tsx
@@ -579,13 +579,13 @@ export function AgentView({
         <Box flexShrink={0}>
           <Text color="remember" bold>{` ${t('agentview-help-title')}`}</Text>
         </Box>
-        <Divider width={columns} />
+        <Divider bleed />
         <Box flexGrow={1} flexShrink={1}>
           {t('agentview-help').split('\n').map((line, index) => (
             <Text key={index} dimColor>{` ${line}`}</Text>
           ))}
         </Box>
-        <Divider width={columns} />
+        <Divider bleed />
         <Box flexShrink={0}>
           <Text dimColor italic><HintLine text={t('agentview-hint-help')} /></Text>
         </Box>
@@ -615,7 +615,7 @@ export function AgentView({
         </Box>
       )}
       {ruleBudget > 0 && (<Box flexShrink={0}>
-        <Divider width={columns} />
+        <Divider bleed />
       </Box>)}
 
       {approvalVisible && (
@@ -729,7 +729,7 @@ export function AgentView({
       )}
 
       {ruleBudget > 1 && (<Box flexShrink={0}>
-        <Divider width={columns} />
+        <Divider bleed />
       </Box>)}
       <Box flexShrink={0}>
         <Text dimColor italic>

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -9,6 +9,7 @@ import { hasPath } from '../dsh-adapter/settingsEditor.js'
 import { planReload, type ReloadKind } from '../reload.js'
 import { AlternateScreen, Box, Text, useInput, ScrollBox, type ScrollBoxHandle, useTheme, useTerminalSize } from '../ui.js'
 import * as tuiKit from '../ui.js'
+import { usePageInset } from '../components/PageMargin.js'
 import { POINTER } from '../cc/figures.js'
 import { isPlainReturnInput, modLabel } from '../utils/modifiers.js'
 import { actionMatches } from '../utils/keymap.js'
@@ -2235,6 +2236,7 @@ export function Chat({
    * every animation tick. The tick only re-colours the cells it already has.
    */
   const { columns: terminalColumns } = useTerminalSize()
+  const pageInsetX = usePageInset().x
   const wakeWidth = miniWakeWidth(terminalColumns)
   const wakeBand = React.useMemo(
         () =>
@@ -3400,7 +3402,14 @@ export function Chat({
           }}
         />
       )}
-      <Box flexDirection="row" flexGrow={1} flexShrink={1} width="100%">
+      {/* Transcript row. Under PageMargin the negative right margin makes
+          the row stretch past the content column to the terminal edge —
+          the gutter (timeline rail / scrollbar) thus lands at the very
+          edge while the transcript TEXT stays inside the page margin
+          (structural chrome convention: dividers and the rail bleed, text
+          and cards keep the content column). No explicit width: cross-axis
+          stretch with the margin yields exactly content+margin. */}
+      <Box flexDirection="row" flexGrow={1} flexShrink={1} marginRight={-pageInsetX}>
         <ScrollBox ref={setHandle} flexDirection="column" flexGrow={1} flexShrink={1} stickyScroll>
         <LogoHeader
           key={logoNonce}

--- a/src/screens/SessionBrowser.tsx
+++ b/src/screens/SessionBrowser.tsx
@@ -5,6 +5,7 @@ import type { WheelEvent } from '../ink/events/wheel-event.js'
 import { Divider } from '../components/design-system/Divider.js'
 import { HintLine } from '../components/design-system/HintLine.js'
 import { SearchBox } from '../components/SearchBox.js'
+import { PageInsetContext } from '../components/PageMargin.js'
 import { SessionListRow } from '../components/sessions/SessionListRow.js'
 import { SessionPreview } from '../components/sessions/SessionPreview.js'
 import { WorkspaceListRow } from '../components/sessions/WorkspaceListRow.js'
@@ -152,6 +153,7 @@ export function SessionBrowser({
   onClose: () => void
 }): React.ReactNode {
   const { columns, rows } = useTerminalSize()
+  const inset = React.useContext(PageInsetContext)
   const isTerminalFocused = useTerminalFocus()
 
   const [sessions, setSessions] = React.useState<readonly SessionSummary[]>([])
@@ -1117,7 +1119,7 @@ export function SessionBrowser({
       )}
 
       {rules.has(2) && (<Box flexShrink={0}>
-        <Divider width={columns} />
+        <Divider bleed />
       </Box>)}
       <Box flexShrink={0}>
         <Text dimColor italic>
@@ -1128,12 +1130,14 @@ export function SessionBrowser({
       {/* Right-click session menu: a floating popup anchored one cell past
           the pointer, clamped so it never clips off the terminal. Its own
           clicks hit-test first (absolute hit list), and the root Box's
-          onClick dismisses it on any outside click. */}
+          onClick dismisses it on any outside click. 指针坐标是屏幕坐标，
+          而 absolute 盒相对内容区原点——有 PageMargin 页边距时需补回
+          inset（同 TooltipLayer 的补偿规则）。 */}
       {menu !== undefined && menuTarget !== undefined && (
         <Box
           position="absolute"
-          left={Math.max(0, Math.min(menu.col + 1, columns - MENU_WIDTH))}
-          top={Math.max(0, Math.min(menu.row + 1, rows - MENU_HEIGHT))}
+          left={Math.max(inset.x, Math.min(menu.col + 1, inset.x + Math.max(0, columns - MENU_WIDTH)))}
+          top={Math.max(inset.y, Math.min(menu.row + 1, inset.y + Math.max(0, rows - MENU_HEIGHT)))}
           width={MENU_WIDTH}
           height={MENU_HEIGHT}
           flexDirection="column"

--- a/src/screens/SessionTree.tsx
+++ b/src/screens/SessionTree.tsx
@@ -681,7 +681,7 @@ export function SessionTree({
         </Box>
       )}
 
-      {rules.has(2) && (<Box flexShrink={0}><Divider width={columns} /></Box>)}
+      {rules.has(2) && (<Box flexShrink={0}><Divider bleed /></Box>)}
       <Box flexShrink={0}>
         <Text dimColor italic>
           <HintLine text={hint} />

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -785,7 +785,9 @@ export function Settings({
         ))}
       </ink-box>
       <Box flexGrow={1} />
-      <Divider />
+      {/* Page-level rule: full-bleed to the terminal edges (text above and
+          below keeps the page margin — the divider is structural chrome). */}
+      <Divider bleed />
       <Text color={notice?.tone === 'error' ? 'error' : 'success'}>
         {notice === undefined ? ' ' : `${notice.tone === 'error' ? MULTIPLICATION_X : TICK} ${notice.text}`}
       </Text>

--- a/src/tuiDisplayPrefs.ts
+++ b/src/tuiDisplayPrefs.ts
@@ -129,3 +129,120 @@ export function formatContextUsage(
   const counts = `${formatTokenCount(safeUsed)}/${formatTokenCount(contextWindow)}`
   return compact ? `${percentText} (${counts})` : `${counts} (${percentText})`
 }
+
+/**
+ * Root page inset (settings `dsh-tui.pageMargin`): some terminals carry
+ * their own viewport padding (Windows Terminal's 8px default, GUI
+ * emulators), others — bare WSL, tmux, SSH — have none, so the UI text
+ * touches the screen edges. A setting is either a preset name
+ * (none/slim/normal/roomy) or a custom spec (see {@link PageMarginSpec}).
+ * The resolved geometry is what `PageMargin` (the root inset box above
+ * Chat) renders; the channel carries the setting for tests, the module
+ * store below is what the box itself subscribes to (the channel's version
+ * bump only re-renders below Chat).
+ */
+export type PageMarginMode = 'none' | 'slim' | 'normal' | 'roomy'
+
+/** Custom spec: `NxM` — N blank columns per side, M blank rows top/bottom
+ *  (e.g. `3x1`). */
+export type PageMarginSpec = `${number}x${number}`
+
+/** A stored page-margin setting: a preset name or a custom spec. */
+export type PageMarginSetting = PageMarginMode | PageMarginSpec
+
+/** Page inset per preset: `{ x }` = blank columns per side, `{ y }` = blank
+ *  rows top/bottom. `normal` is the default and matches the original
+ *  hard-coded inset (2 columns / 1 row). */
+export const PAGE_MARGIN_PRESETS: Readonly<Record<PageMarginMode, { readonly x: number; readonly y: number }>> = Object.freeze({
+  none: { x: 0, y: 0 },
+  slim: { x: 1, y: 1 },
+  normal: { x: 2, y: 1 },
+  roomy: { x: 4, y: 2 },
+})
+
+export const DEFAULT_PAGE_MARGIN: PageMarginMode = 'normal'
+
+/** Custom-spec bounds: beyond this a layout is either useless (a 40-col
+ *  terminal would starve) or pure waste. */
+export const PAGE_MARGIN_MAX_X = 8
+export const PAGE_MARGIN_MAX_Y = 4
+
+const PAGE_MARGIN_MODES = new Set<PageMarginMode>(['none', 'slim', 'normal', 'roomy'])
+// `N` (rows default to 1) or `NxN` / `N×N` / `N,N` — the settings field and
+// cordis.yml both write through this; CJK 全角逗号/乘号 also accepted for
+// zh users typing without switching layouts.
+const PAGE_MARGIN_SPEC_RE = /^(\d{1,2})(?:[x×,，](\d{1,2}))?$/u
+
+export function isPageMarginMode(value: string): value is PageMarginMode {
+  return PAGE_MARGIN_MODES.has(value as PageMarginMode)
+}
+
+/** Parse a custom spec (canonicalizes `N` → `Nx1`); undefined when invalid
+ *  or out of bounds. */
+export function parsePageMarginSpec(text: string): PageMarginSpec | undefined {
+  const match = PAGE_MARGIN_SPEC_RE.exec(text.trim().toLowerCase())
+  if (match === null) return undefined
+  const x = Number.parseInt(match[1]!, 10)
+  const y = match[2] === undefined ? 1 : Number.parseInt(match[2]!, 10)
+  if (x > PAGE_MARGIN_MAX_X || y > PAGE_MARGIN_MAX_Y) return undefined
+  return `${x}x${y}` as PageMarginSpec
+}
+
+/** Normalize untrusted/config-layer values without mutating the input:
+ *  preset names and valid custom specs pass through, everything else falls
+ *  back to the default preset. */
+export function normalizePageMargin(value: unknown): PageMarginSetting {
+  if (typeof value === 'string') {
+    if (isPageMarginMode(value)) return value
+    const spec = parsePageMarginSpec(value)
+    if (spec !== undefined) return spec
+  }
+  return DEFAULT_PAGE_MARGIN
+}
+
+/** Resolve a stored setting to its geometry (presets via the table, custom
+ *  specs via their numbers; anything unparseable → the default preset). */
+export function resolvePageMargin(setting: PageMarginSetting): { readonly x: number; readonly y: number } {
+  if (isPageMarginMode(setting)) return PAGE_MARGIN_PRESETS[setting]
+  const spec = parsePageMarginSpec(setting)
+  if (spec !== undefined) {
+    const [x, y] = spec.split('x')
+    return {
+      x: Number.parseInt(x!, 10),
+      y: Number.parseInt(y!, 10),
+    }
+  }
+  return PAGE_MARGIN_PRESETS[DEFAULT_PAGE_MARGIN]
+}
+
+// ── Live module store ──────────────────────────────────────────────────
+// PageMargin sits ABOVE Chat in the tree, so it cannot observe the
+// channel's version bump used to re-render everything below Chat. The
+// settings watch therefore mirrors the applied setting through this store;
+// PageMargin subscribes with useSyncExternalStore and re-lays out.
+const pageMarginListeners = new Set<() => void>()
+let pageMarginState: PageMarginSetting = DEFAULT_PAGE_MARGIN
+
+/** Subscribe to page-margin setting changes; returns the unsubscribe fn. */
+export function subscribePageMargin(listener: () => void): () => void {
+  pageMarginListeners.add(listener)
+  return () => { pageMarginListeners.delete(listener) }
+}
+
+/** Current applied setting (normalized; safe for useSyncExternalStore —
+ *  a primitive string identity is stable). */
+export function getPageMarginSetting(): PageMarginSetting {
+  return normalizePageMargin(pageMarginState)
+}
+
+/** Apply a new setting (normalized, no-op when unchanged). Returns the
+ *  value that ended up applied — useful for the plugin to mirror the
+ *  channel. */
+export function applyPageMargin(setting: unknown): PageMarginSetting {
+  const next = normalizePageMargin(setting)
+  if (next !== pageMarginState) {
+    pageMarginState = next
+    for (const listener of [...pageMarginListeners]) listener()
+  }
+  return next
+}


### PR DESCRIPTION
**页边距（pageMargin）设置 + 常规排版设计：内容列留边距、结构性 chrome 出血到终端边缘**

## 背景
Windows Terminal 的 PowerShell 等 profile 自带 8px 视口内边距，而裸 WSL / tmux / SSH 终端完全没有——文字直接贴着屏幕四边，观感压抑。TUI 读不到终端的 padding，于是自备一层可配置的页边距。

## 设置
`/settings` → dsh-tui → **Page margin（页边距）**，文本输入，改完**立即生效**：

| 输入 | 效果 |
|---|---|
| `none` / `slim` / `normal` / `roomy` | 四档预设（0/0、1列1行、2列1行、4列2行） |
| `3x1`（或 `3×1` / `3,1`） | 自定义：左右各 3 列 × 上下各 1 行，上限 8×4 |
| `5` | 单值 = 左右 5 列，上下保持 1 行 |
| 清空 | 恢复默认 `normal` |

## 排版设计（常规杂志/网页排版原则）
- **内容列留边距**：聊天正文、消息、输入框卡片、状态栏文字、面板/卡片内部的线——都在页边距内。
- **结构性 chrome 出血到终端边缘**：
  - 页面级分割线（设置屏、会话浏览器、会话树、AgentView）从第 0 列画到最后一列（`Divider` 新增 `bleed`）；
  - 转录滚动轨 / 比例滚动条贴住终端右缘；
  - 全屏草稿编辑器遮罩盖满整个终端。

## 实现要点
- `PageMargin` 根盒 padding + 嵌套覆盖 `TerminalSizeContext`（内容区尺寸下传，换行宽度/输入区预算/虚拟化自动按内容列计算）+ `PageInsetContext`（屏幕坐标浮层如 Tooltip/右键菜单做偏移补偿）。
- 模块级 store 驱动即时重布局：边距盒在 Chat 之上，channel 的版本 bump 到不了它，/settings 写入经 `applyDisplay` 镜像进 store。
- schema 用 schemastery `transform` 归一化：自定义 `NxM` 能过 cordis.yml 与设置服务两层校验，垃圾值回退 `normal`。
- 顺带修一个渲染坑：ink 的百分比宽度按父盒全宽（含 padding）解析，`PageMargin` 里 `width="100%"` 会宽出 2·inset（滚动轨曾被推到 x=100 出屏）——内容盒改用确定数值宽度。

## 测试
- 新增 `verify-page-margin`（40 断言：尺寸收敛/四档+自定义即时切换/解析边界/分割线出血/轨道贴边/对照组），登记 `render-scroll` 组。
- 本地验证：`pnpm build` 全绿（i18n 989）；verify-page-margin 40/40；verify-scrollbar-gutter、verify-timeline-rail、verify-divider-stability、verify-divider-width、verify-session-browser×2、repro-settings 全过；`git diff --check` 干净。

> 附注：`scripts/verify-display-settings.tsx` 有个与本次无关的**预存失败**（#573 给 `DEFAULT_STATUS_BAR` 加了 `cost: true` 但该测试硬编码期望未同步；此脚本未登记进任何 CI 组，所以一直没被发觉）。建议单独跟进。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable page margins with preset options and custom width-by-height values.
  - Margin changes apply live throughout the terminal interface.
  - Added full-bleed dividers that extend to the terminal edges while preserving content alignment.

- **Bug Fixes**
  - Improved positioning for tooltips, menus, prompt overlays, scrollbars, and timeline elements when page margins are enabled.
  - Preserved fullscreen behavior and correct content boundaries across layouts.

- **Tests**
  - Added regression coverage for page-margin sizing, presets, custom values, and layout boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->