### PR TITLE
fix(exit+perf): semantic integration of #701 (two-phase shutdown) x #713 (CPU idle) onto #711 latch state machine

### DIFF
--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -384,6 +384,12 @@ the required credentials.
   such as `DSH_TUI_DEBUG`, or the existing `DSH_TUI_RENDER_LOG` frame capture.
 - Preserve raw-mode, cursor, alternate-screen, synchronized-output, mouse,
   focus, and terminal-query cleanup on success, error, interrupt, and teardown.
+  The physical raw-mode restore (`setRawMode(false)`) belongs solely to the
+  exit funnel's conclude phase (`finishExit` → `concludeShutdown`): the
+  error-boundary and Ctrl+C paths must never release it themselves; when
+  React's error unwinding already released it before the latch,
+  `beginShutdown` re-acquires raw mode (tty-local only — no mode-enable
+  sequences are re-emitted) so the settle window is still spent raw (#522).
 - Avoid render-time unbounded collections or per-token/per-frame allocations.
   Streaming sessions are long lived, and this repository has explicit
   regressions for prior OOM and scroll-performance failures.

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -263,6 +263,7 @@ change, also run the closest focused script:
 | Mouse pointer event pipeline (wheel coords/modifier bits, click/hover dispatch, out-of-bounds clamping, pointer-state reset) | `node --import tsx/esm scripts/verify-pointer-events.ts` |
 | Hover event performance (complete interest boundaries, no-interest rect fast path, frame/multi-root invalidation) | `node --import tsx/esm scripts/verify-hover-coalesce.tsx` |
 | Prompt-input mouse selection editing (drag/Shift+click/double-click word select, delete/replace, layered Esc, Ctrl+C copy, CJK wide cells, fold-side clamping) | `node --import tsx/esm scripts/verify-input-selection.tsx` |
+| Exit-funnel terminal cleanup (finishExit: latch → stdout queue barrier → synchronous DISABLE/cleanup writes → raw-mode settle → cooked restore in finally) | `node --import tsx/esm scripts/verify-exit-mouse-disable-order.tsx`, `node --import tsx/esm scripts/verify-exit-mouse-residue.tsx`, `node --import tsx/esm scripts/verify-exit-mouse-cleanup.tsx` |
 
 Most focused scripts invoked with plain `node` import `lib/types/`; run
 `pnpm build` first. Scripts that import TypeScript sources declare the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -295,7 +295,11 @@ TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式�
   诊断。用 opt-in 的 stderr/调试路径（如 `DSH_TUI_DEBUG`）或既有
   `DSH_TUI_RENDER_LOG` 帧捕获。
 - 在成功、错误、中断与收尾时都保持 raw 模式、光标、alt-screen、同步输出、
-  鼠标、焦点与终端查询的清理。
+  鼠标、焦点与终端查询的清理。raw 模式的物理恢复（`setRawMode(false)`）
+  只归退出漏斗的 conclude 阶段（`finishExit` → `concludeShutdown`）：
+  error boundary 与 Ctrl+C 路径不得自行释放；React 错误解卷若在闩锁前
+  已释放，`beginShutdown` 会重新获取（仅 tty 本地模式，不重发启用序列），
+  保证 settle 窗在 raw 态度过（#522）。
 - 避免渲染期无界集合或每 token/每帧分配。流式会话长命，本仓库对先前的 OOM
   与滚动性能失败有明确回归。
 - 布局改动不得让 transcript 内容挤掉输入行与状态行。改动相关路径时演练

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -202,6 +202,7 @@ CI 回归都要跑。窄改动还要跑最近的聚焦脚本：
 | 鼠标指针事件管线（滚轮坐标/修饰位、点击/hover 派发、越界 clamp、指针态重置） | `node --import tsx/esm scripts/verify-pointer-events.ts` |
 | Hover 事件性能（兴趣边界完整、无兴趣矩形快路径、帧边界/多 root 失效） | `node --import tsx/esm scripts/verify-hover-coalesce.tsx` |
 | 输入框鼠标选区编辑（拖选/Shift+click/双击选词/删除替换/Esc 分层/Ctrl+C 复制、CJK 宽字符与 fold 侧钳制） | `node --import tsx/esm scripts/verify-input-selection.tsx` |
+| 退出漏斗终端清理（finishExit：闩锁→stdout 队列 barrier→同步写 DISABLE/清理块→raw 态 settle→finally 恢复 cooked） | `node --import tsx/esm scripts/verify-exit-mouse-disable-order.tsx`、`node --import tsx/esm scripts/verify-exit-mouse-residue.tsx`、`node --import tsx/esm scripts/verify-exit-mouse-cleanup.tsx` |
 
 多数用普通 `node` 调用的脚本 import `lib/types/`——先跑 `pnpm build`。import
 TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式。不要凭

--- a/scripts/repro-slow-stdout.tsx
+++ b/scripts/repro-slow-stdout.tsx
@@ -1,0 +1,147 @@
+/**
+ * Slow-stdout reproduction: a stream that rejects writes (returns false,
+ * holds the callback, never drains on its own) must NOT put the renderer
+ * into a fixed ~4ms re-probe loop, must not accumulate an unbounded write
+ * backlog, and must resume on the stream's own `drain` event. Teardown
+ * must clear the drain listener and the fallback timer.
+ *
+ *   A. Backpressured window: bounded write count (fallback backoff, not a
+ *      4ms busy loop) and bounded backlog (frames coalesce, no growth).
+ *   B. `drain` event resumes writes.
+ *   C. unmount clears the drain listener and timers.
+ *
+ * Run via `node --import tsx/esm scripts/repro-slow-stdout.tsx`.
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { render }, { Text }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/ui.js'),
+])
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** An animated node so renders keep coming while we watch the gate. */
+function Animated(): React.ReactNode {
+  const [tick, setTick] = React.useState(0)
+  React.useEffect(() => {
+    const timer = setInterval(() => setTick(t => t + 1), 100)
+    return () => clearInterval(timer)
+  }, [])
+  return React.createElement(Text, null, `tick ${tick} `.repeat(40))
+}
+
+class SlowStdout extends Writable {
+  columns = 100
+  rows = 24
+  isTTY = true
+  writes = 0
+  heldCallbacks: Array<() => void> = []
+  term!: { write(chunk: string, cb: () => void): void }
+  override _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    this.writes += 1
+    // Hold the callback: the stream never flushes on its own (SSH-like
+    // saturated pipe). The internal buffer grows until write() returns
+    // false, which is exactly the state the backpressure gate must handle.
+    // When a held callback eventually fires (the B-phase flush), the bytes
+    // reach the simulated terminal — so the final-content assertion is real.
+    this.heldCallbacks.push(() => {
+      callback()
+      this.term.write(String(chunk), () => {})
+    })
+  }
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+
+const stdout = new SlowStdout()
+const stdin = new FakeStdin()
+const term = new (await import('@xterm/headless')).Terminal({ cols: 100, rows: 24, scrollback: 100, allowProposedApi: true })
+stdout.term = term
+const instance = await render(
+  React.createElement(Animated),
+  { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+)
+for (const value of instances.values()) instances.set(process.stdout, value)
+const ink = instances.get(stdout) ?? instances.values().next().value
+
+// Let the first paint land and the write buffer saturate (the held
+// callbacks make writableLength climb past the 8192 gate). Wait until the
+// ink instance actually reports backpressure before measuring anything.
+let saturated = false
+for (let i = 0; i < 100 && !saturated; i++) {
+  await sleep(50)
+  saturated = (ink as { backpressured?: boolean }).backpressured === true
+}
+check('saturation: the renderer reports backpressure', saturated, '')
+stdout.writes = 0
+
+// ── A. Backpressured window: bounded wakeups, bounded backlog ─────────────
+const startLength = (stdout as unknown as { writableLength: number }).writableLength
+await sleep(1500)
+const writesInWindow = stdout.writes
+// Fallback ladder 250+500+1000ms ⇒ ≤ ~5 re-probes in 1.5s. A 4ms busy loop
+// would be ~375. Allow slack for boundary effects.
+check('A1: backpressured renderer does not busy-poll at 4ms',
+  writesInWindow <= 8,
+  `writes=${writesInWindow} over 1.5s`)
+const endLength = (stdout as unknown as { writableLength: number }).writableLength
+check('A2: write backlog stays bounded while backpressured',
+  endLength - startLength <= 8192,
+  `backlog delta=${endLength - startLength} bytes (≤ one frame)`)
+// A second window must not keep growing the backlog: the gate holds it at
+// the saturation level instead of stacking a frame per render.
+const startLength2 = endLength
+await sleep(1500)
+const endLength2 = (stdout as unknown as { writableLength: number }).writableLength
+check('A3: backlog plateaus (no infinite growth)',
+  endLength2 <= startLength2 + 1024,
+  `second-window delta=${endLength2 - startLength2} bytes`)
+
+// ── B. The stream's own drain resumes painting ────────────────────────────
+stdout.writes = 0
+// Flush the held chunk (the drain that a real stream would emit after the
+// buffer empties) then signal drain explicitly.
+for (const cb of stdout.heldCallbacks) cb()
+if (process.env.SLOW_DEBUG === '1') console.error('[slow] B-phase flush done')
+stdout.heldCallbacks = []
+stdout.emit('drain')
+await sleep(400)
+check('B: drain event resumes frame writes', stdout.writes > 0, `writes=${stdout.writes} after drain`)
+// The coalesced frames must have painted the LATEST content: a skipped
+// frame's delta is re-computed against the last-written baseline, so the
+// terminal holds the final state, not a stale one.
+const buffer = term.buffer.active
+const screenText = Array.from({ length: 24 }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+check('B2: final terminal content is complete (no lost frames)',
+  /tick \d+/.test(screenText) && screenText.includes('tick'),
+  screenText.slice(0, 60).replace(/\n/g, '|'))
+
+// ── C. Teardown clears listener + timers ──────────────────────────────────
+instance.unmount()
+instances.delete(stdout)
+await sleep(50)
+check('C1: unmount removes the drain listener',
+  stdout.listenerCount('drain') === 0,
+  `drain listeners=${stdout.listenerCount('drain')}`)
+const drainTimerCleared =
+  (ink as { drainTimer?: unknown }).drainTimer === null ||
+  (ink as { drainTimer?: unknown }).drainTimer === undefined
+check('C2: unmount clears the fallback timer', drainTimerCleared, '')
+stdout.destroy()
+
+console.log(failed === 0 ? 'repro-slow-stdout: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -167,6 +167,18 @@ const GROUPS = {
 // concludeShutdown）；写前 stdout 队列 barrier 排空预排队帧/ENABLE；
 // 写入失败（fd 与 stream 都抛）仍必进 conclude/handoff/done。
     ["verify-exit-mouse-disable-order", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-disable-order.tsx']],
+// finishExit runtime 选择回归（#701 整合审）：显式传入的 render handle 优先
+// 于 instances map——map/process.stdout 指向 B 时 finishExit(...,A) 只
+// begin/conclude A、清理字节只落 A 的流，B 零 latch 零清理；无 handle 时
+// map 兜底仍可用。
+    ["verify-exit-runtime-selection", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-runtime-selection.tsx']],
+// #711（手势/协议闩锁）× #701（两相 shutdown）交叉回归：Case A 手势
+// active 时退出零 probe/ENABLE/DECRQM 且 DISABLE→EXIT_ALT 保序；Case B
+// 分片 SGR candidate active 时退出不等待补全、shutdown 后输入 drain-only；
+// Case C pendingAltScreenReentry/pendingProbe 被 beginShutdown 永久取消；
+// Case D 正常手势的 release→batch-tail→probe 恢复不被 shutdown gate 破坏；
+// 各 Case 均断言 teardown 后 stdin readable listener === 0。
+    ["verify-exit-gesture-protocol", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-gesture-protocol.tsx']],
 // 组件级拖拽协议回归：无修饰左键 press 捕获 drag target，首动 dragstart、
 // 连续 dragmove、release/focus-out/reset 收尾 dragend；未移动仍走 click，
 // 无 handler 与修饰键区域保留基线文本选择；真实 SGR 管线 + 最小滑块消费者。

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -126,6 +126,25 @@ const GROUPS = {
 // 恢复历史会话落点回归：/resume 后最新消息末行必须可见且可达
 // （scrollToBottom 补画完成后的锚定终态），不再落屏外。
     ["repro-resume-position", ['node', '--import', 'tsx/esm', 'scripts/repro-resume-position.tsx']],
+// rowsGeneration 缓存身份回归（#713 整合审 blocker 1-3）：/clear 复用
+// row id（同一 live 数组、同长度、同 streaming bits、不同 generation）
+// 后——MessageList 可见行缓存渲染新行；failureHint 不钉在新行上；
+// lastUserRowId 重跟新 transcript 且 auto recap 在新 generation 的首条
+// user 消息即退场。
+    ["verify-rows-generation", ['node', '--import', 'tsx/esm', 'scripts/verify-rows-generation.tsx']],
+// formatWhen 边界确定性回归（#713 整合审 blocker 6）：now→minutes、
+// 分钟内、分钟→小时、小时→天、day 7→绝对日期的精确翻转时刻（嵌套
+// round 语义、oracle 二分），绝对日期后 Infinity（零 wake）。
+    ["verify-format-when-boundary", ['node', '--import', 'tsx/esm', 'scripts/verify-format-when-boundary.ts']],
+// GoalTodoPanel elapsed 基线回归（#713 整合审 blocker 5）：active 推进、
+// paused 冻结零 timer、resume 以已提交 transition 重定基线（标签从 ~0s
+// 重新计）、新 goal id 换新基线——transition 只落在 commit 后的 effect。
+    ["verify-goal-todo-baseline", ['node', '--import', 'tsx/esm', 'scripts/verify-goal-todo-baseline.tsx']],
+// 静态 UI 零空闲唤醒回归（#713）：Chat idle / JobsPanel settled /
+// GoalTodo paused / AgentView 静态列表在静默窗口零 frame，对应活跃态
+// 有 frame；trajectory seam 渲染零 getter 调用（含 mount 时）。
+    ["verify-idle-wakeups", ['node', '--import', 'tsx/esm', 'scripts/verify-idle-wakeups.tsx']],
+    ["verify-trajectory-cache", ['node', '--import', 'tsx/esm', 'scripts/verify-trajectory-cache.tsx']],
   ],
   'input-terminal': [
 // 按键解析回归（issue #110）：Option+Enter（ESC CR）精确/合并/分块
@@ -179,6 +198,11 @@ const GROUPS = {
 // Case D 正常手势的 release→batch-tail→probe 恢复不被 shutdown gate 破坏；
 // 各 Case 均断言 teardown 后 stdin readable listener === 0。
     ["verify-exit-gesture-protocol", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-gesture-protocol.tsx']],
+// #713（stdout 背压）× #701（shutdown 漏斗）交叉回归（整合审 §8）：饱和
+// stdout + drain listener/fallback 在挂时执行 finishExit——shutdown 窗口
+// 内 emit drain 不得触发普通 frame；DISABLE→EXIT_ALT 保序；结束后
+// drain listener 与 fallback timer 均为 0、stdin readable 为 0。
+    ["verify-exit-backpressure", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-backpressure.tsx']],
 // 组件级拖拽协议回归：无修饰左键 press 捕获 drag target，首动 dragstart、
 // 连续 dragmove、release/focus-out/reset 收尾 dragend；未移动仍走 click，
 // 无 handler 与修饰键区域保留基线文本选择；真实 SGR 管线 + 最小滑块消费者。
@@ -228,6 +252,10 @@ const GROUPS = {
 // 转录拉进不可选取区。真实 Chat 树 + SGR 拖选注入，静息/上滚阅读+
 // 流式并发/流式结束后三场景断言 OSC 52 携带完整选中文本。
     ["repro-drag-select-streaming", ['node', '--import', 'tsx/esm', 'scripts/repro-drag-select-streaming.tsx']],
+// grants 文件 watcher 回归（#713）：目录 watcher 事件驱动通知（原子
+// rename/delete-recreate 均覆盖）、退订即停、父目录不存在时经 2s 轮询
+// fallback 拾取新建（真 fallback 路径——目录本身不存在时 fs.watch 才失败）。
+    ["verify-grants-watch", ['node', '--import', 'tsx/esm', 'scripts/verify-grants-watch.ts']],
   ],
   'session-workspace': [
 // 审批服务配置回归（issue #49 尾巴）：裸组合 cordis.yml 必须挂载

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -162,6 +162,11 @@ const GROUPS = {
 // 字节、不得拉回 raw mode——在途回复与鼠标事件由清理后的 re-drain
 // 吞掉，不再落入 shell。
     ["verify-exit-mouse-residue", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-residue.tsx']],
+// 退出回显窗口回归（#522 的 SSH 慢链路门）：DISABLE_MOUSE 同步写在 raw
+// mode 仍持有时落盘，settle 窗也在 raw 态度过（cooked 恢复只在最后的
+// concludeShutdown）；写前 stdout 队列 barrier 排空预排队帧/ENABLE；
+// 写入失败（fd 与 stream 都抛）仍必进 conclude/handoff/done。
+    ["verify-exit-mouse-disable-order", ['node', '--import', 'tsx/esm', 'scripts/verify-exit-mouse-disable-order.tsx']],
 // 组件级拖拽协议回归：无修饰左键 press 捕获 drag target，首动 dragstart、
 // 连续 dragmove、release/focus-out/reset 收尾 dragend；未移动仍走 click，
 // 无 handler 与修饰键区域保留基线文本选择；真实 SGR 管线 + 最小滑块消费者。

--- a/scripts/verify-exit-backpressure.tsx
+++ b/scripts/verify-exit-backpressure.tsx
@@ -1,0 +1,175 @@
+/**
+ * verify-exit-backpressure — #713 (stdout backpressure) × #701 (shutdown
+ * funnel) cross-invariant (integration review §8).
+ *
+ * With a backpressured stdout (drain listener attached + fallback timer
+ * armed + pending drain), finishExit's beginShutdown must — BEFORE the
+ * stdout barrier and terminal cleanup — set the renderer shutdown latch,
+ * cancel the throttled render, invalidate pending microtask renders,
+ * detach the stdout drain listener, clear the fallback timer, and tear
+ * down the backpressure recovery producer. Otherwise a late `drain` event
+ * could fire the renderer callback and write an ordinary frame AFTER
+ * DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN landed.
+ *
+ * Scenario:
+ *   1. stdout saturation (a Writable that never flushes — chunks queue,
+ *      write() returns false, writableLength grows past PTY_BACKLOG_BYTES);
+ *   2. a render arms the backpressure wait (listener + fallback timer);
+ *   3. finishExit runs with the drain/fallback still pending;
+ *   4. 'drain' is EMITTED inside the shutdown window.
+ *
+ * Asserts:
+ *   - ordinary renderer frames stop at beginShutdown (frame count frozen);
+ *   - the drain event triggers NO frame (listener detached);
+ *   - cleanup order preserved (DISABLE_MOUSE before EXIT_ALT_SCREEN);
+ *   - listener and fallback timer counts are 0 at the end.
+ *
+ * Run: node --import tsx/esm scripts/verify-exit-backpressure.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [
+  streamMod,
+  ReactMod,
+  { render, AlternateScreen, useInput },
+  textMod,
+  pluginMod,
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/ink/components/Text.js'),
+  import('../src/dsh-adapter/plugin.js'),
+])
+const { finishExit } = pluginMod
+const React = ReactMod
+const { PassThrough, Writable } = streamMod
+const Text = textMod.default
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  const mark = ok ? 'ok  ' : 'FAIL'
+  console.log(`${mark} ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures++
+}
+
+const COLS = 100
+const ROWS = 30
+const DISABLE_MOUSE = '\x1b[?1006l'
+const EXIT_ALT = '\x1b[?1049l'
+
+const writes: string[] = []
+let frames = 0
+/** Never flushes: every chunk queues forever (write() returns false once
+ * past the tiny high-water mark; writableLength keeps growing — exactly the
+ * stalled-ssh/ConPTY saturation shape). */
+class SaturatingStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  constructor() {
+    super({ highWaterMark: 16 })
+  }
+  write(chunk: any, enc?: BufferEncoding | (() => void), cb?: () => void): boolean {
+    const ok = super.write(chunk, enc as BufferEncoding, cb)
+    writes.push(String(chunk))
+    return ok
+  }
+  _write(_chunk: unknown, _enc: BufferEncoding, _cb: () => void): void {
+    // Deliberately never calls back: the stream stays saturated forever.
+  }
+}
+class FakeStderr extends Writable {
+  isTTY = true
+  _write(_c: unknown, _e: BufferEncoding, cb: () => void) {
+    cb()
+  }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() {
+    return this
+  }
+  ref() {
+    return this
+  }
+  unref() {
+    return this
+  }
+}
+
+const stdout = new SaturatingStdout()
+const stdin = new FakeStdin()
+
+function Scene(props: { marker: string }): React.ReactNode {
+  useInput(() => {})
+  return (
+    <AlternateScreen>
+      <Text>{props.marker}</Text>
+    </AlternateScreen>
+  )
+}
+
+const instance = await render(<Scene marker="BP-ONE" /> as never, {
+  stdout: stdout as never,
+  stdin: stdin as never,
+  stderr: new FakeStderr() as never,
+  exitOnCtrlC: false,
+  patchConsole: false,
+  onFrame: () => {
+    frames += 1
+  },
+})
+// Let the AlternateScreen insertion effect run (ENTER_ALT + mouse enable).
+await new Promise(resolve => setTimeout(resolve, 150))
+const framesAtStart = frames
+
+// Force frames through until the stream saturates and the backpressure gate
+// engages (listener + fallback timer armed, writes coalesced).
+let marker = 'BP-ONE'
+for (let i = 0; i < 40 && frames - framesAtStart < 8; i++) {
+  marker = `BP-${i}`
+  instance.rerender(<Scene marker={marker} /> as never)
+  await new Promise(resolve => setTimeout(resolve, 25))
+}
+const saturated = stdout.writableLength > 0
+check('setup: stdout saturated (backpressure engaged)', saturated, `writableLength=${stdout.writableLength}`)
+check('setup: frames were being produced before shutdown', frames > framesAtStart, `frames=${frames - framesAtStart}`)
+
+// finishExit with the drain/fallback still pending; emit 'drain' INSIDE the
+// shutdown window (during the 150ms settle).
+const writesAtExit = writes.length
+let done = false
+const exitPromise = finishExit(
+  { logger: { debug() {} } } as never,
+  instance as never,
+  true,
+  undefined,
+  undefined,
+  () => {
+    done = true
+  },
+)
+setTimeout(() => {
+  ;(stdout as unknown as { emit(ev: string): boolean }).emit('drain')
+}, 60)
+await exitPromise
+await new Promise(resolve => setTimeout(resolve, 250))
+
+check('X1: finishExit completes (done executed)', done)
+const tail = writes.slice(writesAtExit).join('')
+check('X2: cleanup order DISABLE_MOUSE → EXIT_ALT_SCREEN preserved',
+  tail.indexOf(DISABLE_MOUSE) >= 0 && tail.indexOf(EXIT_ALT) >= 0 && tail.indexOf(DISABLE_MOUSE) < tail.indexOf(EXIT_ALT))
+check('X3: no frame marker written after beginShutdown (renderer latch)',
+  !tail.includes('BP-'), `tailLen=${tail.length}`)
+const drainListeners = stdout.listeners('drain').length
+check('X4: stdout drain listener detached after shutdown', drainListeners === 0, `listeners=${drainListeners}`)
+check(
+  'X5: teardown 后 stdin readable listener 为 0',
+  (stdin as unknown as { listenerCount(e: string): number }).listenerCount('readable') === 0,
+)
+
+console.log(failures === 0 ? 'verify-exit-backpressure: all checks passed' : `FAILURES: ${failures}`)
+if (failures > 0) process.exit(1)

--- a/scripts/verify-exit-gesture-protocol.tsx
+++ b/scripts/verify-exit-gesture-protocol.tsx
@@ -1,0 +1,309 @@
+/**
+ * verify-exit-gesture-protocol — #711（鼠标手势/协议闩锁状态机）× #701
+ * （两相 shutdown 漏斗）交叉回归。
+ *
+ * 整合不变量：正常运行时 #711 的 gesture/protocol lifecycle 照常工作；
+ * beginShutdown 之后一切 probe / reassert / reentry / frame producer 永久
+ * 停止，stdin 只 drain，raw mode 保持到 settle 窗结束才 conclude。
+ *
+ *   Case A  鼠标 physical gesture active 时触发 exit：
+ *           beginShutdown 后不得有 probe、不得有 ENABLE_MOUSE_TRACKING、
+ *           不得有 DECRQM 写；cleanup 顺序 DISABLE_MOUSE → EXIT_ALT。
+ *   Case B  protocol candidate（分片 SGR mouse report）active 时触发
+ *           exit：shutdown 不等待 candidate 正常 completion（不发送补全
+ *           字节也能完成退出）；shutdown 窗口内输入 drain-only；candidate
+ *           补全字节在 shutdown 后到达不产生任何协议写（falling edge
+ *           不得排空 pending probe）。
+ *   Case C  存在 pendingAltScreenReentry / pendingProbe 时触发 exit：
+ *           beginShutdown 永久取消这些 producer —— DISABLE_MOUSE 之后
+ *           不得重新 reenter（ENTER_ALT）/ ENABLE。
+ *   Case D  正常非退出 gesture：#711 的 release → batch-tail drain →
+ *           probe 恢复行为保持，不被 shutdown gate 破坏。
+ *
+ * 共同断言（#701 §5 last-live App retention）：teardown 后
+ * stdin.listenerCount('readable') === 0 —— 旧 runtime 不得吞下一个
+ * mount 的输入。
+ *
+ * Run: node --import tsx/esm scripts/verify-exit-gesture-protocol.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+
+const [
+  streamMod,
+  ReactMod,
+  xtermMod,
+  uiMod,
+  textMod,
+  instancesMod,
+  pluginMod,
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/ink/components/Text.js'),
+  import('../src/ink/instances.js'),
+  import('../src/dsh-adapter/plugin.js'),
+])
+
+const { finishExit } = pluginMod
+const instances = instancesMod.default
+const React = ReactMod
+const { PassThrough, Writable } = streamMod
+const { Terminal: XTerm } = xtermMod
+const { render, AlternateScreen, useInput } = uiMod
+const Text = textMod.default
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  const mark = ok ? 'ok  ' : 'FAIL'
+  console.log(`${mark} ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures++
+}
+
+const COLS = 100
+const ROWS = 30
+const ENTER_ALT = '\x1b[?1049h'
+const EXIT_ALT = '\x1b[?1049l'
+const ENABLE_MOUSE = '\x1b[?1000h'
+const DISABLE_MOUSE = '\x1b[?1006l'
+const DECRQM_1049 = '\x1b[?1049$p'
+
+interface Scene {
+  stdin: PassThrough & { isTTY: boolean; setRawMode(): unknown; ref(): unknown; unref(): unknown }
+  stdout: { writes: string[] }
+  instance: { unmount(): void }
+  ink(): Record<string, unknown>
+  app(): Record<string, unknown>
+  press(c: number, r: number): void
+  motion(c: number, r: number): void
+  release(c: number, r: number): void
+}
+
+async function makeScene(marker: string): Promise<Scene> {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const writes: string[] = []
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    write(chunk: any, enc?: BufferEncoding | (() => void), cb?: () => void): boolean {
+      writes.push(String(chunk))
+      return super.write(chunk, enc as BufferEncoding, cb)
+    }
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+      term.write(String(chunk), cb)
+    }
+  }
+  class FakeStderr extends Writable {
+    isTTY = true
+    _write(_c: unknown, _e: BufferEncoding, cb: () => void) {
+      cb()
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode() {
+      return this
+    }
+    ref() {
+      return this
+    }
+    unref() {
+      return this
+    }
+  }
+  const stdin = new FakeStdin()
+  const stdout = new FakeStdout()
+
+  function Scene() {
+    useInput(() => {})
+    return (
+      <AlternateScreen>
+        <Text>{marker}</Text>
+      </AlternateScreen>
+    )
+  }
+  const instance = await render(<Scene /> as never, {
+    stdout: stdout as never,
+    stdin: stdin as never,
+    stderr: new FakeStderr() as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  // 等 AlternateScreen 的 insertion effect 跑完（ENTER_ALT + mouse enable）
+  await new Promise(resolve => setTimeout(resolve, 120))
+  return {
+    stdin: stdin as never,
+    stdout: { writes },
+    instance: instance as never,
+    ink: () => instances.get(stdout as never) as unknown as Record<string, unknown>,
+    app: () =>
+      (instances.get(stdout as never) as unknown as { app: Record<string, unknown> }).app,
+    press: (c: number, r: number) => stdin.write(`\x1b[<0;${c + 1};${r + 1}M`),
+    motion: (c: number, r: number) => stdin.write(`\x1b[<32;${c + 1};${r + 1}M`),
+    release: (c: number, r: number) => stdin.write(`\x1b[<0;${c + 1};${r + 1}m`),
+  }
+}
+
+/** 首个包含 needle 的写入下标；找不到返回 -1。 */
+function firstIndexAfter(writes: string[], needle: string, from: number): number {
+  for (let i = from; i < writes.length; i++) {
+    if (writes[i]!.includes(needle)) return i
+  }
+  return -1
+}
+
+const ctx = { logger: { debug() {} } } as never
+
+// ── Case A：physical gesture active 时触发 exit ──────────────────
+{
+  const scene = await makeScene('CASEA')
+  const writes = scene.stdout.writes as string[]
+  scene.press(10, 5)
+  await new Promise(resolve => setTimeout(resolve, 80))
+  const latched =
+    (scene.ink().pointerGestureActive as boolean) === true
+  check('A: press 后物理手势闩锁 active', latched)
+  const beginAt = writes.length
+  let doneA = false
+  await finishExit(ctx, scene.instance as never, true, undefined, undefined, () => {
+    doneA = true
+  })
+  check('A: finishExit 完成（done 执行）', doneA)
+  const tail = writes.slice(beginAt).join('')
+  check('A: beginShutdown 后无 ENABLE_MOUSE_TRACKING', !tail.includes(ENABLE_MOUSE))
+  check('A: beginShutdown 后无 DECRQM write', !tail.includes(DECRQM_1049))
+  const disableIdx = firstIndexAfter(writes, DISABLE_MOUSE, beginAt)
+  const exitAltIdx = firstIndexAfter(writes, EXIT_ALT, beginAt)
+  check(
+    'A: cleanup 顺序 DISABLE_MOUSE → EXIT_ALT_SCREEN',
+    disableIdx >= 0 && exitAltIdx >= 0 && disableIdx <= exitAltIdx,
+    `disable@${disableIdx} exitAlt@${exitAltIdx}`,
+  )
+  check(
+    'A: teardown 后 stdin readable listener 为 0',
+    (scene.stdin as unknown as { listenerCount(e: string): number }).listenerCount('readable') === 0,
+  )
+}
+
+// ── Case B：protocol candidate active 时触发 exit ────────────────
+{
+  const scene = await makeScene('CASEB')
+  const writes = scene.stdout.writes as string[]
+  // 分片 SGR mouse report：只写前缀，不发送补全字节
+  scene.stdin.write('\x1b[<0;10')
+  await new Promise(resolve => setTimeout(resolve, 50))
+  const candidateLatched =
+    (scene.ink().protocolCandidateActive as boolean) === true
+  check('B: 分片前缀后 protocol candidate 闩锁 active', candidateLatched)
+  const beginAt = writes.length
+  const startedAt = Date.now()
+  let doneB = false
+  // 不发送 candidate 补全字节 —— shutdown 不得等待其正常 completion
+  await finishExit(ctx, scene.instance as never, true, undefined, undefined, () => {
+    doneB = true
+  })
+  const elapsedMs = Date.now() - startedAt
+  check('B: shutdown 不等待 candidate completion 即完成', doneB)
+  const tail = writes.slice(beginAt).join('')
+  check('B: shutdown 窗口无 probe / ENABLE 写', !tail.includes(ENABLE_MOUSE) && !tail.includes(DECRQM_1049))
+  // candidate 补全字节在 shutdown 后到达：drain-only，不解析、不产生写
+  const writeCountAfter = writes.length
+  scene.stdin.write(';5M') // 补全一次 press —— falling edge 不得排空任何 probe
+  scene.stdin.write('\x1b[<0;11;6m') // release
+  await new Promise(resolve => setTimeout(resolve, 120))
+  check(
+    'B: shutdown 后输入 drain-only，candidate falling edge 零写入',
+    writes.length === writeCountAfter,
+    `writes=${writes.length - writeCountAfter}`,
+  )
+  check(
+    'B: teardown 后 stdin readable listener 为 0',
+    (scene.stdin as unknown as { listenerCount(e: string): number }).listenerCount('readable') === 0,
+  )
+  void elapsedMs
+}
+
+// ── Case C：pendingAltScreenReentry / pendingProbe 时触发 exit ───
+{
+  const scene = await makeScene('CASEC')
+  const writes = scene.stdout.writes as string[]
+  const ink = scene.ink()
+  // 直接置位：模拟 DECRPM 已确认 1049 reset + probe 被手势挡下
+  ink.pendingAltScreenReentry = true
+  ink.pendingProbeRequest = { skipMouseReassert: true }
+  const beginAt = writes.length
+  let doneC = false
+  await finishExit(ctx, scene.instance as never, true, undefined, undefined, () => {
+    doneC = true
+  })
+  check('C: finishExit 完成', doneC)
+  const tail = writes.slice(beginAt).join('')
+  const disableIdx = firstIndexAfter(writes, DISABLE_MOUSE, beginAt)
+  const exitAltIdx = firstIndexAfter(writes, EXIT_ALT, beginAt)
+  check(
+    'C: cleanup 顺序 DISABLE_MOUSE → EXIT_ALT_SCREEN',
+    disableIdx >= 0 && exitAltIdx >= 0 && disableIdx <= exitAltIdx,
+  )
+  check('C: DISABLE 后无 reenter（无 ENTER_ALT）', !tail.includes(ENTER_ALT))
+  check('C: DISABLE 后无 ENABLE_MOUSE', !tail.includes(ENABLE_MOUSE))
+  // beginShutdown 之后手动触发 drain（模拟迟到的 release tail）—— 仍不得写。
+  // 注意 instances 条目已被 beginShutdown 删除：用 exit 前抓好的对象引用。
+  const countAfter = writes.length
+  const inkAny = ink as unknown as {
+    drainReleaseTail: () => void
+    drainAltScreenReentry: () => void
+    drainPendingProbe: () => void
+  }
+  inkAny.drainReleaseTail()
+  inkAny.drainAltScreenReentry()
+  inkAny.drainPendingProbe()
+  await new Promise(resolve => setTimeout(resolve, 80))
+  check(
+    'C: beginShutdown 永久取消 producer（迟到 drain 零写入）',
+    writes.length === countAfter,
+    `writes=${writes.length - countAfter}`,
+  )
+  check('C: pendingProbeRequest 被清除', ink.pendingProbeRequest === undefined)
+  check(
+    'C: teardown 后 stdin readable listener 为 0',
+    (scene.stdin as unknown as { listenerCount(e: string): number }).listenerCount('readable') === 0,
+  )
+}
+
+// ── Case D：正常非退出 gesture 的 #711 行为保持 ──────────────────
+{
+  const scene = await makeScene('CASED')
+  const writes = scene.stdout.writes as string[]
+  scene.press(8, 4)
+  await new Promise(resolve => setTimeout(resolve, 60))
+  const gestureStart = writes.length
+  scene.motion(9, 4)
+  scene.motion(10, 4)
+  await new Promise(resolve => setTimeout(resolve, 60))
+  const gestureTail = writes.slice(gestureStart).join('')
+  check('D: 手势窗口零协议写入（#711 闩锁）', !gestureTail.includes(ENABLE_MOUSE) && !gestureTail.includes(DECRQM_1049))
+  // 手势期间塞入一个 pending probe（模拟被挡下的探测请求）
+  const ink = scene.ink() as { pendingProbeRequest?: { skipMouseReassert?: boolean } }
+  ink.pendingProbeRequest = { skipMouseReassert: true }
+  scene.release(10, 4)
+  await new Promise(resolve => setTimeout(resolve, 150))
+  // release → batch tail → drainPendingProbe：未被 shutdown gate 破坏，
+  // probe 恢复（DECRQM 查询出现在 release 之后）
+  const releaseIdx = (() => {
+    for (let i = gestureStart; i < writes.length; i++) {
+      // release 触发的重渲染/选择写不易辨别，用时间锚：直接找 drain 之后的
+      // DECRQM —— 只要最终出现即证明 probe 管线活着
+      if (writes[i]!.includes(DECRQM_1049)) return i
+    }
+    return -1
+  })()
+  check('D: release 后 pending probe 正常恢复（#711 行为未被 gate 破坏）', releaseIdx >= 0, `decrqm@${releaseIdx}`)
+  check('D: 手势后 runtime 仍存活（未 latch）', (scene.ink().isUnmounted as boolean) !== true)
+}
+
+console.log(failures === 0 ? 'verify-exit-gesture-protocol: all checks passed' : `FAILURES: ${failures}`)
+if (failures > 0) process.exit(1)

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -105,6 +105,10 @@ const sleep = (ms: number): Promise<void> =>
     typeof instance.detachForShutdown === 'function',
   )
   check(
+    'render handle exposes beginShutdown/concludeShutdown (finishExit split phases)',
+    typeof instance.beginShutdown === 'function' && typeof instance.concludeShutdown === 'function',
+  )
+  check(
     'render handle exposes detachStdinForHandoff',
     typeof instance.detachStdinForHandoff === 'function',
   )
@@ -203,7 +207,99 @@ const sleep = (ms: number): Promise<void> =>
 }
 
 // ---------------------------------------------------------------------------
-// 4. serializeDiff keeps the empty-diff contract after the extraction.
+// 4. React error-boundary path: a throwing mount drives componentDidCatch →
+//    handleExit → Ink.unmount, which writes the synchronous cleanup itself
+//    and latches exitCleanupWritten. The finishExit funnel must then SKIP
+//    re-writing the mode resets (exactly one DISABLE_MOUSE_TRACKING and one
+//    EXIT_ALT_SCREEN in the fd trace) while still running latch → settle →
+//    conclude → handoff. finishExit never sees process.stdout swapped here,
+//    so the notice landing in the file also proves the funnel targets the
+//    runtime's own stream (stdout identity, #522).
+// ---------------------------------------------------------------------------
+{
+  const { finishExit } = await import('../src/dsh-adapter/plugin.js')
+  const tmpFile = join(tmpdir(), `dsh-tui-exit-boundary-${process.pid}.out`)
+  const tmpFd = openSync(tmpFile, 'w')
+  const stdout = fakeTTY({ fd: tmpFd })
+  const stdin = new FakeStdin()
+  const stderr = fakeTTY()
+
+  // Throw on the FIRST UPDATE, not on mount: a mount-time throw aborts the
+  // commit before AlternateScreen's insertion effect runs, so the app never
+  // enters the alt screen and the cleanup legitimately omits EXIT_ALT_SCREEN.
+  // The real error-boundary path (#522 crash reports) throws with the app
+  // already running — alt screen active, frames rendered.
+  const Bomb = (): React.ReactElement => {
+    const [boom, setBoom] = React.useState(false)
+    React.useEffect(() => { setBoom(true) }, [])
+    if (boom) throw new Error('render boom')
+    return React.createElement(Text, null, 'running before boom')
+  }
+
+  let renderThrew = false
+  let instance: Awaited<ReturnType<typeof render>> | undefined
+  try {
+    instance = await render(
+      React.createElement(AlternateScreen, null, React.createElement(Bomb)),
+      {
+        stdout,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stderr,
+        exitOnCtrlC: false,
+        patchConsole: true,
+      },
+    )
+    // componentDidCatch → handleExit → Ink.unmount rejects the exit promise;
+    // awaiting it (with catch) is also the sync point for "unmount done".
+    await instance.waitUntilExit().catch(() => {})
+  } catch {
+    renderThrew = true
+  }
+
+  check('error boundary catches the throwing mount (render does not throw out)', !renderThrew && instance !== undefined)
+
+  if (instance) {
+    check('unmount already wrote the exit cleanup (hasWrittenExitCleanup latched)',
+      instance.hasWrittenExitCleanup === true)
+
+    const ctx = { logger: { debug() {} } } as never
+    let done = false
+    let finishThrew = false
+    try {
+      await finishExit(ctx, instance, true, 'hint-boundary', undefined, () => { done = true })
+    } catch {
+      finishThrew = true
+    }
+    closeSync(tmpFd)
+
+    const trace = readFileSync(tmpFile, 'utf8')
+    // React's error unwinding runs <AlternateScreen>'s insertion-effect
+    // cleanup (async writeRaw → stream buffer) before Ink.unmount's writeSync
+    // block, and setAltScreenActive(false) then suppresses unmount's
+    // redundant EXIT_ALT_SCREEN — so EXIT_ALT lands exactly once across BOTH
+    // channels (buffer + fd trace), while the fd trace alone proves whether
+    // finishExit double-wrote its cleanup block (a broken skip would add a
+    // second writeSync DISABLE_MOUSE_TRACKING to the file).
+    const combined = drain(stdout) + trace
+    const count = (haystack: string, needle: string): number => haystack.split(needle).length - 1
+    check('finishExit survives the post-boundary funnel', !finishThrew && done)
+    check('fd trace has exactly one writeSync DISABLE (finishExit skip worked)',
+      count(trace, DISABLE_MOUSE_TRACKING) === 1)
+    check('EXIT_ALT_SCREEN reaches the terminal exactly once (no double write)',
+      count(combined, EXIT_ALT_SCREEN) === 1)
+    check('skip-branch still parks the notice on the runtime stream', trace.includes('hint-boundary'))
+    // The mount itself legitimately enables mouse tracking — the contract is
+    // that nothing re-enables it AFTER the final EXIT_ALT_SCREEN.
+    const postExitTail = combined.slice(combined.lastIndexOf(EXIT_ALT_SCREEN))
+    check('no ENABLE_MOUSE_TRACKING after the final EXIT_ALT_SCREEN', !postExitTail.includes(ENABLE_MOUSE_TRACKING))
+    check('concludeShutdown still ran in the finally (raw mode released)', stdin.isRaw === false)
+  } else {
+    closeSync(tmpFd)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. serializeDiff keeps the empty-diff contract after the extraction.
 // ---------------------------------------------------------------------------
 {
   const sink = new PassThrough() as unknown as NodeJS.WriteStream

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -23,7 +23,7 @@ import { closeSync, openSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
-import { render, AlternateScreen, Text } from '../src/ui.js'
+import { render, AlternateScreen, Text, useInput } from '../src/ui.js'
 import instances from '../src/ink/instances.js'
 import {
   DISABLE_MOUSE_TRACKING,
@@ -44,9 +44,12 @@ const check = (name: string, ok: boolean) => {
 class FakeStdin extends PassThrough {
   isTTY = true
   isRaw = false
+  /** Physical raw-mode transitions with timestamps (performance.now()). */
+  rawTransitions: Array<{ value: boolean; at: number }> = []
 
   setRawMode(value: boolean): this {
     this.isRaw = value
+    this.rawTransitions.push({ value, at: performance.now() })
     return this
   }
 
@@ -228,7 +231,15 @@ const sleep = (ms: number): Promise<void> =>
   // commit before AlternateScreen's insertion effect runs, so the app never
   // enters the alt screen and the cleanup legitimately omits EXIT_ALT_SCREEN.
   // The real error-boundary path (#522 crash reports) throws with the app
-  // already running — alt screen active, frames rendered.
+  // already running — alt screen active, frames rendered. RawHolder is the
+  // realistic raw-mode borrower (PromptInput's useInput): its effect cleanup
+  // runs DURING React's error unwinding — before componentDidCatch — so it
+  // physically releases raw mode before the shutdown latch exists, and the
+  // latch must re-acquire it for the settle window.
+  const RawHolder = (): React.ReactElement => {
+    useInput(() => {})
+    return React.createElement(Text, null, 'raw holder')
+  }
   const Bomb = (): React.ReactElement => {
     const [boom, setBoom] = React.useState(false)
     React.useEffect(() => { setBoom(true) }, [])
@@ -240,7 +251,7 @@ const sleep = (ms: number): Promise<void> =>
   let instance: Awaited<ReturnType<typeof render>> | undefined
   try {
     instance = await render(
-      React.createElement(AlternateScreen, null, React.createElement(Bomb)),
+      React.createElement(AlternateScreen, null, React.createElement(RawHolder), React.createElement(Bomb)),
       {
         stdout,
         stdin: stdin as unknown as NodeJS.ReadStream,
@@ -262,9 +273,18 @@ const sleep = (ms: number): Promise<void> =>
     check('unmount already wrote the exit cleanup (hasWrittenExitCleanup latched)',
       instance.hasWrittenExitCleanup === true)
 
+    // Mid-point, finishExit not yet called: the crash-unmount must have kept
+    // (re-acquired) raw mode — the settle window is only meaningful raw —
+    // and the cleanup bytes must have been written in that state (#522:
+    // cooked+echo before the terminal processes DISABLE is the echo bug).
+    const midTrace = readFileSync(tmpFile, 'utf8')
+    check('raw mode survives the crash-unmount (settle-window precondition)', stdin.isRaw === true)
+    check('crash-unmount wrote DISABLE while raw mode was held', midTrace.includes(DISABLE_MOUSE_TRACKING))
+
     const ctx = { logger: { debug() {} } } as never
     let done = false
     let finishThrew = false
+    const finishStart = performance.now()
     try {
       await finishExit(ctx, instance, true, 'hint-boundary', undefined, () => { done = true })
     } catch {
@@ -293,13 +313,56 @@ const sleep = (ms: number): Promise<void> =>
     const postExitTail = combined.slice(combined.lastIndexOf(EXIT_ALT_SCREEN))
     check('no ENABLE_MOUSE_TRACKING after the final EXIT_ALT_SCREEN', !postExitTail.includes(ENABLE_MOUSE_TRACKING))
     check('concludeShutdown still ran in the finally (raw mode released)', stdin.isRaw === false)
+    // The physical raw-off must happen INSIDE finishExit, after its 150ms
+    // raw-mode settle window — never before the funnel (the pre-fix path
+    // released it in App.handleExit, ahead of the cleanup write itself).
+    const lastOff = stdin.rawTransitions.filter(t => !t.value).at(-1)
+    check('raw-off happened only after the settle window (finishExit-owned)',
+      lastOff !== undefined && lastOff.at - finishStart >= 140)
   } else {
     closeSync(tmpFd)
   }
 }
 
 // ---------------------------------------------------------------------------
-// 5. serializeDiff keeps the empty-diff contract after the extraction.
+// 5. unmount() on a TTY-like stream WITHOUT an fd must write the cleanup to
+//    the stream's own ordered queue — never writeSync(1): fd 1 belongs to
+//    the host process, so a wrapped/embedder stream would lose every reset
+//    while its enable writes still reached the TTY (#522 review). The queued
+//    fallback also preserves frame → EXIT_ALT_SCREEN ordering for free.
+//    (Pre-fix, this stream captured NOTHING — the bytes went to real fd 1.)
+// ---------------------------------------------------------------------------
+{
+  class NoFdTty extends PassThrough {
+    isTTY = true
+    columns = 40
+    rows = 10
+    // Explicitly no `fd` property.
+  }
+  const stdout = new NoFdTty() as unknown as NodeJS.WriteStream
+  const stdin = new FakeStdin()
+  const instance = await render(
+    React.createElement(AlternateScreen, null, React.createElement(Text, null, 'no-fd cleanup target')),
+    {
+      stdout,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      exitOnCtrlC: false,
+      patchConsole: true,
+    },
+  )
+  drain(stdout)
+  instance.unmount()
+  const out = drain(stdout)
+  check('no-fd unmount writes EXIT_ALT_SCREEN to the stream itself', out.includes(EXIT_ALT_SCREEN))
+  check('no-fd unmount writes DISABLE_MOUSE_TRACKING to the stream itself', out.includes(DISABLE_MOUSE_TRACKING))
+  check('no-fd unmount orders EXIT_ALT_SCREEN before DISABLE',
+    out.indexOf(EXIT_ALT_SCREEN) !== -1 && out.indexOf(EXIT_ALT_SCREEN) < out.indexOf(DISABLE_MOUSE_TRACKING))
+  // An external (funnel-less) unmount must restore cooked mode itself.
+  check('external unmount restores cooked mode (no funnel follows)', stdin.isRaw === false)
+}
+
+// ---------------------------------------------------------------------------
+// 6. serializeDiff keeps the empty-diff contract after the extraction.
 // ---------------------------------------------------------------------------
 {
   const sink = new PassThrough() as unknown as NodeJS.WriteStream

--- a/scripts/verify-exit-mouse-cleanup.tsx
+++ b/scripts/verify-exit-mouse-cleanup.tsx
@@ -341,8 +341,14 @@ const sleep = (ms: number): Promise<void> =>
   }
   const stdout = new NoFdTty() as unknown as NodeJS.WriteStream
   const stdin = new FakeStdin()
+  // A real raw-mode borrower (useInput) so the unmount must actually detach
+  // the readable pump — without it the listener-leak checks below are vacuous.
+  const RawHolder = (): React.ReactElement => {
+    useInput(() => {})
+    return React.createElement(Text, null, 'holder')
+  }
   const instance = await render(
-    React.createElement(AlternateScreen, null, React.createElement(Text, null, 'no-fd cleanup target')),
+    React.createElement(AlternateScreen, null, React.createElement(RawHolder), React.createElement(Text, null, 'no-fd cleanup target')),
     {
       stdout,
       stdin: stdin as unknown as NodeJS.ReadStream,
@@ -359,6 +365,11 @@ const sleep = (ms: number): Promise<void> =>
     out.indexOf(EXIT_ALT_SCREEN) !== -1 && out.indexOf(EXIT_ALT_SCREEN) < out.indexOf(DISABLE_MOUSE_TRACKING))
   // An external (funnel-less) unmount must restore cooked mode itself.
   check('external unmount restores cooked mode (no funnel follows)', stdin.isRaw === false)
+  // ...and the App-level conclude must run even though React already nulled
+  // the ref during teardown: a leaked latched pump keeps draining a shared
+  // stdin in drain-only mode and starves the next mounted instance (#522 CI:
+  // verify-session-tree / verify-help-scroll remount-on-shared-stdin).
+  check('external unmount detaches the stdin readable pump', stdin.listenerCount('readable') === 0)
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/verify-exit-mouse-disable-order.tsx
+++ b/scripts/verify-exit-mouse-disable-order.tsx
@@ -1,0 +1,432 @@
+/**
+ * 退出回显窗口回归：finishExit 必须把 150ms settle 窗放在 raw mode 仍
+ * 持有时度过——先闩锁（beginShutdown：停掉一切输出生产者，但不恢复
+ * cooked），再经 stdout 队列 barrier 排空预排队字节，有序写
+ * DISABLE_MOUSE_TRACKING 与清理块，settle 后才在 finally 里
+ * concludeShutdown 恢复 cooked+echo。且退出写必须永不抛、永不乱序：
+ * 失败也不能跳过 cooked 恢复与 stdin 交接，barrier 超时也不能让
+ * direct-fd 写越过仍在排队的迟到字节。
+ *
+ * 症状：SSH 链路卡顿/写阻塞时触发退出（含"自动退出"），冻结的 TUI 画面
+ * 上、prompt 框里冒出 `^[[<35;130;47M` 之类 caret 记法的 SGR 鼠标报文
+ * ——内核 canonical+ECHOCTL 把终端仍在发送的鼠标报文回显在停泊光标处。
+ * writeSync 只证明字节进了内核 tty 缓冲，不代表远端终端已处理；若
+ * cooked 恢复先于 settle 窗结束，窗口内到达的报文就被回显（#522）。
+ *
+ * 场景蒸馏（无需真 tty / 慢链路）：
+ *   A. TTY 路径（fake stdout 持真实文件 fd，新形分相 runtime 携带自身
+ *      stdout 与 raw 状态）：闩锁先于 DISABLE 落盘；settle 窗在 raw 态
+ *      度过（drain 发生时 isRaw 仍为 true）；raw-off（conclude）时刻
+ *      DISABLE 已在盘且距入口 ≥140ms（旧实现 detach 立即 raw-off，≈0
+ *      必红）；事件序 begin→drain→conclude→handoff；两笔退出写全部走
+ *      writeSync（零异步 stream write）。
+ *   B. 无 fd 的 fake stdout（自定义 embedder / 回归替身）：回退有序
+ *      stream 写，顺序约束不变——begin 先于 DISABLE、DISABLE 先于
+ *      EXIT_ALT_SCREEN、字节完整、conclude/handoff/done 均执行。
+ *   C. 写入全灭（无效 fd + _write 抛错）且 concludeShutdown 抛错
+ *      （模拟 TTY 被撤销）：begin/conclude/handoff/done 仍全部被调用
+ *      ——handoff 不被 conclude 的异常跳过（/update 子进程不能撞上
+ *      残留 readable pump，#284/#307）。
+ *   D. stdout 队列 barrier（显式 Promise gate 挂起预排队的
+ *      ENABLE_MOUSE_TRACKING + 帧标记）：gate 未开前 DISABLE 绝不落盘
+ *      （无时序假设——DISABLE 只在 barrier 放行后写出）；最终字节流
+ *      ENABLE 在 DISABLE 前、帧标记在 EXIT_ALT_SCREEN 前，且
+ *      EXIT_ALT_SCREEN 之后的尾部无 ENABLE/帧。
+ *   E. barrier 超时（gate 1100ms 才开 > 1s 上限）：退出序列切换为有序
+ *      stream 写，跟在迟到 ENABLE/帧之后——最终字节序仍然
+ *      ENABLE→帧→DISABLE→EXIT_ALT_SCREEN，flush 等到全部落盘
+ *      （旧实现 barrier 超时后 writeSync 越过队列，ENABLE 落在
+ *      EXIT_ALT_SCREEN 之后）。
+ *   F. stdout identity drift：render handle 的 runtime 属于流 A，而
+ *      process.stdout 已被宿主换成流 B（B 还有挂起队列）——barrier 与
+ *      全部清理写必须作用于 A，B 零字节、零等待。
+ *
+ * Run: node --import tsx/esm scripts/verify-exit-mouse-disable-order.tsx
+ */
+import { closeSync, openSync, readFileSync, rmSync, writeSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Writable } from 'node:stream'
+import { finishExit } from '../src/dsh-adapter/plugin.js'
+import instances from '../src/ink/instances.js'
+import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, EXIT_ALT_SCREEN } from '../src/ink/termio/dec.js'
+
+let failures = 0
+const results: string[] = []
+const check = (name: string, ok: boolean, extra = ''): void => {
+  results.push(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures += 1
+}
+
+const ctx = { logger: { debug() {} } } as never
+const originalStdout = process.stdout
+const swapStdout = (stream: NodeJS.WriteStream): void => {
+  Object.defineProperty(process, 'stdout', {
+    value: stream,
+    configurable: true,
+    writable: true,
+    enumerable: true,
+  })
+}
+const tick = (): Promise<void> => new Promise(resolve => setImmediate(resolve))
+
+/** _write 挂起在显式 gate 上的流；gate 开后先补放存量，再即时落盘。 */
+class GatedFdStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  fd: number
+  gateOpen = false
+  held: Array<{ text: string; cb: () => void }> = []
+  constructor(fd: number) {
+    super()
+    this.fd = fd
+  }
+  _write(chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    const text = String(chunk)
+    if (this.gateOpen) {
+      writeSync(this.fd, text)
+      cb()
+      return
+    }
+    this.held.push({ text, cb })
+  }
+  release(): void {
+    this.gateOpen = true
+    for (const { text, cb } of this.held.splice(0)) {
+      writeSync(this.fd, text)
+      cb()
+    }
+  }
+}
+
+// ── Case A：TTY 路径（文件 fd + 新形分相 runtime + raw 状态跟踪）───────
+const traceFileA = join(tmpdir(), `dsh-tui-exit-order-a-${process.pid}.log`)
+const fdA = openSync(traceFileA, 'w')
+let asyncWritesA = 0
+class FdStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  fd: number = fdA
+  _write(_chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    asyncWritesA += 1
+    cb()
+  }
+}
+const stdoutA = new FdStdout() as unknown as NodeJS.WriteStream
+
+const eventsA: string[] = []
+let rawOffAtA = -1
+let isRawA = true
+let isRawAtDrainA: boolean | undefined
+let disableSeenAtBeginA: boolean | undefined
+let disableSeenAtConcludeA: boolean | undefined
+let unmountsA = 0
+instances.set(stdoutA, {
+  stdout: stdoutA,
+  beginShutdown() {
+    eventsA.push('begin')
+    // 闩锁必须先于 DISABLE 落盘：先停输出生产者，再写禁用序列。
+    disableSeenAtBeginA = readFileSync(traceFileA, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+  },
+  concludeShutdown() {
+    // raw-off 时刻：DISABLE 链必须已经在 fd 指向的文件里，且距入口已经
+    // 度过了整个 settle 窗（旧实现 detach 立即 raw-off，rawOffAt≈0）。
+    eventsA.push('conclude')
+    rawOffAtA = Date.now()
+    isRawA = false
+    disableSeenAtConcludeA = readFileSync(traceFileA, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+  },
+  detachStdinForHandoff() { eventsA.push('handoff') },
+  drainStdin() {
+    eventsA.push('drain')
+    // settle 窗在 raw 态度过的直接证据：drain 发生时 cooked 尚未恢复。
+    isRawAtDrainA = isRawA
+  },
+} as never)
+
+swapStdout(stdoutA)
+const t0A = Date.now()
+let doneA = false
+await finishExit(
+  ctx,
+  { unmount() { unmountsA += 1 } } as never,
+  true,
+  'hint-order',
+  undefined,
+  () => { doneA = true },
+)
+swapStdout(originalStdout)
+instances.delete(stdoutA)
+closeSync(fdA)
+
+const traceA = readFileSync(traceFileA, 'utf8')
+rmSync(traceFileA, { force: true })
+check('A: 闩锁先于 DISABLE 落盘（begin 时文件尚无 DISABLE）', disableSeenAtBeginA === false)
+check('A: settle 窗在 raw 态度过（drain 时 isRaw 仍为 true）', isRawAtDrainA === true)
+check('A: raw-off 时 DISABLE 已落盘', disableSeenAtConcludeA === true)
+check('A: raw-off 距入口 ≥140ms（settle 窗完整）',
+  rawOffAtA >= 0 && rawOffAtA - t0A >= 140,
+  rawOffAtA >= 0 ? `rawOffAt-t0=${rawOffAtA - t0A}ms` : 'conclude 未被调用')
+check('A: 退出写全部走同步 fd 路径（零异步 stream write）', asyncWritesA === 0,
+  asyncWritesA > 0 ? `异步写 ${asyncWritesA} 次` : '')
+check('A: 清理块完整（EXIT_ALT_SCREEN + notice）', traceA.includes(EXIT_ALT_SCREEN) && traceA.includes('hint-order'))
+check('A: 事件序 begin→drain→conclude→handoff，done 执行，不走 unmount 兜底',
+  eventsA.join(',') === 'begin,drain,conclude,handoff' && doneA && unmountsA === 0,
+  `事件序: ${eventsA.join(',') || '(空)'}`)
+
+// ── Case B：无 fd 回退（有序 stream 写，顺序约束不变）──────────────────
+const eventsB: string[] = []
+const chunksB: string[] = []
+class CapturingStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  _write(chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    const text = String(chunk)
+    chunksB.push(text)
+    if (text.includes(DISABLE_MOUSE_TRACKING)) eventsB.push('disable')
+    if (text.includes(EXIT_ALT_SCREEN)) eventsB.push('exit-alt')
+    cb()
+  }
+}
+const stdoutB = new CapturingStdout() as unknown as NodeJS.WriteStream
+instances.set(stdoutB, {
+  stdout: stdoutB,
+  beginShutdown() { eventsB.push('begin') },
+  concludeShutdown() { eventsB.push('conclude') },
+  detachStdinForHandoff() { eventsB.push('handoff') },
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutB)
+let doneB = false
+await finishExit(
+  ctx,
+  { unmount() {} } as never,
+  // fullscreen=true：清理块带 EXIT_ALT_SCREEN，顺序断言才覆盖两笔写的先后。
+  true,
+  'hint-fallback',
+  undefined,
+  () => { doneB = true },
+)
+swapStdout(originalStdout)
+instances.delete(stdoutB)
+
+const joinedB = chunksB.join('')
+const seqB = eventsB.join(',')
+check('B: 回退路径事件序 begin→disable→exit-alt→conclude→handoff',
+  seqB === 'begin,disable,exit-alt,conclude,handoff', `事件序: ${seqB || '(空)'}`)
+check('B: 回退路径字节完整（DISABLE + notice），done 执行',
+  joinedB.includes(DISABLE_MOUSE_TRACKING) && joinedB.includes('hint-fallback') && doneB)
+
+// ── Case C：写入全灭 + conclude 抛错，handoff/done 仍必执行 ───────────
+const eventsC: string[] = []
+class ThrowingStdout extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  // 无效 fd：writeSync 必抛 EBADF → 落入有序 stream 路径；_write 再抛——
+  // 两条写入路径全灭，finishExit 仍必须走完 conclude/handoff/done。
+  fd = 9999
+  _write(_chunk: unknown, _enc: BufferEncoding, _cb: () => void): void {
+    throw new Error('simulated stream write failure')
+  }
+}
+const stdoutC = new ThrowingStdout() as unknown as NodeJS.WriteStream
+instances.set(stdoutC, {
+  stdout: stdoutC,
+  beginShutdown() { eventsC.push('begin') },
+  concludeShutdown() {
+    eventsC.push('conclude')
+    // TTY 被撤销：raw-off 的 handleSetRawMode 写入抛错——不得跳过 handoff。
+    throw new Error('simulated revoked tty')
+  },
+  detachStdinForHandoff() { eventsC.push('handoff') },
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutC)
+let doneC = false
+let threwC = false
+try {
+  await finishExit(
+    ctx,
+    { unmount() {} } as never,
+    false,
+    'hint-throw',
+    undefined,
+    () => { doneC = true },
+  )
+} catch {
+  threwC = true
+}
+swapStdout(originalStdout)
+instances.delete(stdoutC)
+
+check('C: 写入失败被吞（finishExit 正常 resolve）', !threwC)
+check('C: 写入全灭 + conclude 抛错仍调用 begin/conclude/handoff/done',
+  eventsC.join(',') === 'begin,conclude,handoff' && doneC,
+  `事件序: ${eventsC.join(',') || '(空)'}, done=${doneC}`)
+
+// ── Case D：barrier（Promise gate 挂起预排队 ENABLE+帧，无时序假设）────
+const traceFileD = join(tmpdir(), `dsh-tui-exit-order-d-${process.pid}.log`)
+const fdD = openSync(traceFileD, 'w')
+const FRAME_MARKER = 'QUEUED-FRAME-MARKER'
+const stdoutD = new GatedFdStdout(fdD) as unknown as NodeJS.WriteStream
+let disableSeenAtConcludeD: boolean | undefined
+instances.set(stdoutD, {
+  stdout: stdoutD,
+  beginShutdown() {},
+  concludeShutdown() {
+    disableSeenAtConcludeD = readFileSync(traceFileD, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+  },
+  detachStdinForHandoff() {},
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutD)
+// 闩锁前排入：一笔 ENABLE（自愈探针的最后一笔）+ 一帧渲染。
+stdoutD.write(ENABLE_MOUSE_TRACKING)
+stdoutD.write(FRAME_MARKER)
+let doneD = false
+const finishD = finishExit(
+  ctx,
+  { unmount() {} } as never,
+  true,
+  'hint-barrier',
+  undefined,
+  () => { doneD = true },
+)
+// 让 finishExit 进入 barrier 等待（latch 同步完成、poll 定时器已排上）；
+// 此处无 wall-clock 假设：DISABLE 只在 barrier 放行后写出，gate 未开时
+// 无论调度快慢它都不可能在盘。
+await tick()
+await tick()
+const disableBeforeGateD = readFileSync(traceFileD, 'utf8').includes(DISABLE_MOUSE_TRACKING)
+;(stdoutD as unknown as GatedFdStdout).release()
+await finishD
+swapStdout(originalStdout)
+instances.delete(stdoutD)
+closeSync(fdD)
+
+const traceD = readFileSync(traceFileD, 'utf8')
+rmSync(traceFileD, { force: true })
+const idxEnableD = traceD.indexOf(ENABLE_MOUSE_TRACKING)
+const idxDisableD = traceD.indexOf(DISABLE_MOUSE_TRACKING)
+const idxExitAltD = traceD.indexOf(EXIT_ALT_SCREEN)
+const tailD = idxExitAltD === -1 ? '' : traceD.slice(idxExitAltD)
+check('D: barrier 等待队列排空（gate 未开时 DISABLE 未落盘）', !disableBeforeGateD)
+check('D: 预排队 ENABLE 落在 DISABLE 之前（最终鼠标态是 DISABLE）',
+  idxEnableD !== -1 && idxDisableD !== -1 && idxEnableD < idxDisableD,
+  `enable@${idxEnableD}, disable@${idxDisableD}`)
+check('D: 预排队帧落在 EXIT_ALT_SCREEN 之前，且尾部无 ENABLE/帧（主屏零污染）',
+  traceD.includes(FRAME_MARKER) && traceD.indexOf(FRAME_MARKER) < idxExitAltD
+  && !tailD.includes(ENABLE_MOUSE_TRACKING) && !tailD.includes(FRAME_MARKER))
+check('D: raw-off 时 DISABLE 已落盘，done 执行', disableSeenAtConcludeD === true && doneD)
+
+// ── Case E：barrier 超时（gate 1100ms 才开）→ 有序 stream 写保序 ──────
+const traceFileE = join(tmpdir(), `dsh-tui-exit-order-e-${process.pid}.log`)
+const fdE = openSync(traceFileE, 'w')
+const stdoutE = new GatedFdStdout(fdE) as unknown as NodeJS.WriteStream
+instances.set(stdoutE, {
+  stdout: stdoutE,
+  beginShutdown() {},
+  concludeShutdown() {},
+  detachStdinForHandoff() {},
+  drainStdin() {},
+} as never)
+
+swapStdout(stdoutE)
+stdoutE.write(ENABLE_MOUSE_TRACKING)
+stdoutE.write(FRAME_MARKER)
+// gate 在 barrier 1s 上限之后才开：barrier 必超时，退出序列必须切到有序
+// stream 路径跟在迟到字节之后，而不是 writeSync 越过队列。
+const gateTimerE = setTimeout(() => (stdoutE as unknown as GatedFdStdout).release(), 1100)
+const t0E = Date.now()
+let doneE = false
+await finishExit(
+  ctx,
+  { unmount() {} } as never,
+  true,
+  'hint-timeout',
+  undefined,
+  () => { doneE = true },
+)
+clearTimeout(gateTimerE)
+swapStdout(originalStdout)
+instances.delete(stdoutE)
+closeSync(fdE)
+const elapsedE = Date.now() - t0E
+
+const traceE = readFileSync(traceFileE, 'utf8')
+rmSync(traceFileE, { force: true })
+const idxEnableE = traceE.indexOf(ENABLE_MOUSE_TRACKING)
+const idxFrameE = traceE.indexOf(FRAME_MARKER)
+const idxDisableE = traceE.indexOf(DISABLE_MOUSE_TRACKING)
+const idxExitAltE = traceE.indexOf(EXIT_ALT_SCREEN)
+const tailE = idxExitAltE === -1 ? '' : traceE.slice(idxExitAltE)
+check('E: barrier 超时后走有序 stream 路径（耗时 ≥1s 上限）', elapsedE >= 1000, `elapsed=${elapsedE}ms`)
+check('E: 迟到 ENABLE/帧仍落在 DISABLE 之前（保序，无交错）',
+  idxEnableE !== -1 && idxFrameE !== -1 && idxDisableE !== -1
+  && idxEnableE < idxDisableE && idxFrameE < idxDisableE,
+  `enable@${idxEnableE}, frame@${idxFrameE}, disable@${idxDisableE}`)
+check('E: EXIT_ALT_SCREEN 完整落盘且尾部无 ENABLE/帧',
+  idxExitAltE !== -1 && idxExitAltE > idxDisableE
+  && !tailE.includes(ENABLE_MOUSE_TRACKING) && !tailE.includes(FRAME_MARKER))
+check('E: flush 等到全部字节落盘，done 执行', traceE.includes('hint-timeout') && doneE)
+
+// ── Case F：stdout identity drift（runtime 属流 A，process.stdout 是 B）─
+const traceFileFA = join(tmpdir(), `dsh-tui-exit-order-fa-${process.pid}.log`)
+const traceFileFB = join(tmpdir(), `dsh-tui-exit-order-fb-${process.pid}.log`)
+const fdFA = openSync(traceFileFA, 'w')
+const fdFB = openSync(traceFileFB, 'w')
+const streamFA = new GatedFdStdout(fdFA) as unknown as NodeJS.WriteStream
+streamFA.release() // A 队列畅通
+const streamFB = new GatedFdStdout(fdFB) as unknown as NodeJS.WriteStream
+// B 挂着一笔永远不放行的写：若 barrier 错轮询 B，finishExit 会白等 1s。
+streamFB.write('WEDGED-ON-B')
+const eventsF: string[] = []
+instances.set(streamFA, {
+  stdout: streamFA,
+  beginShutdown() { eventsF.push('begin') },
+  concludeShutdown() { eventsF.push('conclude') },
+  detachStdinForHandoff() { eventsF.push('handoff') },
+  drainStdin() {},
+} as never)
+
+swapStdout(streamFB)
+const t0F = Date.now()
+let doneF = false
+await finishExit(
+  ctx,
+  // render handle 即 runtime 的载体（instances map 按 B 查找必 miss）。
+  instances.get(streamFA) as never,
+  true,
+  'hint-drift',
+  undefined,
+  () => { doneF = true },
+)
+const elapsedF = Date.now() - t0F
+swapStdout(originalStdout)
+instances.delete(streamFA)
+;(streamFB as unknown as GatedFdStdout).release()
+closeSync(fdFA)
+closeSync(fdFB)
+
+const traceFA = readFileSync(traceFileFA, 'utf8')
+const traceFB = readFileSync(traceFileFB, 'utf8')
+rmSync(traceFileFA, { force: true })
+rmSync(traceFileFB, { force: true })
+check('F: 清理写作用于 runtime 所属流 A（DISABLE/EXIT_ALT/notice 齐全）',
+  traceFA.includes(DISABLE_MOUSE_TRACKING) && traceFA.includes(EXIT_ALT_SCREEN) && traceFA.includes('hint-drift'))
+check('F: 替换后的 process.stdout（B）零退出字节', !traceFB.includes(DISABLE_MOUSE_TRACKING) && !traceFB.includes(EXIT_ALT_SCREEN),
+  traceFB.length > 0 ? `B 收到 ${traceFB.length} 字节` : '')
+check('F: barrier 不错等 B 的挂起队列（无 1s 白等）', elapsedF < 900, `elapsed=${elapsedF}ms`)
+check('F: 事件序 begin→conclude→handoff，done 执行',
+  eventsF.join(',') === 'begin,conclude,handoff' && doneF, `事件序: ${eventsF.join(',') || '(空)'}`)
+
+console.log(results.join('\n'))
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURES`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify-exit-mouse-residue.tsx
+++ b/scripts/verify-exit-mouse-residue.tsx
@@ -6,30 +6,46 @@
  * 残留 = 退出清理（DISABLE_MOUSE_TRACKING）之后仍有任何代码写出 ENABLE。
  *
  * 场景蒸馏（无需时序竞态）：
- *   1. 挂载 AlternateScreen（altScreenActive=true，mouseTracking=true——
- *      probe 的全部前置条件就位）；
- *   2. 模拟退出漏斗 finishExit 的同序两步：detachForShutdown()（置
- *      isUnmounted）→ 写出 DISABLE_MOUSE_TRACKING；
- *   3. 过 250ms 节流窗后调 probeAltScreenHealth()——对应退出前窗口期
- *      （writeStream 1s + disposeRootAndThen 5s 兜底）内任何按键/鼠标
- *      输入触发的健康探针；
- *   4. 断言：清理序列之后不得再出现任何鼠标 ENABLE（?1000h/1002h/1003h/
- *      1006h）。未修复的 probe 不检查 isUnmounted，每次必红。
+ *   1. 挂载 AlternateScreen + Probe（altScreenActive=true、mouseTracking=
+ *      true——probe 的全部前置条件就位；Probe 消费 useInput 与
+ *      TerminalWriteContext，与 PromptInput 的异步 OSC 52 clipboard 回调
+ *      持有的是同一支 writeRaw）；
+ *   2. 先证明输入派发管线已接线（闩锁前注入 'a' 必被 useInput 收到）；
+ *   3. 模拟退出漏斗 finishExit 的同序两步：beginShutdown()（置
+ *      isUnmounted 闩锁、停输出生产者，raw mode 仍持有）→ 写出
+ *      DISABLE_MOUSE_TRACKING（cooked 恢复属于最后的 concludeShutdown）；
+ *   4. 闩锁后断言核心契约：isRaw 仍为 true（settle 窗在 raw 态度过）、
+ *      注入输入只 drain 不派发、经 context 的 writeRaw 零字节落盘；
+ *   5. 过 250ms 节流窗后调 probeAltScreenHealth()——对应退出前窗口期
+ *      （settle 窗 + disposeRootAndThen 5s 兜底）内任何按键/鼠标
+ *      输入触发的健康探针；断言清理序列之后不得再出现任何鼠标 ENABLE
+ *      （?1000h/1002h/1003h/1006h）。未修复的 probe 不检查 isUnmounted，
+ *      每次必红；
+ *   6. concludeShutdown() 之后断言 isRaw === false（cooked 恢复才在
+ *      finally 里发生）。
  *
  * Run: node --import tsx/esm scripts/verify-exit-mouse-residue.tsx
  */
 process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen, Text }, { default: instances }, { TerminalQuerier, decrqm }] =
-  await Promise.all([
-    import('node:stream'),
-    import('react'),
-    import('@xterm/headless'),
-    import('../src/ui.js'),
-    import('../src/ink/instances.js'),
-    import('../src/ink/terminal-querier.js'),
-  ])
+const [
+  { PassThrough, Writable },
+  React,
+  { Terminal: XTerm },
+  { render, useInput, AlternateScreen, Text },
+  { default: instances },
+  { TerminalQuerier, decrqm },
+  { TerminalWriteContext },
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/ink/instances.js'),
+  import('../src/ink/terminal-querier.js'),
+  import('../src/ink/useTerminalNotification.js'),
+])
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -58,7 +74,11 @@ class FakeStdout extends Writable {
 }
 class FakeStdin extends PassThrough {
   isTTY = true
-  setRawMode(): this { return this }
+  isRaw = false
+  setRawMode(value: boolean): this {
+    this.isRaw = value
+    return this
+  }
   ref(): this { return this }
   unref(): this { return this }
 }
@@ -69,9 +89,21 @@ const flush = (): Promise<void> => lastFlushed
 const MOUSE_ENABLE = /\x1b\[\?100[0236]h/
 const MOUSE_DISABLE = /\x1b\[\?100[0236]l/
 
+// ── Probe：useInput 记录派发到的输入；经 TerminalWriteContext 捕获
+// writeRaw——即 PromptInput 异步 OSC 52 clipboard 回调持有的同一支
+// （ink.tsx 以 Ink.writeRaw 为 provider 值，闩锁门在那里）。
+const received: string[] = []
+let rawWriter: ((data: string) => void) | null = null
+const Probe = (): React.ReactElement => {
+  useInput(input => { received.push(input) })
+  const writeRaw = React.useContext(TerminalWriteContext)
+  React.useEffect(() => { rawWriter = writeRaw }, [writeRaw])
+  return <Text>exit-residue probe</Text>
+}
+
 await render(
   <AlternateScreen>
-    <Text>exit-residue probe</Text>
+    <Probe />
   </AlternateScreen>,
   { stdout, stdin, stderr: stdout, exitOnCtrlC: false, patchConsole: false },
 )
@@ -79,6 +111,9 @@ await render(
 /** 三条防线的最小驱动面（避免 as any，按仓库 unknown 收窄惯例）。 */
 type InkDriver = {
   detachForShutdown(): void
+  /** 退出分相：begin = 闩锁+停生产者（raw 仍持有）；conclude = raw-off。 */
+  beginShutdown(): void
+  concludeShutdown(): void
   probeAltScreenHealth(): void
   reassertTerminalModes(includeAltScreen?: boolean): void
   app?: { querier?: TerminalQuerier }
@@ -89,16 +124,34 @@ if (!ink) process.exit(1)
 await flush()
 await sleep(50)
 
-// ── 模拟退出漏斗 finishExit（src/dsh-adapter/plugin.ts）：先 detach（置
-// isUnmounted），cleanup 序列随后写出——与真实退出同序。detach 置位后，
-// 窗口期一切终端写入都不应再发生。
-ink.detachForShutdown()
+// ── 前置证据：闩锁前输入派发管线已接线（否则闩锁后的"不派发"断言无意义）。
+stdin.write('a')
+await sleep(30)
+check('闩锁前 useInput 正常派发（管线已接线）', received.join('') === 'a',
+  `received: ${JSON.stringify(received)}`)
+check('挂载后 stdin 处于 raw mode（useInput 的 layout effect 已生效）', stdin.isRaw === true)
+
+// ── 模拟退出漏斗 finishExit（src/dsh-adapter/plugin.ts）：先 beginShutdown
+// 闩锁（置 isUnmounted、停输出生产者，raw mode 仍持有），cleanup 序列在
+// raw 态下写出——与真实退出同序；cooked 恢复是最后的 concludeShutdown。
+ink.beginShutdown()
+check('beginShutdown 之后 raw mode 仍持有（settle 窗的前提）', stdin.isRaw === true)
 stdout.write('\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l')
 await flush()
 
 const cut = bytes.length
 const cleanupTail = bytes.slice(0, cut).join('')
 check('退出清理序列已写出（DISABLE 到达终端）', MOUSE_DISABLE.test(cleanupTail))
+
+// ── 闩锁后的写入/输入闸门（settle 窗内不得有任何字节再落盘）：
+//   · 注入按键与 SGR 鼠标报文——handleReadable 闩锁后只 drain 不派发，
+//     useInput 不得再收到（否则会触发新的 clipboard/探针动作）；
+//   · 经 context 拿到的 writeRaw 写 OSC 52——Ink.writeRaw 的闩锁门必须
+//     丢弃它（模拟 PromptInput copySelectionNoClear 的异步回调迟到）。
+stdin.write('b')
+stdin.write('\x1b[<35;1;1M')
+rawWriter?.('\x1b]52;c;QUJDRA==\x07')
+await sleep(30)
 
 // ── 250ms 节流窗过去，退出前窗口期的输入派发触发健康探针。
 await sleep(300)
@@ -107,6 +160,10 @@ await flush()
 await sleep(50)
 
 const tail = bytes.slice(cut).join('')
+check('闩锁后输入只 drain 不派发（useInput 零新增）', received.join('') === 'a',
+  received.length > 1 ? `多收到: ${JSON.stringify(received.slice(1))}` : '')
+check('闩锁后 writeRaw 零字节（OSC 52 迟到回调被门丢弃）', !tail.includes('\x1b]52'),
+  tail.includes('\x1b]52') ? `泄漏: ${JSON.stringify(tail.slice(0, 40))}` : '')
 check('清理之后无任何鼠标 ENABLE 残留（probe 尊重 isUnmounted）', !MOUSE_ENABLE.test(tail),
   tail.match(MOUSE_ENABLE) ? `残留序列: ${JSON.stringify(tail.match(MOUSE_ENABLE))}` : '')
 
@@ -122,8 +179,8 @@ check('退出后 reassertTerminalModes 零字节写出（kitty keyboard 不重�
 
 // ── 第三刀防线：dispose 之后的 querier 不得再发查询、不得再拉回 raw mode
 // （#507 的 DECRPM/DA1 回复泄漏 shell + ?2004h raw mode 重开）。
-// detach 链（ink → App.detachForShutdown）已 dispose querier；绕过 probe
-// 直接打 querier，模拟退出窗口期任何残余调用方。
+// beginShutdown 链（ink → App.beginShutdown）已 dispose querier；绕过
+// probe 直接打 querier，模拟退出窗口期任何残余调用方。
 const cut3 = bytes.length
 const querier: TerminalQuerier | undefined = ink.app?.querier
 check('querier 存在且已被 detach 链持有', querier !== undefined)
@@ -137,6 +194,10 @@ if (querier) {
   check('dispose 后 querier 零查询字节 / 不拉回 raw mode', !QUERY_BYTES.test(tail3),
     tail3 ? `写出了 ${JSON.stringify(tail3.slice(0, 40))}` : '')
 }
+
+// ── 收尾：cooked 恢复/末次 drain（真实漏斗在 settle 窗之后的 finally 里做）。
+ink.concludeShutdown()
+check('concludeShutdown 之后 raw mode 已释放（cooked 恢复）', stdin.isRaw === false)
 
 console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILURES`)
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-exit-runtime-selection.tsx
+++ b/scripts/verify-exit-runtime-selection.tsx
@@ -1,0 +1,123 @@
+/**
+ * Runtime-selection regression for finishExit (PR #701 integration review):
+ * the explicitly passed render handle is the runtime THIS exit call
+ * corresponds to and must WIN over the instances-map lookup. The previous
+ * map-first order (`instances.get(process.stdout) ?? handle`) could latch the
+ * WRONG runtime when two runtimes exist (multi-instance embedder) or when
+ * process.stdout identity drifted after render: finishExit(..., instanceA)
+ * would begin/conclude runtime B and write B's terminal cleanup while A —
+ * the runtime actually exiting — kept its stdin pump, TTY handlers and mouse
+ * state, and A's own stream never received the cleanup bytes.
+ *
+ * Scenario (from the integration review):
+ *   - runtime A renders to stdout A, runtime B renders to stdout B
+ *   - process.stdout (and therefore the instances lookup) points at B
+ *   - finishExit(..., instanceA, ...) runs
+ *   - ONLY A may be begun/concluded; cleanup bytes land ONLY on stdout A;
+ *     B must not be latched and must receive no terminal cleanup.
+ */
+import { Writable } from 'node:stream'
+import { finishExit } from '../src/dsh-adapter/plugin.js'
+import instances from '../src/ink/instances.js'
+
+let failures = 0
+const results: string[] = []
+const check = (name: string, ok: boolean) => {
+  results.push(`${ok ? 'PASS' : 'FAIL'}: ${name}`)
+  if (!ok) failures++
+}
+
+class CapturingStream extends Writable {
+  isTTY = true
+  columns = 80
+  rows = 24
+  chunks: string[] = []
+  _write(chunk: unknown, _enc: BufferEncoding, cb: () => void): void {
+    this.chunks.push(String(chunk))
+    cb()
+  }
+}
+
+const originalStdout = process.stdout
+const swapStdout = (stream: NodeJS.WriteStream): void => {
+  Object.defineProperty(process, 'stdout', {
+    value: stream,
+    configurable: true,
+    writable: true,
+    enumerable: true,
+  })
+}
+const ctx = { logger: { debug() {} } } as never
+
+interface FakeRuntimeEvents {
+  stream: CapturingStream
+  events: string[]
+  handle: Record<string, unknown>
+}
+
+const makeRuntime = (name: string): FakeRuntimeEvents => {
+  const stream = new CapturingStream()
+  const events: string[] = []
+  const stdout = stream as unknown as NodeJS.WriteStream
+  const runtime = {
+    stdout,
+    beginShutdown() { events.push(`${name}:begin`) },
+    concludeShutdown() { events.push(`${name}:conclude`) },
+    detachStdinForHandoff() { events.push(`${name}:handoff`) },
+    drainStdin() { events.push(`${name}:drain`) },
+  }
+  instances.set(stdout, runtime as never)
+  return {
+    stream,
+    events,
+    // The render() handle callers pass: exposes the shutdown hooks, exactly
+    // like the Instance returned by root.renderSync.
+    handle: runtime as unknown as Record<string, unknown>,
+  }
+}
+
+const runtimeA = makeRuntime('A')
+const runtimeB = makeRuntime('B')
+
+// The instances lookup (keyed by process.stdout) resolves to B — the drift
+// scenario: the host swapped process.stdout, or a second runtime mounted on
+// the process stream after A rendered to its own custom stdout.
+swapStdout(runtimeB.stream as unknown as NodeJS.WriteStream)
+
+let doneCalls = 0
+await finishExit(
+  ctx,
+  runtimeA.handle as never,
+  false,
+  'exit-notice',
+  undefined,
+  () => { doneCalls += 1 },
+)
+swapStdout(originalStdout)
+instances.delete(runtimeA.stream as unknown as NodeJS.WriteStream)
+instances.delete(runtimeB.stream as unknown as NodeJS.WriteStream)
+
+const cleanupOnA = runtimeA.stream.chunks.join('')
+const cleanupOnB = runtimeB.stream.chunks.join('')
+
+check('handle-first: runtime A is the one begun/concluded/handed off',
+  runtimeA.events.join(',') === 'A:begin,A:drain,A:conclude,A:handoff')
+check('handle-first: runtime B is never latched', runtimeB.events.length === 0)
+check('handle-first: terminal cleanup bytes land on stdout A only',
+  cleanupOnA.includes('\x1b[?1000l') && cleanupOnA.includes('exit-notice'))
+check('handle-first: stdout B receives no terminal cleanup', cleanupOnB === '')
+check('handle-first: done() fires exactly once for the winning exit', doneCalls === 1)
+
+// Map fallback still works when NO handle is passed (or the handle carries no
+// Ink hooks): the instances lookup must serve the runtime.
+const runtimeC = makeRuntime('C')
+swapStdout(runtimeC.stream as unknown as NodeJS.WriteStream)
+let doneC = false
+await finishExit(ctx, undefined, false, 'map-fallback', undefined, () => { doneC = true })
+swapStdout(originalStdout)
+instances.delete(runtimeC.stream as unknown as NodeJS.WriteStream)
+check('map fallback: runtime resolved from instances when no handle given',
+  runtimeC.events.join(',') === 'C:begin,C:drain,C:conclude,C:handoff' && doneC)
+
+console.log(results.join('\n'))
+if (failures > 0) process.exit(1)

--- a/scripts/verify-format-when-boundary.ts
+++ b/scripts/verify-format-when-boundary.ts
@@ -1,0 +1,105 @@
+/**
+ * verify-format-when-boundary — deterministic boundary tests for
+ * nextFormatWhenChange (the AgentView idle-wake scheduler, #713 integration
+ * review blocker 6).
+ *
+ * formatWhen's nested rounding (`seconds = round(ageMs/1000)`,
+ * `minutes = round(seconds/60)`, `hours = round(minutes/60)`,
+ * `days = round(hours/24)`) makes the true label boundaries anything but
+ * the naive half-minute/half-hour marks. nextFormatWhenChange computes the
+ * next change with formatWhen itself as the oracle; these tests pin the
+ * exact instants and the flip exactness:
+ *
+ *   T1  now → minutes:  flips at age 44.5s (round(seconds)=45);
+ *   T2  mid-minute:     "5m" flips to "6m" at age 5m29.5s (seconds=330);
+ *   T3  minutes → hours: "59m" flips to "1h" at age 59m29.5s (minutes=60);
+ *   T4  hours → days:   "23h" flips to "1d" at age 23h29.5m (hours=24);
+ *   T5  day 7 → absolute date: flips at ~7.47 days (hours=180 → days=8);
+ *   T6  absolute-date regime: Infinity (no further wake, ever);
+ *   T7  flip exactness: formatWhen differs at the boundary and is identical
+ *       one millisecond before, for every case above.
+ *
+ * Run: node --import tsx/esm scripts/verify-format-when-boundary.ts
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const { formatWhen, nextFormatWhenChange } = await import('../src/sessions/format.js')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const AT = 1_700_000_000_000
+const sec = (s: number): number => Math.round(s * 1000)
+
+// T1: "now" flips to minutes when round(age/1000) hits 45 → age 44.5s.
+{
+  const now = AT + sec(40)
+  const next = nextFormatWhenChange(AT, now)
+  check('T1: now→minutes boundary at age 44.5s', next === AT + sec(44.5), `next-age=${next - AT}ms`)
+}
+
+// T2: mid-minute label "5m" → "6m" when seconds reach 330 → age 329.5s.
+{
+  const now = AT + sec(320) // label: round(320/60)=5 → "5m"
+  const next = nextFormatWhenChange(AT, now)
+  check('T2: minute label flips at seconds=330 (age 329.5s)', next === AT + sec(329.5), `next-age=${next - AT}ms`)
+}
+
+// T3: minutes → hours: minutes=60 at seconds=3570 → age 3569.5s shows "1h".
+{
+  const now = AT + sec(3560) // seconds=3560 → minutes=round(59.33)=59 → "59m"
+  const next = nextFormatWhenChange(AT, now)
+  check('T3: minutes→hours flip at age 59m29.5s', next === AT + sec(3569.5), `next-age=${next - AT}ms`)
+}
+
+// T4: hours → days: hours=24 when minutes=1410 → seconds=84570 → age 84569.5s.
+{
+  const now = AT + sec(84_000) // seconds=84000 → minutes=1400 → hours=round(23.33)=23 → "23h"
+  const next = nextFormatWhenChange(AT, now)
+  check('T4: hours→days flip at age 23h29m29.5s', next === AT + sec(84_569.5), `next-age=${next - AT}ms`)
+}
+
+// T5: day 7 → absolute date: days=8 when hours=180 → minutes=10770 →
+// seconds=646170 → age 646169.5s (~7.47 days).
+{
+  const now = AT + 7.4 * 24 * 60 * 60 * 1000 // ~7.4 days → days=round(7.4*24/24)... label "7d"
+  const next = nextFormatWhenChange(AT, now)
+  check('T5: day-7 label flips to absolute date at ~7.47 days', next === AT + sec(646_169.5), `next-age=${next - AT}ms`)
+}
+
+// T6: absolute-date regime never wakes again.
+{
+  const now = AT + 10 * 24 * 60 * 60 * 1000
+  const next = nextFormatWhenChange(AT, now)
+  check('T6: absolute-date label schedules no further wake (Infinity)', next === Infinity, `next=${next}`)
+  // And it stays Infinity however far out we ask.
+  const far = nextFormatWhenChange(AT, now + 365 * 24 * 60 * 60 * 1000)
+  check('T6b: Infinity persists a year later', far === Infinity, `next=${far}`)
+}
+
+// T7: flip exactness — the label differs exactly AT the computed boundary
+// and is identical one millisecond before (all finite cases above).
+{
+  const cases: Array<[label: string, ageAtAsk: number]> = [
+    ['T1', 40],
+    ['T2', 320],
+    ['T3', 3560],
+    ['T4', 84_000],
+    ['T5', 7.4 * 24 * 3600],
+  ]
+  for (const [label, ageS] of cases) {
+    const now = AT + sec(ageS)
+    const next = nextFormatWhenChange(AT, now)
+    const before = formatWhen(AT, next - 1)
+    const at = formatWhen(AT, next)
+    check(`T7 ${label}: label differs at the boundary and not 1ms before`,
+      before === formatWhen(AT, now) && at !== before,
+      `before="${before}" at="${at}"`)
+  }
+}
+
+console.log(failed === 0 ? 'verify-format-when-boundary: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-goal-todo-baseline.tsx
+++ b/scripts/verify-goal-todo-baseline.tsx
@@ -1,5 +1,5 @@
 /**
- * verify-goal-todo-baseline 鈥?GoalTodoPanel elapsed-baseline regression
+ * verify-goal-todo-baseline — GoalTodoPanel elapsed-baseline regression
  * (#713 integration review blocker 5).
  *
  * The elapsed clock's baseline (startRef) may only move in COMMITTED
@@ -10,7 +10,7 @@
  *   1. active: elapsed advances (label grows);
  *   2. paused: elapsed frozen AND no animation timer;
  *   3. paused 鈫?active resume: elapsed RE-BASES at the committed transition
- *      (label restarts near 0s 鈥?a stale baseline would show the
+ *      (label restarts near 0s — a stale baseline would show the
  *      accumulated total);
  *   4. a new goal id: fresh baseline from its own commit.
  *
@@ -151,7 +151,7 @@ const goalOf = (id: string, phase: 'active' | 'paused' | 'complete') => ({
   await sleep(2200)
   const later = h.elapsedLabel()
   check('1: active goal elapsed advances', later !== '' && later !== early, `early=${early} later=${later}`)
-  check('1: active baseline started near mount (early reading is small)', /^([0-2]s)$/.test(early), `early=${early}`)
+  check('1: active baseline started near mount (early reading is small)', /^([0-4]s)$/.test(early), `early=${early}`)
 
   // 2. paused: frozen + no timer.
   const beforePause = h.elapsedLabel()
@@ -166,8 +166,9 @@ const goalOf = (id: string, phase: 'active' | 'paused' | 'complete') => ({
   check('2: paused goal freezes the elapsed label', afterPause === settledLabel && afterPause === beforePause, `before=${beforePause} after=${afterPause}`)
   check('2: paused goal holds no animation timer', pausedFrames === 0, `frames=${pausedFrames}`)
 
-  // 3. resume: re-base at the COMMITTED transition 鈥?the label must restart
-  // near 0s, not continue from the pre-pause accumulated total.
+  // 3. resume: re-base at the COMMITTED transition — the label must restart
+  // near 0s, not continue from the pre-pause accumulated total (a stale
+  // baseline would read ~5-7s here; the bound stays far below that).
   const pausedFor = 2200
   h.channel.goal = goalOf('g1', 'active')
   h.emit()
@@ -181,7 +182,7 @@ const goalOf = (id: string, phase: 'active' | 'paused' | 'complete') => ({
   }
   check(
     '3: resume re-bases the clock at the committed transition',
-    resumed !== '' && parseMs(resumed) <= 1000 + pausedFor * 0 + 1000,
+    resumed !== '' && parseMs(resumed) <= 2600,
     `resumed=${resumed} (pre-pause label was ${beforePause})`,
   )
   void pausedFor
@@ -192,7 +193,7 @@ const goalOf = (id: string, phase: 'active' | 'paused' | 'complete') => ({
   h.emit()
   await sleep(300)
   const fresh = h.elapsedLabel()
-  check('4: new goal id restarts the baseline', /^([0-1]s)$/.test(fresh), `fresh=${fresh}`)
+  check('4: new goal id restarts the baseline', /^([0-3]s)$/.test(fresh), `fresh=${fresh}`)
 
   h.unmount()
 }

--- a/scripts/verify-goal-todo-baseline.tsx
+++ b/scripts/verify-goal-todo-baseline.tsx
@@ -1,0 +1,201 @@
+/**
+ * verify-goal-todo-baseline 鈥?GoalTodoPanel elapsed-baseline regression
+ * (#713 integration review blocker 5).
+ *
+ * The elapsed clock's baseline (startRef) may only move in COMMITTED
+ * transitions (the useEffect): render-phase ref writes let an abandoned
+ * concurrent render pollute the baseline for every later reading. This
+ * script behaviorally pins the four contracts:
+ *
+ *   1. active: elapsed advances (label grows);
+ *   2. paused: elapsed frozen AND no animation timer;
+ *   3. paused 鈫?active resume: elapsed RE-BASES at the committed transition
+ *      (label restarts near 0s 鈥?a stale baseline would show the
+ *      accumulated total);
+ *   4. a new goal id: fresh baseline from its own commit.
+ *
+ * Purity-by-construction (no render-phase startRef/phase writes remain) is
+ * enforced by the effect-only mutation in GoalTodoPanel.tsx.
+ *
+ * Run: node --import tsx/esm scripts/verify-goal-todo-baseline.tsx
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { GoalTodoPanel }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/components/GoalTodoPanel.js'),
+  ])
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+// 120 cols keeps the goal badge line well clear of the right edge: at 100
+// the `· 2s` suffix sits exactly on the wrap boundary and an emoji-width
+// measurement hiccup can push the trailing `s` to the next line.
+const COLS = 120
+const ROWS = 24
+
+async function makeHarness() {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 100, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const listeners = new Set<() => void>()
+  const channel: Record<string, unknown> = {
+    version: 0,
+    rows: [],
+    status: 'idle',
+    sessionTitle: 'goal probe',
+    agentId: 'probe',
+    model: 'm',
+    tokens: { input: 0, output: 0 },
+    cwd: 'C:/x',
+    displayCwd: 'C:/x',
+    gitBranch: 'main',
+    working: true,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    turnStart: Date.now(),
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: false,
+    goal: undefined,
+    todos: [],
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+  const emit = (): void => {
+    channel.version = Number(channel.version) + 1
+    for (const listener of [...listeners]) listener()
+    rerender()
+  }
+  let frames = 0
+  const instance = { unmount(): void { /* set below */ } }
+  const makeNode = (): React.ReactNode =>
+    React.createElement(GoalTodoPanel, { channel: channel as never })
+  const ink = await render(makeNode(), {
+    stdout: stdout as never,
+    stdin: stdin as never,
+    stderr: stdout as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+    onFrame: () => { frames += 1 },
+  })
+  instance.unmount = () => ink.unmount()
+  // GoalTodoPanel has no subscription of its own — Chat's re-render is what
+  // usually drives it. The standalone harness re-renders explicitly: emit()
+  // bumps the channel and the rerender below lands the fresh props.
+  const rerender = (): void => {
+    ink.rerender(makeNode())
+  }
+  const screen = (): string => {
+    const buffer = term.buffer.active
+    return Array.from({ length: ROWS }, (_, y) =>
+      buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '',
+    ).join('\n')
+  }
+  /** The elapsed label rendered inside the PhaseBadge (`· 12s` / `· 1m03s`). */
+  const elapsedLabel = (): string => {
+    const match = screen().match(/·\s*(\d+[sm][0-9s]*)/)
+    return match?.[1] ?? ''
+  }
+  const countFrames = async (windowMs: number): Promise<number> => {
+    frames = 0
+    await sleep(windowMs)
+    return frames
+  }
+  return { channel, emit, elapsedLabel, countFrames, screen, unmount: () => { ink.unmount(); instances.delete(stdout); term.dispose() } }
+}
+
+const goalOf = (id: string, phase: 'active' | 'paused' | 'complete') => ({
+  id, objective: 'g', roundsStarted: 1, maxGoalRounds: 4, phase, blockedReason: undefined,
+})
+
+{
+  const h = await makeHarness()
+  // 1. active: baseline starts at commit; elapsed advances.
+  h.channel.goal = goalOf('g1', 'active')
+  h.emit()
+  await sleep(300)
+  const early = h.elapsedLabel()
+  await sleep(2200)
+  const later = h.elapsedLabel()
+  check('1: active goal elapsed advances', later !== '' && later !== early, `early=${early} later=${later}`)
+  check('1: active baseline started near mount (early reading is small)', /^([0-2]s)$/.test(early), `early=${early}`)
+
+  // 2. paused: frozen + no timer.
+  const beforePause = h.elapsedLabel()
+  h.channel.goal = goalOf('g1', 'paused')
+  h.emit()
+  // Settle the transition paint first: the paused commit itself renders one
+  // frame (that is the phase change, not a timer).
+  await sleep(400)
+  const settledLabel = h.elapsedLabel()
+  const pausedFrames = await h.countFrames(2200)
+  const afterPause = h.elapsedLabel()
+  check('2: paused goal freezes the elapsed label', afterPause === settledLabel && afterPause === beforePause, `before=${beforePause} after=${afterPause}`)
+  check('2: paused goal holds no animation timer', pausedFrames === 0, `frames=${pausedFrames}`)
+
+  // 3. resume: re-base at the COMMITTED transition 鈥?the label must restart
+  // near 0s, not continue from the pre-pause accumulated total.
+  const pausedFor = 2200
+  h.channel.goal = goalOf('g1', 'active')
+  h.emit()
+  await sleep(400)
+  const resumed = h.elapsedLabel()
+  const parseMs = (label: string): number => {
+    const m = label.match(/^(\d+)s$/)
+    if (m) return Number(m[1]) * 1000
+    const mm = label.match(/^(\d+)m(\d+)s$/)
+    return mm ? (Number(mm[1]) * 60 + Number(mm[2])) * 1000 : Number.NaN
+  }
+  check(
+    '3: resume re-bases the clock at the committed transition',
+    resumed !== '' && parseMs(resumed) <= 1000 + pausedFor * 0 + 1000,
+    `resumed=${resumed} (pre-pause label was ${beforePause})`,
+  )
+  void pausedFor
+
+  // 4. a new goal id takes a fresh baseline from its own commit.
+  await sleep(1500)
+  h.channel.goal = goalOf('g2', 'active')
+  h.emit()
+  await sleep(300)
+  const fresh = h.elapsedLabel()
+  check('4: new goal id restarts the baseline', /^([0-1]s)$/.test(fresh), `fresh=${fresh}`)
+
+  h.unmount()
+}
+
+console.log(failed === 0 ? 'verify-goal-todo-baseline: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-grants-watch.ts
+++ b/scripts/verify-grants-watch.ts
@@ -12,7 +12,7 @@
  *
  * Run via `node --import tsx/esm scripts/verify-grants-watch.mjs`.
  */
-import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { sleep } from './lib/term-test.mjs'
@@ -58,18 +58,24 @@ const check = (name: string, ok: boolean, extra = ''): void => {
   rmSync(dir, { recursive: true, force: true })
 }
 
-// ── B. Missing file: slow fallback poll picks up creation ─────────────────
+// ── B. Missing PARENT DIRECTORY: the slow fallback poll is what runs ──────
+// The watcher targets the PARENT DIRECTORY (atomic-replace safety), so a
+// missing file alone does NOT force the fallback — fs.watch(dirname) still
+// succeeds and the scenario would silently test the directory watcher
+// instead. Subscribe while the parent directory ITSELF does not exist:
+// fs.watch must fail (ENOENT) and arm the 2s fallback poll.
 {
-  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const dir = join(tmpdir(), `dsh-grants-watch-missing-${process.pid}-${Date.now()}`)
   const file = join(dir, EXTENSION_GRANTS_FILE)
   const store = readGrantStore(dir)
   let notified = 0
   const stop = store.onChange?.(() => { notified += 1 })
-  check('B0: onChange seam exists on a missing file', typeof stop === 'function')
+  check('B0: onChange seam exists on a missing directory', typeof stop === 'function')
   await sleep(300)
-  // fs.watch on a nonexistent path errors → the 2s fallback poll arms.
-  // Create the file: the poll must pick it up (allow up to ~2.8s for the
-  // first poll tick + debounce).
+  // fs.watch on a nonexistent directory errors → the 2s fallback poll arms.
+  // Create the directory + file: the poll must pick it up (allow up to ~2.8s
+  // for the first poll tick).
+  mkdirSync(dir, { recursive: true })
   writeFileSync(file, JSON.stringify({ grants: { late: ['commands.invoke'] } }))
   await sleep(2800)
   check('B1: fallback poll picks up a created file', notified >= 1, `notified=${notified}`)

--- a/scripts/verify-grants-watch.ts
+++ b/scripts/verify-grants-watch.ts
@@ -1,0 +1,116 @@
+/**
+ * Grants-file watcher regression: the fallback GrantStore must notify on
+ * file changes (event-driven, not a 50ms poll), stop polling once the last
+ * subscriber unsubscribes, and fall back to a slow bounded poll when
+ * fs.watch cannot watch the file (e.g. it does not exist yet).
+ *
+ *   A. Live file: a write notifies subscribers promptly; an unchanged file
+ *      notifies nothing; unsubscribe stops the watcher (later writes do
+ *      not notify).
+ *   B. Missing file: fs.watch fails → slow fallback poll still picks up a
+ *      subsequently created file.
+ *
+ * Run via `node --import tsx/esm scripts/verify-grants-watch.mjs`.
+ */
+import { mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { sleep } from './lib/term-test.mjs'
+const { readGrantStore, EXTENSION_GRANTS_FILE } = await import('../src/dsh-adapter/grants.js')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+// ── A. Live file: event-driven notify + cleanup ───────────────────────────
+{
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const file = join(dir, EXTENSION_GRANTS_FILE)
+  writeFileSync(file, JSON.stringify({ grants: { live: [] } }))
+  const store = readGrantStore(dir)
+  let notified = 0
+  const stop = store.onChange?.(() => { notified += 1 })
+  check('A0: onChange seam exists', typeof stop === 'function')
+  await sleep(300) // settle: any initial watcher chatter must not notify
+  const baseline = notified
+  // A write that does not change the content must not notify (signature
+  // dedupe), and the watcher must be quiet while the file is static.
+  writeFileSync(file, JSON.stringify({ grants: { live: [] } }))
+  await sleep(300)
+  check('A1: unchanged file content notifies nothing', notified === baseline, `notified=${notified}`)
+  // A real change notifies promptly (fs.watch + 50ms debounce ≪ 250ms).
+  writeFileSync(file, JSON.stringify({
+    grants: { live: [{ name: 'session.input.intercept', scope: 'tui/input' }] },
+  }))
+  await sleep(250)
+  check('A2: a change notifies within a bounded delay', notified === baseline + 1, `notified=${notified}`)
+  // Revocation semantics stay live: allows() reads the file fresh.
+  check('A3: allows() reads the fresh file',
+    store.allows({ componentId: 'live' }, 'session.input.intercept', 'tui/input') === true)
+  // Unsubscribe stops the watcher: later writes must not notify.
+  stop?.()
+  notified = 0
+  writeFileSync(file, JSON.stringify({ grants: { live: [] } }))
+  await sleep(300)
+  check('A4: unsubscribe stops the watcher', notified === 0, `notified=${notified}`)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// ── B. Missing file: slow fallback poll picks up creation ─────────────────
+{
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const file = join(dir, EXTENSION_GRANTS_FILE)
+  const store = readGrantStore(dir)
+  let notified = 0
+  const stop = store.onChange?.(() => { notified += 1 })
+  check('B0: onChange seam exists on a missing file', typeof stop === 'function')
+  await sleep(300)
+  // fs.watch on a nonexistent path errors → the 2s fallback poll arms.
+  // Create the file: the poll must pick it up (allow up to ~2.8s for the
+  // first poll tick + debounce).
+  writeFileSync(file, JSON.stringify({ grants: { late: ['commands.invoke'] } }))
+  await sleep(2800)
+  check('B1: fallback poll picks up a created file', notified >= 1, `notified=${notified}`)
+  // Cleanup: the fallback poll must stop with the last subscriber.
+  notified = 0
+  stop?.()
+  writeFileSync(file, JSON.stringify({ grants: { late: [] } }))
+  await sleep(2500)
+  check('B2: fallback poll stops after unsubscribe', notified === 0, `notified=${notified}`)
+  rmSync(dir, { recursive: true, force: true })
+}
+
+// ── C. Atomic replace (temp file + rename) must still notify ─────────────
+// The common editor/writer pattern swaps the inode; a watcher pinned to the
+// old FILE would go silent. The directory watcher must see the rename.
+{
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-grants-watch-'))
+  const file = join(dir, EXTENSION_GRANTS_FILE)
+  writeFileSync(file, JSON.stringify({ grants: { atomic: [] } }))
+  const store = readGrantStore(dir)
+  let notified = 0
+  const stop = store.onChange?.(() => { notified += 1 })
+  await sleep(300)
+  const tmp = `${file}.tmp`
+  writeFileSync(tmp, JSON.stringify({ grants: { atomic: [{ name: 'commands.invoke', scope: 'root.command' }] } }))
+  renameSync(tmp, file)
+  await sleep(250)
+  check('C1: atomic replace notifies subscribers',
+    notified >= 1, `notified=${notified}`)
+  check('C2: allows() sees the replaced file',
+    store.allows({ componentId: 'atomic' }, 'commands.invoke', 'root.command') === true)
+  // delete/recreate: the directory watcher must also survive removal.
+  rmSync(file)
+  await sleep(250)
+  const afterDelete = notified
+  writeFileSync(file, JSON.stringify({ grants: { atomic: [] } }))
+  await sleep(250)
+  check('C3: delete/recreate notifies again', notified > afterDelete, `notified=${notified}`)
+  stop?.()
+  rmSync(dir, { recursive: true, force: true })
+}
+
+console.log(failed === 0 ? 'verify-grants-watch: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-idle-wakeups.tsx
+++ b/scripts/verify-idle-wakeups.tsx
@@ -1,0 +1,304 @@
+/**
+ * Idle-wakeup regression: static UI states must not hold animation clocks
+ * or periodic timers. Asserts, per component, that a quiet window produces
+ * ZERO frames (no renderer commits) in the static state and a non-zero
+ * frame count in the corresponding live state.
+ *
+ *   A. Chat idle (working=false, activity off): no frames after settle.
+ *   B. Chat working with the mini-wake enabled: frames while wide, no
+ *      frames on a narrow terminal (width gate) or with the wake disabled.
+ *   C. ActivityLine done: no frames; live phase: frames.
+ *   D. JobsPanel all-settled: no frames; with a running job: frames.
+ *   E. GoalTodoPanel paused/blocked: no frames; active: frames.
+ *
+ * Run via `node --import tsx/esm scripts/verify-idle-wakeups.tsx`.
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { Box }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/dsh-adapter/questions.js'),
+    import('../src/ui.js'),
+  ])
+const { ActivityLine } = await import('../src/components/ActivityLine.js')
+const { JobsPanel } = await import('../src/components/JobsPanel.js')
+const { GoalTodoPanel } = await import('../src/components/GoalTodoPanel.js')
+const { AgentView } = await import('../src/screens/AgentView.js')
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** Mount a React node in a headless terminal; counts painted frames. */
+async function mountProbe(cols: number, rows: number, node: React.ReactNode): Promise<{
+  countFrames: (windowMs: number) => Promise<number>
+  unmount: () => void
+}> {
+  const term = new XTerm({ cols, rows, scrollback: 100, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  let frames = 0
+  const causes: string[] = []
+  const instance = await render(node, {
+    stdout: stdout as never,
+    stdin: stdin as never,
+    stderr: stdout as never,
+    exitOnCtrlC: false,
+    patchConsole: false,
+    onFrame: () => { frames += 1 },
+  })
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  // Settle the initial paint (and any one-shot intro animations, plus the
+  // MessageList measure cascade / paint-expansion hold).
+  await sleep(900)
+  const countFrames = async (windowMs: number): Promise<number> => {
+    frames = 0
+    await sleep(windowMs)
+    return frames
+  }
+  const frameLog = (): void => {
+    // eslint-disable-next-line no-console
+    console.error(`[probe] frames=${frames}`)
+  }
+  const unmount = (): void => {
+    instance.unmount()
+    instances.delete(stdout)
+    term.dispose()
+  }
+  return { countFrames, unmount }
+}
+
+function makeChannel(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  // 40 rows: past the LogoHeader intro threshold (rows.length > 30 skips
+  // the ~3.4s whale animation), so the idle probe measures the steady state.
+  const rows = Array.from({ length: 40 }, (_, i) => ({
+    id: i,
+    kind: (i % 3 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    text: `row ${i}`,
+  }))
+  return {
+    version: 0,
+    rows,
+    status: 'idle',
+    sessionTitle: 'idle probe',
+    agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    tokens: { input: 600, output: 120 },
+    cwd: 'C:/code/demo',
+    displayCwd: 'C:/code/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    turnStart: Date.now() - 60_000,
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: true,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: true, shortcutHint: false,
+    },
+    activityFrames: [],
+    loadedContext: undefined,
+    goal: undefined,
+    todos: [],
+    traceEvents: () => [],
+    trajectory: () => ({ nodes: [], counts: { rows: 0, errors: 0 } }),
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => {},
+    clear: (): void => {},
+    notify: (): void => {},
+    ...overrides,
+  }
+}
+
+const chatNode = (channel: Record<string, unknown>): React.ReactNode =>
+  React.createElement(Chat, {
+    channel: channel as never,
+    questionStore: new QuestionStore() as never,
+    onExit: () => {},
+    fullscreen: false,
+    trajectorySeen: true,
+  })
+
+// ── A. Idle Chat: no periodic Chat-level renders ──────────────────────────
+{
+  const probe = await mountProbe(120, 30, chatNode(makeChannel()))
+  const frames = await probe.countFrames(1500)
+  check('A: idle Chat produces no periodic frames', frames === 0, `frames=${frames} over 1.5s`)
+  probe.unmount()
+}
+
+// ── B. MiniWake clock gating (wide/narrow/disabled) ───────────────────────
+{
+  // Wide + working + wake enabled: the 120ms wake clock ticks → frames.
+  const wide = await mountProbe(120, 30, chatNode(makeChannel({ working: true })))
+  const wideFrames = await wide.countFrames(1000)
+  check('B1: working Chat with wake enabled renders periodically',
+    wideFrames > 0, `frames=${wideFrames} over 1s`)
+  wide.unmount()
+
+  // The working spinner is a separate, legitimate animation (~17fps); the
+  // wake clock adds its own 120ms ticks on top. The gate assertions below
+  // therefore compare against the enabled baseline: when the wake is gated
+  // off (narrow terminal / disabled status-bar field), the frame rate must
+  // drop back to the spinner-only level.
+  // Narrow (<84 cols): miniWakeWidth()=0 → wake clock off despite working.
+  const narrow = await mountProbe(80, 30, chatNode(makeChannel({ working: true })))
+  const narrowFrames = await narrow.countFrames(1000)
+  check('B2: narrow terminal stops the wake clock',
+    narrowFrames > 0 && narrowFrames < wideFrames,
+    `frames=${narrowFrames} vs enabled=${wideFrames}`)
+  narrow.unmount()
+
+  // Wake disabled in the status bar: same gate, no clock.
+  const disabled = await mountProbe(120, 30, chatNode(makeChannel({
+    working: true,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: false, shortcutHint: false,
+    },
+  })))
+  const disabledFrames = await disabled.countFrames(1000)
+  check('B3: wake-disabled status bar stops the clock',
+    disabledFrames > 0 && disabledFrames < wideFrames,
+    `frames=${disabledFrames} vs enabled=${wideFrames}`)
+  disabled.unmount()
+}
+
+// ── C. ActivityLine static-done branch ────────────────────────────────────
+{
+  const done = {
+    phase: 'done' as const, line: '3 tools · thought 2s worked 1s', toolCount: 3, turnElapsedMs: 4000,
+  }
+  const doneProbe = await mountProbe(100, 20, React.createElement(ActivityLine, { activity: done }))
+  const doneFrames = await doneProbe.countFrames(1000)
+  check('C1: ActivityLine(done) holds no animation clock', doneFrames === 0, `frames=${doneFrames}`)
+  doneProbe.unmount()
+
+  const live = {
+    phase: 'thinking' as const, line: 'thinking · total 3s', toolCount: 0, turnElapsedMs: 3000,
+  }
+  const liveProbe = await mountProbe(100, 20, React.createElement(ActivityLine, { activity: live }))
+  const liveFrames = await liveProbe.countFrames(1000)
+  check('C2: ActivityLine(live) animates', liveFrames > 0, `frames=${liveFrames}`)
+  liveProbe.unmount()
+}
+
+// ── D. JobsPanel settled vs live ──────────────────────────────────────────
+{
+  const settledJobs = [
+    { id: 'j1', kind: 'shell', label: 'done job', status: 'completed' as const, startedAt: Date.now() - 5000, finishedAt: Date.now() - 1000, outputLines: [], command: undefined, detail: undefined, lastOutputAt: undefined, exitCode: 0 },
+  ]
+  const settledProbe = await mountProbe(100, 24, React.createElement(JobsPanel, {
+    jobs: settledJobs, onClose: () => {}, onKill: () => {},
+  }))
+  const settledFrames = await settledProbe.countFrames(1000)
+  check('D1: all-settled JobsPanel holds no clock', settledFrames === 0, `frames=${settledFrames}`)
+  settledProbe.unmount()
+
+  const emptyProbe = await mountProbe(100, 24, React.createElement(JobsPanel, {
+    jobs: [], onClose: () => {}, onKill: () => {},
+  }))
+  const emptyFrames = await emptyProbe.countFrames(1000)
+  check('D2: empty JobsPanel holds no clock', emptyFrames === 0, `frames=${emptyFrames}`)
+  emptyProbe.unmount()
+
+  const runningJobs = [
+    { id: 'j2', kind: 'shell', label: 'live job', status: 'running' as const, startedAt: Date.now() - 2000, finishedAt: undefined, outputLines: [], command: undefined, detail: undefined, lastOutputAt: Date.now() - 100, exitCode: undefined },
+  ]
+  const liveProbe = await mountProbe(100, 24, React.createElement(JobsPanel, {
+    jobs: runningJobs, onClose: () => {}, onKill: () => {},
+  }))
+  const liveFrames = await liveProbe.countFrames(1500)
+  check('D3: running job ticks the clock', liveFrames > 0, `frames=${liveFrames}`)
+  liveProbe.unmount()
+}
+
+// ── E. GoalTodoPanel paused/blocked vs active ─────────────────────────────
+{
+  const goalBase = {
+    id: 'g1', objective: 'build the thing', roundsStarted: 1, maxGoalRounds: 4,
+    phase: 'paused' as const, blockedReason: undefined,
+  }
+  const channel = (phase: 'paused' | 'blocked' | 'active'): Record<string, unknown> => {
+    const base = makeChannel()
+    base.goal = { ...goalBase, phase }
+    base.todos = [{ id: 't1', content: 'step one', status: 'pending' }]
+    return base
+  }
+  const pausedProbe = await mountProbe(100, 24, React.createElement(GoalTodoPanel, { channel: channel('paused') as never }))
+  const pausedFrames = await pausedProbe.countFrames(1200)
+  check('E1: paused goal holds no elapsed clock', pausedFrames === 0, `frames=${pausedFrames}`)
+  pausedProbe.unmount()
+
+  const blockedProbe = await mountProbe(100, 24, React.createElement(GoalTodoPanel, { channel: channel('blocked') as never }))
+  const blockedFrames = await blockedProbe.countFrames(1200)
+  check('E2: blocked goal holds no elapsed clock', blockedFrames === 0, `frames=${blockedFrames}`)
+  blockedProbe.unmount()
+
+  const activeProbe = await mountProbe(100, 24, React.createElement(GoalTodoPanel, { channel: channel('active') as never }))
+  const activeFrames = await activeProbe.countFrames(1500)
+  check('E3: active goal ticks the elapsed clock', activeFrames > 0, `frames=${activeFrames}`)
+  activeProbe.unmount()
+}
+
+// ── F. AgentView static list: bucket-boundary clock, not a 1s poll ────────
+{
+  const agentViewChannel = makeChannel()
+  agentViewChannel.agentViewRows = () => [
+    { id: 's1', status: 'completed', title: 'done session', summary: '', cwd: '/tmp', createdAt: Date.now() - 3600_000, updatedAt: Date.now() - 3600_000, current: false, needsInput: false },
+    { id: 's2', status: 'stopped', title: 'old session', summary: '', cwd: '/tmp', createdAt: Date.now() - 7200_000, updatedAt: Date.now() - 7200_000, current: false, needsInput: false },
+  ]
+  agentViewChannel.subscribeAgentView = () => () => {}
+  const probe = await mountProbe(120, 30, React.createElement(AgentView, {
+    channel: agentViewChannel as never,
+    home: '/home',
+    approval: null,
+    onApprove: () => {},
+    onClose: () => {},
+  }))
+  // Rows aged 1-2h: the next display bucket (minute/half-hour boundary) is
+  // minutes away, so a 2s window must contain NO clock-driven frames — a
+  // 1s polling clock would produce 1-2.
+  const frames = await probe.countFrames(2000)
+  check('F: static AgentView list holds no 1s clock', frames === 0, `frames=${frames} over 2s`)
+  probe.unmount()
+}
+
+console.log(failed === 0 ? 'verify-idle-wakeups: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-rows-generation.tsx
+++ b/scripts/verify-rows-generation.tsx
@@ -1,0 +1,262 @@
+/**
+ * verify-rows-generation — rowsGeneration cache-identity regressions
+ * (#713 integration review blockers 1-3).
+ *
+ * Row ids are TRANSCRIPT-SCOPED: `/clear` / rewind / reset keep the live
+ * rows array identity and restart ids at 0 under the same agentId. Every
+ * cache that treats `agentId (+ ids)` as identity can therefore serve the
+ * PREVIOUS transcript's data for id-identical fresh rows.
+ *
+ *   Case 1  MessageList visible-rows cache: same live array, same length,
+ *           same ids, same streaming bits, different generation → the
+ *           rendered transcript must be the NEW rows (stale cache would
+ *           keep painting the old ChatRow objects).
+ *   Case 2  failureHintRowId: tool failure carries the trajectory footnote;
+ *           /clear + fresh rows REUSING the id → the new healthy row must
+ *           NOT wear the stale failure footnote.
+ *   Case 3  lastUserRowId + auto recap: recap active with a large
+ *           rowsAtTrigger; /clear; new user row re-appears at id 0 → the
+ *           O(1) scan must re-track the new transcript AND the auto recap
+ *           must retire on the user's first new message.
+ *
+ * Run: node --import tsx/esm scripts/verify-rows-generation.tsx
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/dsh-adapter/questions.js'),
+  ])
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep, settled } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+const COLS = 100
+const ROWS = 30
+
+function makeChannel(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    version: 0,
+    rows: [],
+    rowsGeneration: 0,
+    rowsStreamingVersion: 0,
+    status: 'idle',
+    sessionTitle: 'gen probe',
+    agentId: 'gen-agent',
+    model: 'deepseek-v4-flash',
+    tokens: { input: 600, output: 120 },
+    cwd: 'C:/code/demo',
+    displayCwd: 'C:/code/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    turnStart: Date.now() - 60_000,
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: false,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: false, shortcutHint: false,
+    },
+    activityFrames: [],
+    loadedContext: undefined,
+    goal: undefined,
+    todos: [],
+    traceEvents: () => [],
+    trajectory: () => ({ nodes: [], counts: { rows: 0, errors: 0 } }),
+    autoRecapOnOpen: false,
+    recapRecent: async () => ({ summary: null, title: undefined, error: undefined }),
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => {},
+    clear: (): void => {},
+    notify: (): void => {},
+    ...overrides,
+  }
+}
+
+async function mount(channel: Record<string, unknown>): Promise<{
+  screen: () => string
+  publish: () => void
+  unmount: () => void
+}> {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 200, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const listeners = new Set<() => void>()
+  channel.subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+  )
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  return {
+    screen: (): string => {
+      const buffer = term.buffer.active
+      return Array.from({ length: ROWS }, (_, y) =>
+        buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '',
+      ).join('\n')
+    },
+    publish: (): void => {
+      channel.version = Number(channel.version) + 1
+      for (const listener of [...listeners]) listener()
+    },
+    unmount: (): void => {
+      instance.unmount()
+      instances.delete(process.stdout)
+      term.dispose()
+    },
+  }
+}
+
+const toolRow = (id: number, status: 'ok' | 'error', name: string): Record<string, unknown> => ({
+  id,
+  kind: 'tool',
+  text: '',
+  tool: {
+    callId: `call-${id}`,
+    name,
+    argsText: '{}',
+    status,
+    errorText: status === 'error' ? 'boom' : undefined,
+    startedAt: Date.now() - 1000,
+    durationMs: 1000,
+  },
+})
+
+// ── Case 1: visible-rows cache identity includes rowsGeneration ────────────
+{
+  const channel = makeChannel({})
+  const rows = channel.rows as Array<Record<string, unknown>>
+  rows.push(
+    { id: 0, kind: 'user', text: 'OLD-PROMPT-MARKER' },
+    { id: 1, kind: 'assistant', text: 'OLD-REPLY-MARKER' },
+  )
+  const h = await mount(channel)
+  await sleep(700)
+  check('C1a: initial transcript renders', h.screen().includes('OLD-PROMPT-MARKER'))
+  // /clear semantics: SAME live array, emptied and refilled in place; ids
+  // restart at 0; streaming bits identical (none); only the generation and
+  // the row CONTENT differ.
+  rows.length = 0
+  rows.push(
+    { id: 0, kind: 'user', text: 'NEW-PROMPT-MARKER' },
+    { id: 1, kind: 'assistant', text: 'NEW-REPLY-MARKER' },
+  )
+  channel.rowsGeneration = 1
+  h.publish()
+  await sleep(500)
+  const screen = h.screen()
+  check('C1b: fresh generation renders the NEW rows', screen.includes('NEW-PROMPT-MARKER') && screen.includes('NEW-REPLY-MARKER'))
+  check('C1c: stale rows never leak through the cache', !screen.includes('OLD-PROMPT-MARKER') && !screen.includes('OLD-REPLY-MARKER'))
+  h.unmount()
+}
+
+// ── Case 2: failureHintRowId survives a /clear id-reuse ────────────────────
+{
+  let errors = 1
+  const channel = makeChannel({
+    trajectory: () => ({ nodes: [], counts: { rows: 1, errors } }),
+  })
+  const rows = channel.rows as Array<Record<string, unknown>>
+  rows.push(
+    { id: 0, kind: 'user', text: 'run the thing' },
+    toolRow(1, 'error', 'bash'),
+  )
+  const h = await mount(channel)
+  await sleep(700)
+  check('C2a: failed tool row carries the trajectory footnote', h.screen().includes('看完整轨迹'))
+  // /clear + id reuse: the new transcript's id-1 row is a HEALTHY tool.
+  rows.length = 0
+  rows.push(
+    { id: 0, kind: 'user', text: 'fresh start' },
+    toolRow(1, 'ok', 'read'),
+  )
+  channel.rowsGeneration = 1
+  h.publish()
+  await sleep(500)
+  const screen = h.screen()
+  check('C2b: fresh healthy row wears NO stale failure footnote', !screen.includes('看完整轨迹'))
+  check('C2c: the new rows themselves render', screen.includes('fresh start'))
+  void errors
+  h.unmount()
+}
+
+// ── Case 3: lastUserRowId re-tracks + auto recap retires on /clear ────────
+{
+  const channel = makeChannel({
+    autoRecapOnOpen: true,
+    recapRecent: async () => ({ summary: 'RECAP-SUMMARY-MARKER', title: undefined, error: undefined }),
+  })
+  const rows = channel.rows as Array<Record<string, unknown>>
+  // A transcript with a LARGE lastUserRowId before the clear.
+  for (let i = 0; i <= 40; i++) {
+    rows.push(i % 2 === 0
+      ? { id: i, kind: 'user', text: `old user ${i}` }
+      : { id: i, kind: 'assistant', text: `old reply ${i}` })
+  }
+  const h = await mount(channel)
+  // recapRecent resolves → the dim AutoRecapRow shows the summary marker.
+  check('C3a: auto recap appears', await settled(() => h.screen().includes('RECAP-SUMMARY-MARKER'), 4000))
+  // /clear: same agentId, ids restart at 0.
+  rows.length = 0
+  channel.rowsGeneration = 1
+  h.publish()
+  await sleep(400)
+  // The user starts a NEW message: row id 0 (way below the old trigger 40).
+  rows.push({ id: 0, kind: 'user', text: 'brand new user row' })
+  h.publish()
+  await sleep(600)
+  const screen = h.screen()
+  check('C3b: old transcript is gone after the clear', !screen.includes('old user 40') && !screen.includes('RECAP-SUMMARY-MARKER'))
+  // (The blank paint itself is a stub-harness scroll artifact — the real
+  // /clear path resets the transcript scroll via Chat's repaint plumbing,
+  // which the raw channel stub bypasses. The retire behavior is C3c.)
+  check('C3c: auto recap retired by the first new message', !screen.includes('RECAP-SUMMARY-MARKER'))
+  h.unmount()
+}
+
+console.log(failed === 0 ? 'verify-rows-generation: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-shutdown-fallback.tsx
+++ b/scripts/verify-shutdown-fallback.tsx
@@ -83,5 +83,33 @@ instances.delete(captured)
 check('runtime-present shutdown detaches without unmount', detaches === 1 && handoffs === 1 && unmountsB === 0 && doneB)
 check('runtime-present shutdown prints the notice', captured.chunks.join('').includes('hint-two'))
 
+// Case C: concurrent finishExit calls share ONE cleanup — the second awaits
+// the in-flight first and deliberately never invokes its own done(): the
+// process-level exit action belongs to the exit that actually ran the
+// terminal cleanup (double-run would repeat the exit sequence and could
+// spawn the /update or /restart handoff twice).
+const streamC = new CapturingStream() as unknown as NodeJS.WriteStream
+const eventsC: string[] = []
+instances.set(streamC, {
+  stdout: streamC,
+  beginShutdown() { eventsC.push('begin') },
+  concludeShutdown() { eventsC.push('conclude') },
+  detachStdinForHandoff() { eventsC.push('handoff') },
+  drainStdin() {},
+} as never)
+swapStdout(streamC)
+let doneC1 = 0
+let doneC2 = 0
+await Promise.all([
+  finishExit(ctx, fakeInstance(() => {}), false, 'hint-concurrent', undefined, () => { doneC1 += 1 }),
+  finishExit(ctx, fakeInstance(() => {}), false, 'hint-concurrent', undefined, () => { doneC2 += 1 }),
+])
+swapStdout(originalStdout)
+instances.delete(streamC)
+const noticeCount = streamC.chunks.join('').split('hint-concurrent').length - 1
+check('concurrent finishExit runs latch/conclude/handoff exactly once', eventsC.join(',') === 'begin,conclude,handoff')
+check('concurrent finishExit writes the exit sequence once', noticeCount === 1)
+check('concurrent finishExit invokes done() once (first caller wins)', doneC1 === 1 && doneC2 === 0)
+
 console.log(results.join('\n'))
 if (failures > 0) process.exit(1)

--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -455,13 +455,21 @@ fire('skills/change')
   // Establish a last-good command set first (complete observation).
   let snapshotCalls = 0
   let incomplete = false
+  let recovered = false
   ctx.get = (name) => {
     if (name === 'commands') return { list: () => [{ name: 'plan', description: 'Toggle plan mode' }] }
     if (name === 'skills') {
       return {
         snapshot: async () => {
           snapshotCalls += 1
-          return incomplete ? { skills: [], complete: false } : {
+          if (incomplete) return { skills: [], complete: false }
+          if (recovered) {
+            return {
+              skills: [{ name: 'recovered-skill', description: 'Recovered', invocation: { modelInvocable: true, userInvocable: true } }],
+              complete: true,
+            }
+          }
+          return {
             skills: [{ name: 'kept-skill', description: 'Kept', invocation: { modelInvocable: true, userInvocable: true } }],
             complete: true,
           }
@@ -494,11 +502,18 @@ fire('skills/change')
     `snapshot calls=${snapshotCalls}`)
   check('retry ladder: last-good skills survive the exhausted ladder',
     channel.commandList.some(command => command.name === 'kept-skill'))
-  // Recovery: the provider's own skills/change re-enters and completes.
+  // Recovery: the provider's own skills/change re-enters and completes. The
+  // provider now returns a DIFFERENT skill — asserting on `kept-skill` again
+  // would be a false positive (last-good kept it visible through the whole
+  // exhausted ladder, so the old check passed even if the re-read never
+  // landed). The NEW command appearing is the actual proof of recovery.
   incomplete = false
+  recovered = true
   fire('skills/change')
-  check('retry ladder: a later skills/change recovers',
-    await settled(() => channel.commandList.some(command => command.name === 'kept-skill')))
+  check('retry ladder: a later skills/change recovers with fresh content',
+    await settled(() => channel.commandList.some(command => command.name === 'recovered-skill')))
+  check('retry ladder: recovered snapshot replaced the last-good entry',
+    !channel.commandList.some(command => command.name === 'kept-skill'))
 }
 
 console.log(failed === 0 ? 'ALL PASS' : `${failed} FAILED`)

--- a/scripts/verify-skill-commands.mjs
+++ b/scripts/verify-skill-commands.mjs
@@ -43,7 +43,11 @@ const commandService = {
     if (registered.has(descriptor.name)) throw new Error(`duplicate command: ${descriptor.name}`)
     registered.set(descriptor.name, descriptor)
     fire('commands/change')
-    return () => { registered.delete(descriptor.name) }
+    // Real dsh-commands emits commands/change on unregister too (the effect
+    // disposer tears the layer down and notifyChange() fires); the menu
+    // merge must hear about a disposed handler or it keeps listing skills
+    // whose dispatch command no longer exists.
+    return () => { registered.delete(descriptor.name); fire('commands/change') }
   },
 }
 
@@ -441,6 +445,60 @@ fire('skills/change')
     'current agent B returns a fresh /skills snapshot',
     freshSkills?.some(skill => skill.name === 'fresh') === true,
   )
+}
+
+// ---- an observation that NEVER completes retries a bounded number of
+// times with backoff, then stops polling and keeps last-good until the
+// next skills/change (the provider's own invalidation). Without the cap a
+// broken provider would keep an 800ms re-read loop alive forever.
+{
+  // Establish a last-good command set first (complete observation).
+  let snapshotCalls = 0
+  let incomplete = false
+  ctx.get = (name) => {
+    if (name === 'commands') return { list: () => [{ name: 'plan', description: 'Toggle plan mode' }] }
+    if (name === 'skills') {
+      return {
+        snapshot: async () => {
+          snapshotCalls += 1
+          return incomplete ? { skills: [], complete: false } : {
+            skills: [{ name: 'kept-skill', description: 'Kept', invocation: { modelInvocable: true, userInvocable: true } }],
+            complete: true,
+          }
+        },
+      }
+    }
+    return undefined
+  }
+  ctx.logger = { warn() {} }
+  fire('skills/change')
+  check('retry ladder: last-good established',
+    await settled(() => channel.commandList.some(command => command.name === 'kept-skill')))
+  const callsAfterGood = snapshotCalls
+  incomplete = true
+  fire('skills/change')
+  // Each skills/change fires BOTH consumers (the menu merge AND the
+  // command registration), so one change costs two snapshot reads; the
+  // registration ladder then retries 800+1600+3200ms (3 re-reads). The
+  // bound: 2 (change) + 3 (ladder) = 5 extra snapshot calls max.
+  await sleep(6800)
+  const callsAfterRetries = snapshotCalls
+  check('retry ladder: incomplete observation retries a bounded number of times',
+    callsAfterRetries <= callsAfterGood + 5,
+    `snapshot calls=${callsAfterRetries} after ladder (good=${callsAfterGood})`)
+  // A further window must see ZERO additional retries: the ladder is
+  // exhausted and last-good is preserved.
+  await sleep(1500)
+  check('retry ladder: retries stop after the cap',
+    snapshotCalls === callsAfterRetries,
+    `snapshot calls=${snapshotCalls}`)
+  check('retry ladder: last-good skills survive the exhausted ladder',
+    channel.commandList.some(command => command.name === 'kept-skill'))
+  // Recovery: the provider's own skills/change re-enters and completes.
+  incomplete = false
+  fire('skills/change')
+  check('retry ladder: a later skills/change recovers',
+    await settled(() => channel.commandList.some(command => command.name === 'kept-skill')))
 }
 
 console.log(failed === 0 ? 'ALL PASS' : `${failed} FAILED`)

--- a/scripts/verify-trajectory-cache.tsx
+++ b/scripts/verify-trajectory-cache.tsx
@@ -157,6 +157,13 @@ function makeHarness(cols: number, rows: number): {
   for (const value of instances.values()) instances.set(process.stdout, value)
   await sleep(200)
   const callsAfterMount = traceCalls
+  // The mount itself must be getter-free too: recording a post-mount
+  // baseline and only checking "no increase" would let a mount that called
+  // traceEvents 20 times pass — the trajectory() seam must be authoritative
+  // from the very first render.
+  check('A0: mount itself never calls traceEvents (trajectory seam authoritative)',
+    callsAfterMount === 0,
+    `traceCalls=${callsAfterMount} at mount`)
   // Ten idle version bumps (the streaming-cadence wakeup pattern): renders
   // must not re-read events through the getter.
   for (let i = 0; i < 10; i++) {

--- a/scripts/verify-trajectory-cache.tsx
+++ b/scripts/verify-trajectory-cache.tsx
@@ -1,0 +1,244 @@
+/**
+ * Trajectory cache regression: Chat renders must not reach the session
+ * event getter, and the legacy `traceEvents()`-only fallback must fold by
+ * snapshot identity (one getter call per snapshot, not per render).
+ *
+ *   A. A channel providing `trajectory()`: `traceEvents` is never called
+ *      during render, across many version bumps.
+ *   B. A legacy stub providing only `traceEvents()`: repeated renders with
+ *      an unchanged snapshot call the getter exactly once; a NEW snapshot
+ *      (appended event) costs exactly one more call; the folded build
+ *      grows incrementally.
+ *
+ * Run via `node --import tsx/esm scripts/verify-trajectory-cache.tsx`.
+ */
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }] =
+  await Promise.all([
+    import('node:stream'),
+    import('react'),
+    import('@xterm/headless'),
+    import('../src/ui.js'),
+    import('../src/screens/Chat.js'),
+    import('../src/dsh-adapter/questions.js'),
+  ])
+const instances = (await import('../src/ink/instances.js')).default
+const { sleep } = await import('./lib/term-test.mjs')
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = ''): void => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+/** A minimal session event log: one turn with a user + assistant message. */
+const makeEvents = (): Record<string, unknown>[] => [
+  { type: 'turn/start', seq: 1, time: 1000, data: { turn: 1 } },
+  {
+    type: 'user/message', seq: 2, time: 1100,
+    data: { turn: 1, content: [{ type: 'text', text: 'hello' }], source: { kind: 'user' } },
+  },
+  {
+    type: 'assistant/message', seq: 3, time: 1200,
+    data: { turn: 1, content: [{ type: 'text', text: 'hi there' }] },
+  },
+  { type: 'turn/end', seq: 4, time: 1300, data: { turn: 1, reason: { kind: 'completed' } } },
+]
+
+function makeChannel(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    version: 0,
+    rows: [],
+    status: 'idle',
+    sessionTitle: 'cache probe',
+    agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    tokens: { input: 600, output: 120 },
+    cwd: 'C:/code/demo',
+    displayCwd: 'C:/code/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    turnStart: Date.now() - 60_000,
+    lastUserText: '',
+    pending: [],
+    commandList: [],
+    notifications: [],
+    activityEnabled: false,
+    contextBarEnabled: true,
+    statusBar: {
+      compact: true, model: true, thinking: true, cwd: true, contextUsage: true,
+      cache: true, tokens: false, tps: false, gitBranch: false, sessionTitle: false,
+      sessionId: false, mode: false, contextBar: false, activity: false,
+      trajectory: true, shortcutHint: false,
+    },
+    activityFrames: [],
+    loadedContext: undefined,
+    goal: undefined,
+    todos: [],
+    traceEvents: () => [],
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => {},
+    clear: (): void => {},
+    notify: (): void => {},
+    ...overrides,
+  }
+}
+
+function makeHarness(cols: number, rows: number): {
+  stdout: Writable
+  stdin: PassThrough
+  term: XTerm
+  screen: () => string
+  dispose: () => void
+} {
+  const term = new XTerm({ cols, rows, scrollback: 200, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode(): this { return this }
+    ref(): this { return this }
+    unref(): this { return this }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const screen = (): string => {
+    const buffer = term.buffer.active
+    return Array.from({ length: rows }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+  }
+  return { stdout, stdin, term, screen, dispose: () => { term.dispose() } }
+}
+
+// ── A. Real trajectory seam: renders never touch the event getter ─────────
+{
+  const { stdout, stdin, dispose } = makeHarness(100, 24)
+  let traceCalls = 0
+  let build = { nodes: [] as unknown[], counts: { rows: 0, errors: 0 } }
+  const listeners = new Set<() => void>()
+  const events = makeEvents()
+  const channel = makeChannel({
+    traceEvents: () => {
+      traceCalls += 1
+      return events
+    },
+    trajectory: () => build,
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  })
+  const publish = (): void => {
+    channel.version = Number(channel.version) + 1
+    for (const listener of listeners) listener()
+  }
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+  )
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  await sleep(200)
+  const callsAfterMount = traceCalls
+  // Ten idle version bumps (the streaming-cadence wakeup pattern): renders
+  // must not re-read events through the getter.
+  for (let i = 0; i < 10; i++) {
+    publish()
+    await sleep(20)
+  }
+  check('A1: trajectory seam renders never call traceEvents',
+    traceCalls === callsAfterMount,
+    `traceCalls=${traceCalls} after mount+10 bumps`)
+  // A session append changes the build: the channel folds it at event time
+  // (exercised through extendTrajectory directly), and a render reads the
+  // new build without touching the getter.
+  build = { nodes: [{ seq: 5 } as never], counts: { rows: 1, errors: 0 } }
+  publish()
+  await sleep(50)
+  check('A2: appended build is read without traceEvents',
+    traceCalls === callsAfterMount,
+    `traceCalls=${traceCalls}`)
+  instance.unmount()
+  instances.delete(process.stdout)
+  dispose()
+}
+
+// ── B. Legacy fallback: snapshot-identity cached fold ─────────────────────
+{
+  const { stdout, stdin, dispose } = makeHarness(100, 24)
+  let events = makeEvents()
+  let traceCalls = 0
+  const listeners = new Set<() => void>()
+  const channel = makeChannel({
+    // Working + trajectory-enabled + wide terminal: the status-line wake
+    // clock ticks at 120ms, re-rendering Chat WITHOUT version bumps — the
+    // perfect "idle render" source for the fallback probe.
+    working: true,
+    traceEvents: () => {
+      traceCalls += 1
+      return events
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  })
+  const publish = (): void => {
+    channel.version = Number(channel.version) + 1
+    for (const listener of listeners) listener()
+  }
+  const instance = await render(
+    React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: false,
+      trajectorySeen: true,
+    }),
+    { stdout: stdout as never, stdin: stdin as never, stderr: stdout as never, exitOnCtrlC: false, patchConsole: false },
+  )
+  for (const value of instances.values()) instances.set(process.stdout, value)
+  await sleep(150)
+  const afterMount = traceCalls
+  check('B1: legacy fallback folds once at mount',
+    afterMount >= 1 && afterMount <= 2,
+    `traceCalls=${afterMount}`)
+  // Wake-clock renders (unchanged channel version): the version gate must
+  // keep the getter silent — no per-render re-reads on an idle render.
+  await sleep(600)
+  check('B2: unchanged version renders never call traceEvents',
+    traceCalls === afterMount,
+    `traceCalls=${traceCalls} after ~5 wake ticks`)
+  // One appended event → one new snapshot → exactly one more getter call,
+  // and the fold extends the previous build (incremental path).
+  const appended = events
+  events = [...appended, { type: 'turn/start', seq: 5, time: 2000, data: { turn: 2 } }]
+  publish()
+  await sleep(50)
+  check('B3: one appended event costs exactly one getter call',
+    traceCalls === afterMount + 1,
+    `traceCalls=${traceCalls}`)
+  instance.unmount()
+  instances.delete(process.stdout)
+  dispose()
+}
+
+console.log(failed === 0 ? 'verify-trajectory-cache: all checks passed' : `${failed} check(s) failed.`)
+process.exit(failed === 0 ? 0 : 1)

--- a/scripts/verify-working-activity.mjs
+++ b/scripts/verify-working-activity.mjs
@@ -198,17 +198,18 @@ sessionEvent()(agent.session, {
 assert.match(minimalChannel.workingActivity.line, /思考中|Thinking/)
 
 // ── the 500ms tick retires once the turn is done and the line is stable ───
-// (P1-4): a live phase holds the tick; a done summary keeps it only through
-// the completed-tool fragment window (~3s), then the timer stops and an
-// idle conversation emits nothing.
 {
-  const fresh = makeAgent('agent-3', 'session-3')
-  const tickChannel = createChannel(ctx, fresh, {
+  const opts = {
     model: 'test-model', provider: 'test-provider', cwd: testHome, activity: true,
-  })
+  }
+  const fresh = makeAgent('agent-3', 'session-3')
+  const tickChannel = createChannel(ctx, fresh, opts)
   let emits = 0
   const unsubscribe = tickChannel.subscribe(() => { emits += 1 })
-  // Run a full turn to completion.
+  // LIVE phase first: start a turn and keep it live (thinking). The 500ms
+  // timer must ACTUALLY fire while the turn is open — recording the emit
+  // baseline only after turn/end would prove nothing (a predicate already
+  // satisfied by the done phase cannot evidence a live tick).
   handlers.get('agent/status')({ agent: fresh, status: 'running' })
   handlers.get('session/event')(fresh.session, {
     type: 'turn/start', seq: 0, time: Date.now(), data: { turn: 'tick-turn' },
@@ -217,6 +218,14 @@ assert.match(minimalChannel.workingActivity.line, /思考中|Thinking/)
     type: 'assistant/chunk', seq: 1, time: Date.now(),
     data: { turn: 'tick-turn', step: 'step-1', chunk: { type: 'text-delta', text: 'hi' } },
   })
+  assert.equal(tickChannel.workingActivity?.phase, 'thinking')
+  const emitsAtLive = emits
+  const liveElapsedBefore = tickChannel.workingActivity.turnElapsedMs
+  assert.ok(
+    await settled(() => emits > emitsAtLive && tickChannel.workingActivity.turnElapsedMs >= liveElapsedBefore + 450),
+    'live phase holds a real timer-driven 500ms emit (elapsed advances while the turn is open)',
+  )
+  // Only NOW end the turn.
   handlers.get('session/event')(fresh.session, {
     type: 'turn/end', seq: 2, time: Date.now(),
     data: { turn: 'tick-turn', reason: { kind: 'completed' } },
@@ -225,12 +234,56 @@ assert.match(minimalChannel.workingActivity.line, /思考中|Thinking/)
   assert.equal(tickChannel.workingActivity?.phase, 'done')
   // The done summary carries a short-lived fragment; after it stabilizes
   // (~3s window + 4s grace) the tick must stop: no further emits.
-  const emitsAtDone = emits
-  await settled(() => emits > emitsAtDone || tickChannel.workingActivity?.phase === 'done')
   await sleep(5500)
   const emitsAfterIdle = emits
   await sleep(2000)
   assert.equal(emits, emitsAfterIdle, 'no activity emits while the done line is stable')
+
+  // ── failure injection: projection unavailable retires the tick ──────────
+  // The tick's `rendered === undefined` funnel is the SAME one a throwing
+  // tracker.render() lands in (updateWorkingActivity catches and returns
+  // undefined); the options.activity flip reaches it deterministically.
+  // A live turn arms the tick; flipping the sidecar off must retire it on
+  // the NEXT tick (≤ ~600ms) instead of spinning forever, and a later REAL
+  // activity event must be able to re-arm it.
+  handlers.get('agent/status')({ agent: fresh, status: 'running' })
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/start', seq: 3, time: Date.now(), data: { turn: 'tick-turn-2' },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 4, time: Date.now(),
+    data: { turn: 'tick-turn-2', step: 'step-1', chunk: { type: 'text-delta', text: 'hi' } },
+  })
+  assert.equal(tickChannel.workingActivity?.phase, 'thinking')
+  const emitsLive2 = emits
+  const live2Elapsed = tickChannel.workingActivity.turnElapsedMs
+  assert.ok(
+    await settled(() => emits > emitsLive2 && tickChannel.workingActivity.turnElapsedMs >= live2Elapsed + 450),
+    'tick re-armed for the new live turn (timer-driven elapsed advance)',
+  )
+  // Poison the projection: every updateWorkingActivity now yields undefined.
+  opts.activity = false
+  const emitsAtPoison = emits
+  await sleep(1600)
+  const emitsAfterPoison = emits
+  await sleep(1200)
+  assert.equal(emits, emitsAfterPoison, 'tick retired after projection became unavailable (no 500ms wake loop)')
+  assert.ok(
+    emitsAfterPoison - emitsAtPoison <= 2,
+    `at most the in-flight tick fired once more (delta=${emitsAfterPoison - emitsAtPoison})`,
+  )
+  // Recovery: a REAL activity event re-arms the tick once the projection is
+  // available again.
+  opts.activity = true
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 5, time: Date.now(),
+    data: { turn: 'tick-turn-2', step: 'step-2', chunk: { type: 'text-delta', text: 'again' } },
+  })
+  const recoveredElapsed = tickChannel.workingActivity?.turnElapsedMs ?? 0
+  assert.ok(
+    await settled(() => (tickChannel.workingActivity?.turnElapsedMs ?? 0) >= recoveredElapsed + 450),
+    'a later real activity event re-arms the tick',
+  )
   unsubscribe()
 }
 

--- a/scripts/verify-working-activity.mjs
+++ b/scripts/verify-working-activity.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { settled } from './lib/term-test.mjs'
+import { settled, sleep } from './lib/term-test.mjs'
 
 const testHome = mkdtempSync(join(tmpdir(), 'dsh-tui-activity-home-'))
 process.env.HOME = testHome
@@ -196,6 +196,78 @@ sessionEvent()(agent.session, {
   data: { turn: 'minimal-turn', step: 'step-1', chunk: { type: 'text-delta', text: 'hi' } },
 })
 assert.match(minimalChannel.workingActivity.line, /思考中|Thinking/)
+
+// ── the 500ms tick retires once the turn is done and the line is stable ───
+// (P1-4): a live phase holds the tick; a done summary keeps it only through
+// the completed-tool fragment window (~3s), then the timer stops and an
+// idle conversation emits nothing.
+{
+  const fresh = makeAgent('agent-3', 'session-3')
+  const tickChannel = createChannel(ctx, fresh, {
+    model: 'test-model', provider: 'test-provider', cwd: testHome, activity: true,
+  })
+  let emits = 0
+  const unsubscribe = tickChannel.subscribe(() => { emits += 1 })
+  // Run a full turn to completion.
+  handlers.get('agent/status')({ agent: fresh, status: 'running' })
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/start', seq: 0, time: Date.now(), data: { turn: 'tick-turn' },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 1, time: Date.now(),
+    data: { turn: 'tick-turn', step: 'step-1', chunk: { type: 'text-delta', text: 'hi' } },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/end', seq: 2, time: Date.now(),
+    data: { turn: 'tick-turn', reason: { kind: 'completed' } },
+  })
+  handlers.get('agent/status')({ agent: fresh, status: 'idle' })
+  assert.equal(tickChannel.workingActivity?.phase, 'done')
+  // The done summary carries a short-lived fragment; after it stabilizes
+  // (~3s window + 4s grace) the tick must stop: no further emits.
+  const emitsAtDone = emits
+  await settled(() => emits > emitsAtDone || tickChannel.workingActivity?.phase === 'done')
+  await sleep(5500)
+  const emitsAfterIdle = emits
+  await sleep(2000)
+  assert.equal(emits, emitsAfterIdle, 'no activity emits while the done line is stable')
+  unsubscribe()
+}
+
+// ── streaming revive bumps rowsStreamingVersion (P2-7) ────────────────────
+// A reconnect replay that revives a previously sealed assistant row flips
+// `streaming` IN PLACE — invisible to rows identity/length, so the
+// transcript filter cache must hear about it via the version counter.
+{
+  const fresh = makeAgent('agent-4', 'session-4')
+  const reviveChannel = createChannel(ctx, fresh, {
+    model: 'test-model', provider: 'test-provider', cwd: testHome, activity: false,
+  })
+  const before = reviveChannel.rowsStreamingVersion
+  // Stream a step, then seal it with an assistant/message.
+  handlers.get('session/event')(fresh.session, {
+    type: 'turn/start', seq: 0, time: Date.now(), data: { turn: 1, step: 1 },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 1, time: Date.now(),
+    data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: 'hello' } },
+  })
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/message', seq: 2, time: Date.now(),
+    data: { turn: 1, step: 1, message: { content: [{ type: 'text', text: 'hello' }] } },
+  })
+  assert.ok(reviveChannel.rowsStreamingVersion > before, 'settle bumps rowsStreamingVersion')
+  const settledVersion = reviveChannel.rowsStreamingVersion
+  // A reconnect replay of the same step's chunk revives the sealed row.
+  handlers.get('session/event')(fresh.session, {
+    type: 'assistant/chunk', seq: 3, time: Date.now(),
+    data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: 'hello' } },
+  })
+  assert.ok(
+    reviveChannel.rowsStreamingVersion > settledVersion,
+    'revive of a sealed row bumps rowsStreamingVersion',
+  )
+}
 
 for (const dispose of effects.reverse()) dispose()
 rmSync(testHome, { recursive: true, force: true })

--- a/src/components/ActivityLine.tsx
+++ b/src/components/ActivityLine.tsx
@@ -46,16 +46,18 @@ export function ActivityLine({
   warnDanger?: boolean
   suffix?: string
 }): React.ReactNode {
-  // 60ms frames: the shimmer sweep advances one column per frame (3.3× the
-  // ported 200ms cadence — the slow crawl read as lag).
-  const [, time] = useAnimationFrame(60)
+  // Static branch stays static: the done summary renders a fixed line, so it
+  // must not subscribe to the animation clock (a null interval unsubscribes).
+  // The live branch drives the shimmer sweep + frame rotation at 60ms.
+  const animate = activity.phase !== 'done'
+  const [, time] = useAnimationFrame(animate ? 60 : null)
   const [themeName] = useTheme()
   const theme = getTheme(themeName)
   const preset = React.useMemo(
     () => resolvePreset(activityFrames),
     [activityFrames],
   )
-  const frameIndex = Math.floor(time / preset.intervalMs) % preset.frames.length
+  const frameIndex = animate ? Math.floor(time / preset.intervalMs) % preset.frames.length : 0
   const frame = preset.frames[frameIndex] ?? '·'
   const color =
     activity.phase === 'done' || activity.phase === 'tool'

--- a/src/components/GoalTodoPanel.tsx
+++ b/src/components/GoalTodoPanel.tsx
@@ -130,30 +130,40 @@ export function GoalTodoPanel({
     ? allTodos
     : allTodos.filter(todo => todo.status !== 'completed')
 
-  // Local goal timer: remember when this goal id first rendered. Written in
-  // render (idempotent lazy ref init) so a fresh mount with a live goal
-  // starts counting immediately.
+  // Local goal timer: remember when this goal id first rendered AND when it
+  // last (re)entered the active phase. Both refs are written ONLY from the
+  // committed transition effect below — never during render: an abandoned
+  // concurrent render (StrictMode double render, interrupted render) must
+  // not pollute the elapsed baseline, or every later reading would count
+  // from a transition the user never saw commit.
   const startRef = React.useRef<{ id: string; at: number } | undefined>(undefined)
-  const phaseRef = React.useRef<ChannelGoal['phase'] | undefined>(undefined)
-  if (goal !== undefined) {
-    if (startRef.current?.id !== goal.id) {
-      startRef.current = { id: goal.id, at: Date.now() }
-    } else if (phaseRef.current !== undefined && phaseRef.current !== 'active' && goal.phase === 'active') {
-      // Resume from paused/blocked: re-base the elapsed clock so the count
-      // restarts at the moment the goal becomes active again (frozen time
-      // does not silently accrue while paused).
-      startRef.current = { id: goal.id, at: Date.now() }
-    }
-    phaseRef.current = goal.phase
-  }
+  const committedPhaseRef = React.useRef<ChannelGoal['phase'] | undefined>(undefined)
   const [now, setNow] = React.useState(() => Date.now())
   // Hover tint for the clickable todo fold header (mouse affordance).
   const [headerHovered, setHeaderHovered] = React.useState(false)
+  // Committed phase transitions (post-commit, so abandoned renders leave the
+  // refs untouched): a fresh goal id starts the clock, and a
+  // paused/blocked → active transition re-bases it so frozen time does not
+  // silently accrue while paused. setNow re-renders so the new baseline
+  // shows immediately instead of one tick late.
+  const goalId = goal?.id
+  const goalPhase = goal?.phase
+  React.useEffect(() => {
+    if (goalId === undefined || goalPhase === undefined) return
+    const prevPhase = committedPhaseRef.current
+    const isNewGoal = startRef.current?.id !== goalId
+    const resumed = prevPhase !== undefined && prevPhase !== 'active' && goalPhase === 'active'
+    if (isNewGoal || resumed) {
+      startRef.current = { id: goalId, at: Date.now() }
+      setNow(Date.now())
+    }
+    committedPhaseRef.current = goalPhase
+  }, [goalId, goalPhase])
   React.useEffect(() => {
     // Tick only while the goal is actively running: a complete goal freezes
     // the last elapsed reading instead of counting past the finish line, and
     // paused/blocked goals are static — no periodic wakeup for a frozen
-    // timer (resume re-bases via the phaseRef transition above).
+    // timer (resume re-bases via the committed transition above).
     if (goal === undefined || goal.phase !== 'active') return
     const timer = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(timer)

--- a/src/components/GoalTodoPanel.tsx
+++ b/src/components/GoalTodoPanel.tsx
@@ -134,16 +134,27 @@ export function GoalTodoPanel({
   // render (idempotent lazy ref init) so a fresh mount with a live goal
   // starts counting immediately.
   const startRef = React.useRef<{ id: string; at: number } | undefined>(undefined)
-  if (goal !== undefined && startRef.current?.id !== goal.id) {
-    startRef.current = { id: goal.id, at: Date.now() }
+  const phaseRef = React.useRef<ChannelGoal['phase'] | undefined>(undefined)
+  if (goal !== undefined) {
+    if (startRef.current?.id !== goal.id) {
+      startRef.current = { id: goal.id, at: Date.now() }
+    } else if (phaseRef.current !== undefined && phaseRef.current !== 'active' && goal.phase === 'active') {
+      // Resume from paused/blocked: re-base the elapsed clock so the count
+      // restarts at the moment the goal becomes active again (frozen time
+      // does not silently accrue while paused).
+      startRef.current = { id: goal.id, at: Date.now() }
+    }
+    phaseRef.current = goal.phase
   }
   const [now, setNow] = React.useState(() => Date.now())
   // Hover tint for the clickable todo fold header (mouse affordance).
   const [headerHovered, setHeaderHovered] = React.useState(false)
   React.useEffect(() => {
-    // Tick only while the goal is open; a complete goal freezes the last
-    // elapsed reading instead of counting past the finish line.
-    if (goal === undefined || goal.phase === 'complete') return
+    // Tick only while the goal is actively running: a complete goal freezes
+    // the last elapsed reading instead of counting past the finish line, and
+    // paused/blocked goals are static — no periodic wakeup for a frozen
+    // timer (resume re-bases via the phaseRef transition above).
+    if (goal === undefined || goal.phase !== 'active') return
     const timer = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(timer)
   }, [goal])

--- a/src/components/JobsPanel.tsx
+++ b/src/components/JobsPanel.tsx
@@ -123,8 +123,14 @@ export function JobsPanel({ jobs, onClose, onKill }: JobsPanelProps): React.Reac
   const [focusIndex, setFocusIndex] = React.useState(0)
   const scrollRef = React.useRef<ScrollBoxHandle | null>(null)
   const { rows } = useTerminalSize()
-  // 1s tick keeps live durations counting while the panel is open.
-  const [clockRef] = useAnimationFrame(1000)
+  // 1s tick keeps live durations counting while the panel is open — but only
+  // while a live job exists to count: an empty or all-settled panel is a
+  // static render and must not hold a clock subscription.
+  const liveCount = jobs.reduce(
+    (count, job) => count + (job.status === 'running' || job.status === 'stopping' ? 1 : 0),
+    0,
+  )
+  const [clockRef] = useAnimationFrame(liveCount > 0 ? 1000 : null)
 
   const focus = Math.min(focusIndex, Math.max(0, jobs.length - 1))
 

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -215,6 +215,8 @@ export function MessageList({
   onLoadOlder,
   thinkingVisible = true,
   historyPaintEnabled = true,
+  streamingVersion,
+  rowsGeneration,
   registerRowRef,
   scrollHandle,
   forceMountRowId,
@@ -266,6 +268,24 @@ export function MessageList({
    * seconds of lex/highlight/layout before first paint).
    */
   historyPaintEnabled?: boolean
+  /**
+   * Channel-owned counter that bumps exactly when an existing row's
+   * `streaming` flag flips IN PLACE (turn settle, revive). The filter cache
+   * keys on it so a settle that changes the empty-assistant filter boundary
+   * rebuilds without scanning every row per render. Absent on embedders
+   * that pass no channel metadata — they fall back to the allocation-free
+   * bit scan.
+   */
+  streamingVersion?: number
+  /**
+   * Transcript generation from the channel: bumped whenever the transcript
+   * is cleared and row ids restart at 0 (clear, session swap, loadOlder
+   * prepend, rewind/new/model/workspace switch). All per-row-id caches
+   * (heights, layout signatures, painted-once marks, timeline previews,
+   * header base) must be dropped on a generation change — ids alone cannot
+   * distinguish a fresh transcript from a previous one.
+   */
+  rowsGeneration?: number
   /** Transcript search: register each row's DOM element for scroll-to-match. */
   registerRowRef?: (rowId: number, el: DOMElement | null) => void
   /** Scroll viewport the list virtualizes against. */
@@ -337,6 +357,8 @@ export function MessageList({
      * in place, rows identity/length unchanged) changes empty-assistant
      * filtering below, so the cache must rebuild on any bit change. */
     streamBits: Uint8Array
+    /** The streamingVersion the bits were captured at (-1 = scanned). */
+    streamVersion: number
   } | null>(null)
   /** Generation counter for the visibleRows cache (timeline memo key). */
   const visGenRef = React.useRef(0)
@@ -345,12 +367,22 @@ export function MessageList({
   // settle) are invisible to the rows-identity/length key above, but an
   // assistant row that settles with EMPTY text crosses the empty-assistant
   // filter boundary (visible-while-streaming → filtered-when-settled).
-  // Allocation-free scan; rebuild only when a bit actually flipped.
-  let streamBitsSame = visibleCache !== null && visibleCache.streamBits.length === rows.length
-  if (streamBitsSame) {
-    const bits = visibleCache!.streamBits
-    for (let i = 0; i < rows.length; i++) {
-      if (bits[i] !== (rows[i]!.streaming === true ? 1 : 0)) { streamBitsSame = false; break }
+  // The channel owns a version counter that bumps exactly on such in-place
+  // flips, so the cache key can skip the O(rows) scan per render; hosts
+  // that pass no seam fall back to the allocation-free scan.
+  let streamBitsSame = false
+  if (visibleCache !== null && visibleCache.streamBits.length === rows.length) {
+    if (streamingVersion !== undefined) {
+      streamBitsSame = visibleCache.streamVersion === streamingVersion
+    } else {
+      const bits = visibleCache.streamBits
+      streamBitsSame = true
+      for (let i = 0; i < rows.length; i++) {
+        if (bits[i] !== (rows[i]!.streaming === true ? 1 : 0)) {
+          streamBitsSame = false
+          break
+        }
+      }
     }
   }
   if (
@@ -417,6 +449,7 @@ export function MessageList({
       out,
       margins,
       streamBits,
+      streamVersion: streamingVersion ?? -1,
     }
     visGenRef.current++
   }
@@ -517,6 +550,12 @@ export function MessageList({
     heightsVersionRef.current++
     baseRef.current = null
   }
+
+  // A transcript generation change (clear / session swap / loadOlder /
+  // rewind / new) reuses row ids from 0: every per-row-id cache belongs to
+  // the PREVIOUS transcript and must be dropped wholesale, or a fresh
+  // session would inherit stale heights, painted-once marks and previews.
+  const lastRowsGeneration = React.useRef(rowsGeneration)
 
   // --- layout signature: stale-height invalidation ------------------------
   // heightsRef entries outlive the commits that measured them, but many
@@ -866,33 +905,45 @@ export function MessageList({
   let upTurnIndex: number | null = null
   let downTurnIndex: number | null = null
   const timelineMemoRef = React.useRef<{ key: string; turns: TimelineTurn[] } | null>(null)
+  const timelineListRef = React.useRef<{
+    key: string
+    turns: Array<{ id: number; preview: string }>
+  } | null>(null)
+  const timelineTopsRef = React.useRef<{ key: string; tops: Map<number, number> } | null>(null)
+  // A transcript generation change (clear / session swap / loadOlder /
+  // rewind / new) reuses row ids from 0: every per-row-id cache belongs to
+  // the PREVIOUS transcript and must be dropped wholesale, or a fresh
+  // session would inherit stale heights, painted-once marks and previews.
+  // Placed after every cache ref it touches is declared.
+  if (lastRowsGeneration.current !== rowsGeneration) {
+    lastRowsGeneration.current = rowsGeneration
+    heightsRef.current.clear()
+    heightsVersionRef.current++
+    sigRef.current.clear()
+    paintedOnceRef.current = new Set()
+    paintedBaseRef.current = undefined
+    baseRef.current = null
+    previewCacheRef.current.clear()
+    timelineMemoRef.current = null
+    timelineListRef.current = null
+    timelineTopsRef.current = null
+    paintEdgeRef.current = -1
+    lastStartRef.current = -1
+  }
+
   {
-    // Split into (a) a GEOMETRY-memoized turns list and (b) a per-frame
-    // allocation-free target scan. Before the split this block rebuilt on
-    // EVERY scroll tick: an 800-object turns array, an 800-entry
-    // measuredTops Map, and the report effect's turns.map().join('|')
-    // signature — several hundred KB of churn per second of scrolling on a
-    // tool-heavy session.
-    //
-    // (a) turns/tops/folded change ONLY when geometry changes: row heights
-    // (heightsVersion — bumped at every heightsRef mutation), the visible
-    // window's content (visGen — bumped when the visibleRows cache
-    // rebuilds), the measured header base, or the rows array growing. Key
-    // on those; previews stay in their own id-keyed cache.
-    const memo = timelineMemoRef.current
-    const memoKey = `${visGenRef.current}:${heightsVersionRef.current}:${base}:${rows.length}:${columns}`
-    if (memo === null || memo.key !== memoKey) {
+    // Split into THREE caches so a scroll tick or a streaming commit does not
+    // rebuild the whole timeline: (a) the turns LIST (id + preview) keyed on
+    // the visibleRows cache generation — user rows never leave the list, so
+    // visGen is its only input; (b) the measured Tops map keyed on geometry
+    // (visGen + heightsVersion + base); (c) the merged array keyed on the
+    // tops key. A streaming commit bumps heightsVersion (growing row) but
+    // NOT visGen, so the O(rows) walk of (a) runs only when the fold window
+    // actually moves; the per-frame target scan below stays allocation-free.
+    const listKey = `${visGenRef.current}`
+    if (timelineListRef.current === null || timelineListRef.current.key !== listKey) {
       const previewCache = previewCacheRef.current
       if (previewCache.size > 2000) previewCache.clear()
-      // Measured tops for turns INSIDE the fold window (user rows are never
-      // filtered by the thinking toggle, so a user row absent from
-      // visibleRows is exactly a folded one).
-      const measuredTops = new Map<number, number>()
-      for (let i = 0; i < visibleRows.length; i++) {
-        const row = visibleRows[i]!
-        if (row.kind !== 'user') continue
-        measuredTops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
-      }
       // Walk ALL rows (not the fold window): the rail must cover the whole
       // conversation — a tool-heavy session packs 300 rows into a handful
       // of turns, and window-only turns made the rail show "2-3 nodes".
@@ -900,7 +951,7 @@ export function MessageList({
       // until revealed (they are all ABOVE the viewport, so active/down
       // over measured turns is unaffected; ▲ may name a folded turn — its
       // click goes through the reveal path, not scrollTo).
-      const turns: TimelineTurn[] = []
+      const turns: Array<{ id: number; preview: string }> = []
       for (const row of rows) {
         if (row.kind !== 'user') continue
         let cached = previewCache.get(row.id)
@@ -908,14 +959,37 @@ export function MessageList({
           cached = { len: row.text.length, preview: clipPreview(row.text) }
           previewCache.set(row.id, cached)
         }
-        const textTop = measuredTops.get(row.id)
+        turns.push({ id: row.id, preview: cached.preview })
+      }
+      timelineListRef.current = { key: listKey, turns }
+    }
+    const topsKey = `${visGenRef.current}:${heightsVersionRef.current}:${base}`
+    if (timelineTopsRef.current === null || timelineTopsRef.current.key !== topsKey) {
+      // Measured tops for turns INSIDE the fold window (user rows are never
+      // filtered by the thinking toggle, so a user row absent from
+      // visibleRows is exactly a folded one).
+      const tops = new Map<number, number>()
+      for (let i = 0; i < visibleRows.length; i++) {
+        const row = visibleRows[i]!
+        if (row.kind !== 'user') continue
+        tops.set(row.id, base + offsets[i]! + (margins.get(row.id) === true ? 1 : 0))
+      }
+      timelineTopsRef.current = { key: topsKey, tops }
+    }
+    const memo = timelineMemoRef.current
+    if (memo === null || memo.key !== topsKey) {
+      const tops = timelineTopsRef.current!.tops
+      const list = timelineListRef.current!.turns
+      const turns: TimelineTurn[] = []
+      for (const entry of list) {
+        const textTop = tops.get(entry.id)
         if (textTop !== undefined) {
-          turns.push({ id: row.id, top: textTop, preview: cached.preview })
+          turns.push({ id: entry.id, top: textTop, preview: entry.preview })
         } else {
-          turns.push({ id: row.id, top: -1, preview: cached.preview, folded: true })
+          turns.push({ id: entry.id, top: -1, preview: entry.preview, folded: true })
         }
       }
-      timelineMemoRef.current = { key: memoKey, turns }
+      timelineMemoRef.current = { key: topsKey, turns }
     }
     timelineTurns = timelineMemoRef.current!.turns
     // (b) per-frame target scan — pure integer comparisons over the

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -349,6 +349,14 @@ export function MessageList({
   const visibleRowsCacheRef = React.useRef<{
     rows: readonly ChatRow[]
     rowsLength: number
+    /** Transcript epoch for the cached pass (channel.rowsGeneration). The
+     * rows array is LIVE and mutated in place: /clear / rewind / session
+     * swap keep its identity while row ids restart from 0 — the same
+     * length + ids + streaming bits can recur, and a generation-blind key
+     * would serve the PREVIOUS transcript's ChatRow objects for the new
+     * one. undefined = host passes no seam; then identity+length+bits is
+     * the best available key. */
+    rowsGeneration: number | undefined
     showAll: boolean
     thinkingVisible: boolean
     out: readonly ChatRow[]
@@ -389,6 +397,7 @@ export function MessageList({
     visibleCache === null ||
     visibleCache.rows !== rows ||
     visibleCache.rowsLength !== rows.length ||
+    visibleCache.rowsGeneration !== rowsGeneration ||
     visibleCache.showAll !== (showAll || hiddenCount <= 0) ||
     visibleCache.thinkingVisible !== thinkingVisible ||
     !streamBitsSame
@@ -444,6 +453,7 @@ export function MessageList({
     visibleRowsCacheRef.current = {
       rows,
       rowsLength: rows.length,
+      rowsGeneration,
       showAll: showAll || hiddenCount <= 0,
       thinkingVisible,
       out,

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -8466,7 +8466,17 @@ ${output}
     activityTickTimer = setInterval(() => {
       const previous = state.workingActivity
       const rendered = updateWorkingActivity('activity tick')
-      if (rendered === undefined) return
+      if (rendered === undefined) {
+        // Projection unavailable (render/projection error — updateWorkingActivity
+        // swallowed and reported it, or the activity sidecar was switched off).
+        // Retire the tick instead of spinning forever: every 500ms wake would
+        // re-throw inside the tracker for zero UI value. A later REAL activity
+        // event (turn start, phase change, tool start) goes through
+        // updateWorkingActivity again, whose live-phase branch re-arms this
+        // tick — so recovery costs nothing.
+        stopActivityTick()
+        return
+      }
       if (rendered.phase === 'done') {
         // Retire once the done line has been stable past the fragment
         // window — no more React updates, timer or tracker work needed.

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -87,6 +87,7 @@ import type { SpinnerMode } from '../components/Spinner/spinnerMode.js'
 import { ActivityTracker, type ActivityState } from 'dsh-working-activity/status'
 import type { TrackerConfig } from 'dsh-working-activity/status'
 import { featureOn } from 'dsh-working-activity/config'
+import { emptyTrajectory, extendTrajectory, extendTrajectoryEvents, type TrajBuild } from './trajectory/index.js'
 import { setMinimalMode } from '../minimalMode.js'
 import { readActivityConfig } from '../activityPrefs.js'
 import { attachSessionToWorkspace } from './workspace.js'
@@ -1253,6 +1254,23 @@ export interface Channel {
    * time; agent swaps (/resume /rewind /new) are reflected immediately.
    */
   traceEvents(): readonly SessionEvent[]
+  /**
+   * The session trajectory projection, folded incrementally by the channel
+   * as session events arrive — never on the render path. The returned build
+   * is stable between event batches (screens may read it during render);
+   * agent swaps (/resume /rewind /new) rebuild it from the new session's
+   * log. Headless/stub channels that do not provide the seam fall back to
+   * the same module-level empty build.
+   */
+  trajectory(): TrajBuild
+  /**
+   * Counter bumped exactly when an existing transcript row's `streaming`
+   * flag flips in place (turn settle, revive). MessageList keys its filter
+   * cache on it; new rows bump `rows.length` instead.
+   */
+  rowsStreamingVersion: number
+  /** Transcript generation (see the ChannelState field). */
+  rowsGeneration: number
 }
 
 /** @internal */
@@ -1355,6 +1373,22 @@ export interface ChannelState {
   tpsSamples: { tps: number; at: number }[]
   /** Latest working-activity snapshot (see the public Channel type). */
   workingActivity: ActivityStatus | undefined
+  /** Incremental trajectory projection (see the public Channel type). */
+  trajectory: () => TrajBuild
+  /**
+   * Counter bumped exactly when an existing row's `streaming` flag flips in
+   * place (turn settle, revive) — the transcript list's filter cache keys on
+   * it so settles invalidate without an O(rows) scan per render.
+   */
+  rowsStreamingVersion: number
+  /**
+   * Transcript generation: bumped whenever the transcript is cleared and
+   * row ids restart at 0 (clear, session swap, loadOlder prepend, rewind,
+   * new, workspace/model switch). MessageList keys its height/painted/
+   * signature caches on it so a fresh transcript never reuses a previous
+   * one's per-id state.
+   */
+  rowsGeneration: number
   /** Working-activity indicator preset (see the public Channel type). */
   activityFrames: string | undefined
   /** Raw cordis.yml pins `/reload` must respect (see the public Channel type). */
@@ -2666,6 +2700,7 @@ export function createChannel(
     lastReasoningRow = undefined
     toolCards.clear()
     nextRowId = 0
+    state.rowsGeneration += 1
     state.rows.length = 0
     resetSubagentProjection()
     resetJobProjection()
@@ -3394,6 +3429,7 @@ export function createChannel(
     lastReasoningRow = undefined
     toolCards.clear()
     nextRowId = 0
+    state.rowsGeneration += 1
     state.rows.length = 0
     state.todos = []
     state.pending = []
@@ -3553,6 +3589,7 @@ export function createChannel(
     lastReasoningRow = undefined
     toolCards.clear()
     nextRowId = 0
+    state.rowsGeneration += 1
     state.rows.length = 0
     state.todos = []
     state.pending = []
@@ -3668,6 +3705,9 @@ export function createChannel(
     mode: sessionModes[0]!,
     modeIndex: 0,
     workingActivity: undefined,
+    trajectory: () => trajectoryBuild,
+    rowsStreamingVersion: 0,
+    rowsGeneration: 0,
     activityFrames: options.activityFrames,
     configuredProvider: options.configuredProvider,
     configuredModel: options.configuredModel,
@@ -5006,6 +5046,7 @@ export function createChannel(
       lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       resetSubagentProjection()
       resetJobProjection()
@@ -5199,6 +5240,7 @@ export function createChannel(
       assistantRowsByStep.clear()
       lastTextDelta.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       resetSubagentProjection()
       resetJobProjection()
@@ -5395,6 +5437,7 @@ export function createChannel(
       lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       resetSubagentProjection()
       resetJobProjection()
@@ -5478,6 +5521,7 @@ export function createChannel(
     clear() {
       state.rows.length = 0
       nextRowId = 0
+      state.rowsGeneration += 1
       streaming = undefined
       reasoning = undefined
       toolCards.clear()
@@ -6477,6 +6521,7 @@ export function createChannel(
       lastReasoningRow = undefined
       toolCards.clear()
       nextRowId = 0
+      state.rowsGeneration += 1
       state.rows.length = 0
       state.todos = []
       state.pending = []
@@ -7175,6 +7220,23 @@ export function createChannel(
   const skillCommandsRefused = new Set<string>()
   /** Pending re-read after an incomplete catalog observation. */
   let skillCommandsRetry: ReturnType<typeof setTimeout> | undefined
+  /**
+   * Bounded retry ladder for `complete:false` observations: a provider still
+   * warming its watcher re-reads a few times with exponential backoff, then
+   * gives up and keeps the last-good command set until the next
+   * `skills/change` (the provider's own invalidation) or an explicit
+   * refresh. Without the cap a provider that NEVER completes keeps an
+   * 800ms retry loop alive forever, re-snapshotting the catalog each time.
+   */
+  let skillRetryAttempts = 0
+  let skillRetryDelayMs = SKILL_COMMAND_RETRY_MS
+  const MAX_SKILL_RETRY_ATTEMPTS = 3
+  /**
+   * Refresh generation: bumped by releaseContributions (and rebinds) so an
+   * in-flight snapshot resolving afterwards is recognized as stale and
+   * never re-registers commands against a released channel.
+   */
+  let skillCommandSeq = 0
 
   /**
    * Publish every user-invocable skill as a slash command (issue #86).
@@ -7197,6 +7259,10 @@ export function createChannel(
   const refreshSkillCommands = async (): Promise<void> => {
     if (commandService === undefined) return
     const target = agent
+    // Generation snapshot: only release/rebind bump skillCommandSeq, so
+    // concurrent refreshes share one generation and all land (last write
+    // wins); a released/rebound channel invalidates every in-flight read.
+    const token = skillCommandSeq
     const registry = skillRegistryFor(target)
     if (registry === undefined) return
     let observation
@@ -7206,15 +7272,48 @@ export function createChannel(
       ctx.logger.warn('skill commands: catalog read failed: %o', error)
       return
     }
-    if (target !== agent) return
+    if (token !== skillCommandSeq || target !== agent) return
     // A provider still warming its watcher reports an incomplete observation;
-    // re-read once so a cold start cannot leave the menu permanently short.
-    if (!observation.complete && skillCommandsRetry === undefined) {
-      skillCommandsRetry = setTimeout(() => {
-        skillCommandsRetry = undefined
-        void refreshSkillCommands()
-      }, SKILL_COMMAND_RETRY_MS)
+    // re-read a bounded number of times with exponential backoff so a cold
+    // start cannot leave the menu permanently short, while a provider that
+    // NEVER completes stops retrying (the next skills/change re-enters and
+    // the last-good command set stays in place). The partial observation
+    // still reconciles below — registering the visible subset is idempotent
+    // (same names/descriptions dispose nothing) and keeps a warm start as
+    // complete as the provider can make it.
+    if (!observation.complete) {
+      // Incomplete (provider failure/rescan mid-flight): NOT authoritative —
+      // neither the menu merge (refreshCommandList) nor the command registry
+      // may reconcile against it. In particular the registry must KEEP every
+      // currently registered handler: refreshCommandList only restores the
+      // last-good MENU entries, not disposed command handlers, so disposing
+      // here would leave the menu pointing at handlers that no longer exist.
+      if (skillCommandsRetry === undefined && skillRetryAttempts < MAX_SKILL_RETRY_ATTEMPTS) {
+        skillRetryAttempts += 1
+        skillCommandsRetry = setTimeout(() => {
+          skillCommandsRetry = undefined
+          void refreshSkillCommands()
+        }, skillRetryDelayMs)
+        skillCommandsRetry.unref?.()
+        skillRetryDelayMs *= 2
+        ctx.logger.warn(
+          `skill command merge: incomplete catalog observation (%d/%d attempts), retrying in %dms`,
+          skillRetryAttempts,
+          MAX_SKILL_RETRY_ATTEMPTS,
+          skillRetryDelayMs / 2,
+        )
+      } else {
+        ctx.logger.warn(
+          'skill command merge: incomplete catalog observation, retries exhausted — keeping last-good skills until skills/change',
+        )
+      }
+      return
     }
+    // Complete observation: the catalog is authoritative, so reset the
+    // retry ladder (a later transient failure starts back at the base
+    // delay with a fresh attempt budget).
+    skillRetryAttempts = 0
+    skillRetryDelayMs = SKILL_COMMAND_RETRY_MS
     const wanted = new Map<string, string>(
       observation.skills
         .filter(skill => isUserInvocable(skill))
@@ -7318,6 +7417,9 @@ export function createChannel(
   })
   /** See {@link Channel.releaseContributions}. */
   const releaseSkillCommands = (): void => {
+    // Invalidate any in-flight refresh (its token no longer matches), then
+    // cancel the retry ladder and dispose the registered handlers.
+    skillCommandSeq += 1
     if (skillCommandsRetry !== undefined) clearTimeout(skillCommandsRetry)
     skillCommandsRetry = undefined
     for (const entry of skillCommands.values()) entry.dispose()
@@ -7329,6 +7431,17 @@ export function createChannel(
   void refreshSkillCommands()
 
   let nextRowId = 0
+
+  /**
+   * Bump the rows-streaming version: the transcript list keys its filter
+   * cache on this counter, which changes ONLY when an existing row's
+   * `streaming` flag flips in place (turn settle, revive). New rows change
+   * rows.length instead, so they need no bump. Declared before
+   * renderEvent/replayEvents — the boot replay settles rows and calls this.
+   */
+  const markStreamingChanged = (): void => {
+    state.rowsStreamingVersion += 1
+  }
   /** The leaf's bash executor (dsh-bash-local in the example leaf) — the DSH
  *  execution seam for local `!` commands and the git status breadcrumb. The
  *  service registers under `ctx.shell` (ShellExecutor; dsh-bash-local and
@@ -7529,6 +7642,7 @@ ${output}
       : [...state.rows].reverse().find(row => row.kind === 'assistant' && row.seq === seq)
     if (existing !== undefined) {
       existing.streaming = true
+      markStreamingChanged()
       streaming = existing
       return existing
     }
@@ -7557,6 +7671,7 @@ ${output}
       ) {
         reasoning = lastReasoningRow.row
         reasoning.streaming = true
+        markStreamingChanged()
         const sealedIdx = sealedReasoning.indexOf(reasoning)
         if (sealedIdx !== -1) sealedReasoning.splice(sealedIdx, 1)
         reasoningStart = Date.now() - (reasoning.durationMs ?? 0)
@@ -7590,12 +7705,14 @@ ${output}
     const duration = Math.max(0, Date.now() - reasoningStart)
     reasoning.durationMs = duration
     reasoning.streaming = false
+    markStreamingChanged()
     sealedReasoning.push(reasoning)
     reasoning = undefined
     logForDebugging(`thinking: folded at ${where} (${duration}ms)`)
   }
 
   const settleStreaming = (): void => {
+    const flipped = streaming !== undefined || sealedReasoning.length > 0 || reasoning !== undefined
     if (streaming !== undefined) streaming.streaming = false
     streaming = undefined
     const folded = sealedReasoning.length + (reasoning !== undefined ? 1 : 0)
@@ -7606,6 +7723,7 @@ ${output}
       reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
     }
     reasoning = undefined
+    if (flipped) markStreamingChanged()
     if (folded > 0) logForDebugging(`thinking: folded ${folded} reasoning row(s) at turn settle`)
   }
 
@@ -7814,7 +7932,13 @@ ${output}
             const row = assistantRowsByStep.get(key) ?? ensureStreaming(event.seq)
             assistantRowsByStep.set(key, row)
             streaming = row
-            row.streaming = true
+            // Revive of a previously sealed row (reconnect replay): the
+            // in-place streaming flip is invisible to rows identity/length,
+            // so the transcript list's filter cache must hear about it.
+            if (row.streaming !== true) {
+              row.streaming = true
+              markStreamingChanged()
+            }
             const before = row.text.length
             appendTextDelta(row, chunk.text)
             state.responseChars += Math.max(0, row.text.length - before)
@@ -7896,6 +8020,7 @@ ${output}
           row.time = event.time
           if (text) row.text = text
           row.streaming = false
+          markStreamingChanged()
           // Live settles keep the smooth-reveal cursor alive (a one-shot
           // non-streaming delivery still paints as a flow); replayed
           // settles must not — the transcript would typewrite on open.
@@ -7911,7 +8036,10 @@ ${output}
           // (/settings opt-in) keeps the block expanded until turn settle
           // — settleStreaming folds the sealed rows then.
           reasoning.durationMs = Math.max(0, Date.now() - reasoningStart)
-          if (state.thinkingFold === 'preview') reasoning.streaming = false
+          if (state.thinkingFold === 'preview') {
+            reasoning.streaming = false
+            markStreamingChanged()
+          }
           sealedReasoning.push(reasoning)
           logForDebugging(`thinking: step sealed (${reasoning.durationMs}ms), expanded until turn/end`)
         }
@@ -8311,11 +8439,64 @@ ${output}
     return new ActivityTracker(prefs.config, Date.now, prefs.customActions)
   })()
   let activityTickTimer: NodeJS.Timeout | undefined
+  /**
+   * Wall-clock since the done line last changed. The done summary keeps a
+   * short-lived completed-tool fragment (~3s, upstream DONE_FRAGMENT_MS),
+   * so the tick retires only once the line has been STABLE for a grace
+   * window — then it stops until a live phase returns (updateWorkingActivity
+   * re-arms it). An idle conversation therefore holds no 500ms wakeup.
+   */
+  const ACTIVITY_DONE_STABLE_MS = 4000
+  let activityDoneStableSince: number | undefined
 
   const stopActivityTick = (): void => {
     if (activityTickTimer === undefined) return
     clearInterval(activityTickTimer)
     activityTickTimer = undefined
+  }
+
+  /**
+   * Create the 500ms activity tick if it is not running. `activity: false`
+   * never creates it (the projection is not read then). Live phases
+   * (waiting/thinking/tool) emit every tick so turnElapsedMs stays current;
+   * settled phases emit only when the line actually changes.
+   */
+  const ensureActivityTick = (): void => {
+    if (options.activity === false || activityTickTimer !== undefined) return
+    activityTickTimer = setInterval(() => {
+      const previous = state.workingActivity
+      const rendered = updateWorkingActivity('activity tick')
+      if (rendered === undefined) return
+      if (rendered.phase === 'done') {
+        // Retire once the done line has been stable past the fragment
+        // window — no more React updates, timer or tracker work needed.
+        if (previous !== undefined && previous.line === rendered.line) {
+          activityDoneStableSince ??= Date.now()
+          if (Date.now() - activityDoneStableSince >= ACTIVITY_DONE_STABLE_MS) {
+            stopActivityTick()
+            return
+          }
+        } else {
+          activityDoneStableSince = undefined
+        }
+      } else {
+        activityDoneStableSince = undefined
+      }
+      // Live phases deliberately wake at 500 ms even when the formatted line
+      // has not crossed its next whole-second boundary: turnElapsedMs remains
+      // a current state value, while line changes cover phrase rotation and
+      // the short-lived completed-tool summary.
+      if (
+        rendered.phase === 'waiting' ||
+        rendered.phase === 'thinking' ||
+        rendered.phase === 'tool' ||
+        previous?.phase !== rendered.phase ||
+        previous.line !== rendered.line
+      ) {
+        state.emit()
+      }
+    }, 500)
+    activityTickTimer.unref()
   }
 
   /** Render the current tracker into the TUI-only projection. */
@@ -8340,7 +8521,18 @@ ${output}
   ): ActivityStatus | undefined => {
     try {
       update?.()
-      return renderWorkingActivity()
+      const rendered = renderWorkingActivity()
+      // Live phases need the 500ms tick to keep turnElapsedMs/phrase
+      // rotation current — (re)arm it whenever an event or status change
+      // brings the tracker back to a live phase (a done/idle phase lets
+      // the tick retire itself, see maybeRetireActivityTick).
+      if (
+        rendered !== undefined &&
+        (rendered.phase === 'waiting' || rendered.phase === 'thinking' || rendered.phase === 'tool')
+      ) {
+        ensureActivityTick()
+      }
+      return rendered
     } catch (error: unknown) {
       if (!activityFailureReported) {
         activityFailureReported = true
@@ -8370,11 +8562,45 @@ ${output}
     updateSpinnerMode()
   }
 
+  // ── trajectory projection (channel-owned, event-driven) ───────────────────
+  // The session trajectory is folded HERE — at event time — so Chat renders
+  // never touch the session event getter (hosts without a snapshot cache pay
+  // an O(n) copy per render otherwise). The fold is incremental: identical
+  // prefix (object identity at the previous last index) → tail-only consume;
+  // anything else (session swap, rewind fork, /new) rebuilds from scratch.
+  // bindAgent resets the build explicitly so a swap can never extend a stale
+  // projection.
+  let trajectoryBuild: TrajBuild = emptyTrajectory()
+  /**
+   * Fold ONE newly observed main-session event into the trajectory build —
+   * incrementally, from the event the observer already holds. The session
+   * getter (`agent.session.events`) is O(n) on hosts that rebuild a frozen
+   * snapshot per append, so it must stay off the token-rate path: a full
+   * fold happens only in bindAgent (once per agent swap, where O(n) is
+   * the correct cost).
+   */
+  const foldTrajectoryEvent = (event: SessionEvent): void => {
+    trajectoryBuild = extendTrajectoryEvents(trajectoryBuild, [event])
+  }
+
   const bindAgent = (): void => {
     agentBindingGeneration += 1
     state.agentBindingGeneration = agentBindingGeneration
     for (const dispose of agentSubscriptions) dispose()
     stopActivityTick()
+    // A new agent starts with a fresh skill-retry budget (an old ladder's
+    // attempt counter must not shorten the new agent's retries). In-flight
+    // refreshes from the previous agent are already stale via the
+    // `target !== agent` check — the refresh generation is NOT bumped here
+    // because the boot-time refresh resolves AFTER this first bindAgent.
+    skillRetryAttempts = 0
+    skillRetryDelayMs = SKILL_COMMAND_RETRY_MS
+    // The trajectory build belongs to ONE bound agent's session log. A
+    // replacement (rewind/resume/new/workspace/model-switch) must never
+    // extend the previous session's projection — reset and fold the new
+    // session's full log once here (O(n) once per swap, never per event).
+    trajectoryBuild = emptyTrajectory()
+    trajectoryBuild = extendTrajectory(trajectoryBuild, agent.session.events)
     // Cancel state and deferred interrupt delivery belong to one bound agent.
     // A replacement must neither inherit the old latch nor receive its queued
     // microtask after the session identity changes.
@@ -8383,26 +8609,8 @@ ${output}
     const prefs = activityPrefsSnapshot()
     activityTracker = new ActivityTracker(prefs.config, Date.now, prefs.customActions)
     activityFailureReported = false
+    activityDoneStableSince = undefined
     updateWorkingActivity('agent bind', () => activityTracker.onAgentStatus(agent.status))
-    activityTickTimer = setInterval(() => {
-      const previous = state.workingActivity
-      const rendered = updateWorkingActivity('activity tick')
-      if (rendered === undefined) return
-      // Live phases deliberately wake at 500 ms even when the formatted line
-      // has not crossed its next whole-second boundary: turnElapsedMs remains
-      // a current state value, while line changes cover phrase rotation and
-      // the short-lived completed-tool summary.
-      if (
-        rendered.phase === 'waiting' ||
-        rendered.phase === 'thinking' ||
-        rendered.phase === 'tool' ||
-        previous?.phase !== rendered.phase ||
-        previous.line !== rendered.line
-      ) {
-        state.emit()
-      }
-    }, 500)
-    activityTickTimer.unref()
     // Re-couple the channel-owned model selection to the new agent's
     // assembly/request waterfalls, then re-apply the persisted effort when
     // this agent's route offers it (dsh-agent installModelSelection).
@@ -8539,6 +8747,12 @@ ${output}
           }
         }
         renderEvent(event)
+        // Fold the trajectory incrementally here — at EVENT time, not render
+        // time: Chat renders must never touch the session getter, and the
+        // token-rate path must not re-read the O(n) session snapshot. The
+        // observer already holds the event, so the fold consumes it directly
+        // (chunks are pure timing updates, O(1) with no state copy).
+        foldTrajectoryEvent(event)
         // Streaming deltas (one event per token) take the frame-aligned
         // path; every other event keeps synchronous notification.
         if (event.type === 'assistant/chunk') state.emitStream()

--- a/src/dsh-adapter/grants.ts
+++ b/src/dsh-adapter/grants.ts
@@ -1,7 +1,7 @@
 /** Live, scoped plugin grant evaluation. */
 
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync, watch as watchFile } from 'node:fs'
+import { dirname, join } from 'node:path'
 import type { PermissionRegistry } from '../plugin-spec/types.js'
 import { normalizePermissionScope, permissionScopeCovers } from '../plugin-spec/permission-scope.js'
 import { loadSpecData } from '../plugin-spec/registry.js'
@@ -198,12 +198,16 @@ export function readGrantStore(dir: string = DATA_DIR, registry?: PermissionRegi
       table: missing
         ? { grants: new Map(), denies: new Map(), corrupt: false }
         : parseTable(text),
-      signature: text,
+      // The existence bit is part of the signature: a missing file and an
+      // existing empty file both read as '' but are different states.
+      signature: `${missing ? 'M' : 'E'}:${text}`,
     }
   }
   const listeners = new Set<() => void>()
   let watching = false
   let watchTimer: ReturnType<typeof setInterval> | undefined
+  let watcher: ReturnType<typeof watchFile> | undefined
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
   let signature = readCurrent().signature
   const changed = (): void => {
     const next = readCurrent().signature
@@ -218,23 +222,74 @@ export function readGrantStore(dir: string = DATA_DIR, registry?: PermissionRegi
       }
     }
   }
+  // Debounced file-change notification: fs.watch can fire several events per
+  // write (rename+change on atomic replace), so coalesce them into one read.
+  const scheduleCheck = (): void => {
+    if (debounceTimer !== undefined) return
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined
+      changed()
+    }, 50)
+  }
+  const startWatching = (): void => {
+    // Prefer fs.watch on the PARENT DIRECTORY, not the file itself: the
+    // common atomic-replace write (temp file + rename) swaps the inode the
+    // file watcher holds, after which the old watcher goes silent. A
+    // directory watcher sees the rename/create/delete and the debounce
+    // re-reads the (possibly new) file. A poll fallback covers filesystems
+    // and edge cases where the watcher cannot be established. Both stop
+    // when the last listener unsubscribes; the fallback deliberately polls
+    // at a low frequency — the synchronous per-operation read remains the
+    // authorization source of truth, so this loop only needs to release
+    // grant-owned subscriptions promptly after a revocation, not keep them
+    // perfectly current.
+    let watchingFailed = false
+    try {
+      watcher = watchFile(dirname(file), { persistent: false }, () => scheduleCheck())
+      watcher.on('error', () => {
+        watchingFailed = true
+        watcher?.close()
+        watcher = undefined
+        if (listeners.size > 0 && watchTimer === undefined) {
+          watchTimer = setInterval(changed, 2000)
+          watchTimer.unref?.()
+        }
+      })
+      // fs.watch on some platforms silently misses events (or refuses to
+      // watch a not-yet-existing directory); a first error already re-arms
+      // the fallback above, and the watcher stays authoritative while
+      // healthy.
+    } catch {
+      watchingFailed = true
+      watcher = undefined
+    }
+    if (watchingFailed && watchTimer === undefined) {
+      watchTimer = setInterval(changed, 2000)
+      watchTimer.unref?.()
+    }
+  }
   const onChange = (listener: () => void): (() => void) => {
     listeners.add(listener)
     if (!watching) {
       watching = true
-      // A small unref'ed poll is deterministic across filesystems and
-      // timestamp granularities. The synchronous read on every operation
-      // remains the authorization source of truth; this loop only releases
-      // grant-owned subscriptions promptly after a revocation.
-      watchTimer = setInterval(changed, 50)
-      watchTimer.unref?.()
+      startWatching()
     }
     return () => {
       listeners.delete(listener)
       if (watching && listeners.size === 0) {
         watching = false
-        if (watchTimer !== undefined) clearInterval(watchTimer)
-        watchTimer = undefined
+        if (debounceTimer !== undefined) {
+          clearTimeout(debounceTimer)
+          debounceTimer = undefined
+        }
+        if (watchTimer !== undefined) {
+          clearInterval(watchTimer)
+          watchTimer = undefined
+        }
+        if (watcher !== undefined) {
+          watcher.close()
+          watcher = undefined
+        }
       }
     }
   }

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { writeSync } from 'node:fs'
 import React from 'react'
 import { SessionId } from '@deepseek-ai/dsh-session'
 import type { Agent, AgentHandle } from '@deepseek-ai/dsh-agent'
@@ -1785,6 +1786,19 @@ export function isExitResumable(deps: {
 type InkShutdownState = {
   detachForShutdown?: () => void
   /**
+   * Phase 1 of the shutdown split: latch isUnmounted and stop every output
+   * producer while raw mode is STILL held, so the exit sequence below is
+   * consumed by the remote terminal during the raw-mode settle window
+   * instead of being echoed as caret garbage after cooked returns (#522).
+   */
+  beginShutdown?: () => void
+  /**
+   * Phase 2 of the shutdown split: restore cooked mode and drain stdin.
+   * finishExit runs it from a finally, so even a failed exit write cannot
+   * skip the raw-mode restore.
+   */
+  concludeShutdown?: () => void
+  /**
    * Full stdin detach for the /update child handoff (issues #284/#307):
    * removes the readable/data listeners and pauses the pump so the
    * lingering parent stops racing the restarted TUI for keypresses.
@@ -1792,6 +1806,21 @@ type InkShutdownState = {
   detachStdinForHandoff?: () => void
   /** Drain pending stdin bytes; the exit funnel re-drains after cleanup. */
   drainStdin?: () => void
+  /**
+   * The stream this runtime renders to. The barrier and every exit write
+   * must target THIS object — not whatever process.stdout points at during
+   * shutdown: the instances-map lookup missed precisely because the host
+   * replaced process.stdout, so writing the cleanup to the CURRENT
+   * process.stdout would leave the runtime's own stream (its queued frames,
+   * its mouse state) unhandled (stdout identity drift, #522).
+   */
+  stdout?: NodeJS.WriteStream
+  /**
+   * True after Ink.unmount wrote the terminal cleanup block itself (React
+   * error-boundary / signal-exit path); finishExit then skips re-writing
+   * the mode resets and only parks the cursor and prints the notice.
+   */
+  hasWrittenExitCleanup?: boolean
   frontFrame?: { cursor?: { x: number; y: number } }
   displayCursor?: { x: number; y: number } | null
 }
@@ -1808,6 +1837,7 @@ export async function finishExit(
   stderrNotice: string | undefined,
   done: () => void,
 ): Promise<void> {
+  let runtime: InkShutdownState | undefined
   try {
     // Resolve the Ink runtime twice: the instances map is keyed by stdout
     // identity, so a replaced/overridden stdout misses it; the render()
@@ -1817,11 +1847,13 @@ export async function finishExit(
     // ENABLE_MOUSE_TRACKING after DISABLE_MOUSE_TRACKING had been sent).
     const fromMap = readInkShutdownState(instances.get(process.stdout))
     const fromHandle = instance === undefined ? undefined : readInkShutdownState(instance)
-    // A handle that exposes neither detach hook is not an Ink runtime we can
-    // latch (e.g. the fake render handles in shutdown regressions) — treat it
-    // as a lookup miss so the full-unmount fallback below can still run.
-    const runtime = fromMap ?? (
-      fromHandle?.detachForShutdown === undefined && fromHandle?.detachStdinForHandoff === undefined
+    // A handle that exposes no shutdown hook at all is not an Ink runtime we
+    // can latch (e.g. the fake render handles in shutdown regressions) —
+    // treat it as a lookup miss so the full-unmount fallback below can run.
+    runtime = fromMap ?? (
+      fromHandle?.detachForShutdown === undefined
+      && fromHandle?.beginShutdown === undefined
+      && fromHandle?.detachStdinForHandoff === undefined
         ? undefined
         : fromHandle
     )
@@ -1844,60 +1876,297 @@ export async function finishExit(
       ctx.logger.debug('dsh-tui: Ink runtime resolved from the render handle (instances map missed); detaching')
     }
     const cursor = fullscreen ? '' : cursorMoveToFrameEnd(runtime)
+    // Every byte below targets the runtime's OWN stream. The instances map
+    // is keyed by stdout identity, so a missed lookup means the host
+    // replaced process.stdout after render — writing the cleanup to the
+    // CURRENT process.stdout would latch one stream's runtime while the
+    // bytes land on another (stdout identity drift, #522). Only the
+    // runtime-less fallback keeps the historical process.stdout target.
+    const target = runtime?.stdout ?? process.stdout
 
+    // Phase 1 latch, taken while raw mode is STILL HELD: stop every output
+    // producer (render, alt-screen health probe, mode re-assert) so nothing
+    // can re-write ENABLE_MOUSE_TRACKING or queue a frame while the disable
+    // bytes below are in flight. Raw mode must survive until the settle
+    // window below has elapsed: writeSync only proves the bytes reached the
+    // kernel tty buffer, not that the remote terminal consumed them — on a
+    // slow/stalled link (ssh is #522's environment) the terminal keeps
+    // sending SGR mouse reports for a while, and only raw mode keeps the
+    // kernel line discipline from echoing them as caret-notation
+    // `^[[<35;130;47M` garbage over the frozen UI. Compat: pre-split
+    // runtimes expose only the composite detachForShutdown, which already
+    // latches first (its cooked restore then happens here, same as before).
+    const latch = runtime?.beginShutdown ?? runtime?.detachForShutdown
     try {
-      runtime?.detachForShutdown?.()
-      // The /update continuation spawns children that inherit this stdin;
-      // strip the readable pump so the parent cannot swallow their input
-      // (issues #284/#307). Harmless on plain exits — the process exits
-      // right after this cleanup anyway.
-      runtime?.detachStdinForHandoff?.()
+      latch?.call(runtime)
     } catch {
-      ctx.logger.debug('dsh-tui: Ink shutdown detach failed; continuing with generic terminal cleanup')
+      ctx.logger.debug('dsh-tui: Ink shutdown latch failed; continuing with generic terminal cleanup')
     }
-    const cleanup = [
-      fullscreen ? EXIT_ALT_SCREEN : '',
-      cursor,
-      DISABLE_MOUSE_TRACKING,
-      DISABLE_MODIFY_OTHER_KEYS,
-      DISABLE_KITTY_KEYBOARD,
-      DISABLE_WIN32_INPUT_MODE,
-      DFE,
-      DBP,
-      SHOW_CURSOR,
-      CLEAR_ITERM2_PROGRESS,
-      supportsTabStatus() ? wrapForMultiplexer(CLEAR_TAB_STATUS) : '',
-    ].join('')
+    // Queue barrier between the latch and the exit writes: queued Ink frames
+    // or a last-moment ENABLE_MOUSE_TRACKING can still sit in Node's
+    // user-space buffer, and a direct-fd writeSync would overtake them —
+    // landing ENABLE after DISABLE (mouse tracking back on at the shell) or
+    // a frame after EXIT_ALT_SCREEN (garbage on the main screen). Everything
+    // after the latch is gated by isUnmounted, so nothing new queues. On
+    // timeout the queue is still draining (stalled link): the writer then
+    // stays in ORDERED stream mode — late bytes land BEFORE the exit
+    // sequence, never interleaved after it.
+    const queueDrained = await flushExitWriteBarrier(target)
+    if (!queueDrained) {
+      ctx.logger.debug('dsh-tui: stdout queue still draining after 1s; exit sequence switches to ordered queued writes')
+    }
+    const writer = createExitWriter(target, queueDrained)
     const suffix = notice === undefined ? '' : `${notice}\n`
-    await writeStream(process.stdout, `${cleanup}\r\n${suffix}`)
-    // Re-drain AFTER the cleanup sequences have landed (#507): terminal
-    // replies and mouse packets already in flight when the exit started
-    // keep arriving while cleanup is being written — the detach-time drain
-    // cannot see them. Unconsumed at process exit they land in the shell's
-    // input queue (DECRPM/DA1/XTVERSION garbage pasted into the prompt).
-    // 150ms settle covers reply RTT on slow links (ssh/ghostty is #522's
-    // environment; 50ms proved too tight there) while staying well inside
-    // the exit window the user already waits through.
+    if (runtime?.hasWrittenExitCleanup === true) {
+      // React error-boundary / signal-exit path: Ink.unmount already wrote
+      // the mode resets (and released raw mode before the funnel could hold
+      // it). Re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN here would
+      // double-reset the terminal; only the cursor park and notice remain.
+      writer.write(`${cursor}\r\n${suffix}`)
+    } else {
+      writer.write(DISABLE_MOUSE_TRACKING)
+      const cleanup = [
+        fullscreen ? EXIT_ALT_SCREEN : '',
+        cursor,
+        DISABLE_MODIFY_OTHER_KEYS,
+        DISABLE_KITTY_KEYBOARD,
+        DISABLE_WIN32_INPUT_MODE,
+        DFE,
+        DBP,
+        SHOW_CURSOR,
+        CLEAR_ITERM2_PROGRESS,
+        supportsTabStatus() ? wrapForMultiplexer(CLEAR_TAB_STATUS) : '',
+      ].join('')
+      writer.write(`${cleanup}\r\n${suffix}`)
+    }
+    // Ordered completion wait: queued writes must be acknowledged before
+    // the settle window (and before process.exit after done()), otherwise
+    // the disable bytes can still be truncated from Node's user-space
+    // buffer (#522 through a different door). A false result means the
+    // stream is wedged — the bytes remain queued IN ORDER, so the worst
+    // case is truncation at process exit, never an ENABLE-after-DISABLE
+    // scramble.
+    await writer.flush()
+    // Settle window spent in RAW mode (#507 + #522): terminal replies and
+    // mouse packets already in flight when the exit started keep arriving
+    // while cleanup is being written — the latch-time drain cannot see
+    // them. Held raw, the bytes sit in the tty input buffer unread instead
+    // of being echoed by the kernel; the drain below then empties the
+    // buffer so nothing leaks into the shell's input queue (DECRPM/DA1/
+    // XTVERSION garbage pasted into the prompt). 150ms covers reply RTT on
+    // slow links (ssh/ghostty is #522's environment; 50ms proved too tight
+    // there) while staying well inside the exit window the user already
+    // waits through.
     await new Promise<void>(resolve => setTimeout(resolve, 150))
     runtime?.drainStdin?.()
+  } catch {
+    ctx.logger.debug('dsh-tui: terminal cleanup failed; continuing with process shutdown')
+  } finally {
+    // Phase 2, unconditionally: only NOW restore cooked+echo (the remote
+    // terminal has had the full settle window to consume the disable
+    // bytes). Each release is isolated: concludeShutdown can throw on a
+    // revoked tty (its handleSetRawMode writes) and must NOT skip the
+    // stdin handoff — the /update child would otherwise race the lingering
+    // readable pump (issues #284/#307; harmless on plain exits).
+    try {
+      runtime?.concludeShutdown?.()
+    } catch {
+      ctx.logger.debug('dsh-tui: Ink shutdown conclude failed; continuing with generic terminal cleanup')
+    }
+    try {
+      runtime?.detachStdinForHandoff?.()
+    } catch {
+      ctx.logger.debug('dsh-tui: Ink stdin handoff detach failed; continuing with process shutdown')
+    }
     if (stderrNotice !== undefined) {
       await writeStream(process.stderr, `\n${stderrNotice}\n`)
     }
-  } catch {
-    ctx.logger.debug('dsh-tui: terminal cleanup failed; continuing with process shutdown')
   }
   done()
+}
+
+/**
+ * Exit-write barrier: flush whatever Node's user-space queue still holds
+ * (queued Ink frames, a re-asserted ENABLE_MOUSE_TRACKING) BEFORE the
+ * direct-fd writeSync calls of the exit sequence. writeSync overtakes any
+ * queued bytes — without the barrier, a pre-queued ENABLE would land after
+ * DISABLE (mouse tracking back on at the shell) and a queued frame after
+ * EXIT_ALT_SCREEN (garbage painted on the main screen). `write('', cb)` is
+ * NOT usable as the barrier — the empty chunk's callback fires out of
+ * order — so poll writableLength on a short interval (writableLength covers
+ * both queued AND in-flight chunks: Node decrements it only when the
+ * chunk's _write callback fires). Returns whether the queue drained: on
+ * timeout (stalled link) the caller must NOT fall through to direct-fd
+ * writes — createExitWriter then stays in ordered stream mode instead. The
+ * poll timer is REF'd on purpose: the barrier is an intentional bounded
+ * wait inside the exit window (exactly like the 150ms settle) — unref'd,
+ * it would let the process exit from under finishExit the moment the queue
+ * drains and the loop has nothing else to keep it alive.
+ */
+function flushExitWriteBarrier(stdout: NodeJS.WriteStream): Promise<boolean> {
+  if (typeof stdout.writableLength !== 'number' || stdout.writableLength === 0) {
+    return Promise.resolve(true)
+  }
+  return new Promise(resolve => {
+    const started = Date.now()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const finish = (drained: boolean): void => {
+      if (timer !== undefined) clearTimeout(timer)
+      resolve(drained)
+    }
+    const poll = (): void => {
+      if (stdout.writableLength === 0) {
+        finish(true)
+        return
+      }
+      if (Date.now() - started >= 1000) {
+        finish(false)
+        return
+      }
+      timer = setTimeout(poll, 5)
+    }
+    poll()
+  })
+}
+
+/**
+ * Spin bed for the EAGAIN retry below: Atomics.wait blocks the main thread
+ * for ~10ms per retry — acceptable inside the exit window, and the only
+ * synchronous sleep available here.
+ */
+const exitWriteRetryBed = new Int32Array(new SharedArrayBuffer(4))
+
+/**
+ * Ordered writer for the exit sequence. Two disciplines, never mixed:
+ *
+ * - FAST PATH (fd known, queue drained by the barrier): writeSync straight
+ *   to the stream's own fd (never a hard-coded 1, issue #522), looping on
+ *   short writes and retrying EINTR / bounded EAGAIN. Bytes reach the
+ *   kernel tty buffer before process.exit instead of sitting in Node's
+ *   user-space buffer where exit would truncate them.
+ * - ORDERED PATH (no fd, barrier timed out, or any sync write failed /
+ *   short-wrote): plain stream.write, which queues BEHIND whatever is
+ *   still in flight — a pre-queued ENABLE lands before DISABLE, a late
+ *   frame before EXIT_ALT_SCREEN. STICKY: once any byte goes through the
+ *   queue, every later write queues too, because a direct-fd write would
+ *   overtake the queued remainder and scramble the sequence. flush() then
+ *   waits (bounded 1s) for the last chunk's callback — write callbacks
+ *   fire in order, so it acknowledges everything queued before it. On a
+ *   wedged stream the bytes stay queued IN ORDER: worst case is ordered
+ *   truncation at process exit, never interleaving.
+ *
+ * Residual: a blocking fd with a full kernel buffer (wedged pty) can still
+ * park writeSync — no synchronous API can bound the syscall itself. The
+ * barrier makes it vanishingly unlikely: the link demonstrably moved just
+ * before. NEVER THROWS either way: finishExit's finally must reach the
+ * cooked-mode restore even when the terminal is already gone (revoked tty,
+ * closed fd, EIO).
+ */
+function createExitWriter(
+  stdout: NodeJS.WriteStream,
+  queueDrained: boolean,
+): { write: (text: string) => void; flush: () => Promise<boolean> } {
+  const stdoutWithFd = stdout as NodeJS.WriteStream & { fd?: number | null }
+  const fd = queueDrained && typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : undefined
+  let streamMode = fd === undefined
+  let completion: Promise<void> | undefined
+
+  const queueWrite = (chunk: string | Uint8Array): void => {
+    // Never rejects, never throws — finishExit's finally must run even when
+    // the stream is destroyed underneath us.
+    completion = new Promise<void>(resolve => {
+      try {
+        stdout.write(chunk, () => resolve())
+      } catch {
+        resolve()
+      }
+    })
+  }
+
+  const write = (text: string): void => {
+    if (text === '') return
+    if (streamMode) {
+      queueWrite(text)
+      return
+    }
+    const bytes = Buffer.from(text)
+    let offset = 0
+    let eagainBudget = 3
+    let eintrBudget = 3
+    while (offset < bytes.length) {
+      let written = 0
+      try {
+        // eslint-disable-next-line custom-rules/no-sync-fs -- process exiting; async writes would be dropped
+        written = writeSync(fd as number, bytes, offset, bytes.length - offset, null)
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code
+        // Interrupted syscall: retry immediately, on its own budget.
+        if (code === 'EINTR' && eintrBudget > 0) {
+          eintrBudget -= 1
+          continue
+        }
+        // Non-blocking fd, full kernel buffer (stalled link): bounded spin.
+        if ((code === 'EAGAIN' || code === 'EWOULDBLOCK') && eagainBudget > 0) {
+          eagainBudget -= 1
+          Atomics.wait(exitWriteRetryBed, 0, 0, 10)
+          continue
+        }
+        break
+      }
+      if (written <= 0) {
+        // Zero progress on a live fd: same treatment as EAGAIN, bounded.
+        if (eagainBudget > 0) {
+          eagainBudget -= 1
+          Atomics.wait(exitWriteRetryBed, 0, 0, 10)
+          continue
+        }
+        break
+      }
+      offset += written
+    }
+    if (offset >= bytes.length) return
+    // Partial/failed sync write: queue ONLY the remainder and stay in
+    // stream mode for the rest of the sequence.
+    streamMode = true
+    queueWrite(bytes.subarray(offset))
+  }
+
+  const flush = (): Promise<boolean> => {
+    if (completion === undefined) return Promise.resolve(true)
+    const pending = completion
+    return new Promise(resolve => {
+      const timer = setTimeout(() => resolve(false), 1000)
+      void pending.then(() => {
+        clearTimeout(timer)
+        resolve(true)
+      })
+    })
+  }
+
+  return { write, flush }
 }
 
 function readInkShutdownState(value: unknown): InkShutdownState | undefined {
   if (value === null || typeof value !== 'object') return undefined
   const candidate = value as Record<string, unknown>
   if (candidate.detachForShutdown !== undefined && typeof candidate.detachForShutdown !== 'function') return undefined
+  if (candidate.beginShutdown !== undefined && typeof candidate.beginShutdown !== 'function') return undefined
+  if (candidate.concludeShutdown !== undefined && typeof candidate.concludeShutdown !== 'function') return undefined
   if (candidate.detachStdinForHandoff !== undefined && typeof candidate.detachStdinForHandoff !== 'function') return undefined
   if (candidate.drainStdin !== undefined && typeof candidate.drainStdin !== 'function') return undefined
+  if (candidate.stdout !== undefined && !isWritableLike(candidate.stdout)) return undefined
+  if (candidate.hasWrittenExitCleanup !== undefined && typeof candidate.hasWrittenExitCleanup !== 'boolean') return undefined
   if (candidate.frontFrame !== undefined && !isFrameState(candidate.frontFrame)) return undefined
   if (candidate.displayCursor !== undefined && candidate.displayCursor !== null && !isCursorState(candidate.displayCursor)) return undefined
   return value as InkShutdownState
+}
+
+function isWritableLike(value: unknown): value is NodeJS.WriteStream {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as Record<string, unknown>).write === 'function'
+  )
 }
 
 function isFrameState(value: unknown): value is { cursor?: { x: number; y: number } } {

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1587,6 +1587,16 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     funnel.markTeardown()
     channel.releaseContributions()
     instance?.unmount()
+    // Safety net for the crash-then-teardown race: an app-driven unmount
+    // DEFERS the cooked-mode restore to finishExit, but markTeardown makes
+    // the funnel swallow that exit — without this, raw mode would leak on
+    // the live process. Idempotent (shutdownPhase guard); a plain teardown
+    // already concluded inside unmount().
+    try {
+      instance?.concludeShutdown?.()
+    } catch {
+      ctx.logger.debug('dsh-tui: teardown conclude failed; terminal may be left raw')
+    }
   })
 
   // The TUI is the front door: when the user unmounts it (Ctrl+C), dispose
@@ -1826,10 +1836,41 @@ type InkShutdownState = {
 }
 
 /**
+ * In-flight guard for finishExit: the exit funnel serializes USER exits, but
+ * finishExit is exported and process-level — concurrent callers (racing exit
+ * actions, embedder helpers) must not re-run the cleanup/handoff. A second
+ * call while one is running simply awaits the first; its done() is
+ * deliberately NOT invoked — the process-level exit action belongs to the
+ * exit that actually ran the terminal cleanup.
+ */
+let activeFinishExit: Promise<void> | undefined
+
+/**
  * Finish terminal I/O before handing control to a process-level exit action.
  * Exported for scripts/verify-shutdown-fallback.
  */
 export async function finishExit(
+  ctx: Context,
+  instance: Awaited<ReturnType<typeof render>> | undefined,
+  fullscreen: boolean,
+  notice: string | undefined,
+  stderrNotice: string | undefined,
+  done: () => void,
+): Promise<void> {
+  if (activeFinishExit !== undefined) {
+    ctx.logger.debug('dsh-tui: exit already in flight; awaiting it instead of re-running terminal cleanup')
+    return activeFinishExit
+  }
+  const run = finishExitOnce(ctx, instance, fullscreen, notice, stderrNotice, done)
+  activeFinishExit = run
+  try {
+    await run
+  } finally {
+    if (activeFinishExit === run) activeFinishExit = undefined
+  }
+}
+
+async function finishExitOnce(
   ctx: Context,
   instance: Awaited<ReturnType<typeof render>> | undefined,
   fullscreen: boolean,
@@ -1919,8 +1960,9 @@ export async function finishExit(
     const suffix = notice === undefined ? '' : `${notice}\n`
     if (runtime?.hasWrittenExitCleanup === true) {
       // React error-boundary / signal-exit path: Ink.unmount already wrote
-      // the mode resets (and released raw mode before the funnel could hold
-      // it). Re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN here would
+      // the mode resets (with raw mode still held — the cooked restore is
+      // deferred to the concludeShutdown in this funnel's finally).
+      // Re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN here would
       // double-reset the terminal; only the cursor park and notice remain.
       writer.write(`${cursor}\r\n${suffix}`)
     } else {

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1842,6 +1842,24 @@ type InkShutdownState = {
  * call while one is running simply awaits the first; its done() is
  * deliberately NOT invoked — the process-level exit action belongs to the
  * exit that actually ran the terminal cleanup.
+ *
+ * INVARIANT (process-owning runtime uniqueness): dsh-tui creates exactly ONE
+ * process-owning TUI runtime per process — plugin apply() renders a single
+ * Ink root (the single `render(tree)` call), and /restart + /update hand the
+ * terminal to CHILD processes rather than mounting a second in-process
+ * runtime. Under that invariant this module-global guard is sound: any two
+ * concurrent finishExit calls necessarily target the same (or an already
+ * dead) runtime, so exactly-once terminal cleanup and exactly-one final
+ * process action is the required semantics — a /exit vs error-boundary vs
+ * /restart vs /update race must never double-run terminal cleanup nor fire
+ * two process actions. If that invariant ever changes (multiple independent
+ * Ink roots in one process), this guard must move per-runtime: the terminal
+ * cleanup serialization keyed by the runtime (or its stdout), with only the
+ * process-level exit action arbiter staying global.
+ *
+ * Regression: scripts/verify-shutdown-fallback.tsx exercises the concurrent
+ * calls; scripts/verify-exit-runtime-selection.tsx additionally proves a
+ * map-vs-handle drift cannot latch the wrong runtime.
  */
 let activeFinishExit: Promise<void> | undefined
 
@@ -1880,24 +1898,28 @@ async function finishExitOnce(
 ): Promise<void> {
   let runtime: InkShutdownState | undefined
   try {
-    // Resolve the Ink runtime twice: the instances map is keyed by stdout
-    // identity, so a replaced/overridden stdout misses it; the render()
-    // handle is the caller's own instance and always matches (issue #522 —
-    // a missed lookup skipped detachForShutdown, leaving the stdin pump,
-    // TTY handlers and querier alive so the self-heal probe re-wrote
-    // ENABLE_MOUSE_TRACKING after DISABLE_MOUSE_TRACKING had been sent).
+    // Resolve the Ink runtime. HANDLE-FIRST: the explicitly passed render
+    // handle is the runtime THIS exit call actually corresponds to — when it
+    // is a valid Ink runtime (exposes any shutdown hook), it wins. The
+    // instances map is only a fallback for callers without a handle. The
+    // previous map-first order could clean up the WRONG runtime in
+    // multi-instance / custom-stdout / process.stdout-identity-drift setups:
+    // finishExit(..., instanceA) with instances.get(process.stdout) === B
+    // latched B (begin/conclude + cleanup bytes on B's stream) while A —
+    // the runtime actually exiting — kept its pump, TTY handlers and mouse
+    // state (issue #522's residue through a second door).
     const fromMap = readInkShutdownState(instances.get(process.stdout))
     const fromHandle = instance === undefined ? undefined : readInkShutdownState(instance)
     // A handle that exposes no shutdown hook at all is not an Ink runtime we
     // can latch (e.g. the fake render handles in shutdown regressions) —
     // treat it as a lookup miss so the full-unmount fallback below can run.
-    runtime = fromMap ?? (
-      fromHandle?.detachForShutdown === undefined
-      && fromHandle?.beginShutdown === undefined
-      && fromHandle?.detachStdinForHandoff === undefined
-        ? undefined
-        : fromHandle
-    )
+    const handleIsRuntime =
+      fromHandle !== undefined && (
+        fromHandle.detachForShutdown !== undefined ||
+        fromHandle.beginShutdown !== undefined ||
+        fromHandle.detachStdinForHandoff !== undefined
+      )
+    runtime = handleIsRuntime ? fromHandle : fromMap
     if (runtime === undefined) {
       ctx.logger.debug('dsh-tui: Ink runtime unavailable during shutdown; using generic terminal cleanup')
       if (instance !== undefined) {
@@ -1913,8 +1935,8 @@ async function finishExitOnce(
           ctx.logger.debug('dsh-tui: Ink shutdown unmount fallback failed; continuing with generic terminal cleanup')
         }
       }
-    } else if (fromMap === undefined) {
-      ctx.logger.debug('dsh-tui: Ink runtime resolved from the render handle (instances map missed); detaching')
+    } else if (!handleIsRuntime) {
+      ctx.logger.debug('dsh-tui: Ink runtime resolved from the instances map (no usable render handle); detaching')
     }
     const cursor = fullscreen ? '' : cursorMoveToFrameEnd(runtime)
     // Every byte below targets the runtime's OWN stream. The instances map

--- a/src/dsh-adapter/trajectory/index.ts
+++ b/src/dsh-adapter/trajectory/index.ts
@@ -13,6 +13,7 @@ export {
   buildTrajectory,
   emptyTrajectory,
   extendTrajectory,
+  extendTrajectoryEvents,
   type StepTiming,
   type TrajBuild,
 } from './projection.js'

--- a/src/dsh-adapter/trajectory/projection.ts
+++ b/src/dsh-adapter/trajectory/projection.ts
@@ -76,6 +76,13 @@ export interface StepTiming {
 export interface TrajBuild {
   /** The snapshot this build consumed; identity-compared on the next append. */
   readonly source: readonly RawTrajEvent[]
+  /**
+   * Monotonic content revision: bumps by one per consumed event (including
+   * events that only CLOSE or mutate existing nodes in place — the node
+   * array identity and length do not change then, so consumers must key
+   * their memos on this, not on `nodes`).
+   */
+  readonly revision: number
   /** The ledger, in log order, after burst folding. */
   readonly nodes: TrajNode[]
   /** Per-step timing keyed `${turn}:${step}`, for the hotspot aggregate. */
@@ -721,7 +728,7 @@ function consume(state: FoldState, nodes: TrajNode[], timing: Map<string, StepTi
 /** An empty build, used as the identity element and for empty sessions. */
 export function emptyTrajectory(): TrajBuild {
   const state = newState()
-  return { source: [], nodes: [], timing: new Map(), counts: state.counts, state }
+  return { source: [], revision: 0, nodes: [], timing: new Map(), counts: state.counts, state }
 }
 
 /**
@@ -750,14 +757,50 @@ export function extendTrajectory(
       consume(state, nodes, timing, raw[index]!)
     }
     syncRowCount(state, nodes)
-    return { source: raw, nodes, timing, counts: state.counts, state }
+    return { source: raw, nodes, timing, counts: state.counts, state, revision: previous.revision + (raw.length - previous.source.length) }
   }
   const nodes: TrajNode[] = []
   const timing = new Map<string, StepTiming>()
   const state = newState()
   for (const event of raw) consume(state, nodes, timing, event)
   syncRowCount(state, nodes)
-  return { source: raw, nodes, timing, counts: state.counts, state }
+  return { source: raw, nodes, timing, counts: state.counts, state, revision: raw.length }
+}
+
+/**
+ * Incrementally fold a batch of NEW events into a previous build WITHOUT
+ * re-reading the session snapshot — the caller (the channel's event
+ * observer) already holds the appended events, so the O(n) snapshot getter
+ * stays off the token-rate hot path.
+ *
+ * No prefix-identity check: the caller guarantees `appended` continues the
+ * log the build consumed. `source` keeps the last known snapshot reference
+ * (stale by design — nothing re-validates against it on this path; a full
+ * rebuild via {@link extendTrajectory} after a session swap starts from
+ * `emptyTrajectory`).
+ *
+ * Chunk-only batches (pure timing updates) reuse the shared fold state
+ * without cloning the bracket maps — the token-rate path pays O(1).
+ */
+export function extendTrajectoryEvents(
+  previous: TrajBuild,
+  appended: readonly SessionEvent[],
+): TrajBuild {
+  if (appended.length === 0) return previous
+  const nodes = previous.nodes
+  const timing = previous.timing
+  const pureTiming = appended.every(event => (event as { type: string }).type === 'assistant/chunk')
+  const state = pureTiming ? previous.state : cloneState(previous.state)
+  for (const event of appended) consume(state, nodes, timing, event)
+  syncRowCount(state, nodes)
+  return {
+    source: previous.source,
+    nodes,
+    timing,
+    counts: state.counts,
+    state,
+    revision: previous.revision + appended.length,
+  }
 }
 
 /**

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -746,6 +746,14 @@ export default class App extends PureComponent<Props, State> {
 		try {
 			let chunk;
 			while ((chunk = this.props.stdin.read() as string | null) !== null) {
+				// Chunk-level shutdown gate: a mid-batch exit (Ctrl+C in an
+				// earlier chunk of this same readable event) latches
+				// beginShutdown synchronously — later chunks in the loop must
+				// not be dispatched to React handlers anymore. Drain them.
+				if (this.shutdownLatched) {
+					void chunk;
+					continue;
+				}
 				// Process the input chunk
 				this.processInput(chunk);
 			}

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -220,6 +220,12 @@ export default class App extends PureComponent<Props, State> {
 	// handleReadable to drain-only so no input is dispatched to React
 	// handlers during the exit funnel's settle window.
 	shutdownLatched = false;
+	// Whether the tty is physically in raw mode. Separate from the borrow
+	// count because the shutdown latch DEFERS the physical release: React
+	// effect cleanups during unmount drain the count to zero while the exit
+	// funnel is still spending its settle window in raw mode (#522) — the
+	// actual setRawMode(false) then happens in concludeShutdown.
+	private rawModePhysicallyHeld = false;
 	internal_eventEmitter = new EventEmitter();
 	keyParseState = INITIAL_STATE;
 	// Timer for flushing incomplete escape sequences
@@ -450,13 +456,17 @@ export default class App extends PureComponent<Props, State> {
 		if (this.props.stdout.isTTY) {
 			this.props.stdout.write(SHOW_CURSOR);
 		}
-		this.detachForShutdown();
+		// Latch only: the cooked-mode restore is owned by the exit funnel
+		// (finishExit's concludeShutdown) so it happens after the raw-mode
+		// settle window. Ink.unmount concludes itself when NO funnel follows
+		// (host teardown / signal-exit).
+		this.beginShutdown();
 	}
 
 	/**
 	 * Release timers and stdin ownership without requiring a React unmount.
-	 * Composite of the two shutdown phases — componentWillUnmount and other
-	 * one-shot callers want both; the exit funnel (finishExit) calls the
+	 * Composite of the two shutdown phases for one-shot callers that must
+	 * restore cooked mode themselves; the exit funnel (finishExit) calls the
 	 * phases separately so raw mode survives across its settle window.
 	 */
 	detachForShutdown() {
@@ -501,6 +511,25 @@ export default class App extends PureComponent<Props, State> {
 				}
 			},
 			() => this.querier.dispose(),
+			// React's error unwinding runs the throwing subtree's effect
+			// cleanups BEFORE the boundary's componentDidCatch — so by the time
+			// handleExit latches, a useInput cleanup may already have drained
+			// the borrow count and physically released raw mode. The settle
+			// window contract (cleanup consumed while raw, #522) matters MORE
+			// on exactly that crash path, so re-acquire raw mode here if it
+			// was lost: tty-local only (no mode-enable escape sequences —
+			// re-emitting EBP/EFE/kitty after the cleanup's disables would be
+			// the residue bug through another door), with the readable pump
+			// re-attached in the latched drain-only mode. concludeShutdown
+			// performs the final release either way.
+			() => {
+				if (!this.isRawModeSupported() || this.rawModePhysicallyHeld) return;
+				const { stdin } = this.props;
+				stdin.ref();
+				stdin.setRawMode(true);
+				this.rawModePhysicallyHeld = true;
+				stdin.addListener("readable", this.handleReadable);
+			},
 		];
 		for (const step of steps) {
 			try {
@@ -521,6 +550,10 @@ export default class App extends PureComponent<Props, State> {
 		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {
 			while (this.rawModeEnabledCount > 0) this.handleSetRawMode(false);
+			// The count may already be drained (React effect cleanups during
+			// unmount ran while latched and only deferred the release) — the
+			// physical restore is owed regardless.
+			this.releaseRawModePhysical();
 		}
 	}
 	override componentDidCatch(error: Error) {
@@ -541,6 +574,10 @@ export default class App extends PureComponent<Props, State> {
 		}
 		stdin.setEncoding("utf8");
 		if (isEnabled) {
+			// Post-latch the tty's raw state is owned by the shutdown funnel:
+			// new borrowers get nothing, and their symmetric cleanups no-op on
+			// the zero count below.
+			if (this.shutdownLatched) return;
 			// Ensure raw mode is enabled only once
 			if (this.rawModeEnabledCount === 0) {
 				// Stop early input capture right before we add our own readable handler.
@@ -550,6 +587,7 @@ export default class App extends PureComponent<Props, State> {
 				stopCapturingEarlyInput();
 				stdin.ref();
 				stdin.setRawMode(true);
+				this.rawModePhysicallyHeld = true;
 				stdin.addListener("readable", this.handleReadable);
 				// Enable bracketed paste mode
 				this.props.stdout.write(EBP);
@@ -616,11 +654,29 @@ export default class App extends PureComponent<Props, State> {
 			this.props.stdout.write(DFE);
 			// Disable bracketed paste mode
 			this.props.stdout.write(DBP);
-			stdin.setRawMode(false);
-			stdin.removeListener("readable", this.handleReadable);
-			stdin.unref();
+			// Latched: the exit funnel keeps raw mode held across its settle
+			// window (#522) — the physical release is owed to
+			// concludeShutdown, which the funnel runs LAST.
+			if (!this.shutdownLatched) this.releaseRawModePhysical();
 		}
 	};
+
+	/**
+	 * The actual cooked-mode restore (setRawMode(false) + pump detach). Split
+	 * from the borrow bookkeeping so the shutdown latch can defer it: once
+	 * beginShutdown latches, draining the count updates bookkeeping only, and
+	 * concludeShutdown performs the physical release as the funnel's LAST
+	 * step — after the settle window gave the terminal time to consume the
+	 * disable bytes (#522).
+	 */
+	private releaseRawModePhysical(): void {
+		if (!this.rawModePhysicallyHeld) return;
+		this.rawModePhysicallyHeld = false;
+		const { stdin } = this.props;
+		stdin.setRawMode(false);
+		stdin.removeListener("readable", this.handleReadable);
+		stdin.unref();
+	}
 
 	// Helper to flush incomplete escape sequences
 	flushIncomplete = (): void => {
@@ -804,9 +860,15 @@ export default class App extends PureComponent<Props, State> {
 		// keyboard protocol terminals (Ghostty, iTerm2, kitty, WezTerm)
 	};
 	handleExit = (error?: Error): void => {
-		if (this.isRawModeSupported()) {
-			this.handleSetRawMode(false);
-		}
+		// Latch producers immediately (writeRaw gated, stdin drained without
+		// dispatch) but DO NOT release raw mode here: the exit funnel owns the
+		// raw-mode lifecycle end to end — cleanup bytes must be written (and
+		// the settle window spent) while raw is still held, or late mouse
+		// reports echo as caret garbage once cooked+echo returns (#522).
+		// Raw is released by concludeShutdown: Ink.unmount runs it for
+		// funnel-less exits (teardown / signal-exit), finishExit's finally
+		// runs it for every funneled exit — including this one.
+		this.beginShutdown();
 		this.props.onExit(error);
 	};
 	handleTerminalFocus = (isFocused: boolean): void => {

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -216,6 +216,10 @@ export default class App extends PureComponent<Props, State> {
 	// Count how many components enabled raw mode to avoid disabling
 	// raw mode until all components don't need it anymore
 	rawModeEnabledCount = 0;
+	// Shutdown latch (set by beginShutdown): gates writeRaw and switches
+	// handleReadable to drain-only so no input is dispatched to React
+	// handlers during the exit funnel's settle window.
+	shutdownLatched = false;
 	internal_eventEmitter = new EventEmitter();
 	keyParseState = INITIAL_STATE;
 	// Timer for flushing incomplete escape sequences
@@ -375,6 +379,11 @@ export default class App extends PureComponent<Props, State> {
 	// <AlternateScreen>'s insertion effect every frame, flapping the alt
 	// screen on/off.
 	writeRaw = (data: string): void => {
+		// Shutdown gate: once beginShutdown latches, app-side raw writes
+		// (async OSC 52 clipboard callbacks, notification sequences) must not
+		// reach the terminal — they would land between DISABLE_MOUSE_TRACKING
+		// and the settle drain, or on the main screen after EXIT_ALT_SCREEN.
+		if (this.shutdownLatched) return;
 		if (data.includes("\x1b[?1049")) {
 			logMouseDebug("stdout:1049", { len: data.length, head: data.slice(0, 60) });
 		}
@@ -444,22 +453,71 @@ export default class App extends PureComponent<Props, State> {
 		this.detachForShutdown();
 	}
 
-	/** Release timers and stdin ownership without requiring a React unmount. */
+	/**
+	 * Release timers and stdin ownership without requiring a React unmount.
+	 * Composite of the two shutdown phases — componentWillUnmount and other
+	 * one-shot callers want both; the exit funnel (finishExit) calls the
+	 * phases separately so raw mode survives across its settle window.
+	 */
 	detachForShutdown() {
-		// Clear any pending timers
-		if (this.incompleteEscapeTimer) {
-			clearTimeout(this.incompleteEscapeTimer);
-			this.incompleteEscapeTimer = null;
+		this.beginShutdown();
+		this.concludeShutdown();
+	}
+
+	/**
+	 * Phase 1: stop input/output producers — clear pending timers, dispose
+	 * the querier, and latch the shutdown gate (writeRaw blocked, stdin
+	 * drained without dispatch) — WITHOUT touching raw mode. The exit funnel
+	 * sends its DISABLE/cleanup sequences and waits out its settle window
+	 * while still raw, so late mouse reports are consumed as input instead
+	 * of echoed by the kernel line discipline. querier.dispose() releases
+	 * pending raw-mode holds, but every hold sits on top of the app's own
+	 * useInput hold (a pending query implies rawModeEnabledCount >= 2), so
+	 * cooked mode cannot be reached from here. Idempotent, and each step is
+	 * isolated: a throwing dispose (raw-hold release on a revoked tty) must
+	 * not skip the remaining teardown.
+	 */
+	beginShutdown() {
+		if (this.shutdownLatched) return;
+		this.shutdownLatched = true;
+		const steps: Array<() => void> = [
+			// Clear any pending timers
+			() => {
+				if (this.incompleteEscapeTimer) {
+					clearTimeout(this.incompleteEscapeTimer);
+					this.incompleteEscapeTimer = null;
+				}
+			},
+			() => {
+				if (this.pendingHyperlinkTimer) {
+					clearTimeout(this.pendingHyperlinkTimer);
+					this.pendingHyperlinkTimer = null;
+				}
+			},
+			() => {
+				if (this.xtversionProbe) {
+					clearImmediate(this.xtversionProbe);
+					this.xtversionProbe = null;
+				}
+			},
+			() => this.querier.dispose(),
+		];
+		for (const step of steps) {
+			try {
+				step();
+			} catch (error) {
+				logError(error instanceof Error ? error : new Error(String(error)));
+			}
 		}
-		if (this.pendingHyperlinkTimer) {
-			clearTimeout(this.pendingHyperlinkTimer);
-			this.pendingHyperlinkTimer = null;
-		}
-		if (this.xtversionProbe) {
-			clearImmediate(this.xtversionProbe);
-			this.xtversionProbe = null;
-		}
-		this.querier.dispose();
+	}
+
+	/**
+	 * Phase 2: restore cooked mode — drains the raw-mode borrow count, which
+	 * also removes the readable pump and unrefs stdin. Must run LAST in the
+	 * exit funnel: once the tty flips back to canonical+echo, any mouse
+	 * report still in flight echoes as caret-notation garbage (issue #522).
+	 */
+	concludeShutdown() {
 		// ignore calling setRawMode on an handle stdin it cannot be called
 		if (this.isRawModeSupported()) {
 			while (this.rawModeEnabledCount > 0) this.handleSetRawMode(false);
@@ -661,6 +719,24 @@ export default class App extends PureComponent<Props, State> {
 		}
 	};
 	handleReadable = (): void => {
+		// Shutdown latch: drain-only. Bytes arriving during the exit funnel's
+		// settle window (late mouse reports, terminal replies) must still be
+		// consumed — otherwise the readable event spins and the bytes linger
+		// for the shell — but never dispatched: useInput handlers are output
+		// producers (a selection copy writes OSC 52, keys fire clipboard /
+		// notification side effects), and the writeRaw gate above only
+		// covers their write, not their other effects.
+		if (this.shutdownLatched) {
+			try {
+				let chunk;
+				while ((chunk = this.props.stdin.read()) !== null) {
+					void chunk;
+				}
+			} catch (error) {
+				logError(error);
+			}
+			return;
+		}
 		// Detect long stdin gaps (tmux attach, ssh reconnect, laptop wake).
 		// The terminal may have reset DEC private modes; re-assert mouse
 		// tracking. One Date.now() covers all chunks in this readable event.

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -676,6 +676,19 @@ export default class App extends PureComponent<Props, State> {
 		stdin.setRawMode(false);
 		stdin.removeListener("readable", this.handleReadable);
 		stdin.unref();
+		// Raw mode fully released: no more input can reach the parser, so
+		// an incomplete escape sequence can never complete. Cancel its
+		// timer and reset the parse state — otherwise the timer re-arms
+		// forever on the leftover readableLength (no reader attached) and
+		// a partial paste/escape corrupts the next raw session. This runs
+		// on BOTH release paths (borrow-drain and the shutdown funnel's
+		// concludeShutdown) because it is the physical release that ends
+		// parser input, not the borrow bookkeeping.
+		if (this.incompleteEscapeTimer) {
+			clearTimeout(this.incompleteEscapeTimer);
+			this.incompleteEscapeTimer = null;
+		}
+		this.keyParseState = { ...INITIAL_STATE };
 	}
 
 	// Helper to flush incomplete escape sequences
@@ -685,6 +698,14 @@ export default class App extends PureComponent<Props, State> {
 
 		// Only proceed if we have incomplete sequences
 		if (!this.keyParseState.incomplete) return;
+
+		// Raw mode released while a sequence was incomplete: the parser is
+		// dead (no readable listener, no further input), so the sequence can
+		// never complete — drop it instead of re-arming forever.
+		if (this.rawModeEnabledCount === 0) {
+			this.keyParseState = { ...INITIAL_STATE };
+			return;
+		}
 
 		// Fullscreen: if stdin has data waiting, it's almost certainly the
 		// continuation of the buffered sequence (e.g. `[<64;74;16M` after a

--- a/src/ink/constants.ts
+++ b/src/ink/constants.ts
@@ -2,6 +2,17 @@
 export const FRAME_INTERVAL_MS = 16
 
 /**
+ * Backoff ladder for the scroll-drain re-probe while stdout is
+ * backpressured: the stream's own 'drain' event is the fast path; this
+ * bounded fallback (250ms → 500ms → 1s) covers streams that never emit it.
+ * Deliberately far from a busy loop — each fire re-checks the backlog, so a
+ * drained stream resumes at the normal quarter-interval cadence on the next
+ * cycle.
+ */
+export const DRAIN_BACKOFF_BASE_MS = 250
+export const DRAIN_BACKOFF_MAX_MS = 1000
+
+/**
  * In-flight pty gate threshold (bytes) for scroll-drain frames — Grok
  * Build's Presenter in_flight gate. While stdout holds more unflushed
  * output than this, drain frames hold off instead of stacking latency

--- a/src/ink/geometry-trace.ts
+++ b/src/ink/geometry-trace.ts
@@ -27,6 +27,7 @@ export type FrameCause =
   | 'resize'
   | 'reanchor'
   | 'immediate'
+  | 'backpressure'
 
 export const GEOMETRY_TRACE_ENABLED = process.env.DSH_TUI_GEOMETRY_TRACE !== undefined &&
   process.env.DSH_TUI_GEOMETRY_TRACE !== ''

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -100,6 +100,13 @@ export default class Ink {
   // DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN and only parks the cursor and
   // prints the notice.
   private exitCleanupWritten = false;
+  // Set when the exit was driven by the app itself (Ctrl+C, error boundary,
+  // a component calling exit()): the plugin's exit funnel observes the
+  // settled exit promise and runs finishExit, which owns the cooked-mode
+  // restore (concludeShutdown) after its raw-mode settle window. External
+  // unmounts (host teardown, signal-exit) have no funnel behind them, so
+  // unmount() restores cooked mode itself.
+  private appDrivenExit = false;
   private isPaused = false;
   private readonly container: FiberRoot;
   private rootNode: dom.DOMElement;
@@ -2361,9 +2368,19 @@ export default class Ink {
   private setAppRef(app: App | null): void {
     this.app = app;
   }
+  /**
+   * App-driven exits (Ctrl+C, error boundary, context exit()) always settle
+   * the exit promise, and the plugin's funnel answers every such settle with
+   * finishExit — so unmount() must DEFER the cooked-mode restore to that
+   * funnel (its raw-mode settle window depends on it, #522).
+   */
+  private handleAppExit = (error?: Error): void => {
+    this.appDrivenExit = true;
+    this.unmount(error);
+  };
   render(node: ReactNode): void {
     this.currentNode = node;
-    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.unmount} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onContextMenuAt={this.dispatchContextMenu} onHoverAt={this.dispatchHover} onWheelAt={this.dispatchWheelAt} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onDragTargetAt={this.findDragTargetAt} onDragDispatch={this.dispatchDrag} onPointerGestureChange={this.setPointerGestureActive} onProtocolCandidateChange={this.setProtocolCandidateActive} onReleaseTail={this.drainReleaseTail} onClickProbe={this.clickProbeAtBatchTail} onStdinResume={this.reassertTerminalModes} onTerminalFocus={this.handleTerminalFocusProbe} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
+    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.handleAppExit} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onContextMenuAt={this.dispatchContextMenu} onHoverAt={this.dispatchHover} onWheelAt={this.dispatchWheelAt} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onDragTargetAt={this.findDragTargetAt} onDragDispatch={this.dispatchDrag} onPointerGestureChange={this.setPointerGestureActive} onProtocolCandidateChange={this.setProtocolCandidateActive} onReleaseTail={this.drainReleaseTail} onClickProbe={this.clickProbeAtBatchTail} onStdinResume={this.reassertTerminalModes} onTerminalFocus={this.handleTerminalFocusProbe} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
         <TerminalWriteProvider value={this.writeRaw}>
           {node}
         </TerminalWriteProvider>
@@ -2421,7 +2438,16 @@ export default class Ink {
         // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
         // doesn't declare it, hence the local intersection cast.
         const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
-        const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
+        const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : undefined;
+        // With no usable fd (TTY-like custom streams, wrapped embedders) fall
+        // back to the stream's OWN ordered queue — never a hard-coded
+        // writeSync(1): fd 1 belongs to the host process, so the cleanup
+        // would bypass the target stream entirely while the enable writes
+        // reached it (#522). Queueing also keeps these bytes behind any
+        // in-flight frames, preserving the frame → EXIT_ALT_SCREEN order.
+        const emit = stdoutFd === undefined
+          ? (text: string): void => { this.options.stdout.write(text); }
+          : (text: string): void => { writeSync(stdoutFd, text); };
         // Any segment failure leaves exitCleanupWritten false, so the
         // finishExit funnel rewrites the whole block (all sequences are
         // idempotent resets) rather than trusting a partial cleanup.
@@ -2433,12 +2459,12 @@ export default class Ink {
           // switch to the main screen, painting misplaced residue over the
           // shell (issue #522).
           if (lastFrame !== '') {
-            writeSync(stdoutFd, lastFrame);
+            emit(lastFrame);
           }
           if (this.altScreenActive) {
             // <AlternateScreen>'s unmount effect won't run during signal-exit.
             // Exit alt screen FIRST so other cleanup sequences go to the main screen.
-            writeSync(stdoutFd, EXIT_ALT_SCREEN);
+            emit(EXIT_ALT_SCREEN);
           }
         } catch (segmentError) {
           cleanupFailed = true;
@@ -2448,7 +2474,7 @@ export default class Ink {
           // Disable mouse tracking — unconditional because altScreenActive can be
           // stale if AlternateScreen's unmount (which flips the flag) raced a
           // blocked event loop + SIGINT. No-op if tracking was never enabled.
-          writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
+          emit(DISABLE_MOUSE_TRACKING);
           // Drain stdin so in-flight mouse events don't leak to the shell
           this.drainStdin();
         } catch (segmentError) {
@@ -2457,20 +2483,20 @@ export default class Ink {
         }
         try {
           // Disable extended key reporting (both kitty and modifyOtherKeys)
-          writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
-          writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
+          emit(DISABLE_MODIFY_OTHER_KEYS);
+          emit(DISABLE_KITTY_KEYBOARD);
           // Disable win32-input-mode (no-op where never enabled)
-          writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
+          emit(DISABLE_WIN32_INPUT_MODE);
           // Disable focus events (DECSET 1004)
-          writeSync(stdoutFd, DFE);
+          emit(DFE);
           // Disable bracketed paste mode
-          writeSync(stdoutFd, DBP);
+          emit(DBP);
           // Show cursor
-          writeSync(stdoutFd, SHOW_CURSOR);
+          emit(SHOW_CURSOR);
           // Clear iTerm2 progress bar
-          writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
+          emit(CLEAR_ITERM2_PROGRESS);
           // Clear tab status (OSC 21337) so a stale dot doesn't linger
-          if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
+          if (supportsTabStatus()) emit(wrapForMultiplexer(CLEAR_TAB_STATUS));
         } catch (segmentError) {
           cleanupFailed = true;
           logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
@@ -2493,6 +2519,19 @@ export default class Ink {
       reconciler.updateContainerSync(null, this.container, null, noop);
       // @ts-ignore -- ported CC build; type drift tolerated flushSyncWork exists in react-reconciler but not in @types/react-reconciler
       reconciler.flushSyncWork();
+      // Cooked-mode restore: app-driven exits defer it to the exit funnel
+      // (finishExit holds raw mode across its post-cleanup settle window,
+      // #522); external unmounts (host teardown, signal-exit) have no funnel
+      // behind them, so restore cooked mode here. Idempotent via the
+      // shutdownPhase guard, and the React teardown above already ran
+      // App.componentWillUnmount's beginShutdown latch.
+      if (!this.appDrivenExit) {
+        try {
+          this.concludeShutdown();
+        } catch (concludeError) {
+          logError(concludeError instanceof Error ? concludeError : new Error(String(concludeError)));
+        }
+      }
       instances.delete(this.options.stdout);
 
       // Free the root yoga node, then clear its reference. Children are already

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -11,10 +11,11 @@ import { getYogaCounters } from '../native-ts/yoga-layout/index.js';
 import { logForDebugging } from '../utils/debug.js';
 import { logError } from '../utils/log.js';
 import { format } from 'util';
+import type { Writable } from 'stream';
 import { colorize } from './colorize.js';
 import App from './components/App.js';
 import type { CursorDeclaration, CursorDeclarationSetter } from './components/CursorDeclarationContext.js';
-import { FRAME_INTERVAL_MS, PTY_BACKLOG_BYTES } from './constants.js';
+import { DRAIN_BACKOFF_BASE_MS, DRAIN_BACKOFF_MAX_MS, FRAME_INTERVAL_MS, PTY_BACKLOG_BYTES } from './constants.js';
 import * as dom from './dom.js';
 import { beginGeometryFrame, endGeometryFrame, GEOMETRY_TRACE_ENABLED, noteFrameCause } from './geometry-trace.js';
 import { callWithUpdateOverflowGuard, installNestedUpdateOverflowProcessGuard } from './update-overflow-guard.js';
@@ -128,11 +129,20 @@ export default class Ink {
   private readonly unsubscribeTTYHandlers?: () => void;
   private terminalColumns: number;
   private terminalRows: number;
+  /** Columns the Yoga root was last constrained with (see onComputeLayout). */
+  private lastLayoutColumns = -1;
   private currentNode: ReactNode = null;
   private frontFrame: Frame;
   private backFrame: Frame;
   private lastPoolResetTime = performance.now();
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  /** True while the stream holds unflushed output above the backlog gate;
+   *  frame writes are skipped (coalesced) until the stream drains. */
+  private backpressured = false;
+  /** The pending stdout 'drain' listener (one per stream). */
+  private drainListener: (() => void) | null = null;
+  /** Fallback re-probe delay while backpressured (bounded backoff). */
+  private drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
   // Every scheduled microtask carries the generation that created it. Immediate
   // renders invalidate older trailing work before it can append an old frame.
   private renderGeneration = 0;
@@ -320,8 +330,23 @@ export default class Ink {
       }
       if (this.rootNode.yogaNode) {
         const t0 = performance.now();
-        this.rootNode.yogaNode.setWidth(this.terminalColumns);
-        this.rootNode.yogaNode.calculateLayout(this.terminalColumns);
+        const root = this.rootNode.yogaNode;
+        // setWidth marks the WHOLE tree dirty — calling it with an unchanged
+        // value would force a full layout pass on every commit (idle commits
+        // included). Only touch the constraint when the terminal width
+        // actually changed; handleResize re-renders with the new size, so
+        // the first commit after a resize still re-constrains.
+        if (this.lastLayoutColumns !== this.terminalColumns) {
+          this.lastLayoutColumns = this.terminalColumns;
+          root.setWidth(this.terminalColumns);
+        }
+        // Clean-tree early bail: every style/text mutation marks its node
+        // dirty (the engine's own dirty-skip depends on it), so a fully
+        // clean tree with unchanged constraints has nothing to recompute —
+        // skip the layout walk (and its round pass) entirely.
+        if (root.isDirty()) {
+          root.calculateLayout(this.terminalColumns);
+        }
         const ms = performance.now() - t0;
         recordYogaMs(ms);
         const c = getYogaCounters();
@@ -418,6 +443,8 @@ export default class Ink {
     this.renderGeneration++;
     this.pendingRenderGeneration = null;
     this.scheduleRender.cancel?.();
+    this.detachDrainListener();
+    this.backpressured = false;
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
@@ -589,7 +616,14 @@ export default class Ink {
     this.renderGeneration++;
     this.pendingRenderGeneration = null;
     this.scheduleRender.cancel?.();
-    if (this.drainTimer !== null) {
+    // A fresh frame is being produced right now — any pending drain-wait
+    // (listener or timer) is obsolete; this render re-arms what it needs.
+    // EXCEPT while backpressured: the drain event may already have been
+    // emitted before the listener attached (a one-shot signal), and the
+    // backing-off re-probe is then the ONLY recovery path — cancelling it
+    // here on every animation render would deadlock the writer.
+    this.detachDrainListener();
+    if (this.drainTimer !== null && !this.backpressured) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
     }
@@ -607,31 +641,94 @@ export default class Ink {
    *    (DECSTBM + ~10 patches); scroll throughput is unchanged.
    *  - IN-FLIGHT GATE: while stdout still holds unflushed bytes above
    *    PTY_BACKLOG_BYTES (slow ConPTY round trip, ssh link), queue nothing
-   *    further — re-probe at quarter interval instead. Grok's equivalent
-   *    (in_flight_target + writer ack) exists to keep latency bounded
-   *    under exactly this backpressure; without it each stacked frame adds
-   *    its full render+write to the input→paint latency, which reads as
-   *    sticky, laggy scrolling on Windows terminals.
+   *    further — wait for the stream's OWN drain event instead of
+   *    re-probing at quarter interval (a 250Hz busy loop that never
+   *    advances while the terminal stays saturated). A bounded fallback
+   *    timer (backing off 250ms → 1s) covers streams that never emit
+   *    drain; each fire re-checks the backlog and either resumes or
+   *    re-arms. Grok's equivalent (in_flight_target + writer ack) exists
+   *    to keep latency bounded under exactly this backpressure; without it
+   *    each stacked frame adds its full render+write to the
+   *    input→paint latency, which reads as sticky, laggy scrolling on
+   *    Windows terminals.
    *
    * The gate holds only DRAIN frames; React-driven renders (keystrokes,
    * streaming) still render via the normal throttle — user-visible updates
    * must never wait behind scroll output.
    */
   private scheduleDrain(): void {
-    if (this.drainTimer !== null) return;
-    const stdout = this.options.stdout;
+    const stdout = this.options.stdout as Writable & { writableLength?: number };
     const backlog =
-      typeof (stdout as { writableLength?: number }).writableLength === 'number'
-        ? (stdout as { writableLength: number }).writableLength
+      typeof stdout.writableLength === 'number'
+        ? stdout.writableLength
         : 0;
-    if (backlog > PTY_BACKLOG_BYTES) {
-      this.drainTimer = setTimeout(() => {
-        this.drainTimer = null;
-        this.scheduleDrain();
-      }, FRAME_INTERVAL_MS >> 2);
+    // Fast path only when the writer is NOT backpressured: write() === false
+    // is the authoritative signal (a stream with a small high-water mark can
+    // reject writes while writableLength is still under the threshold), and
+    // the backlog check is an additional bound, never a way to override a
+    // rejected write into a 4ms retry loop.
+    if (!this.backpressured && backlog <= PTY_BACKLOG_BYTES) {
+      if (this.drainTimer !== null) return;
+      this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
       return;
     }
-    this.drainTimer = setTimeout(this.renderNow, FRAME_INTERVAL_MS >> 2);
+    // Backpressure path: wait for the stream's own drain event (fires once
+    // the buffered bytes flush after a rejected write); a bounded, backing-
+    // off re-probe covers streams that never emit it. The re-probe
+    // OPTIMISTICALLY clears the flag at the slow cadence (250ms→1s) — the
+    // write result re-asserts the true state — so a stream that silently
+    // recovered resumes painting without ever busy-looping. Never a fixed
+    // 4ms poll while backpressured.
+    this.backpressured = true;
+    // ALWAYS ensure the drain listener exists while backpressured — even
+    // when the fallback timer is already armed. renderNow() detaches the
+    // listener on every immediate render (obsolete-wait invalidation) but
+    // deliberately KEEPS the backoff timer; if this early-returned on the
+    // armed timer, a drain event landing in that window would be missed and
+    // recovery would degrade from drain-first (~instant) to polling
+    // (250ms→1s backoff). Listener first, timer second.
+    this.attachDrainListener();
+    if (this.drainTimer !== null) return;
+    this.drainTimer = setTimeout(() => {
+      this.drainTimer = null;
+      if (this.isUnmounted) return;
+      const nowBacklog =
+        typeof stdout.writableLength === 'number'
+          ? stdout.writableLength
+          : 0;
+      if (nowBacklog <= PTY_BACKLOG_BYTES) {
+        // The stream looks drained (or never reports a backlog): try a
+        // frame; the write result re-asserts the gate.
+        this.backpressured = false;
+      }
+      this.scheduleDrain();
+    }, this.drainBackoffMs);
+    this.drainBackoffMs = Math.min(DRAIN_BACKOFF_MAX_MS, this.drainBackoffMs * 2);
+  }
+
+  /** Arm the one-per-stream 'drain' listener; a no-op when already armed. */
+  private attachDrainListener(): void {
+    if (this.drainListener !== null) return;
+    const stdout = this.options.stdout;
+    const handler = (): void => {
+      this.drainListener = null;
+      stdout.removeListener('drain', handler);
+      if (this.isUnmounted || this.isPaused) return;
+      // The stream drained: clear the gate so this render actually writes
+      // (the write result re-asserts the true backpressure state).
+      this.backpressured = false;
+      this.renderNow();
+    };
+    this.drainListener = handler;
+    stdout.once('drain', handler);
+  }
+
+  /** Cancel the drain listener; keeps the timer handling intact. */
+  private detachDrainListener(): void {
+    if (this.drainListener !== null) {
+      this.options.stdout.removeListener('drain', this.drainListener);
+      this.drainListener = null;
+    }
   }
 
   onRender() {
@@ -642,7 +739,10 @@ export default class Ink {
     // Entering a render cancels any pending drain tick — this render will
     // handle the drain (and re-schedule below if needed). Prevents a
     // wheel-event-triggered render AND a drain-timer render both firing.
-    if (this.drainTimer !== null) {
+    // While backpressured this render SKIPS its write (see the gate below),
+    // so it does not handle the drain — keep the backing-off re-probe
+    // armed or the writer deadlocks (drain may already have been emitted).
+    if (this.drainTimer !== null && !this.backpressured) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
     }
@@ -913,9 +1013,10 @@ export default class Ink {
     // implementation deviates from xterm and garbles scrolling content.
     isDecstbmSafe());
     const diffMs = performance.now() - tDiff;
-    // Swap buffers
-    this.backFrame = this.frontFrame;
-    this.frontFrame = frame;
+    // NOTE: frontFrame/backFrame are NOT swapped here — the candidate frame
+    // may be skipped by the backpressure gate below, and the diff engine
+    // must keep comparing against the last frame the terminal actually
+    // received. The swap happens in the write-success branch.
 
     // Periodically reset char/hyperlink pools to prevent unbounded growth
     // during long sessions. 5 minutes is infrequent enough that the O(cells)
@@ -944,7 +1045,14 @@ export default class Ink {
     const optimized = optimize(diff);
     const optimizeMs = performance.now() - tOptimize;
     const hasDiff = optimized.length > 0;
-    if (this.altScreenActive && hasDiff) {
+    // Backpressure gate, computed BEFORE the optimized patch list is built:
+    // write() === false is the authoritative signal (a stream with a small
+    // high-water mark can reject writes while writableLength is still below
+    // the threshold); the backlog check is an additional bound only.
+    const stdout = this.options.stdout as Writable & { writableLength?: number };
+    const backlog = typeof stdout.writableLength === 'number' ? stdout.writableLength : 0;
+    const writing = !this.backpressured && backlog <= PTY_BACKLOG_BYTES;
+    if (this.altScreenActive && hasDiff && writing) {
       // Prepend CSI H to anchor the physical cursor to (0,0) so
       // log-update's relative moves compute from a known spot (self-healing
       // against out-of-band cursor drift, see the ALT_SCREEN_ANCHOR_CURSOR
@@ -1067,19 +1175,48 @@ export default class Ink {
       }
     }
     const tWrite = performance.now();
-    writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
-    const writeMs = performance.now() - tWrite;
-    // One frame reached the terminal. Components holding a widened mount
-    // window until its content is actually flushed (MessageList's paint
-    // expansion hold) key off this tick — a commit can be superseded before
-    // its frame flushes, so "mounted" alone must never unlock tightening.
-    noteTerminalFlush();
+    // Skip THIS write while backpressured (see the gate above) and wait for
+    // the stream's own drain. The diff engine compares against frontFrame —
+    // the last frame the terminal ACTUALLY received — so a skipped frame
+    // coalesces into the next write instead of being lost (and its erase/
+    // cursor patches never reach the terminal, so needsEraseBeforePaint and
+    // displayCursor stay truthful).
+    let writeMs = 0;
+    if (writing) {
+      const flushed = writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
+      writeMs = performance.now() - tWrite;
+      this.backpressured = !flushed;
+      if (flushed && this.drainBackoffMs !== DRAIN_BACKOFF_BASE_MS) {
+        this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
+      }
+      // One frame reached the terminal. Components holding a widened mount
+      // window until its content is actually flushed (MessageList's paint
+      // expansion hold) key off this tick — a commit can be superseded before
+      // its frame flushes, so "mounted" alone must never unlock tightening.
+      noteTerminalFlush();
 
-    // Update blit safety for the NEXT frame. The frame just rendered
-    // becomes frontFrame (= next frame's prevScreen). If we applied the
-    // selection overlay, that buffer has inverted cells. selActive/hlActive
-    // are only ever true in alt-screen; in main-screen this is false→false.
-    this.prevFrameContaminated = selActive || hlActive;
+      // The terminal now holds `frame`: it becomes the diff baseline for
+      // every later pass. Swap AFTER a successful write — a skipped frame
+      // must never advance the baseline or the delta against it would be
+      // lost forever.
+      this.backFrame = this.frontFrame;
+      this.frontFrame = frame;
+
+      // Update blit safety for the NEXT frame. The frame just rendered
+      // becomes frontFrame (= next frame's prevScreen). If we applied the
+      // selection overlay, that buffer has inverted cells. selActive/hlActive
+      // are only ever true in alt-screen; in main-screen this is false→false.
+      this.prevFrameContaminated = selActive || hlActive;
+    } else {
+      // Skipped write: the frame never reached the terminal, so the cursor
+      // park target (displayCursor, set above) and the contamination flag
+      // must stay at their last-WRITTEN values — displayCursor was already
+      // updated for this frame, so roll it back; the next written frame
+      // recomputes both fresh from the same baseline.
+      this.displayCursor = parked;
+      this.backpressured = true;
+      noteFrameCause('backpressure');
+    }
 
     // A ScrollBox has pendingScrollDelta left to drain — schedule the next
     // frame via scheduleDrain (cadence + pty backpressure gate, see there).
@@ -1089,7 +1226,7 @@ export default class Ink {
     // → leadingEdge fires IMMEDIATELY → double render ~0.1ms apart → jank.
     // If a wheel event or immediate render arrives first, renderNow cancels
     // this timer — no double.
-    if (frame.scrollDrainPending) {
+    if (frame.scrollDrainPending || this.backpressured) {
       noteFrameCause('scroll-drain');
       this.scheduleDrain();
     }
@@ -1406,15 +1543,32 @@ export default class Ink {
     if (this.shutdownPhase >= 1) return;
     this.shutdownPhase = 1;
     this.isUnmounted = true;
+    // Render producer kills (#713 backpressure pipeline × #701 shutdown
+    // funnel): ALL of these must land BEFORE the exit funnel's stdout
+    // barrier / terminal cleanup — a late microtask render or a drain-event
+    // callback firing after DISABLE_MOUSE_TRACKING would write an ordinary
+    // frame onto the post-cleanup terminal.
     const steps: Array<() => void> = [
       // Cancel any pending throttled render so it doesn't fire between
       // cleanupTerminalModes() and process.exit() and write to main screen.
       () => this.scheduleRender.cancel?.(),
+      // Invalidate pending microtask renders: a trailing render scheduled
+      // before the latch must not append a frame after the barrier.
+      () => {
+        this.renderGeneration++;
+        this.pendingRenderGeneration = null;
+      },
+      // Backpressure recovery producers: the stdout drain listener and the
+      // bounded fallback re-probe are ordinary-frame producers — a late
+      // `drain` event must not trigger renderNow past the cleanup bytes.
+      () => this.detachDrainListener(),
       () => {
         if (this.drainTimer !== null) {
           clearTimeout(this.drainTimer);
           this.drainTimer = null;
         }
+        this.backpressured = false;
+        this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
       },
       () => (this.app ?? this.shutdownApp)?.beginShutdown(),
       // Shutdown bypasses the normal unmount path, so release the process
@@ -2520,10 +2674,21 @@ export default class Ink {
 
       // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
       this.scheduleRender.cancel?.();
+      // Invalidate pending microtask renders (see beginShutdown) — a trailing
+      // render must not append a frame past the cleanup block above.
+      this.renderGeneration++;
+      this.pendingRenderGeneration = null;
+      // The final renderNow() above may have re-armed the backpressure wait
+      // (a backpressured final frame re-attaches the drain listener): release
+      // it unconditionally so a stdout that never drains cannot hold the
+      // renderer (and its stream listener) past unmount.
+      this.detachDrainListener();
       if (this.drainTimer !== null) {
         clearTimeout(this.drainTimer);
         this.drainTimer = null;
       }
+      this.backpressured = false;
+      this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
 
       // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler
       reconciler.updateContainerSync(null, this.container, null, noop);

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -84,6 +84,13 @@ export default class Ink {
   private readonly log: LogUpdate;
   private readonly terminal: Terminal;
   private app: App | null = null;
+  // The last live App ref, kept for the shutdown phases: React detaches the
+  // ref (setAppRef(null)) while unmounting the tree, but concludeShutdown
+  // runs AFTER the tree is gone (unmount's finally, or the finishExit
+  // funnel behind an app-driven exit) and still needs the component for its
+  // raw-mode bookkeeping (borrow drain, cooked restore, readable-pump
+  // detach) — a null ref there would silently skip it and leak the pump.
+  private shutdownApp: App | undefined;
   private scheduleRender: (() => void) & {
     cancel?: () => void;
   };
@@ -1409,7 +1416,7 @@ export default class Ink {
           this.drainTimer = null;
         }
       },
-      () => this.app?.beginShutdown(),
+      () => (this.app ?? this.shutdownApp)?.beginShutdown(),
       // Shutdown bypasses the normal unmount path, so release the process
       // and stdout listeners here as well. Otherwise a SIGCONT or resize
       // arriving while an updater is running can re-enter the alternate
@@ -1468,8 +1475,10 @@ export default class Ink {
     };
     const steps: Array<() => void> = [
       // App's raw-off drains the raw-mode borrow count, which also removes
-      // the readable pump and unrefs stdin.
-      () => this.app?.concludeShutdown(),
+      // the readable pump and unrefs stdin. The ref itself is already null
+      // when the React teardown ran first (unmount's finally, finishExit
+      // behind an app-driven exit), so fall back to the last live ref.
+      () => (this.app ?? this.shutdownApp)?.concludeShutdown(),
       () => this.drainStdin(),
       () => {
         if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
@@ -2367,6 +2376,7 @@ export default class Ink {
   };
   private setAppRef(app: App | null): void {
     this.app = app;
+    if (app !== null) this.shutdownApp = app;
   }
   /**
    * App-driven exits (Ctrl+C, error boundary, context exit()) always settle

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -89,6 +89,17 @@ export default class Ink {
   };
   // Ignore last render after unmounting a tree to prevent empty output before exit
   private isUnmounted = false;
+  // Shutdown phase state machine: 0 = live, 1 = beginShutdown ran (latched,
+  // raw mode still held), 2 = concludeShutdown ran (cooked restored). The
+  // guards make the phases idempotent and record how far teardown got, so a
+  // throwing cleanup step can neither skip later steps nor re-run earlier
+  // ones when the exit funnel and a late unmount() race.
+  private shutdownPhase: 0 | 1 | 2 = 0;
+  // Set when unmount() itself wrote the terminal cleanup block (React
+  // error-boundary / signal-exit path): finishExit then skips re-writing
+  // DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN and only parks the cursor and
+  // prints the notice.
+  private exitCleanupWritten = false;
   private isPaused = false;
   private readonly container: FiberRoot;
   private rootNode: dom.DOMElement;
@@ -1321,6 +1332,29 @@ export default class Ink {
   };
 
   /**
+   * The output stream this instance renders to. finishExit must target THIS
+   * stream for its barrier/cleanup/notice writes — not whatever
+   * process.stdout happens to point at during shutdown: a host that swapped
+   * process.stdout after render would otherwise latch THIS instance while
+   * writing the cleanup bytes to the replacement stream, leaving this
+   * stream's queued frames and mouse state unhandled (stdout identity
+   * drift, issue #522).
+   */
+  get stdout(): NodeJS.WriteStream {
+    return this.options.stdout;
+  }
+
+  /**
+   * Whether unmount() already wrote the terminal cleanup block itself
+   * (React error-boundary / signal-exit path). finishExit checks this and
+   * skips re-writing DISABLE_MOUSE_TRACKING / EXIT_ALT_SCREEN, so the
+   * error path no longer double-resets the terminal.
+   */
+  get hasWrittenExitCleanup(): boolean {
+    return this.exitCleanupWritten;
+  }
+
+  /**
    * Mark this instance as unmounted so future unmount() calls early-return.
    * Called by gracefulShutdown's cleanupTerminalModes() after it has sent
    * EXIT_ALT_SCREEN but before the remaining terminal-reset sequences.
@@ -1330,38 +1364,92 @@ export default class Ink {
    * The result is 2-3 redundant EXIT_ALT_SCREEN sequences landing on the
    * main screen AFTER printResumeHint(), which tmux (at least) interprets
    * as restoring the saved cursor position — clobbering the resume hint.
+   *
+   * Composite of beginShutdown() + concludeShutdown() for one-shot callers;
+   * the exit funnel (finishExit) invokes the phases separately so the
+   * cooked-mode restore happens only AFTER its post-cleanup settle window.
    */
   detachForShutdown(): void {
+    this.beginShutdown();
+    this.concludeShutdown();
+  }
+
+  /**
+   * Shutdown phase 1: latch isUnmounted and stop every output producer
+   * (pending renders, health probes, the querier), release process/stdout
+   * listeners and output patches — but KEEP stdin raw mode. The exit funnel
+   * writes DISABLE_MOUSE_TRACKING and the cleanup block, then waits out its
+   * settle window in this state: mouse reports that arrive while the disable
+   * is still in transit are consumed as raw input (and drained below)
+   * instead of echoed by the kernel line discipline once cooked+echo
+   * returns (the `^[[<35;130;47M` residue of issue #522).
+   *
+   * Idempotent (shutdownPhase guard) and step-isolated: a throwing step
+   * (e.g. querier.dispose releasing a raw-mode hold on a revoked tty) is
+   * logged and must not skip the remaining releases.
+   */
+  beginShutdown(): void {
+    if (this.shutdownPhase >= 1) return;
+    this.shutdownPhase = 1;
     this.isUnmounted = true;
-    // Cancel any pending throttled render so it doesn't fire between
-    // cleanupTerminalModes() and process.exit() and write to main screen.
-    this.scheduleRender.cancel?.();
-    if (this.drainTimer !== null) {
-      clearTimeout(this.drainTimer);
-      this.drainTimer = null;
+    const steps: Array<() => void> = [
+      // Cancel any pending throttled render so it doesn't fire between
+      // cleanupTerminalModes() and process.exit() and write to main screen.
+      () => this.scheduleRender.cancel?.(),
+      () => {
+        if (this.drainTimer !== null) {
+          clearTimeout(this.drainTimer);
+          this.drainTimer = null;
+        }
+      },
+      () => this.app?.beginShutdown(),
+      // Shutdown bypasses the normal unmount path, so release the process
+      // and stdout listeners here as well. Otherwise a SIGCONT or resize
+      // arriving while an updater is running can re-enter the alternate
+      // screen or render through this detached instance after terminal
+      // cleanup has completed.
+      () => this.unsubscribeTTYHandlers?.(),
+      () => this.unsubscribeExit(),
+      // unmount() early-returns on isUnmounted above, so its
+      // instances.delete never runs — a detached instance would stay in the
+      // map and a later instances.get(stdout) lookup (Chat's
+      // reanchorViewport plumbing) could hand out a dead renderer. Remove
+      // the mapping here too.
+      () => instances.delete(this.options.stdout),
+      // `detachForShutdown()` deliberately makes later `unmount()` calls a
+      // no-op, so release process-level output patches here rather than
+      // relying on unmount() to do it. The shutdown continuation may run an
+      // updater (or report its failure) after this point; leaving stderr
+      // intercepted would silently route those messages to the debug log
+      // instead of the terminal.
+      () => {
+        if (typeof this.restoreConsole === 'function') {
+          this.restoreConsole();
+        }
+      },
+      () => this.restoreStderr?.(),
+    ];
+    for (const step of steps) {
+      try {
+        step();
+      } catch (error) {
+        logError(error instanceof Error ? error : new Error(String(error)));
+      }
     }
-    this.app?.detachForShutdown();
-    // Shutdown bypasses the normal unmount path, so release the process and
-    // stdout listeners here as well. Otherwise a SIGCONT or resize arriving
-    // while an updater is running can re-enter the alternate screen or render
-    // through this detached instance after terminal cleanup has completed.
-    this.unsubscribeTTYHandlers?.();
-    this.unsubscribeExit();
-    // unmount() early-returns on isUnmounted above, so its instances.delete
-    // never runs — a detached instance would stay in the map and a later
-    // instances.get(stdout) lookup (Chat's reanchorViewport plumbing) could
-    // hand out a dead renderer. Remove the mapping here too.
-    instances.delete(this.options.stdout);
-    // `detachForShutdown()` deliberately makes later `unmount()` calls a
-    // no-op, so release process-level output patches here rather than relying
-    // on unmount() to do it. The shutdown continuation may run an updater
-    // (or report its failure) after this point; leaving stderr intercepted
-    // would silently route those messages to the debug log instead of the
-    // terminal.
-    if (typeof this.restoreConsole === 'function') {
-      this.restoreConsole();
-    }
-    this.restoreStderr?.();
+  }
+
+  /**
+   * Shutdown phase 2: restore cooked mode. Must run LAST in the exit
+   * funnel, after the settle window has given the terminal time to process
+   * DISABLE_MOUSE_TRACKING and late reports have been drained — once the
+   * tty flips back to canonical+echo, any mouse report still in flight is
+   * echoed at the parked cursor (issue #522). Idempotent and step-isolated
+   * like phase 1: the raw-off throw of a revoked tty must not skip the
+   * stdin drain or the fallback restore.
+   */
+  concludeShutdown(): void {
+    if (this.shutdownPhase >= 2) return;
+    this.shutdownPhase = 2;
     // Restore stdin from raw mode. unmount() used to do this via React
     // unmount (App.componentWillUnmount → handleSetRawMode(false)) but we're
     // short-circuiting that path. Must use this.options.stdin — NOT
@@ -1371,14 +1459,28 @@ export default class Ink {
       isRaw?: boolean;
       setRawMode?: (m: boolean) => void;
     };
-    this.drainStdin();
-    if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
+    const steps: Array<() => void> = [
+      // App's raw-off drains the raw-mode borrow count, which also removes
+      // the readable pump and unrefs stdin.
+      () => this.app?.concludeShutdown(),
+      () => this.drainStdin(),
+      () => {
+        if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
+          try {
+            stdin.setRawMode(false);
+          } catch {
+            // The TTY may have been revoked (for example after an SSH
+            // disconnect). Shutdown must continue even if raw-mode
+            // restoration is no longer possible.
+          }
+        }
+      },
+    ];
+    for (const step of steps) {
       try {
-        stdin.setRawMode(false);
-      } catch {
-        // The TTY may have been revoked (for example after an SSH
-        // disconnect). Shutdown must continue even if raw-mode restoration
-        // is no longer possible.
+        step();
+      } catch (error) {
+        logError(error instanceof Error ? error : new Error(String(error)));
       }
     }
   }
@@ -1495,6 +1597,9 @@ export default class Ink {
    */
   drainAltScreenReentry = (): void => {
     if (!this.pendingAltScreenReentry) return;
+    // Shutdown latch: beginShutdown permanently cancels the producer — a
+    // pending re-entry must never re-enter after DISABLE_MOUSE_TRACKING /
+    // EXIT_ALT_SCREEN have been written.
     if (this.isUnmounted || this.isPaused || !this.altScreenActive) return;
     // Dual latch: never re-enter while a physical button is held OR while a
     // protocol candidate (split SGR prefix) is in flight. The destructive
@@ -1515,6 +1620,13 @@ export default class Ink {
   drainPendingProbe = (): void => {
     const req = this.pendingProbeRequest;
     if (!req) return;
+    // Shutdown latch: beginShutdown permanently cancels the producer — a
+    // late release-tail drain (or a throttle-retry timer armed before the
+    // latch) must not write a probe after the exit funnel's cleanup bytes.
+    if (this.isUnmounted) {
+      this.pendingProbeRequest = undefined;
+      return;
+    }
     // Dual latch: never probe while a physical button is held OR while a
     // protocol candidate is in flight — the probe's DECSET/DECRQM writes
     // would corrupt the stream.
@@ -1543,12 +1655,14 @@ export default class Ink {
     this.drainPendingProbe();
   };
   probeAltScreenHealth = (options?: { skipMouseReassert?: boolean }): void => {
-    // Shutdown latch: during the dispose window after detachForShutdown
-    // (up to the 5s fallback exit) stray input, focus, resize or a pending
-    // DECRPM reply would otherwise re-write ENABLE_MOUSE_TRACKING AFTER the
-    // exit cleanup's DISABLE_MOUSE_TRACKING — the mouse-reporting residue
-    // the shell then echoes as SGR garbage (issue #522). isUnmounted is set
-    // by detachForShutdown() before any cleanup sequence is written.
+    // Shutdown latch: during the dispose window after beginShutdown (up to
+    // the 5s fallback exit) stray input, focus, resize or a pending DECRPM
+    // reply would otherwise re-write ENABLE_MOUSE_TRACKING AFTER the exit
+    // cleanup's DISABLE_MOUSE_TRACKING — the mouse-reporting residue the
+    // shell then echoes as SGR garbage (issue #522). The exit funnel latches
+    // isUnmounted via beginShutdown() BEFORE any cleanup sequence is
+    // written, while raw mode is still held; the cooked-mode restore lands
+    // only in concludeShutdown() after the settle window.
     if (this.isUnmounted) return;
     // Dual latch: never write while a physical button is held OR while a
     // protocol candidate (split SGR prefix) is in flight. The physical latch
@@ -2227,6 +2341,12 @@ export default class Ink {
   // cascades through useContext → <AlternateScreen>'s useLayoutEffect dep
   // array → spurious exit+re-enter of the alt screen on every SIGWINCH.
   private writeRaw(data: string): void {
+    // Shutdown gate: once beginShutdown latches, raw writes (async OSC 52
+    // clipboard callbacks from copySelectionNoClear, querier leftovers)
+    // must not reach the terminal — they would land between
+    // DISABLE_MOUSE_TRACKING and the settle drain, or on the main screen
+    // after EXIT_ALT_SCREEN.
+    if (this.isUnmounted) return;
     if (data.includes('\x1b[?1049')) {
       logMouseDebug('stdout:1049', { len: data.length, head: data.slice(0, 60) });
     }
@@ -2289,73 +2409,102 @@ export default class Ink {
     // complete before exit. We unconditionally send all disable sequences
     // because terminal detection may not work correctly (e.g., in tmux,
     // screen) and these are no-ops on terminals that don't support them.
+    //
+    // Each segment is isolated: a throwing fd (revoked tty, EIO after an
+    // ssh drop) must not skip the mouse-tracking disable or the remaining
+    // resets, and the finally below must run the state teardown even when
+    // every write fails — otherwise a late finishExit would see a live
+    // instance and double-write this cleanup, or waitUntilExit would hang.
     /* eslint-disable custom-rules/no-sync-fs -- process exiting; async writes would be dropped */
-    if (this.options.stdout.isTTY) {
-      // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
-      // doesn't declare it, hence the local intersection cast.
-      const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
-      const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
-      // The last frame must land on the ALT screen while it is still up:
-      // writing it through the async stream would race the synchronous
-      // EXIT_ALT_SCREEN below and the frame bytes would arrive AFTER the
-      // switch to the main screen, painting misplaced residue over the
-      // shell (issue #522).
-      if (lastFrame !== '') {
-        writeSync(stdoutFd, lastFrame);
+    try {
+      if (this.options.stdout.isTTY) {
+        // Node's TTY WriteStream exposes .fd; the NodeJS.WriteStream interface
+        // doesn't declare it, hence the local intersection cast.
+        const stdoutWithFd = this.options.stdout as NodeJS.WriteStream & { fd?: number | null };
+        const stdoutFd = typeof stdoutWithFd.fd === 'number' ? stdoutWithFd.fd : 1;
+        // Any segment failure leaves exitCleanupWritten false, so the
+        // finishExit funnel rewrites the whole block (all sequences are
+        // idempotent resets) rather than trusting a partial cleanup.
+        let cleanupFailed = false;
+        try {
+          // The last frame must land on the ALT screen while it is still up:
+          // writing it through the async stream would race the synchronous
+          // EXIT_ALT_SCREEN below and the frame bytes would arrive AFTER the
+          // switch to the main screen, painting misplaced residue over the
+          // shell (issue #522).
+          if (lastFrame !== '') {
+            writeSync(stdoutFd, lastFrame);
+          }
+          if (this.altScreenActive) {
+            // <AlternateScreen>'s unmount effect won't run during signal-exit.
+            // Exit alt screen FIRST so other cleanup sequences go to the main screen.
+            writeSync(stdoutFd, EXIT_ALT_SCREEN);
+          }
+        } catch (segmentError) {
+          cleanupFailed = true;
+          logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
+        }
+        try {
+          // Disable mouse tracking — unconditional because altScreenActive can be
+          // stale if AlternateScreen's unmount (which flips the flag) raced a
+          // blocked event loop + SIGINT. No-op if tracking was never enabled.
+          writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
+          // Drain stdin so in-flight mouse events don't leak to the shell
+          this.drainStdin();
+        } catch (segmentError) {
+          cleanupFailed = true;
+          logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
+        }
+        try {
+          // Disable extended key reporting (both kitty and modifyOtherKeys)
+          writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
+          writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
+          // Disable win32-input-mode (no-op where never enabled)
+          writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
+          // Disable focus events (DECSET 1004)
+          writeSync(stdoutFd, DFE);
+          // Disable bracketed paste mode
+          writeSync(stdoutFd, DBP);
+          // Show cursor
+          writeSync(stdoutFd, SHOW_CURSOR);
+          // Clear iTerm2 progress bar
+          writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
+          // Clear tab status (OSC 21337) so a stale dot doesn't linger
+          if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
+        } catch (segmentError) {
+          cleanupFailed = true;
+          logError(segmentError instanceof Error ? segmentError : new Error(String(segmentError)));
+        }
+        // All three segments landed — finishExit can skip its rewrite.
+        this.exitCleanupWritten = !cleanupFailed;
       }
-      if (this.altScreenActive) {
-        // <AlternateScreen>'s unmount effect won't run during signal-exit.
-        // Exit alt screen FIRST so other cleanup sequences go to the main screen.
-        writeSync(stdoutFd, EXIT_ALT_SCREEN);
+      /* eslint-enable custom-rules/no-sync-fs */
+    } finally {
+      this.isUnmounted = true;
+
+      // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
+      this.scheduleRender.cancel?.();
+      if (this.drainTimer !== null) {
+        clearTimeout(this.drainTimer);
+        this.drainTimer = null;
       }
-      // Disable mouse tracking — unconditional because altScreenActive can be
-      // stale if AlternateScreen's unmount (which flips the flag) raced a
-      // blocked event loop + SIGINT. No-op if tracking was never enabled.
-      writeSync(stdoutFd, DISABLE_MOUSE_TRACKING);
-      // Drain stdin so in-flight mouse events don't leak to the shell
-      this.drainStdin();
-      // Disable extended key reporting (both kitty and modifyOtherKeys)
-      writeSync(stdoutFd, DISABLE_MODIFY_OTHER_KEYS);
-      writeSync(stdoutFd, DISABLE_KITTY_KEYBOARD);
-      // Disable win32-input-mode (no-op where never enabled)
-      writeSync(stdoutFd, DISABLE_WIN32_INPUT_MODE);
-      // Disable focus events (DECSET 1004)
-      writeSync(stdoutFd, DFE);
-      // Disable bracketed paste mode
-      writeSync(stdoutFd, DBP);
-      // Show cursor
-      writeSync(stdoutFd, SHOW_CURSOR);
-      // Clear iTerm2 progress bar
-      writeSync(stdoutFd, CLEAR_ITERM2_PROGRESS);
-      // Clear tab status (OSC 21337) so a stale dot doesn't linger
-      if (supportsTabStatus()) writeSync(stdoutFd, wrapForMultiplexer(CLEAR_TAB_STATUS));
-    }
-    /* eslint-enable custom-rules/no-sync-fs */
 
-    this.isUnmounted = true;
+      // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler
+      reconciler.updateContainerSync(null, this.container, null, noop);
+      // @ts-ignore -- ported CC build; type drift tolerated flushSyncWork exists in react-reconciler but not in @types/react-reconciler
+      reconciler.flushSyncWork();
+      instances.delete(this.options.stdout);
 
-    // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
-    this.scheduleRender.cancel?.();
-    if (this.drainTimer !== null) {
-      clearTimeout(this.drainTimer);
-      this.drainTimer = null;
-    }
-
-    // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler
-    reconciler.updateContainerSync(null, this.container, null, noop);
-    // @ts-ignore -- ported CC build; type drift tolerated flushSyncWork exists in react-reconciler but not in @types/react-reconciler
-    reconciler.flushSyncWork();
-    instances.delete(this.options.stdout);
-
-    // Free the root yoga node, then clear its reference. Children are already
-    // freed by the reconciler's removeChildFromContainer; using .free() (not
-    // .freeRecursive()) avoids double-freeing them.
-    this.rootNode.yogaNode?.free();
-    this.rootNode.yogaNode = undefined;
-    if (error instanceof Error) {
-      this.rejectExitPromise(error);
-    } else {
-      this.resolveExitPromise();
+      // Free the root yoga node, then clear its reference. Children are already
+      // freed by the reconciler's removeChildFromContainer; using .free() (not
+      // .freeRecursive()) avoids double-freeing them.
+      this.rootNode.yogaNode?.free();
+      this.rootNode.yogaNode = undefined;
+      if (error instanceof Error) {
+        this.rejectExitPromise(error);
+      } else {
+        this.resolveExitPromise();
+      }
     }
   }
   async waitUntilExit(): Promise<void> {
@@ -2495,11 +2644,13 @@ export default class Ink {
  *    open /dev/tty fresh with O_NONBLOCK (all fds to the controlling
  *    terminal share one line-discipline input queue).
  *
- * 2. By the time forceExit calls this, detachForShutdown has already put
- *    the TTY back in cooked (canonical) mode. Canonical mode line-buffers
- *    input until newline, so O_NONBLOCK reads return EAGAIN even when
- *    mouse bytes are sitting in the buffer. We briefly re-enter raw mode
- *    so reads return any available bytes, then restore cooked mode.
+ * 2. Callers reach this in mixed tty states: finishExit drains while still
+ *    raw (between its settle window and concludeShutdown's raw-off), while
+ *    concludeShutdown/unmount callers drain after cooked (canonical) mode
+ *    has already returned. Canonical mode line-buffers input until newline,
+ *    so O_NONBLOCK reads return EAGAIN even when mouse bytes are sitting in
+ *    the buffer. When not already raw, we briefly re-enter raw mode so
+ *    reads return any available bytes, then restore the previous state.
  *
  * Safe to call multiple times. Call as LATE as possible in the exit path:
  * DISABLE_MOUSE_TRACKING has terminal round-trip latency, so events can

--- a/src/ink/layout/node.ts
+++ b/src/ink/layout/node.ts
@@ -127,6 +127,8 @@ export type LayoutNode = {
   setMeasureFunc(fn: LayoutMeasureFunc): void
   unsetMeasureFunc(): void
   markDirty(): void
+  /** Whether this node or its subtree needs re-layout (clean-tree fast path). */
+  isDirty(): boolean
 
   // Layout reading (post-layout)
   getComputedLeft(): number

--- a/src/ink/layout/yoga.ts
+++ b/src/ink/layout/yoga.ts
@@ -87,6 +87,10 @@ export class YogaLayoutNode implements LayoutNode {
 
   // Layout
 
+  isDirty(): boolean {
+    return this.yoga.isDirty()
+  }
+
   calculateLayout(width?: number, _height?: number): void {
     this.yoga.calculateLayout(width, undefined, Direction.LTR)
   }

--- a/src/ink/root.ts
+++ b/src/ink/root.ts
@@ -49,6 +49,19 @@ export type RenderOptions = {
  */
 export type Instance = {
   /**
+   * The output stream this instance renders to. finishExit must target THIS
+   * stream for its barrier/cleanup/notice writes — not whatever
+   * process.stdout happens to point at during shutdown (stdout identity
+   * drift, issue #522).
+   */
+  stdout: NodeJS.WriteStream
+  /**
+   * Whether unmount() already wrote the terminal cleanup block itself
+   * (React error-boundary / signal-exit path); finishExit then skips
+   * re-writing the mode resets.
+   */
+  hasWrittenExitCleanup: boolean
+  /**
    * Replace previous root node with a new one or update props of the current root node.
    */
   rerender: Ink['render']
@@ -70,6 +83,20 @@ export type Instance = {
    * tracking after DISABLE_MOUSE_TRACKING has already been written.
    */
   detachForShutdown: Ink['detachForShutdown']
+  /**
+   * First half of the shutdown split: latch isUnmounted and stop every
+   * output producer while raw mode is STILL held. finishExit calls this
+   * before writing the exit sequence so the remote terminal consumes the
+   * mouse-disable bytes during the raw-mode settle window instead of
+   * echoing them as caret garbage after cooked mode returns (#522).
+   */
+  beginShutdown: Ink['beginShutdown']
+  /**
+   * Second half of the shutdown split: release raw mode and drain stdin.
+   * finishExit calls this in a finally after the settle window, so the
+   * cooked-mode restore happens even when the exit write fails.
+   */
+  concludeShutdown: Ink['concludeShutdown']
   /**
    * Fully detach stdin before handing the terminal to a child process that
    * inherits it (the /update and /restart handoffs). See Ink's own method
@@ -118,12 +145,18 @@ export const renderSync = (
   instance.render(node)
 
   return {
+    stdout: inkOptions.stdout,
+    get hasWrittenExitCleanup() {
+      return instance.hasWrittenExitCleanup
+    },
     rerender: instance.render,
     unmount() {
       instance.unmount()
     },
     waitUntilExit: instance.waitUntilExit,
     detachForShutdown: () => instance.detachForShutdown(),
+    beginShutdown: () => instance.beginShutdown(),
+    concludeShutdown: () => instance.concludeShutdown(),
     detachStdinForHandoff: () => instance.detachStdinForHandoff(),
     cleanup: () => instances.delete(inkOptions.stdout),
   }

--- a/src/ink/terminal.ts
+++ b/src/ink/terminal.ts
@@ -471,15 +471,18 @@ export function serializeDiff(
  * @param terminal - the terminal to write to.
  * @param diff - the frame diff patches to render.
  * @param skipSyncMarkers - when true, omit the BSU/ESU wrapping.
+ * @returns `false` when the underlying stream reported backpressure
+ *   (`stdout.write()` returned false) — callers gate scroll-drain and
+ *   backlog handling on this.
  */
 export function writeDiffToTerminal(
   terminal: Terminal,
   diff: Diff,
   skipSyncMarkers = false,
-): void {
+): boolean {
   const buffer = serializeDiff(terminal, diff, skipSyncMarkers)
   if (buffer === '') {
-    return
+    return true
   }
-  terminal.stdout.write(buffer)
+  return terminal.stdout.write(buffer)
 }

--- a/src/screens/AgentView.tsx
+++ b/src/screens/AgentView.tsx
@@ -69,6 +69,44 @@ function statusLabel(status: AgentViewStatus): string {
   }
 }
 
+/** Safety cap for the bucket-boundary wake (local midnight). */
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * The next wall-clock instant at which {@link formatWhen} would render a
+ * DIFFERENT label for a row last touched at `at` — the display-bucket
+ * boundary: "now" flips at 45s, minutes at each half-minute, hours at each
+ * half-hour, days at each half-day, and the date form at the next local
+ * midnight. A view whose rows all fall in the same bucket can sleep until
+ * the nearest of these instead of re-rendering every second.
+ */
+function nextWhenBoundaryAt(at: number, now: number): number {
+  const age = Math.max(0, now - at)
+  const ageSec = age / 1000
+  if (ageSec < 45) return now + (45_000 - age)
+  const minutes = ageSec / 60
+  if (minutes < 60) {
+    // The label shows round(minutes); it changes when the age crosses a
+    // half-minute mark (k + 0.5 minutes).
+    const displayed = Math.round(minutes)
+    return now + Math.max(1, ((displayed + 0.5) * 60_000) - age)
+  }
+  const hours = minutes / 60
+  if (hours < 24) {
+    const displayed = Math.round(hours)
+    return now + Math.max(1, ((displayed + 0.5) * 3_600_000) - age)
+  }
+  const days = hours / 24
+  if (days <= 7) {
+    const displayed = Math.round(days)
+    return now + Math.max(1, ((displayed + 0.5) * 86_400_000) - age)
+  }
+  // Date form: the label changes at the next local midnight.
+  const midnight = new Date(now)
+  midnight.setHours(24, 0, 0, 0)
+  return midnight.getTime()
+}
+
 /** A thrown value's message, for a notification that has to say something. */
 function message(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -233,16 +271,37 @@ export function AgentView({
   const stopArmRef = React.useRef<{ id: string; deadline: number } | null>(null)
 
   // One clock per render pass: every relative time on screen must agree.
+  // Scheduled at the NEXT display-bucket boundary instead of a fixed 1s
+  // interval — `formatWhen` only changes at 45s / minute / hour / day / local
+  // midnight boundaries, so a static list wakes at most once per bucket
+  // (sub-second buckets cannot occur). The wake re-arms itself: `now` is in
+  // the deps, so the effect recomputes the next boundary after every tick
+  // (and on every rows change).
   React.useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(timer)
-  }, [])
+    if (agentRows.length === 0) return
+    const nowMs = Date.now()
+    let boundaryAt = Infinity
+    for (const row of agentRows) {
+      const next = nextWhenBoundaryAt(row.updatedAt, nowMs)
+      if (next < boundaryAt) boundaryAt = next
+    }
+    if (!Number.isFinite(boundaryAt)) return
+    // nextWhenBoundaryAt returns an ABSOLUTE timestamp; setTimeout wants a
+    // relative delay. Cap the target at one day so an anomalous value can
+    // never stall the clock entirely.
+    const target = Math.min(boundaryAt, nowMs + DAY_MS)
+    const delay = Math.max(0, target - nowMs)
+    const timer = setTimeout(() => setNow(Date.now()), delay)
+    return () => clearTimeout(timer)
+  }, [agentRows, now])
 
   // CC parity: working rows animate their glyph (the `·✢*✶✻✽` cycle). The
   // shared clock only runs while at least one row is working and pauses
-  // otherwise, so an idle view costs no extra ticks.
+  // otherwise, so an idle view costs no extra ticks. The ref is attached to
+  // the list container so the viewport gate pauses the clock when the list
+  // is out of view (peek panel covering, narrow split).
   const workingCount = agentRows.filter(row => row.status === 'working').length
-  const [, spinnerTime] = useAnimationFrame(workingCount > 0 ? 120 : null)
+  const [spinnerViewportRef, spinnerTime] = useAnimationFrame(workingCount > 0 ? 120 : null)
   const spinnerFrame = Math.floor(spinnerTime / 120)
 
   // The delete arm expires after its window without an explicit keystroke;
@@ -630,7 +689,7 @@ export function AgentView({
 
       <Box flexGrow={1} flexShrink={1}>
         {!soloPreview && (
-          <Box flexDirection="column" width={listWidth} height={listHeight} flexShrink={0}>
+          <Box ref={spinnerViewportRef} flexDirection="column" width={listWidth} height={listHeight} flexShrink={0}>
             {agentRows.length === 0 && (
               <Text dimColor italic>{` ${truncateWidth(t('agentview-none'), listWidth - 2)}`}</Text>
             )}

--- a/src/screens/AgentView.tsx
+++ b/src/screens/AgentView.tsx
@@ -7,7 +7,7 @@ import { SessionPreview } from '../components/sessions/SessionPreview.js'
 import { useTerminalFocus } from '../ink/hooks/use-terminal-focus.js'
 import { useAnimationFrame } from '../ink/hooks/use-animation-frame.js'
 import { isMod, isPlainReturn } from '../utils/modifiers.js'
-import { formatProject, formatWhen, spreadRow, tailWidth, truncateWidth } from '../sessions/format.js'
+import { formatProject, formatWhen, nextFormatWhenChange, spreadRow, tailWidth, truncateWidth } from '../sessions/format.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { t } from '../i18n.js'
 import type { Channel } from '../dsh-adapter/channel.js'
@@ -69,43 +69,8 @@ function statusLabel(status: AgentViewStatus): string {
   }
 }
 
-/** Safety cap for the bucket-boundary wake (local midnight). */
+/** Safety cap for the bucket-boundary wake (see the clock effect). */
 const DAY_MS = 24 * 60 * 60 * 1000
-
-/**
- * The next wall-clock instant at which {@link formatWhen} would render a
- * DIFFERENT label for a row last touched at `at` — the display-bucket
- * boundary: "now" flips at 45s, minutes at each half-minute, hours at each
- * half-hour, days at each half-day, and the date form at the next local
- * midnight. A view whose rows all fall in the same bucket can sleep until
- * the nearest of these instead of re-rendering every second.
- */
-function nextWhenBoundaryAt(at: number, now: number): number {
-  const age = Math.max(0, now - at)
-  const ageSec = age / 1000
-  if (ageSec < 45) return now + (45_000 - age)
-  const minutes = ageSec / 60
-  if (minutes < 60) {
-    // The label shows round(minutes); it changes when the age crosses a
-    // half-minute mark (k + 0.5 minutes).
-    const displayed = Math.round(minutes)
-    return now + Math.max(1, ((displayed + 0.5) * 60_000) - age)
-  }
-  const hours = minutes / 60
-  if (hours < 24) {
-    const displayed = Math.round(hours)
-    return now + Math.max(1, ((displayed + 0.5) * 3_600_000) - age)
-  }
-  const days = hours / 24
-  if (days <= 7) {
-    const displayed = Math.round(days)
-    return now + Math.max(1, ((displayed + 0.5) * 86_400_000) - age)
-  }
-  // Date form: the label changes at the next local midnight.
-  const midnight = new Date(now)
-  midnight.setHours(24, 0, 0, 0)
-  return midnight.getTime()
-}
 
 /** A thrown value's message, for a notification that has to say something. */
 function message(error: unknown): string {
@@ -271,22 +236,23 @@ export function AgentView({
   const stopArmRef = React.useRef<{ id: string; deadline: number } | null>(null)
 
   // One clock per render pass: every relative time on screen must agree.
-  // Scheduled at the NEXT display-bucket boundary instead of a fixed 1s
-  // interval — `formatWhen` only changes at 45s / minute / hour / day / local
-  // midnight boundaries, so a static list wakes at most once per bucket
-  // (sub-second buckets cannot occur). The wake re-arms itself: `now` is in
-  // the deps, so the effect recomputes the next boundary after every tick
-  // (and on every rows change).
+  // Scheduled at the NEXT true label boundary (nextFormatWhenChange shares
+  // formatWhen's exact nested-rounding semantics) instead of a fixed 1s
+  // interval — a static list wakes at most once per bucket. Rows already in
+  // the absolute-date regime never wake again: that label depends on `at`
+  // alone, so the function returns Infinity and no timer is armed. The wake
+  // re-arms itself: `now` is in the deps, so the effect recomputes the next
+  // boundary after every tick (and on every rows change).
   React.useEffect(() => {
     if (agentRows.length === 0) return
     const nowMs = Date.now()
     let boundaryAt = Infinity
     for (const row of agentRows) {
-      const next = nextWhenBoundaryAt(row.updatedAt, nowMs)
+      const next = nextFormatWhenChange(row.updatedAt, nowMs)
       if (next < boundaryAt) boundaryAt = next
     }
     if (!Number.isFinite(boundaryAt)) return
-    // nextWhenBoundaryAt returns an ABSOLUTE timestamp; setTimeout wants a
+    // nextFormatWhenChange returns an ABSOLUTE timestamp; setTimeout wants a
     // relative delay. Cap the target at one day so an anomalous value can
     // never stall the clock entirely.
     const target = Math.min(boundaryAt, nowMs + DAY_MS)

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -559,6 +559,12 @@ export function Chat({
     auto?: boolean
     expanded?: boolean
     rowsAtTrigger?: number
+    /** rowsGeneration when the auto run started. Row ids are
+     * transcript-SCOPED: /clear restarts them at 0 under the same agentId,
+     * so a same-generation comparison (`lastUserRowId > rowsAtTrigger`)
+     * alone would keep a stale recap on screen long after its transcript
+     * was deleted — in a NEW generation, any new user row retires it. */
+    genAtTrigger?: number
   } | null>(null)
   const recapAbortRef = React.useRef<AbortController | null>(null)
   const closeRecap = () => {
@@ -603,7 +609,7 @@ export function Chat({
     const controller = new AbortController()
     recapAbortRef.current = controller
     const lastUserId = channel.rows.filter(row => row.kind === 'user').at(-1)?.id ?? -1
-    setRecap({ raw: '', summary: '', error: undefined, done: false, titleApplied: false, auto: true, expanded: false, rowsAtTrigger: lastUserId })
+    setRecap({ raw: '', summary: '', error: undefined, done: false, titleApplied: false, auto: true, expanded: false, rowsAtTrigger: lastUserId, genAtTrigger: channel.rowsGeneration })
     void channel.recapRecent({
       signal: controller.signal,
       onText: delta => setRecap(prev => (prev ? { ...prev, raw: prev.raw + delta } : prev)),
@@ -621,18 +627,33 @@ export function Chat({
   // The user starts a new message → the auto recap has served its purpose
   // (catching them up) and bows out. A newer user row is the signal; the
   // assistant's own streamed rows don't count. `lastUserRowId` is tracked
-  // amortized O(1) per render: user rows are only ever APPENDED to the tail
-  // (folds keep the newest), so only rows appended past the last scan can
-  // hold a newer user row, and a session swap (agentId change) rescans the
-  // new session's rows exactly once.
-  const lastUserRowStateRef = React.useRef<{ agentId: string; scanned: number; id: number }>({
+  // amortized O(1) per render: within ONE transcript generation user rows
+  // are only ever APPENDED to the tail (folds keep the newest), so only rows
+  // appended past the last scan can hold a newer user row. The scan state
+  // keys on BOTH agentId and rowsGeneration: `/clear` keeps the agentId and
+  // REUSES row ids from 0, so agentId alone cannot detect the reset — a
+  // stale `scanned` would suppress rescans until the new transcript grew
+  // past the old length, leaving lastUserRowId (and the auto-recap retire
+  // below) stuck on the previous transcript. `rows.length < scanned` is a
+  // defensive reset for hosts without a generation seam.
+  const lastUserRowStateRef = React.useRef<{
+    agentId: string
+    rowsGeneration: number | undefined
+    scanned: number
+    id: number
+  }>({
     agentId: '',
+    rowsGeneration: undefined,
     scanned: 0,
     id: -1,
   })
   const lastUserRowState = lastUserRowStateRef.current
   let lastUserRowId = lastUserRowState.id
-  if (lastUserRowState.agentId !== channel.agentId) {
+  const transcriptEpochChanged =
+    lastUserRowState.agentId !== channel.agentId ||
+    lastUserRowState.rowsGeneration !== channel.rowsGeneration ||
+    channel.rows.length < lastUserRowState.scanned
+  if (transcriptEpochChanged) {
     lastUserRowId = -1
     for (let index = channel.rows.length - 1; index >= 0; index--) {
       if (channel.rows[index]?.kind === 'user') {
@@ -642,6 +663,7 @@ export function Chat({
     }
     lastUserRowStateRef.current = {
       agentId: channel.agentId,
+      rowsGeneration: channel.rowsGeneration,
       scanned: channel.rows.length,
       id: lastUserRowId,
     }
@@ -658,11 +680,17 @@ export function Chat({
       recap !== null &&
       recap.auto &&
       recap.rowsAtTrigger !== undefined &&
-      lastUserRowId > recap.rowsAtTrigger
+      lastUserRowId >= 0 &&
+      // Row ids are transcript-SCOPED: within the recap's own generation a
+      // strictly newer user row retires it; in a NEW generation (/clear
+      // restarted ids at 0 under the same agentId) ANY new user row does —
+      // the old absolute-id comparison would wait for the fresh transcript
+      // to outgrow the deleted one's id space before retiring.
+      (recap.genAtTrigger !== channel.rowsGeneration || lastUserRowId > recap.rowsAtTrigger)
     ) {
       closeRecap()
     }
-  }, [lastUserRowId, recap])
+  }, [lastUserRowId, recap, channel.rowsGeneration])
   /**
    * Session switches that do not go through `/new` (agent-view attach,
    * backgrounding, `/resume`) remount the transcript tree without resetting
@@ -879,7 +907,10 @@ export function Chat({
         ? null
         : channel.rows.find(row => row.id === anchorUserRowId)?.text ?? null,
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [anchorUserRowId, channel.agentId],
+    // rowsGeneration is part of the key: /clear / rewind reuse row ids from
+    // 0 while agentId stays — without it the memo could serve the PREVIOUS
+    // transcript's prompt for the new id-identical anchor row.
+    [anchorUserRowId, channel.agentId, channel.rowsGeneration],
   )
 
   // "N new messages" pill: new rows whose top edge is still BELOW the
@@ -2413,8 +2444,12 @@ export function Chat({
     // off the streaming frame path: an idle/long session re-renders without
     // touching rows at all, and a streaming session scans only when an error
     // actually lands.
+    // rowsGeneration must be part of the key: /clear reuses row ids from 0
+    // under the SAME agentId, so the memoized id could otherwise point at a
+    // fresh, healthy row in the new transcript and pin the stale failure
+    // footnote under it.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [trajectory.counts.errors, channel.agentId, unreadFailures])
+  }, [trajectory.counts.errors, channel.agentId, channel.rowsGeneration, unreadFailures])
 
   // Row seeking under layout virtualization: a mounted row seeks directly;
   // an unmounted one is force-mounted first, then sought by the completion

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -103,7 +103,7 @@ import { useAnimationFrame } from '../ink/hooks/use-animation-frame.js'
 import { useExternalVersion } from '../hooks/useExternalVersion.js'
 import { TrajectoryScene } from './TrajectoryScene.js'
 import { AgentView } from './AgentView.js'
-import { extendTrajectory, projectWave, type TrajBuild } from '../dsh-adapter/trajectory/index.js'
+import { extendTrajectory, emptyTrajectory, projectWave, type TrajBuild } from '../dsh-adapter/trajectory/index.js'
 import { miniWakeWidth } from '../components/trajectory/MiniWake.js'
 import { readTrajectorySeen, writeTrajectorySeen } from '../trajectoryPrefs.js'
 import type { SessionEvent } from '../dsh-adapter/types.js'
@@ -119,8 +119,15 @@ import {
   type WorkspaceFlowInput,
 } from './chatOverlay.js'
 
-/** Shared empty snapshot for hosts whose channel has no event log. */
+/** Shared empty snapshot for channels without an event log (legacy stubs). */
 const NO_EVENTS: readonly SessionEvent[] = []
+/** Shared empty build for channels that provide neither seam (stable
+ *  identity keeps stub renders churn-free). */
+const EMPTY_TRAJECTORY = emptyTrajectory()
+/** Shared no-op unsubscribe for stub channels without an agent-view feed. */
+const EMPTY_SUBSCRIBE = (): (() => void) => () => {}
+/** Shared empty agent-view rows for stub channels (see EMPTY_TRAJECTORY). */
+const EMPTY_AGENT_VIEW_ROWS: readonly never[] = []
 
 const PERMISSION_RESULT_CELLS = 200
 
@@ -294,8 +301,15 @@ export function Chat({
   React.useSyncExternalStore(subscribeLang, getLang)
   // The pending ask-user-question (DSH user-interaction seam): the model's
   // `ask_user_question` tool parks here until the panel is answered.
+  // useSyncExternalStore re-subscribes whenever the subscribe function
+  // identity changes, so these bindings are stable per store instance
+  // (useCallback) instead of fresh closures per render.
+  const subscribeQuestions = React.useCallback(
+    (listener: () => void) => questionStore.subscribe(listener),
+    [questionStore],
+  )
   const questionSnapshot = React.useSyncExternalStore(
-    listener => questionStore.subscribe(listener),
+    subscribeQuestions,
     () => questionStore.getSnapshot(),
   )
   // The pending tool-approval ask (DSH approval seam): the permission layer
@@ -303,8 +317,12 @@ export function Chat({
   // questionnaire since it gates a tool about to run. Hosts that pass no
   // approvalStore share one inert instance that never holds an ask.
   const approvals = approvalStore ?? (fallbackApprovalStore ??= new ApprovalStore())
+  const subscribeApprovals = React.useCallback(
+    (listener: () => void) => approvals.subscribe(listener),
+    [approvals],
+  )
   const approvalSnapshot = React.useSyncExternalStore(
-    listener => approvals.subscribe(listener),
+    subscribeApprovals,
     () => approvals.getSnapshot(),
   )
   // The pending managed plugin dialog (tuiDialogs seam): a plugin's
@@ -313,15 +331,23 @@ export function Chat({
   // plugin's question) and above the questionnaire. Hosts without the
   // extensions row share one inert store that never holds a dialog.
   const dialogs = extensionDialogs ?? (fallbackDialogStore ??= new TuiDialogStore())
+  const subscribeDialogs = React.useCallback(
+    (listener: () => void) => dialogs.subscribe(listener),
+    [dialogs],
+  )
   const dialogSnapshot = React.useSyncExternalStore(
-    listener => dialogs.subscribe(listener),
+    subscribeDialogs,
     () => dialogs.getSnapshot(),
   )
   // Plugin status-line contributions (tuiStatus seam): keyed texts joined
   // into one line above the prompt.
   const statusContributions = extensionStatus ?? (fallbackStatusStore ??= new TuiStatusStore())
+  const subscribeStatus = React.useCallback(
+    (listener: () => void) => statusContributions.subscribe(listener),
+    [statusContributions],
+  )
   const statusEntries = React.useSyncExternalStore(
-    listener => statusContributions.subscribe(listener),
+    subscribeStatus,
     () => statusContributions.getSnapshot(),
   )
   // Shortcut handler failures surface as toasts (the registry also logs
@@ -458,10 +484,13 @@ export function Chat({
   /** Live agent-view rows: the prompt footer's "← N agents" hint reads the
    *  needs-input count from here (cached snapshot in the channel). The
    *  `?.()` fallbacks keep pre-agent-view test stubs (channel facades in
-   *  scripts/*) rendering — the real channel always provides the seams. */
-  const EMPTY_AGENT_VIEW_ROWS: readonly never[] = []
+   *  scripts/*) rendering — the real channel always provides the seams. The
+   *  fallbacks are module-level constants: useSyncExternalStore must see a
+   *  stable subscribe/getSnapshot identity or it re-subscribes (and
+   *  snapshot-compares) on every render.
+   */
   const agentViewRows = React.useSyncExternalStore(
-    listener => channel.subscribeAgentView?.(listener) ?? (() => {}),
+    channel.subscribeAgentView ?? EMPTY_SUBSCRIBE,
     () => channel.agentViewRows?.() ?? EMPTY_AGENT_VIEW_ROWS,
   )
   const backgroundAgentsNeedingInput = agentViewRows.filter(
@@ -591,8 +620,39 @@ export function Chat({
   }, [autoRecapSessionId])
   // The user starts a new message → the auto recap has served its purpose
   // (catching them up) and bows out. A newer user row is the signal; the
-  // assistant's own streamed rows don't count.
-  const lastUserRowId = channel.rows.filter(row => row.kind === 'user').at(-1)?.id ?? -1
+  // assistant's own streamed rows don't count. `lastUserRowId` is tracked
+  // amortized O(1) per render: user rows are only ever APPENDED to the tail
+  // (folds keep the newest), so only rows appended past the last scan can
+  // hold a newer user row, and a session swap (agentId change) rescans the
+  // new session's rows exactly once.
+  const lastUserRowStateRef = React.useRef<{ agentId: string; scanned: number; id: number }>({
+    agentId: '',
+    scanned: 0,
+    id: -1,
+  })
+  const lastUserRowState = lastUserRowStateRef.current
+  let lastUserRowId = lastUserRowState.id
+  if (lastUserRowState.agentId !== channel.agentId) {
+    lastUserRowId = -1
+    for (let index = channel.rows.length - 1; index >= 0; index--) {
+      if (channel.rows[index]?.kind === 'user') {
+        lastUserRowId = channel.rows[index]!.id
+        break
+      }
+    }
+    lastUserRowStateRef.current = {
+      agentId: channel.agentId,
+      scanned: channel.rows.length,
+      id: lastUserRowId,
+    }
+  } else if (channel.rows.length > lastUserRowState.scanned) {
+    for (let index = lastUserRowState.scanned; index < channel.rows.length; index++) {
+      const row = channel.rows[index]
+      if (row?.kind === 'user' && row.id > lastUserRowId) lastUserRowId = row.id
+    }
+    lastUserRowState.scanned = channel.rows.length
+    lastUserRowState.id = lastUserRowId
+  }
   React.useEffect(() => {
     if (
       recap !== null &&
@@ -688,7 +748,7 @@ export function Chat({
 
   /** Open the scene, mark failures seen, and retire the key hint for good. */
   const openScene = React.useCallback(() => {
-    seenFailuresRef.current = trajectoryRef.current?.counts.errors ?? 0
+    seenFailuresRef.current = trajectoryRef.current.counts.errors
     setTrajectorySeen(previous => {
       if (!previous) writeTrajectorySeen()
       return true
@@ -803,6 +863,24 @@ export function Chat({
     (listener: () => void) => (handle ? handle.subscribe(listener) : () => {}),
     [handle],
   )
+  // The sticky header pins the turn owning the viewport top row
+  // (timeline.activeId, reported by MessageList) — scrolled up to an old
+  // turn, it carries THAT turn's prompt, not the latest one. The lookup is
+  // memoized: a user row's text is immutable after creation, so the result
+  // can only change when the anchor id or the session changes (row ids
+  // restart at 0 on a swap). Declared BEFORE the screen-swap early returns
+  // (scene/browser/agent-view): a hook placed after them would drop from
+  // the hook list while a replacement screen is up, and React would throw
+  // "Rendered fewer hooks than expected" on the way back.
+  const anchorUserRowId = timeline.activeId
+  const anchorUserText = React.useMemo(
+    () =>
+      anchorUserRowId === null
+        ? null
+        : channel.rows.find(row => row.id === anchorUserRowId)?.text ?? null,
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [anchorUserRowId, channel.agentId],
+  )
 
   // "N new messages" pill: new rows whose top edge is still BELOW the
   // viewport bottom. The count decrements as the user scrolls down through
@@ -837,10 +915,13 @@ export function Chat({
   // Live view into the prompt's text for the Ctrl+C rule (clears text when
   // non-empty; the double-press exit only arms on an empty input).
   const promptControllerRef = React.useRef<PromptController | null>(null)
-  // Publish the external-injection controller (dsh.nvim etc.) every render so
-  // the adapter-owned socket can append to the prompt and submit. `submit`
+  // Publish the external-injection controller (dsh.nvim etc.) so the
+  // adapter-owned socket can append to the prompt and submit. `submit`
   // mirrors an Enter press: `channel.submit` routes through the DSH inbox
   // (queued after the current turn while working), then the input is cleared.
+  // Mounted once per channel: every closure reads the LIVE prompt controller
+  // through the ref at call time, so the published value never goes stale —
+  // re-running this effect on every commit would churn the ref for nothing.
   React.useEffect(() => {
     if (!injectControllerRef) return
     injectControllerRef.current = {
@@ -863,7 +944,10 @@ export function Chat({
     return () => {
       injectControllerRef.current = null
     }
-  })
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- the ref and
+    // channel identities are stable for the life of the mount; the closures
+    // read live state through refs, so no per-render refresh is needed.
+  }, [channel, injectControllerRef])
   const requestExit = () => {
     if (exitPendingRef.current) {
       onExit()
@@ -2211,22 +2295,45 @@ export function Chat({
   }
 
   /**
-   * The session's trajectory projection, folded here rather than inside the
-   * scene.
+   * The session's trajectory projection, folded incrementally by the channel
+   * at EVENT time — never here. Render reads the ready build (a stable
+   * channel-owned object), so no render touches the session event getter.
    *
-   * Two things fall out of owning it at this level: the status-line chip can
-   * show live counters without a second fold, and opening the scene is
-   * instant because the build is already warm. The fold is incremental — it
-   * consumes only events appended since the last render — so an idle
-   * conversation pays nothing for it.
+   * Legacy/headless channels that only provide `traceEvents()` (test stubs,
+   * bare embeds) fall back to a snapshot-identity-cached fold here: the
+   * getter is called at most ONCE per event-snapshot identity, and the
+   * fold itself is incremental, so the fallback stays O(1) per render on an
+   * unchanged snapshot. Real channels provide `trajectory()` and never hit
+   * this path.
    */
-  const trajectoryRef = React.useRef<TrajBuild | null>(null)
-  trajectoryRef.current = extendTrajectory(
-    trajectoryRef.current,
-    // oxlint-disable-next-line typescript/no-unnecessary-condition -- runtime guard: headless hosts render Chat with a partial channel
-    channel.traceEvents?.() ?? NO_EVENTS,
-  )
-  const trajectory = trajectoryRef.current
+  const trajectoryFallbackRef = React.useRef<{
+    version: number
+    events: readonly SessionEvent[]
+    build: TrajBuild
+  } | null>(null)
+  const trajectory = channel.trajectory
+    ? channel.trajectory()
+    : (() => {
+        const cached = trajectoryFallbackRef.current
+        // Version gate: the getter is consulted only when the channel
+        // version moved (the stub's own change signal); renders triggered
+        // by anything else (animation ticks, local state) pay nothing.
+        if (cached !== null && cached.version === channel.version) return cached.build
+        const events = channel.traceEvents?.() ?? NO_EVENTS
+        if (cached !== null && cached.events === events) {
+          // Same snapshot, new version (a notify without session events):
+          // reuse the build — the fold stays incremental.
+          trajectoryFallbackRef.current = { version: channel.version, events, build: cached.build }
+          return cached.build
+        }
+        const build = extendTrajectory(cached?.build ?? null, events)
+        trajectoryFallbackRef.current = { version: channel.version, events, build }
+        return build
+      })()
+  // Mirrors the current build for callbacks defined before `trajectory` is in
+  // scope (openScene) without re-creating them per render.
+  const trajectoryRef = React.useRef(trajectory)
+  trajectoryRef.current = trajectory
 
   /**
    * The status-line wake.
@@ -2251,11 +2358,32 @@ export function Chat({
         // rather than as short. It simply grows as the session does.
         : projectWave(trajectory.nodes, Math.min(wakeWidth, trajectory.nodes.length), 'sequence'),
     // The node array is mutated in place by the incremental fold, so its
-    // length is the honest dependency; its identity never changes.
+    // identity never changes and its length misses in-place closes (a
+    // tool/result only flips an existing node's status). The build's
+    // monotonic revision covers every consumed event — including closes.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [trajectory.nodes, trajectory.counts.rows, wakeWidth],
+    [trajectory.nodes, trajectory.counts.rows, trajectory.revision, wakeWidth],
   )
-  const [wakeTickRef, wakeTime] = useAnimationFrame(channel.working ? 120 : null)
+  // The mini-wake clock runs ONLY while the strip can actually be seen: the
+  // main chat surface is rendered (no replacement screen owns the viewport —
+  // a swapped-out screen leaves the wake ref's element unmounted and the
+  // viewport hook's isVisible stale at its last value), the terminal is wide
+  // enough for a strip (miniWakeWidth > 0), the trajectory chrome is enabled,
+  // and a turn is actually working. All four are read every render, so the
+  // animation unsubscribes the moment any condition drops.
+  const mainSurfaceRendered =
+    !sceneOpen &&
+    channel.pluginScene === undefined &&
+    !agentViewOpen &&
+    !browserOpen &&
+    !treeOpen &&
+    !settingsOpen &&
+    subagentDetailId === null &&
+    !jobsPanelOpen &&
+    !subagentDashboardOpen
+  const wakeTickActive =
+    channel.working && wakeWidth > 0 && mainSurfaceRendered && channel.statusBar?.trajectory === true
+  const [wakeTickRef, wakeTime] = useAnimationFrame(wakeTickActive ? 120 : null)
   /**
    * The key hint beside the strip retires itself once the trajectory has been
    * opened — teaching belongs in the first minute, not on every frame forever.
@@ -2279,8 +2407,14 @@ export function Chat({
       if (row?.kind === 'tool' && row.tool?.status === 'error') return row.id
     }
     return null
+    // The newest failed tool row can only change when the trajectory's error
+    // count grows or the session swaps — NOT on every channel version bump.
+    // Keying on those (instead of channel.version) keeps the reverse scan
+    // off the streaming frame path: an idle/long session re-renders without
+    // touching rows at all, and a streaming session scans only when an error
+    // actually lands.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [channel.rows, channel.version, unreadFailures])
+  }, [trajectory.counts.errors, channel.agentId, unreadFailures])
 
   // Row seeking under layout virtualization: a mounted row seeks directly;
   // an unmounted one is force-mounted first, then sought by the completion
@@ -3372,16 +3506,6 @@ export function Chat({
   }) && !(overlay.kind === 'permission'
     && (approvalSnapshot !== null || questionSnapshot !== null || dialogSnapshot !== null))
 
-  // The sticky header pins the turn owning the viewport top row
-  // (timeline.activeId, reported by MessageList) — scrolled up to an old
-  // turn, it carries THAT turn's prompt, not the latest one.
-  // channel.rows is a live in-place array, so the lookup is per-render.
-  const anchorUserRowId = timeline.activeId
-  const anchorUserText =
-    anchorUserRowId === null
-      ? null
-      : channel.rows.find(row => row.id === anchorUserRowId)?.text ?? null
-
   return (
     <Box ref={wakeTickRef} flexDirection="column" flexGrow={1} width="100%">
       {!isSticky && anchorUserText && (
@@ -3440,6 +3564,8 @@ export function Chat({
         )}
         <MessageList
           rows={channel.rows}
+          streamingVersion={channel.rowsStreamingVersion}
+          rowsGeneration={channel.rowsGeneration}
           failureHintRowId={failureHintRowId}
           failureHint={t('traj-hint-failure', { key: `${modLabel}t` })}
           expanded={expanded}

--- a/src/screens/TrajectoryScene.tsx
+++ b/src/screens/TrajectoryScene.tsx
@@ -106,15 +106,17 @@ export function TrajectoryScene({
   const { rows: filtered, indexes } = React.useMemo(
     () => applyQuery(nodes, query),
     // `nodes` is mutated in place by the incremental fold, so its length is
-    // the honest dependency — the array identity never changes.
+    // NOT an honest dependency alone — an in-place close (tool/result,
+    // step/end) changes status/duration without touching length. The
+    // build's monotonic revision covers every consumed event.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [nodes, nodes.length, query],
+    [nodes, nodes.length, build.revision, query],
   )
 
   const agg = React.useMemo(
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     () => aggregate(build, sort),
-    [build, nodes.length, sort],
+    [build, nodes.length, build.revision, sort],
   )
 
   // ── arrival + alert detection ────────────────────────────────────────────
@@ -147,7 +149,7 @@ export function TrajectoryScene({
   const band = React.useMemo(
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     () => projectWave(nodes, bandWidth, projection),
-    [nodes, nodes.length, bandWidth, projection],
+    [nodes, nodes.length, build.revision, bandWidth, projection],
   )
   const matchColumns = React.useMemo(() => {
     if (query.empty) return undefined

--- a/src/sessions/format.ts
+++ b/src/sessions/format.ts
@@ -139,6 +139,53 @@ export function formatWhen(at: number, now: number): string {
 }
 
 /**
+ * The next wall-clock instant at which {@link formatWhen} would return a
+ * DIFFERENT string for `at` — computed with `formatWhen` itself as the
+ * oracle, so the two can never drift apart (the nested rounding
+ * `seconds → minutes → hours → days` makes the true boundaries anything but
+ * the naive half-minute/half-hour marks: the minute label flips at
+ * `seconds = 60k+30` where seconds itself is `round(ageMs/1000)`, the
+ * minute→hour cut lands at 59m30s, and day 7 gives way to the date form at
+ * ~7.47 days).
+ *
+ * The label is a nondecreasing step function of age — every derived integer
+ * is nondecreasing in age and no bucket's string ever repeats — so a binary
+ * search over age space finds the exact flip (boundaries sit at
+ * `(2k+1)×500ms` offsets, integer-ms convergent). The horizon only needs to
+ * exceed the last finite boundary (the day-7 → date cutover); the one label
+ * stable past it is the absolute date form, which depends on `at` alone and
+ * therefore NEVER changes again — we return `Infinity` so callers schedule
+ * no wake at all (the whole point of the idle-wakeup elimination).
+ *
+ * @param at - Epoch ms of the moment being described (same as formatWhen).
+ * @param now - Epoch ms of the present.
+ * @returns Epoch ms of the next label change strictly after `now`, or
+ *   `Infinity` in the absolute-date regime (no future change).
+ */
+export function nextFormatWhenChange(at: number, now: number): number {
+  const current = formatWhen(at, now)
+  // A label stable across the horizon is the date form (the only one whose
+  // inputs do not move with now) — no wake needed, ever.
+  const HORIZON_MS = 8 * 24 * 60 * 60 * 1000
+  if (formatWhen(at, now + HORIZON_MS) === current) return Infinity
+  // Binary search the first instant with a different label. Monotonicity:
+  // age ↗ ⇒ seconds ↗ ⇒ minutes/hours/days ↗ ⇒ bucket or number moves
+  // forward, never back — so "label differs" is a monotone predicate over
+  // age and bisection converges to the exact boundary ms.
+  let lo = now
+  let hi = now + HORIZON_MS
+  while (hi - lo > 1) {
+    const mid = Math.floor((lo + hi) / 2)
+    if (formatWhen(at, mid) === current) {
+      lo = mid
+    } else {
+      hi = mid
+    }
+  }
+  return hi
+}
+
+/**
  * Byte size at the precision the number is worth: `812 B`, `142.9 KB`,
  * `4.2 MB`. One decimal from kilobytes up, because the digit distinguishes a
  * short exchange from a long one and a second would not.


### PR DESCRIPTION
# Semantic integration: PR #701 × PR #713 × #711 (#714 included via base)

Semantic integration of #701 and #713 — both are integrated here at function level, not mechanically merged. Their branches and discussions remain the authoritative record for the original designs; how the two original PRs are retired (close / keep for reference) is a maintainer decision, intentionally NOT automated by this PR.

## Why a semantic integration

#701's base (`f7db6057`) predates #711's mouse gesture/protocol-latch refactor, so #701 × main conflicted at **state-machine level** in `App.tsx` / `ink.tsx` (not text level). #713 (based on #711 head) then re-touches the same render/shutdown pipeline. This branch ports #701's three commits onto current main, resolves the conflicts function-by-function, then rebases #713 on top, then fixes every blocker from the integration review.

## What each side kept

- **#711 fully preserved**: `protocolCandidateActive`, `pointerGestureActive`, `heldButtons`, `ambiguousHeld`, parser `mouseTailHold`, pending probe, pending alt-screen reentry, release/focus/no-button batch-tail drain, dual-latch checks on resume/focus/resize probes, DECRQM-reply re-checks.
- **#701 as a higher-priority lifecycle gate**: after `beginShutdown` — no input dispatch (incl. a new chunk-level gate for mid-batch Ctrl+C), no probe, no mode reassert, no reentry, no ordinary frames, stdin drain-only, raw mode held through the settle window → stdout queue barrier → ordered cleanup (`DISABLE_MOUSE` → `EXIT_ALT`) → `concludeShutdown` → cooked restore → stdin handoff. `shutdownApp` last-live-App retention kept intact.
- **#713's performance architecture fully kept** (trajectory incrementality, timer gating, stdout backpressure, Yoga early-bail, width dedupe); only invalidation/lifecycle bugs fixed.

## Blockers fixed on top

**#701**
- `finishExit` runtime selection is now **handle-first** (explicit render handle wins; instances map is fallback only) — multi-instance/stdout-drift can no longer latch the wrong runtime.
- `activeFinishExit` invariant documented (one process-owning TUI runtime per process; migration path noted) + concurrency regression.

**#713**
1. `MessageList` visible-rows cache keyed on `rowsGeneration`.
2. `failureHintRowId` memo keyed on `rowsGeneration`.
3. `lastUserRowId` scan state keyed on `{agentId, rowsGeneration, scanned, id}` + shrink reset; auto-recap retire is generation-aware (`genAtTrigger`) — retires on the first new-transcript user message after `/clear`.
4. `anchorUserText` memo keyed on `rowsGeneration`.
5. `GoalTodoPanel`: elapsed-baseline transitions moved out of render phase into committed effects (abandoned renders can no longer pollute the baseline).
6. AgentView scheduler replaced by `nextFormatWhenChange()` sharing `formatWhen`'s exact nested-rounding semantics (oracle-based bisection); absolute-date regime returns `Infinity` (no midnight wake).
7. Working-activity tick retires on projection-unavailable; later real events re-arm it.
8. `scheduleDrain` re-arms the drain listener while backpressured even when the fallback timer exists (drain-first recovery preserved).
9. §8 cross-invariant: `beginShutdown` now kills render generation, microtask renders, drain listener, fallback timer and backpressure state **before** the stdout barrier / terminal cleanup.

**Test hardening (no assertion weakened)**: grants fallback scenario subscribes with a nonexistent parent dir; skills recovery asserts a NEW `recovered-skill`; trajectory cache asserts `traceCalls === 0` at mount; working-activity proves a live timer-driven emit before `turn/end`.

## New regressions (registered in run-ci-group)

`verify-exit-runtime-selection` · `verify-exit-gesture-protocol` (#711×#701 Cases A–D) · `verify-exit-backpressure` (#713×#701) · `verify-rows-generation` · `verify-format-when-boundary` · `verify-goal-todo-baseline` · plus registration of #713's unregistered `verify-idle-wakeups` / `verify-trajectory-cache` / `verify-grants-watch`.

## Local verification

- `pnpm build` / `pnpm smoke` / `pnpm verify:package` — all green (1408 files, 29 entry targets).
- channel-ui **54/54**, input-terminal **28/28**, render-scroll **39/40** (osc8 = registered Windows-preexisting, reproduced on main), session-workspace **30/33** (3 registered env baselines: python3 / network / POSIX).
- All #701/#711/#713 focused suites green; runtime-selection and failure-hint fixes proven red-on-unfixed.

Credit: @CikeSeven for #701's two-phase shutdown design (commits preserved in history), #713 architecture preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal exit handling under slow or blocked output, including reliable cleanup, input draining, mouse-mode restoration, and concurrent exits.
  - Prevented stale transcript content, recaps, and trajectory displays after clears, session changes, or streaming updates.
  - Corrected elapsed-time behavior for paused, blocked, and resumed goals.
  - Improved grant-change detection across file replacement and watcher failures.

- **Performance**
  - Reduced unnecessary redraws and background timers for completed activity, settled jobs, hidden views, and unchanged layouts.
  - Added incremental trajectory and transcript updates for smoother rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->