### PR TITLE
feat(ui): 悬停浮层只给新增信息——工具卡元数据/门控 + 文件补全/会话行/状态栏悬停

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -365,6 +365,15 @@ const GROUPS = {
 // 不出现、到点内容正确、leave 即隐、leave 早于延迟取消、自定义 delayMs、
 // 多行内容锚点上方、屏顶锚点转下方、resize 隐藏（几何失效）、窄屏水平钳制。
     ["verify-tooltip", ['node', '--import', 'tsx/esm', 'scripts/verify-tooltip.tsx']],
+// 工具卡头部 hover tooltip 内容门控回归：头部已经完整显示（单行标题 / 未
+// 超出预算的 args）时悬停不再弹「重复可见文本」的浮层，改弹卡片元数据
+// （开始/结束时刻、耗时、运行中时长）；折叠的终端脚本与超出 480 字符预算
+// 的 args 仍弹完整内容（弹层优先真隐藏内容）。
+    ["verify-tool-tooltip-gating", ['node', '--import', 'tsx/esm', 'scripts/verify-tool-tooltip-gating.tsx']],
+// 悬停浮层第二批回归：@ 文件补全面板长路径悬停弹全路径（完整可见的短路径
+// 不弹）、会话列表行标题截断悬停弹完整标题+绝对时间+cwd（未截断不重复
+// 标题）、状态栏 model/git 字段悬停明细（provider/ctx 窗口/完整分支）。
+    ["verify-hover-details", ['node', '--import', 'tsx/esm', 'scripts/verify-hover-details.tsx']],
 // 便携包更新解压链安全回归：Windows 解压优先 tar.exe 数组参数，回退
 // Expand-Archive 的两个路径按 PowerShell 约定把 ' 双写为 ''——路径派生
 // 自环境变量，不转义即可注入任意命令；解压与替换之间的提取树校验拒绝

--- a/scripts/verify-hover-details.tsx
+++ b/scripts/verify-hover-details.tsx
@@ -1,0 +1,223 @@
+/**
+ * 悬停浮层第二批回归：「浮层只给屏幕上看不到、悬停马上想知道的信息」
+ * 在另外三处的落地——
+ *
+ *  F. @ 文件补全面板：名称列固定 20 列 + 行宽截断，悬停被截断的长路径行
+ *     弹出完整路径 + 类型；完整可见的短路径行不弹。
+ *  G. 会话列表行：标题截断时悬停弹【完整标题 + 绝对时间 + cwd】；标题
+ *     未截断时浮层不重复标题（只带时间 + cwd）。
+ *  H. 状态栏 model/git 字段：悬停 model 弹 provider + ctx 窗口明细；
+ *     悬停 git 弹完整分支名（原地明细行契约，与 tps/cost 同款）。
+ *
+ * Run: `node --import tsx/esm scripts/verify-hover-details.tsx`
+ */
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'verify-hover-details-data-'))
+process.env.HOME = dataDir
+process.env.USERPROFILE = dataDir
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, ui, tooltip, termTest] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/Tooltip.js'),
+  import('./lib/term-test.mjs'),
+])
+
+const { sleep, settled, screenHas, findText } = termTest
+const { render, AlternateScreen, Box } = ui
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed++
+}
+
+function KeySink(): React.ReactNode {
+  ui.useInput(() => {})
+  return null
+}
+
+function makeRig(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 50, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode() { return this }
+    ref() { return this }
+    unref() { return this }
+  }
+  return { term, stdout: new FakeStdout(), stdin: new FakeStdin() }
+}
+
+/** SGR mode-1003 motion with no buttons → dispatchHover. Coords 1-indexed. */
+const hover = (stdin: PassThrough, col: number, row: number) =>
+  stdin.write(`\x1b[<35;${col};${row}M`)
+
+function hoverText(stdin: PassThrough, term: XTerm, needle: string): void {
+  const at = findText(term, needle)
+  if (at === null) throw new Error(`hover target not found: ${needle}`)
+  hover(stdin, at.col + 1, at.row + 1)
+}
+
+const { FileSuggestions } = await import('../src/components/FileSuggestions.js')
+const { SessionListRow } = await import('../src/components/sessions/SessionListRow.js')
+const { StatusLine } = await import('../src/screens/StatusLine.js')
+const { formatAbsolute } = await import('../src/sessions/format.js')
+
+try {
+  const COLS = 50
+  const ROWS = 30
+  const rig = makeRig(COLS, ROWS)
+  const { term, stdin } = rig
+
+  // --- F. @ 文件补全面板：长路径截断 → 悬停弹全路径 ----------------------
+  // 路径宽 43：行内截断（5+43 > usable=46 边界内）且浮层单行放得下
+  // （内宽 44），屏幕断言与浮层内容一一对应。
+  const LONG_PATH = 'src/components/messages/DeepLongFileName.tsx'
+  const files = [
+    { id: 'f1', path: LONG_PATH, displayPath: LONG_PATH, name: 'DeepLongFileName.tsx', kind: 'file' as const, score: 1 },
+    { id: 'f2', path: 'README.md', displayPath: 'README.md', name: 'README.md', kind: 'file' as const, score: 1 },
+  ]
+  const instance = await render(
+    <AlternateScreen>
+      <Box flexDirection="column">
+        <KeySink />
+        <FileSuggestions files={files} selectedIndex={0} columns={COLS} />
+        <tooltip.TooltipLayer />
+      </Box>
+    </AlternateScreen>,
+    { stdout: rig.stdout, stdin: rig.stdin, exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(600)
+  check('场景 F 就绪：长路径行已截断（尾段不在屏）', await settled(() => !screenHas(term, 'DeepLongFileName.tsx')))
+  hoverText(stdin, term, 'src/components/messages')
+  check('F 截断路径悬停后弹出完整路径', await settled(() => screenHas(term, 'DeepLongFileName.tsx')))
+  // 浮层盖住下方行：先移开再找短路径行的悬停目标。
+  hover(stdin, 1, 1)
+  check('F 移开后长路径浮层消失', await settled(() => !screenHas(term, 'DeepLongFileName.tsx')))
+  // 短路径行：名字完整可见 → 悬停不弹浮层（直查 tooltip store，排除
+  // 「卡片内容恰好与可见文本同字」的歧义）。
+  hoverText(stdin, term, 'README.md')
+  await sleep(900)
+  check('F 完整可见路径悬停不弹浮层', tooltip.getTooltipSnapshot() === null,
+    `snapshot=${JSON.stringify(tooltip.getTooltipSnapshot()?.content ?? null)}`)
+
+  // --- G. 会话列表行：标题截断 → 悬停弹完整标题+绝对时间+cwd ------------
+  const NOW = Date.now()
+  const session = {
+    id: 'sess-1',
+    kind: { kind: 'root' as const },
+    title: { text: '修复一个非常长非常长需要被截断才能看到结尾标记END-OF-TITLE的标题', source: 'auto' as const },
+    cwd: 'D:\\work\\dsh-tui',
+    createdAt: NOW - 86_400_000,
+    updatedAt: NOW - 3_600_000,
+    bytes: 2048,
+    hasPrompt: true,
+    agentPreset: undefined,
+    model: 'deepseek-chat',
+    label: undefined,
+    branch: 'main',
+    childCount: 0,
+  }
+  const sessionTree = (width: number) => (
+    <AlternateScreen>
+      <Box flexDirection="column">
+        <KeySink />
+        <SessionListRow session={session} width={width} depth={0} focused={false} pinned={false} now={NOW} />
+        <tooltip.TooltipLayer />
+      </Box>
+    </AlternateScreen>
+  )
+  instance.rerender(sessionTree(60))
+  // 负值就绪探针会立即在旧帧上返回（term-test 的系统性坑）：先用正值
+  // 等新树真正上屏，再断言截断。
+  check('场景 G 就绪：会话行已渲染', await settled(() => screenHas(term, '修复')))
+  check('场景 G 就绪：长标题已截断（结尾标记不在屏）', !screenHas(term, 'END-OF-TITLE'))
+  hoverText(stdin, term, '修复')
+  check('G 截断标题悬停后弹出完整标题', await settled(() => screenHas(term, 'END-OF-TITLE')))
+  const absolute = formatAbsolute(session.updatedAt)
+  check('G 浮层带绝对时间戳', await settled(() => screenHas(term, absolute)), `abs=${absolute}`)
+  check('G 浮层带 cwd', await settled(() => screenHas(term, 'D:\\work\\dsh-tui')))
+  hover(stdin, 1, 1)
+  check('G 移开即隐藏工具提示', await settled(() => !screenHas(term, 'END-OF-TITLE')))
+
+  // G2：标题完整可见（宽行）→ 浮层不重复标题，只带时间 + cwd。
+  instance.rerender(sessionTree(120))
+  check('场景 G2 就绪：宽行标题完整在屏', await settled(() => screenHas(term, 'END-OF-TITLE')))
+  hoverText(stdin, term, '修复')
+  check('G2 完整标题悬停弹浮层（时间+cwd）', await settled(() => tooltip.getTooltipSnapshot() !== null))
+  {
+    const content = tooltip.getTooltipSnapshot()?.content ?? ''
+    check('G2 浮层不重复完整标题', !content.includes('END-OF-TITLE'), `content=${JSON.stringify(content)}`)
+    check('G2 浮层仍带绝对时间与 cwd', content.includes(absolute) && content.includes('dsh-tui'))
+  }
+  hover(stdin, 1, 1)
+
+  // --- H. 状态栏字段：model/git 悬停明细 ---------------------------------
+  const channelStub = {
+    minimal: false,
+    statusBar: { gitBranch: true },
+    model: 'TM',
+    provider: 'test-provider',
+    contextWindow: 64_000,
+    gitBranch: 'test-branch-long',
+    displayCwd: 'D:\\work\\dsh-tui',
+    cwd: 'D:\\work\\dsh-tui',
+    mode: { plan: false, sandbox: 'workspace-write', approval: 'on-request' },
+    modeIndex: 0,
+    tokens: { input: 0, output: 0 },
+    tpsSamples: [],
+    backgroundJobs: [],
+    contextSegments: {},
+    working: false,
+    workingActivity: undefined,
+    activityFrames: [],
+    goal: undefined,
+    sessionTitle: undefined,
+    agentId: 'abcdef0123456789',
+    reasoningEffort: undefined,
+    tps: undefined,
+    lastUsage: undefined,
+    contextBarEnabled: false,
+  }
+  instance.rerender(
+    <AlternateScreen>
+      <Box flexDirection="column">
+        <KeySink />
+        <StatusLine channel={channelStub as never} />
+        <tooltip.TooltipLayer />
+      </Box>
+    </AlternateScreen>,
+  )
+  check('场景 H 就绪：状态栏 model/git 字段在屏',
+    await settled(() => screenHas(term, 'TM') && screenHas(term, 'test-branch-long')))
+  check('H 未悬停时无明细行', !screenHas(term, 'provider test-provider'))
+  hoverText(stdin, term, 'TM')
+  check('H 悬停 model 字段弹 provider/ctx 明细',
+    await settled(() => screenHas(term, 'provider test-provider') && screenHas(term, 'ctx 64k')))
+  hoverText(stdin, term, 'test-branch-long')
+  check('H 悬停 git 字段弹完整分支明细',
+    await settled(() => screenHas(term, 'git test-branch-long')))
+  check('H 明细随悬停目标切换（model 明细已离开）',
+    await settled(() => !screenHas(term, 'provider test-provider')))
+  hover(stdin, 1, 1)
+
+  instance.unmount()
+  await sleep(100)
+  console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILURES`)
+  process.exit(failed === 0 ? 0 : 1)
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}

--- a/scripts/verify-tool-tooltip-gating.tsx
+++ b/scripts/verify-tool-tooltip-gating.tsx
@@ -1,0 +1,246 @@
+/**
+ * 工具卡头部 hover tooltip 内容回归（用户反馈：旧行为把头部已可见的
+ * 文本再打印一遍——浮层没有新增详情，纯噪音）。
+ *
+ * 断言：
+ *  A. 单行标题完整可见（Edit 卡）→ 悬停弹出**元数据**（结束时刻 + 退出码
+ *     等头部没有的信息），不重复标题（标题全屏仍只出现一次）。
+ *  B. 终端脚本折叠（首行 + `… +N lines`，脚本真被隐藏）→ 悬停弹出
+ *     完整脚本；移开即消失（tooltip 基础设施契约不变）。
+ *  C. title 缺失、args 超出头部显示预算（HEADER_ARGS_BUDGET=480）→
+ *     头部裁剪；悬停弹出完整 args（含 480 字符之后才出现的标记）。
+ *  D. 运行中卡片 → 悬停弹出开始时刻（时长已在 body Running… 行，不入内）。
+ *  E. 单行长标题被布局宽度截断（truncate-end，非 480 预算）→ 悬停弹出
+ *     完整标题 + 元数据（回归：这是旧 tooltip 的原始用途）。
+ *  F. 终端卡非零退出码 → 悬停元数据带「退出码 N」。
+ *
+ * Run: `node --import tsx/esm scripts/verify-tool-tooltip-gating.tsx`
+ */
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'verify-tool-tooltip-data-'))
+process.env.HOME = dataDir
+process.env.USERPROFILE = dataDir
+// 元数据断言含本地化文案（耗时/运行中），钉住语言保证 CI（LANG=C）一致。
+process.env.DSH_TUI_LANG = 'zh'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, ui, tooltip, termTest] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/components/Tooltip.js'),
+  import('./lib/term-test.mjs'),
+])
+
+const { sleep, settled, screenHas, findText, viewportLines } = termTest
+const { render, AlternateScreen, Box } = ui
+
+let failed = 0
+const check = (name: string, ok: boolean, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed++
+}
+
+/** The real Chat always mounts useInput consumers (PromptInput etc.); the
+ *  app wires its stdin parser only when at least one subscriber exists, so
+ *  the rig mirrors that condition instead of silently dropping input
+ *  (hover SGR sequences die without it). */
+function KeySink(): React.ReactNode {
+  ui.useInput(() => {})
+  return null
+}
+
+function makeRig(cols: number, rows: number) {
+  const term = new XTerm({ cols, rows, scrollback: 50, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = cols
+    rows = rows
+    isTTY = true
+    _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+  }
+  class FakeStderr extends Writable {
+    isTTY = true
+    _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+  }
+  class FakeStdin extends PassThrough {
+    isTTY = true
+    setRawMode() { return this }
+    ref() { return this }
+    unref() { return this }
+  }
+  const stdin = new FakeStdin()
+  const stdout = new FakeStdout()
+  return { term, stdout, stdin }
+}
+
+/** SGR mode-1003 motion with no buttons → dispatchHover. Coords 1-indexed. */
+const hover = (stdin: PassThrough, col: number, row: number) =>
+  stdin.write(`\x1b[<35;${col};${row}M`)
+
+/** Hover the cell holding `needle` (first occurrence), then move away. */
+function hoverText(stdin: PassThrough, term: XTerm, needle: string): void {
+  const at = findText(term, needle)
+  if (at === null) throw new Error(`hover target not found: ${needle}`)
+  hover(stdin, at.col + 1, at.row + 1)
+}
+
+/** Rows whose visible text contains `needle` (the tooltip repeats content in
+ *  its own row, so "appears twice" is the old duplicate behavior). */
+function rowCount(term: XTerm, needle: string): number {
+  return viewportLines(term).filter(line => line.includes(needle)).length
+}
+
+const { AssistantToolUseMessage } = await import('../src/components/messages/AssistantToolUseMessage.js')
+
+const base = {
+  callId: 'c1',
+  argsText: '{}',
+  status: 'ok' as const,
+  startedAt: 0,
+  durationMs: 12,
+}
+
+/** Render one tool card as the whole tree (scenario swap via key). */
+function cardTree(key: string, tool: Record<string, unknown>, foldTerminalCommand = false): React.ReactElement {
+  return (
+    <AlternateScreen>
+      <Box flexDirection="column">
+        <KeySink />
+        <AssistantToolUseMessage
+          key={key}
+          tool={{ ...base, ...tool }}
+          addMargin={false}
+          verbose={false}
+          foldTerminalCommand={foldTerminalCommand}
+        />
+        <tooltip.TooltipLayer />
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+try {
+  const COLS = 100
+  const ROWS = 30
+  const rig = makeRig(COLS, ROWS)
+  // 场景 A：settled Edit 卡，携带真实时刻（结束前 5s 起跑、耗时 5s）。
+  const instance = await render(
+    cardTree('edit', {
+      name: 'edit',
+      startedAt: Date.now() - 10_000,
+      durationMs: 5_000,
+      callView: { card: 'diff', title: 'Edit /tmp/a.ts (1 - 100)', diffs: [] },
+    }),
+    { stdout: rig.stdout, stdin: rig.stdin, stderr: new (class extends Writable {
+      isTTY = true
+      _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+    })(), exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(600)
+
+  const { term, stdin } = rig
+
+  // --- A. 完整可见的单行标题：悬停弹元数据，不重复标题 -------------------
+  const TITLE_A = 'Edit /tmp/a.ts (1 - 100)'
+  check('场景 A 就绪：标题在屏', await settled(() => rowCount(term, TITLE_A) === 1))
+  hoverText(stdin, term, TITLE_A)
+  check('A 完整标题悬停后弹出元数据（结束时刻）',
+    await settled(() => screenHas(term, '结束')))
+  check('A 元数据浮层不重复标题文本', rowCount(term, TITLE_A) === 1,
+    `rows=${rowCount(term, TITLE_A)}`)
+  hover(stdin, 1, 1)
+  check('A 移开即隐藏工具提示', await settled(() => !screenHas(term, '结束')))
+
+  // --- B. 折叠的终端脚本：真隐藏内容 → 悬停弹出完整脚本 ------------------
+  const script = [
+    '$items = Get-ChildItem -Recurse',
+    '$items | Where-Object { $_.Length -gt 1kb }',
+    '$items | Sort-Object Length',
+    '$items | Select-Object -First 10 Name',
+  ].join('\n')
+  instance.rerender(cardTree('folded', {
+    name: 'powershell',
+    callView: { card: 'terminal', title: script },
+    resultView: { card: 'terminal', output: '', exitCode: 0 },
+    resultFull: '',
+  }, true))
+  check('场景 B 就绪：折叠标题首行可见', await settled(() => screenHas(term, 'Get-ChildItem -Recurse')))
+  check('场景 B 就绪：脚本其余行未渲染', !screenHas(term, 'Sort-Object'))
+  hoverText(stdin, term, '$items')
+  check('B 折叠脚本悬停后弹出完整命令', await settled(() => screenHas(term, 'Sort-Object')))
+  check('B 弹出内容含末行', await settled(() => screenHas(term, 'Select-Object -First 10 Name')))
+  hover(stdin, 1, 1)
+  check('B 移开即隐藏工具提示', await settled(() => !screenHas(term, 'Sort-Object')))
+
+  // --- C. 无标题 + args 超预算：头部裁剪 → 悬停弹出完整 args ------------
+  const hugeArgs = '{"padding":"' + 'p'.repeat(600) + '","marker":"END-MARKER-98765","file_path":"/tmp/x.ts"}'
+  instance.rerender(cardTree('huge', { name: 'read', argsText: hugeArgs }))
+  // 就绪探针：卡片头部已渲染（超长 args 标题在旧代码上就以跨行 wrap
+  // 呈现——此处只断言卡片已上屏；「头部裁剪」由下方标记不可见断言覆盖）。
+  check('场景 C 就绪：超预算 args 头部渲染', await settled(() => screenHas(term, 'Read{')))
+  check('场景 C 就绪：480 字符后的标记未上屏', !screenHas(term, 'END-MARKER-98765'))
+  hoverText(stdin, term, 'ppp')
+  check('C 裁剪 args 悬停后弹出完整内容', await settled(() => screenHas(term, 'END-MARKER-98765')))
+  hover(stdin, 1, 1)
+  check('C 移开即隐藏工具提示', await settled(() => !screenHas(term, 'END-MARKER-98765')))
+
+  // --- D. 运行中卡片：悬停弹开始时刻（时长在 body Running… 行，不入内） ----
+  instance.rerender(cardTree('running', {
+    name: 'bash',
+    status: 'running',
+    startedAt: Date.now() - 120_000,
+    callView: { card: 'terminal', title: 'sleep 300' },
+  }))
+  check('场景 D 就绪：运行中卡片渲染', await settled(() => screenHas(term, 'sleep 300')))
+  hoverText(stdin, term, 'sleep 300')
+  check('D 运行中悬停弹开始时刻', await settled(() => screenHas(term, '开始')))
+  hover(stdin, 1, 1)
+  check('D 移开即隐藏工具提示', await settled(() => !screenHas(term, '开始')))
+
+  // --- E. 单行长标题被布局宽度截断：悬停弹完整标题（回归：宽截断是旧
+  //       tooltip 的原始用途，布局截断 ≠ 480 预算截断）。只有非终端卡的
+  //       标题 Text 是 truncate-end（终端卡默认 wrap 不截断）；断言走
+  //       tooltip store——长标题在浮层内换行会劈开尾部标记。
+  const LONG_TITLE = 'Edit ' + 'x'.repeat(110) + ' TAIL-END-9900'
+  instance.rerender(cardTree('wide', {
+    name: 'edit',
+    startedAt: Date.now() - 6_000,
+    durationMs: 5_000,
+    callView: { card: 'diff', title: LONG_TITLE, diffs: [] },
+  }))
+  check('场景 E 就绪：宽截断卡片渲染', await settled(() => screenHas(term, 'xxx')))
+  check('场景 E 就绪：宽截断标题尾部未上屏', !screenHas(term, 'TAIL-END-9900'))
+  hoverText(stdin, term, 'Edit')
+  check('E 宽截断标题悬停后弹出完整标题',
+    await settled(() => (tooltip.getTooltipSnapshot()?.content.includes('TAIL-END-9900') ?? false)))
+  check('E 完整标题浮层同时带元数据',
+    await settled(() => (tooltip.getTooltipSnapshot()?.content.includes('结束') ?? false)))
+  hover(stdin, 1, 1)
+  check('E 移开即隐藏工具提示', await settled(() => tooltip.getTooltipSnapshot() === null))
+
+  // --- F. 终端卡非零退出码：悬停元数据带退出码 ---------------------------
+  instance.rerender(cardTree('exit7', {
+    name: 'bash',
+    startedAt: Date.now() - 3_000,
+    durationMs: 3_000,
+    callView: { card: 'terminal', title: 'false' },
+    resultView: { card: 'terminal', output: '', exitCode: 7 },
+    resultFull: '',
+  }))
+  check('场景 F 就绪：结果卡渲染', await settled(() => screenHas(term, 'Bash(false)')))
+  hoverText(stdin, term, 'false')
+  check('F 非零退出码悬停弹出元数据带退出码', await settled(() => screenHas(term, '退出码 7')))
+  hover(stdin, 1, 1)
+  check('F 移开即隐藏工具提示', await settled(() => !screenHas(term, '退出码 7')))
+
+  instance.unmount()
+  await sleep(100)
+  console.log(failed === 0 ? '\nALL PASS' : `\n${failed} FAILURES`)
+  process.exit(failed === 0 ? 0 : 1)
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}

--- a/src/components/FileSuggestions.tsx
+++ b/src/components/FileSuggestions.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text } from '../ui.js'
+import { Box, Text } from '../ui.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { truncateToWidth } from '../ink/truncateToWidth.js'
 import type { Color } from '../ink/styles.js'
@@ -8,6 +8,7 @@ import type { FileCandidate } from '../utils/fileSuggestions.js'
 import { t } from '../i18n.js'
 import { POINTER } from '../cc/figures.js'
 import { SuggestionCard, cardContentWidth, splitQueryMatch } from './SuggestionCard.js'
+import { useTooltip } from './Tooltip.js'
 
 /**
  * The `@` file-completion overlay in CC's suggestion style, wrapped in the
@@ -26,6 +27,69 @@ import { SuggestionCard, cardContentWidth, splitQueryMatch } from './SuggestionC
  * by verify-cjk-truncate.tsx); every pad/truncate uses display width, so CJK
  * names never split a glyph.
  */
+const NAME_COLUMN = 20
+
+/** Display name: directories show without the trailing slash. */
+function nameOf(file: FileCandidate): string {
+  return file.kind === 'directory' && file.path.endsWith('/') ? file.path.slice(0, -1) : file.path
+}
+
+/**
+ * One candidate row: fixed-width name column + kind description. When the
+ * name runs past the row's text budget (`wrap="truncate"` cuts the tail),
+ * hovering pops the full path plus its kind — the 20-cell name column and
+ * the trailing description can both hide on a narrow terminal, and the
+ * path is exactly the piece that decides which candidate to pick.
+ */
+function FileSuggestionRow({ file, isSelected, query, usable, descriptionWidth }: {
+  file: FileCandidate
+  isSelected: boolean
+  query: string
+  /** cardContentWidth: the row's full text budget before truncation. */
+  usable: number
+  descriptionWidth: number
+}): React.ReactNode {
+  const name = nameOf(file)
+  const icon = file.kind === 'directory' ? '▸ ' : '+ '
+  const description = file.kind === 'directory' ? 'directory' : 'file'
+  const renderedDescription =
+    stringWidth(description) > descriptionWidth
+      ? truncateToWidth(description, Math.max(0, descriptionWidth - 1)) + '…'
+      : description
+  // Row prefix = leading space + pointer/gutter + icon = 5 cells. The name
+  // is hidden exactly when it runs past the remaining budget; otherwise the
+  // full path is already on screen and a float would just repeat it.
+  const tooltip = useTooltip(() =>
+    5 + stringWidth(name) > usable
+      ? `${file.path}\n${description}`
+      : '')
+  const padded = name + ' '.repeat(Math.max(1, NAME_COLUMN - stringWidth(name)))
+  const parts = splitQueryMatch(name, query)
+  const pad = ' '.repeat(Math.max(1, NAME_COLUMN - stringWidth(name)))
+  return (
+    <Box {...tooltip}>
+      <Text wrap="truncate">
+        {' '}
+        {isSelected ? (
+          <Text color="suggestion" bold>{`${POINTER} ${icon}${padded}`}</Text>
+        ) : parts ? (
+          // 平铺兄弟 span：嵌套 Text 继承父级 dim，高亮段会被 dim 吞掉。
+          <>
+            <Text dimColor>{`  ${icon}${parts.before}`}</Text>
+            <Text>{parts.match}</Text>
+            <Text dimColor>{`${parts.after}${pad}`}</Text>
+          </>
+        ) : (
+          <Text dimColor>{`  ${icon}${padded}`}</Text>
+        )}
+        <Text color={isSelected ? 'suggestion' : undefined} dimColor={!isSelected}>
+          {renderedDescription}
+        </Text>
+      </Text>
+    </Box>
+  )
+}
+
 export function FileSuggestions({
   files,
   selectedIndex,
@@ -63,12 +127,6 @@ export function FileSuggestions({
   const above = startIndex
   const below = files.length - (startIndex + visible.length)
 
-  const nameOf = (file: FileCandidate): string =>
-    file.kind === 'directory' && file.path.endsWith('/')
-      ? file.path.slice(0, -1)
-      : file.path
-
-  const NAME_COLUMN = 20
   // 行预算：内容宽 − 前导空格 1 − 指针列 2 − 图标列 2。
   const descriptionWidth = Math.max(0, usable - 25)
 
@@ -91,39 +149,16 @@ export function FileSuggestions({
       footer={footer}
       onRowPick={onPick ? index => onPick(startIndex + index) : undefined}
       onWheelStep={onWheelStep}
-      rows={visible.map(file => {
-        const isSelected = file.id === files[safeIndex]?.id
-        const name = nameOf(file)
-        const icon = file.kind === 'directory' ? '▸ ' : '+ '
-        const padded = name + ' '.repeat(Math.max(1, NAME_COLUMN - stringWidth(name)))
-        const description = file.kind === 'directory' ? 'directory' : 'file'
-        const renderedDescription =
-          stringWidth(description) > descriptionWidth
-            ? truncateToWidth(description, Math.max(0, descriptionWidth - 1)) + '…'
-            : description
-        const parts = splitQueryMatch(name, query)
-        const pad = ' '.repeat(Math.max(1, NAME_COLUMN - stringWidth(name)))
-        return (
-          <Text key={file.id} wrap="truncate">
-            {' '}
-            {isSelected ? (
-              <Text color="suggestion" bold>{`${POINTER} ${icon}${padded}`}</Text>
-            ) : parts ? (
-              // 平铺兄弟 span：嵌套 Text 继承父级 dim，高亮段会被 dim 吞掉。
-              <>
-                <Text dimColor>{`  ${icon}${parts.before}`}</Text>
-                <Text>{parts.match}</Text>
-                <Text dimColor>{`${parts.after}${pad}`}</Text>
-              </>
-            ) : (
-              <Text dimColor>{`  ${icon}${padded}`}</Text>
-            )}
-            <Text color={isSelected ? 'suggestion' : undefined} dimColor={!isSelected}>
-              {renderedDescription}
-            </Text>
-          </Text>
-        )
-      })}
+      rows={visible.map(file => (
+        <FileSuggestionRow
+          key={file.id}
+          file={file}
+          isSelected={file.id === files[safeIndex]?.id}
+          query={query}
+          usable={usable}
+          descriptionWidth={descriptionWidth}
+        />
+      ))}
     />
   )
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -14,6 +14,10 @@ import type { PointerEvent } from '../ink/events/pointer-event.js'
  * fields); after a ~600ms dwell the full content pops up in a floating card
  * anchored at the pointer, and disappears the moment the pointer leaves.
  *
+ * Attach it ONLY when the text is actually hidden: a float that repeats
+ * content already visible next to the pointer is noise, not detail (the
+ * tool-call header gates on folded/clipped content for this reason).
+ *
  * Hover events only exist in fullscreen (alternate screen + mouse
  * tracking); inline mode never fires the handlers, so the store can only
  * be written from a live fullscreen tree.

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -9,6 +9,8 @@ import { SplitDiffView } from '../SplitDiffView.js'
 import { SyntaxText } from '../SyntaxText.js'
 import { useTooltip } from '../Tooltip.js'
 import { formatDuration } from '../../cc/format.js'
+import { formatClock } from '../../trajectory/format.js'
+import { t } from '../../i18n.js'
 import type { ToolBackground } from '../../tuiDisplayPrefs.js'
 import type { Theme } from '../../theme.js'
 import type { ClickEvent } from '../../ink/events/click-event.js'
@@ -297,7 +299,37 @@ function foldTerminalTitle(title: string): FoldedTitle | undefined {
   return { first, hidden }
 }
 
-function HeaderTitle({ name, title, isTerminal, folded, displayArgs, argsLanguage, nameColor, filePath, onOpenFile }: {
+/** Metadata line for the header hover tooltip when the header itself is
+ *  complete: start/finish wall-clock and the terminal result's exit code /
+ *  signal — everything the header's relative `· 2m` chip and the body's
+ *  `Running… (…)` line do NOT say. Durations stay out on purpose: showing
+ *  a value twice, once on the card and once in the float, is exactly the
+ *  noise class this tooltip exists to avoid. Returns '' when the row
+ *  carries no timing data. */
+function toolCardMetaTooltip(tool: ToolRow, isRunning: boolean, isError: boolean): string {
+  const parts: string[] = []
+  const startedAt = tool.startedAt
+  if (isRunning) {
+    if (startedAt !== undefined) parts.push(t('tool-tip-started', { time: formatClock(startedAt) }))
+  } else {
+    const durationMs = tool.durationMs
+    if (startedAt !== undefined && durationMs !== undefined) {
+      parts.push(t(isError ? 'tool-tip-failed' : 'tool-tip-finished', { time: formatClock(startedAt + durationMs) }))
+    }
+  }
+  const resultView = tool.resultView
+  if (resultView !== undefined && resultView.card === 'terminal') {
+    if ('exitCode' in resultView && resultView.exitCode !== undefined && resultView.exitCode !== 0) {
+      parts.push(t('tool-tip-exit', { code: resultView.exitCode }))
+    }
+    if ('signal' in resultView && resultView.signal !== undefined) {
+      parts.push(t('tool-tip-signal', { name: String(resultView.signal) }))
+    }
+  }
+  return parts.join(' · ')
+}
+
+function HeaderTitle({ name, title, isTerminal, folded, displayArgs, argsLanguage, nameColor, filePath, onOpenFile, metaTooltip, headerTextBudget }: {
   name: string
   title: string | undefined
   isTerminal: boolean
@@ -310,14 +342,42 @@ function HeaderTitle({ name, title, isTerminal, folded, displayArgs, argsLanguag
    *  segment renders underlined and clickable (opens the file menu). */
   filePath?: string
   onOpenFile?: (path: string) => void
+  /** Metadata line shown on hover when the header is complete: start/finish
+   *  wall-clock, terminal exit code/signal — everything the relative chip
+   *  and the body's Running… line do NOT say. Lazy getter, resolved at
+   *  show time so a running card's start stays fresh. '' = nothing. */
+  metaTooltip: () => string
+  /**
+   * Column budget for `name + (title)` on the header line — what
+   * `useTerminalSize().columns` (already margin-adjusted) minus the fixed
+   * header chrome (loader, hover ▾ indicator, settled chip, gutter slack).
+   * When the wrapped text exceeds it, ink's truncate-end CUTS the title on
+   * the screen and the tooltip must prefer the complete text over the
+   * metadata; otherwise the metadata is everything the float adds.
+   */
+  headerTextBudget: number
 }): React.ReactNode {
-  // Hover tooltip: the header line truncates long paths/commands, so the
-  // full string (or the unfolded terminal script) pops up after a dwell.
-  // Empty content is a no-op inside the hook.
+  // Hover tooltip priority: genuinely HIDDEN content first — a folded
+  // terminal script, args clipped past the 480-char budget, or a single-line
+  // title cut by layout width (truncate-end). Only a header that really
+  // fits its row offers just the metadata, and stays silent when the row
+  // has no timing data. Empty content is a no-op inside the hook.
   const headerTooltip = useTooltip(() => {
-    if (title === undefined) return displayArgs
-    if (isTerminal) return title
-    return title.trim()
+    const meta = metaTooltip()
+    const withMeta = (full: string): string => (meta === '' ? full : `${full}\n${meta}`)
+    if (folded !== undefined) return withMeta(title ?? '')
+    if (title === undefined && clipHeaderArgs(displayArgs) !== displayArgs) return withMeta(displayArgs)
+    // Width truncation: the truncate-end Text cuts long one-line titles by
+    // layout, not by a budget — same hidden-content rule as above.
+    const wrapped = title === undefined
+      ? `(${clipHeaderArgs(displayArgs)})`
+      : isTerminal
+        ? `(${title})`
+        : title.trim()
+    if (stringWidth(name) + stringWidth(wrapped) > headerTextBudget) {
+      return withMeta(title === undefined ? displayArgs : title.trim())
+    }
+    return meta
   })
   if (title === undefined) {
     return (
@@ -475,6 +535,16 @@ export function AssistantToolUseMessage({
   // source line per terminal row (truncate) keeps the panes row-aligned,
   // which the flat add/del line model cannot express.
   const { columns } = useTerminalSize()
+  // Header-row budget for the title Text. useTerminalSize() already reports
+  // the margin-adjusted content width, so this is the fixed chrome of the
+  // line only: loader dot 2 + hover ▾ indicator 2 (present while the pointer
+  // dwells) + the settled elapsed chip + slack for the transcript gutter.
+  // Over the budget ink's truncate-end cuts the title on screen (a *layout*
+  // truncation, not the 480-char budget) — HeaderTitle then prefers the
+  // complete text.
+  const headerTextBudget = Math.max(0, columns - 2 - 2 - stringWidth(name)
+    - (!isRunning && elapsedText !== '' ? stringWidth(elapsedText) : 0)
+    - 4)
   const useSplitDiff = !isError && view?.card === 'diff' &&
     (diffLayout === 'split' || (diffLayout !== 'unified' && columns >= SPLIT_DIFF_MIN_COLS))
   let body: BodyLine[] = []
@@ -553,7 +623,7 @@ export function AssistantToolUseMessage({
             isError={isError}
             toolName={tool.name}
           />
-          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} folded={foldedHeader} displayArgs={displayArgs} argsLanguage={argsLanguage} nameColor={toolNameColor(tool.name)} filePath={filePath} onOpenFile={onOpenFile} />
+          <HeaderTitle name={name} title={headerTitle} isTerminal={headerIsTerminal} folded={foldedHeader} displayArgs={displayArgs} argsLanguage={argsLanguage} nameColor={toolNameColor(tool.name)} filePath={filePath} onOpenFile={onOpenFile} metaTooltip={() => toolCardMetaTooltip(tool, isRunning, isError)} headerTextBudget={headerTextBudget} />
           {!isRunning && (
             <Box flexWrap="nowrap">
               <Text dimColor={!hovered}>{elapsedText}</Text>

--- a/src/components/sessions/SessionListRow.tsx
+++ b/src/components/sessions/SessionListRow.tsx
@@ -5,6 +5,7 @@ import type { ClickEvent } from '../../ink/events/click-event.js'
 import type { ContextMenuEvent } from '../../ink/events/context-menu-event.js'
 import { useTooltip } from '../Tooltip.js'
 import {
+  formatAbsolute,
   formatBytes,
   formatWhen,
   kindMark,
@@ -60,6 +61,21 @@ export function SessionListRow({
   const mark = kindMark(session.kind)
   const [hovered, setHovered] = useState(false)
   const pinTooltip = useTooltip(t(pinned ? 'resume-menu-unpin' : 'resume-menu-pin'))
+  // Title hover tooltip: the row truncates a long title mid-word; when it
+  // does, the float leads with the full title. The absolute timestamp and
+  // cwd ride along in every case — the facts line shows only relative time
+  // and never the working directory, so that pair is always new information
+  // for telling look-alike sessions apart.
+  const titleText = session.label ?? session.title.text
+  const titleBudget = body - 2 - (mark === undefined ? 0 : 2)
+  const shownTitle = truncateWidth(titleText, titleBudget)
+  const titleTooltip = useTooltip(() => {
+    const parts: string[] = []
+    if (shownTitle !== titleText) parts.push(titleText)
+    parts.push(formatAbsolute(session.updatedAt))
+    if (session.cwd !== '') parts.push(session.cwd)
+    return parts.join('\n')
+  })
 
   const facts: string[] = [formatWhen(session.updatedAt, now)]
   if (session.branch !== undefined) facts.push(session.branch)
@@ -101,12 +117,13 @@ export function SessionListRow({
           <Text color={pinned ? 'remember' : undefined} dimColor={!pinned}>{pinned ? '★ ' : '☆ '}</Text>
         </Box>
         {mark !== undefined && <Text color={mark.color}>{`${mark.glyph} `}</Text>}
-        <Text color={titleColor(session.title.source, focused)} bold={focused}>
-          {truncateWidth(
-            session.label ?? session.title.text,
-            body - 2 - (mark === undefined ? 0 : 2),
-          )}
-        </Text>
+        {/* The tooltip rides ONLY the title text, not the whole line: the
+            pin slot's own tooltip must win over its two cells. */}
+        <Box {...titleTooltip}>
+          <Text color={titleColor(session.title.source, focused)} bold={focused}>
+            {shownTitle}
+          </Text>
+        </Box>
       </Box>
       <Box>
         <Text dimColor>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -559,6 +559,16 @@ const dict = {
   'input-expand-editor-hint-send': { zh: 'Ctrl+Enter 发送', en: 'Ctrl+Enter sends' },
   'input-expand-editor-hint-collapse': { zh: 'Esc 收起', en: 'Esc collapses' },
 
+  // ── messages/AssistantToolUseMessage.tsx（工具卡头部悬停元数据浮层）─────
+  // 头部已完整显示标题/参数时，悬停不再重复可见文本，改弹卡片元数据：
+  // 开始/结束/失败时刻、退出码与信号（这些头部都没有）。时长不入内——
+  // settled 卡的头部 chip（`· 5m30s`）与运行中卡的 body 已显示时长。
+  'tool-tip-started': { zh: '开始 {{time}}', en: 'started {{time}}' },
+  'tool-tip-finished': { zh: '结束 {{time}}', en: 'finished {{time}}' },
+  'tool-tip-failed': { zh: '失败 {{time}}', en: 'failed {{time}}' },
+  'tool-tip-exit': { zh: '退出码 {{code}}', en: 'exit {{code}}' },
+  'tool-tip-signal': { zh: '信号 {{name}}', en: 'signal {{name}}' },
+
   // ── components/SuggestionCard.tsx（/ 命令菜单 · @ 文件菜单）─────────
   'sugg-commands-title': { zh: '命令', en: 'commands' },
   'sugg-files-title': { zh: '文件', en: 'files' },

--- a/src/screens/StatusLine.tsx
+++ b/src/screens/StatusLine.tsx
@@ -55,6 +55,8 @@ type HoverTarget =
   | 'cost'
   | 'goal'
   | 'jobs'
+  | 'model'
+  | 'git'
   | 'sessionId'
   | 'cwd'
   | 'title'
@@ -301,7 +303,7 @@ export function StatusLine({
 
   const leftFields: FieldPart[] = [
     ...(statusBar.model
-      ? [{ key: 'model', node: <Text color="inactiveShimmer">{channel.model}</Text> }]
+      ? [{ key: 'model', id: 'model' as const, node: <Text color="inactiveShimmer">{channel.model}</Text> }]
       : []),
     ...(tpsPart !== undefined ? [tpsPart] : []),
     ...(jobsPart !== undefined ? [jobsPart] : []),
@@ -352,6 +354,7 @@ export function StatusLine({
       ? [
           {
             key: 'git',
+            id: 'git' as const,
             node: <Text color="professionalBlue">{channel.gitBranch}</Text>,
           },
         ]
@@ -667,6 +670,24 @@ function buildHoverDetail(
           {dim('jobs ')}
           {shown.map(job => `${job.id} ${job.label} (${formatJobDuration(job)})`).join(' · ')}
           {rest > 0 ? ` · +${rest}` : ''}
+        </Text>
+      )
+    }
+    case 'model': {
+      return (
+        <Text wrap="truncate">
+          {dim('model ')}{channel.model} · {dim('provider ')}{channel.provider}
+          {channel.contextWindow !== undefined
+            ? <> · {dim('ctx ')}{formatTokens(channel.contextWindow)}</>
+            : null}
+        </Text>
+      )
+    }
+    case 'git': {
+      if (channel.gitBranch === undefined) return null
+      return (
+        <Text wrap="truncate">
+          {dim('git ')}{channel.gitBranch}
         </Text>
       )
     }

--- a/src/sessions/format.ts
+++ b/src/sessions/format.ts
@@ -186,6 +186,17 @@ export function nextFormatWhenChange(at: number, now: number): number {
 }
 
 /**
+ * Absolute local wall-clock: `2026-09-01 14:30:22`. Companion to
+ * formatWhen's relative phrasing — the precise answer for telling three
+ * similar-looking sessions apart in a hover tooltip.
+ */
+export function formatAbsolute(at: number): string {
+  const date = new Date(at)
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+}
+
+/**
  * Byte size at the precision the number is worth: `812 B`, `142.9 KB`,
  * `4.2 MB`. One decimal from kilobytes up, because the digit distinguishes a
  * short exchange from a long one and a second would not.


### PR DESCRIPTION
## 目标

悬停浮层（hover tooltip）遵循一条判据：**浮层只给屏幕上看不到、悬停马上想知道的信息**，不做导航入口。本 PR 把这条判据落到四个 UI 面上，并修复旧行为的「重复可见文本」噪音（用户反馈）。

## 内容

**1. 工具卡头部 tooltip 门控 + 元数据**（AssistantToolUseMessage）
- 旧行为：悬停任何工具卡都把完整标题/参数弹一遍——头部已可见文本的纯复制
- 新行为（三级优先）：
  - 折叠终端脚本 / 超 HEADER_ARGS_BUDGET(480) 的 args → 弹完整内容（真隐藏内容）
  - 非终端卡单行标题被布局宽度截断（truncate-end）→ 弹完整标题（回归修复：旧 tooltip 的原始用途）
  - 其余 → 弹**卡片元数据**：开始/结束/失败时刻 + 非零退出码/信号（头部 chip 与 body Running… 行已显示的时长不重复）
- 元数据惰性求值，运行中卡的开始时刻取显示时刻

**2. @ 文件补全面板**（FileSuggestions）：名称超出本行宽度预算才弹完整路径+类型（完整可见不弹，直查 store 验证）

**3. /resume 会话列表行**（SessionListRow）：标题截断时浮层带完整标题；恒带绝对时间戳（新增 formatAbsolute）+ cwd；tooltip 只挂标题文本区，与 pin 星标 tooltip 互不干扰

**4. 状态栏 model/git 字段**（StatusLine）：补上缺失的悬停明细——model 弹 provider+ctx 窗口、git 弹完整分支（与既有的 tps/cost/jobs/goal 明细行同机制）

## 测试

- 新增 erify-tool-tooltip-gating.tsx（24 断言：门控三级 + 宽截断回归 + 退出码 + 移开即隐 + 不重复标题）
- 新增 erify-hover-details.tsx（19 断言：文件补全弹/不弹、会话行三件套、状态栏明细切换）
- 登记 session-workspace 组；i18n +5 键全双语

本地：pnpm build 全绿、verify-i18n 994、verify-cjk-truncate/session-browser/session-browser-layout/file-completion/tooltip 全过、sync:profile:check 0 差异。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual tooltips for truncated file paths, session titles, tool details, model information, Git branches, and status fields.
  * Tooltips now display relevant timing, directory, exit status, signal, provider, and context-window details where applicable.
  * Added localized tooltip text in English and Chinese.

* **Bug Fixes**
  * Prevented redundant tooltips when content is already fully visible.
  * Improved tooltip behavior for truncated and expanded terminal content.

* **Tests**
  * Added automated terminal checks covering tooltip visibility and hover details across tools, files, sessions, and status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->