### PR TITLE
feat(whale): random startup whale intro - classic / heart / sleep

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -431,7 +431,7 @@ dsh-tui 自身区块（写入 settings.yaml 用户层，实时生效）共 21 �
 | 字段 | 说明 |
 |---|---|
 | lang | 界面语言 zh/en（DSH_TUI_LANG 钉死时不可改） |
-| whale | 开屏头部像素鲸鱼娘（默认开） |
+| whale | 开屏头部像素鲸鱼娘（默认开）；每次启动随机三选一开屏动画：经典组合开场（眨眼+喷水+摆尾）/ 爱心 / 睡觉，`/deepseek` 彩蛋每次重掷 |
 | diffLayout | Edit/Write diff 布局：auto（≥110 列双栏）/ split / unified |
 | thinkingFold | 思考块：preview（流式 2-3 行预览 + 落定折叠）/ full（展开到轮末） |
 | smoothStreaming | 流式平滑输出（默认开）：实时回复/展开思考/工具卡正文按 ~30fps 匀速揭示，突发送达不再跳变，一次性到达的非流式回复也平滑打出；回放/历史始终完整直出 |

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -417,6 +417,11 @@ const GROUPS = {
     ["verify-compact", ['node', '--import', 'tsx/esm', 'scripts/verify-compact.mjs']],
     ["verify-channel-goal-todo", ['node', '--import', 'tsx/esm', 'scripts/verify-channel-goal-todo.mjs']],
     ["verify-whale-toggle", ['node', '--import', 'tsx/esm', 'scripts/verify-whale-toggle.mjs']],
+// 开屏鲸鱼三选一（classic 组合开场/heart/sleep）：帧表完整性（22 帧
+// 含 heart/sleep 新调色）、序列合法性（standard 起止/纯自家行为帧、
+// classic 仍捆绑眨眼+喷水+摆尾）、随机选取 API 覆盖/钳制/每次挂载
+// 独立重掷、LogoV2 渲染冒烟（粉爱心/灰 Z 上屏后落定消失）。
+    ["verify-whale-intro", ['node', '--import', 'tsx/esm', 'scripts/verify-whale-intro.mjs']],
 // 计划退出恢复进入前权限；覆盖延迟切换、会话恢复与未知权限不提权。
     ["verify-plan-exit-restore", ['node', 'scripts/verify-plan-exit-restore.mjs']],
 // 会话切换/清屏卫生：子代理投影（行 map/任务描述队列/仪表盘快照）随

--- a/scripts/verify-whale-intro.mjs
+++ b/scripts/verify-whale-intro.mjs
@@ -1,0 +1,233 @@
+/**
+ * Whale startup-intro regression: the three randomized opening sequences —
+ * classic (blink + spout + tail wag), heart, sleep. Frame-table integrity,
+ * sequence validity, the random pick API, and a LogoV2 render smoke that
+ * proves each new palette color (pink heart, gray sleep-Z) actually paints
+ * during its intro and disappears once the header settles.
+ *
+ * Run: node --import tsx/esm scripts/verify-whale-intro.mjs
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_LANG = 'en'
+
+const [
+  { strict: assert },
+  { PassThrough, Writable },
+  React,
+  { render, ThemeProvider },
+  { LogoV2 },
+  whale,
+  { settle, settled },
+] = await Promise.all([
+  import('node:assert'),
+  import('node:stream'),
+  import('react'),
+  import('../src/ui.js'),
+  import('../src/components/LogoV2.js'),
+  import('../src/components/whaleFrames.js'),
+  import('./lib/term-test.mjs'),
+])
+
+let checks = 0
+function check(name, test) {
+  try {
+    test()
+    checks += 1
+    console.log(`PASS: ${name}`)
+  } catch (error) {
+    console.error(`FAIL: ${name}`)
+    throw error
+  }
+}
+
+const { WHALE_FRAMES, WHALE_INTRO_IDS, OPENING_SEQUENCES, pickOpeningSequence } = whale
+
+// ── 1. Frame-table integrity ─────────────────────────────────────────────
+const EXPECTED_NAMES = [
+  'standard', 'blink', 'fin1', 'fin2',
+  'spout1', 'spout2', 'spout3', 'spout4', 'spout5', 'spout6',
+  'tail1', 'tail2', 'tail3', 'tail4',
+  'heart1', 'heart2', 'heart3',
+  'sleep1', 'sleep2', 'sleep3', 'sleep4', 'sleep5',
+]
+
+check('whaleFrames holds all 22 source frames in art order', () => {
+  assert.equal(WHALE_FRAMES.length, 22)
+  assert.deepEqual(WHALE_FRAMES.map(f => f.name), EXPECTED_NAMES)
+})
+
+check('every frame is a 25x40 grid of palette chars', () => {
+  const valid = /^[.DBLWHZ]+$/
+  for (const frame of WHALE_FRAMES) {
+    assert.equal(frame.rows.length, 25, `${frame.name}: row count`)
+    for (const row of frame.rows) {
+      assert.equal(row.length, 40, `${frame.name}: column count`)
+      assert.match(row, valid, `${frame.name}: unexpected char`)
+    }
+  }
+})
+
+check('heart/sleep pixels exist only in their own frames', () => {
+  for (const frame of WHALE_FRAMES) {
+    const text = frame.rows.join('')
+    if (frame.name.startsWith('heart')) {
+      assert.ok(text.includes('H'), `${frame.name}: missing heart`)
+      assert.ok(!text.includes('Z'), `${frame.name}: unexpected sleep-Z`)
+    } else if (frame.name.startsWith('sleep')) {
+      assert.ok(text.includes('Z'), `${frame.name}: missing sleep-Z`)
+      assert.ok(!text.includes('H'), `${frame.name}: unexpected heart`)
+    } else {
+      assert.ok(!text.includes('H') && !text.includes('Z'), `${frame.name}: stray heart/Z`)
+    }
+  }
+})
+
+// ── 2. Sequence validity ─────────────────────────────────────────────────
+// Motion frames each intro may use (beyond the standard bookends). The
+// classic opener keeps the base behaviors bundled — blink (1), spout
+// (4..9) and the full tail wag (10..13) — the way the header always
+// played them; only heart and sleep get standalone intros.
+const FAMILIES = {
+  classic: new Set([1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+  heart: new Set([14, 15, 16]),
+  sleep: new Set([17, 18, 19, 20, 21]),
+}
+
+check('three intro ids, one sequence each', () => {
+  assert.deepEqual([...WHALE_INTRO_IDS], ['classic', 'heart', 'sleep'])
+  assert.deepEqual(Object.keys(OPENING_SEQUENCES).sort(), [...WHALE_INTRO_IDS].sort())
+})
+
+check('every sequence: valid frames, positive dwell, standard bookends', () => {
+  for (const id of WHALE_INTRO_IDS) {
+    const seq = OPENING_SEQUENCES[id]
+    assert.ok(seq.length >= 3, `${id}: too short`)
+    assert.equal(seq[0].frame, 0, `${id}: must open on standard`)
+    assert.equal(seq[seq.length - 1].frame, 0, `${id}: must close on standard`)
+    let motion = 0
+    for (const step of seq) {
+      assert.ok(step.frame >= 0 && step.frame < WHALE_FRAMES.length, `${id}: frame out of range`)
+      assert.ok(step.ms > 0, `${id}: dwell must be positive`)
+      if (step.frame !== 0) motion += 1
+    }
+    assert.ok(motion > 0, `${id}: no motion`)
+  }
+})
+
+check('each sequence animates only its own behavior', () => {
+  for (const id of WHALE_INTRO_IDS) {
+    const family = FAMILIES[id]
+    for (const step of OPENING_SEQUENCES[id]) {
+      if (step.frame === 0) continue
+      assert.ok(family.has(step.frame), `${id}: frame ${step.frame} outside the ${id} family`)
+    }
+  }
+})
+
+check('classic keeps the base behaviors bundled (blink + spout + wag)', () => {
+  const motion = new Set(OPENING_SEQUENCES.classic.map(s => s.frame).filter(f => f !== 0))
+  assert.ok(motion.has(1), 'classic lost the blink')
+  assert.ok([4, 5, 6, 7, 8, 9].some(f => motion.has(f)), 'classic lost the spout bloom')
+  assert.ok([10, 11, 12, 13].some(f => motion.has(f)), 'classic lost the tail wag')
+})
+
+// ── 3. Random pick API ───────────────────────────────────────────────────
+check('pickOpeningSequence covers all three ids across the unit interval', () => {
+  for (let i = 0; i < WHALE_INTRO_IDS.length; i += 1) {
+    const roll = (i + 0.5) / WHALE_INTRO_IDS.length
+    const { id } = pickOpeningSequence(() => roll)
+    assert.equal(id, WHALE_INTRO_IDS[i], `roll ${roll} -> ${id} (want ${WHALE_INTRO_IDS[i]})`)
+  }
+})
+
+check('pickOpeningSequence clamps out-of-range rolls', () => {
+  assert.equal(pickOpeningSequence(() => 1).id, 'sleep')
+  assert.equal(pickOpeningSequence(() => -0.5).id, 'classic')
+})
+
+check('pickOpeningSequence rolls fresh on every call (no per-process cache)', () => {
+  // Each logo mount (startup splash, every /deepseek replay) calls the
+  // roll independently — consecutive calls must never hand back a cached
+  // pick.
+  const a = pickOpeningSequence(() => 0)
+  const b = pickOpeningSequence(() => 0.999)
+  assert.strictEqual(a.sequence, OPENING_SEQUENCES.classic)
+  assert.strictEqual(b.sequence, OPENING_SEQUENCES.sleep)
+  assert.notStrictEqual(a, b, 'callers must get independent result objects')
+})
+
+// ── 4. Render smoke: heart / sleep actually paint, then settle ───────────
+const PINK = '\x1b[38;2;204;51;153m' // #cc3399 heart
+const GRAY = '\x1b[38;2;128;128;128m' // #808080 sleep-Z
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+
+class FakeOutput extends Writable {
+  constructor() {
+    super()
+    this.columns = 100
+  }
+  rows = 30
+  isTTY = true
+  writes = []
+  _write(chunk, _encoding, callback) {
+    this.writes.push(String(chunk))
+    callback()
+  }
+}
+
+async function renderLogo(intro) {
+  const stdout = new FakeOutput()
+  const instance = await render(
+    React.createElement(
+      ThemeProvider,
+      { theme: 'dark' },
+      React.createElement(LogoV2, { model: 'whale-intro-probe', cwd: '/whale/cwd', intro }),
+    ),
+    {
+      stdout,
+      stdin: new FakeStdin(),
+      stderr: new FakeOutput(),
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  )
+  return { stdout, instance }
+}
+
+{
+  const { stdout, instance } = await renderLogo('heart')
+  const sawPink = await settled(() => stdout.writes.join('').includes(PINK))
+  check('heart intro paints the pink heart SGR', () => assert.ok(sawPink, 'pink heart never painted'))
+  // heart total dwell = 2750ms; wait past it, the settled frame must be plain.
+  await new Promise(resolve => setTimeout(resolve, 2750 + 900))
+  const last = stdout.writes.slice(-3).join('')
+  const all = stdout.writes.join('')
+  check('heart intro settles back to the standard pose (no pink)', () => {
+    assert.ok(!last.includes(PINK), 'pink leaked into the settled frame')
+    assert.ok(all.includes('\x1b[38;2;20;38;96m'), 'whale outline never painted')
+  })
+  await instance.unmount()
+}
+
+{
+  const { stdout, instance } = await renderLogo('sleep')
+  const sawGray = await settled(() => stdout.writes.join('').includes(GRAY))
+  check('sleep intro paints the gray Z SGR', () => assert.ok(sawGray, 'gray Z never painted'))
+  // sleep total dwell = 3100ms; wait past it, the settled frame must be plain.
+  await new Promise(resolve => setTimeout(resolve, 3100 + 900))
+  const last = stdout.writes.slice(-3).join('')
+  const all = stdout.writes.join('')
+  check('sleep intro settles back to the standard pose (no Z)', () => {
+    assert.ok(!last.includes(GRAY), 'gray leaked into the settled frame')
+    assert.ok(all.includes('\x1b[38;2;20;38;96m'), 'whale outline never painted')
+  })
+  await instance.unmount()
+}
+
+console.log(`\nAll ${checks} whale-intro checks passed.`)

--- a/src/components/LogoV2.tsx
+++ b/src/components/LogoV2.tsx
@@ -13,7 +13,7 @@ import { renderBigText } from './bigfont.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { BRAND, FLASH, ICE, PALE, sweep } from './shimmer.js'
 import { STANDARD_FRAME_INDEX, WhaleArt } from './Whale.js'
-import { OPENING_SEQUENCE } from './whaleFrames.js'
+import { OPENING_SEQUENCES, pickOpeningSequence, type OpeningStep, type WhaleIntroId } from './whaleFrames.js'
 
 /**
  * Header badge version, read from the installed package.json so the display
@@ -57,11 +57,14 @@ function capitalize(text: string): string {
 }
 
 /**
- * The header splash: one layout, two phases. The **opening** (~3.4s, once)
- * plays the hand-drawn whale animation (blink → water-spout bloom → tail
- * wag) and runs the shimmer sweeps; the **settled** header is the same
- * tree frozen at t=0 — whale on the standard pose, sweep highlights parked
- * off-screen, clock unsubscribed, zero timers.
+ * The header splash: one layout, two phases. The **opening** (~1.7–3.5s,
+ * once) plays one of three whale intros — the classic blink + spout +
+ * tail-wag combo, the heart pass, or the sleep-Z float — rolled on every
+ * mount (see `pickOpeningSequence`): randomly at startup, and again
+ * randomly on each `/deepseek` easter-egg replay — and runs the shimmer
+ * sweeps; the **settled** header is the same tree frozen at t=0 — whale
+ * on the standard pose, sweep highlights parked off-screen, clock
+ * unsubscribed, zero timers.
  *
  * Layout: the 13-row pixel whale beside a text column of matching height —
  * the `✦ dsh-TUI` wordmark with version, the `DEEPSEEK`/`HARNESS` tagline in
@@ -75,6 +78,7 @@ export function LogoV2({
   effort,
   cwd,
   skipIntro = false,
+  intro,
   tip,
   whale = true,
   drift,
@@ -84,6 +88,8 @@ export function LogoV2({
   cwd: string
   /** Test seam: mount straight into the settled header (probes skip the intro). */
   skipIntro?: boolean
+  /** Test seam: pin the intro animation instead of rolling one at startup. */
+  intro?: WhaleIntroId
   /** Test seam: pin the startup tip line (probes need a deterministic tip). */
   tip?: Tip
   /** Show the pixel whale art (settings `dsh-tui.whale`); off → text-only header. */
@@ -92,24 +98,28 @@ export function LogoV2({
    * `undefined` — the production default — auto-detects the install). */
   drift?: UpstreamDriftSummary | null
 }): React.ReactNode {
-  const [step, setStep] = React.useState(skipIntro ? OPENING_SEQUENCE.length : 0)
-  const settled = step >= OPENING_SEQUENCE.length
+  // One intro per logo mount: the production path rolls (startup splash
+  // and each /deepseek replay roll independently), the `intro` seam pins
+  // a specific animation for probes.
+  const [sequence] = React.useState<readonly OpeningStep[]>(() => OPENING_SEQUENCES[intro ?? pickOpeningSequence().id])
+  const [step, setStep] = React.useState(skipIntro ? sequence.length : 0)
+  const settled = step >= sequence.length
 
   // Opening clock: drives the shimmer sweep and big-text highlight only
   // while the intro plays; `null` afterwards unsubscribes so the settled
   // header never repaints. 60ms frames keep the sweep lively.
   const [ref, time] = useAnimationFrame(settled ? null : 60)
 
-  // Frame chain: dwell per OPENING_SEQUENCE entry, then settle for good.
+  // Frame chain: dwell per sequence entry, then settle for good.
   React.useEffect(() => {
     if (settled) return
     const timer = setTimeout(() => {
       setStep(s => s + 1)
-    }, OPENING_SEQUENCE[step].ms)
+    }, sequence[step].ms)
     return () => {
       clearTimeout(timer)
     }
-  }, [step, settled])
+  }, [step, settled, sequence])
 
   const [themeName] = useTheme()
   const theme = getTheme(themeName)
@@ -120,7 +130,7 @@ export function LogoV2({
   const taglineRGB = parseRGB(theme.claudeBlue_FOR_SYSTEM_SPINNER) ?? ICE
 
   const showWhale = whale && columns >= WHALE_MIN_COLUMNS
-  const frameIndex = settled ? STANDARD_FRAME_INDEX : OPENING_SEQUENCE[step].frame
+  const frameIndex = settled ? STANDARD_FRAME_INDEX : sequence[step].frame
   // Frozen clock for the settled header: t=0 parks every sweep highlight
   // off-screen, leaving the static gradient behind.
   const t = settled ? 0 : time

--- a/src/components/Whale.tsx
+++ b/src/components/Whale.tsx
@@ -4,21 +4,24 @@ import { WHALE_FRAMES, type WhaleFrame } from './whaleFrames.js'
 
 /**
  * The DeepSeek pixel whale from the hand-drawn Excel art (whale_frames.zip):
- * a 40×25 sprite in four true-color tones (deep-navy outline, DeepSeek-blue
- * body, ice-blue belly, white mouth). Rendered with the half-block
- * technique — each terminal cell packs two vertical pixels into one `▀`/`▄`
- * glyph (foreground = upper pixel, background = lower), so the whale shows
- * at 40 columns × 13 rows with visually square pixels.
+ * a 40×25 sprite in six true-color tones (deep-navy outline, DeepSeek-blue
+ * body, ice-blue belly, white mouth, pink heart, gray sleep-Z). Rendered
+ * with the half-block technique — each terminal cell packs two vertical
+ * pixels into one `▀`/`▄` glyph (foreground = upper pixel, background =
+ * lower), so the whale shows at 40 columns × 13 rows with visually square
+ * pixels.
  */
 
 type Rgb = readonly [number, number, number]
 
-/** Sprite palette: D outline · B body · L belly · W mouth · `.` transparent. */
+/** Sprite palette: D outline · B body · L belly · W mouth · H heart · Z sleep-Z · `.` transparent. */
 const PALETTE: Record<string, Rgb | undefined> = {
   D: [20, 38, 96],
   B: [78, 111, 255],
   L: [190, 225, 255],
   W: [255, 255, 255],
+  H: [204, 51, 153],
+  Z: [128, 128, 128],
 }
 
 const fg = (rgb: Rgb): string => `\x1b[38;2;${rgb[0]};${rgb[1]};${rgb[2]}m`
@@ -82,7 +85,7 @@ export const STANDARD_FRAME_INDEX = 0
 
 /**
  * One whale pose as an Ink component: 13 rows × 40 columns, never
- * shrinking. Pass `frameIndex` from OPENING_SEQUENCE while animating, or
+ * shrinking. Pass `frameIndex` from the opening sequence while animating, or
  * STANDARD_FRAME_INDEX for the static header whale. `width` pins the box
  * width so the neighbouring text column never shifts when frames widen
  * (the tail-wag frames reach 4 columns further right than standard).

--- a/src/components/whaleFrames.ts
+++ b/src/components/whaleFrames.ts
@@ -1,9 +1,14 @@
 /**
  * Pixel-whale animation frames for the startup splash, converted from
- * the hand-drawn Excel art in `whale_frames.zip` (25x40 cells, palette
- * alphabet shared with Whale.tsx: D outline, B body, L belly, W mouth,
- * `.` transparent). `OPENING_SEQUENCE` plays once at startup: blink,
- * water-spout bloom, tail wag, then the header settles static.
+ * the hand-drawn Excel art (the `dsh-ui-whale` frame set, 25x40 cells,
+ * palette alphabet shared with Whale.tsx: D outline, B body, L belly,
+ * W mouth, H heart, Z sleep-Z, `.` transparent). All 22 source frames
+ * are here; `OPENING_SEQUENCES` packs them into three startup intros —
+ * the classic blink + spout + tail-wag combo, the heart pass, and the
+ * sleep-Z float — of which one is rolled every time the logo header
+ * mounts (see `pickOpeningSequence`): randomly at startup, and again on
+ * every `/deepseek` easter-egg replay. The header then settles static
+ * on the standard pose.
  */
 
 /** One animation frame: 25 sprite rows of 40 palette characters. */
@@ -13,7 +18,7 @@ export interface WhaleFrame {
   readonly rows: readonly string[]
 }
 
-/** The 13 hand-drawn frames. */
+/** The 22 hand-drawn frames (all poses from the source art, incl. heart and sleep). */
 export const WHALE_FRAMES: readonly WhaleFrame[] = [
   {
     name: 'standard',
@@ -405,9 +410,279 @@ export const WHALE_FRAMES: readonly WhaleFrame[] = [
       '........................................',
     ],
   },
+  {
+    name: 'tail4',
+    rows: [
+      '........................................',
+      '........................................',
+      '........................................',
+      '........................................',
+      '................................D.......',
+      '...............................DBD......',
+      '..............................DBBD......',
+      '.......DDDDDDDDD..............DBBD......',
+      '......DBBBBBBBBBDD...........DBBBD......',
+      '.....DBBBBBBBBBBBBDD.........DBBBD....D.',
+      '....DBBBBBBBBBBBBBBBDD.......DBBBBDDDDBD',
+      '...DDBBBBBBBBBBBBBBBBBD.....DBBBBBBBBBBD',
+      '...DBBBBBBBBBBBBBBBBBBBDDDDDBBBBBBBBBBD.',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBBBBBBBBD..',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBBBBDDDD...',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBBBBD.......',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBBBBD........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBBBD.........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBDDD..........',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'heart1',
+    rows: [
+      '........................................',
+      '........................................',
+      '........................D...............',
+      '...H.H.................DBD.......D......',
+      '...HHH.................DBBD.....DBD.....',
+      '....H..................DBBBD..DDBBD.....',
+      '.......................DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'heart2',
+    rows: [
+      '........................................',
+      '........................................',
+      '...H.H..................D...............',
+      '..HHHHH................DBD.......D......',
+      '..HHHHH................DBBD.....DBD.....',
+      '...HHH.................DBBBD..DDBBD.....',
+      '....H..................DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'heart3',
+    rows: [
+      '........................................',
+      '..HH.HH.................................',
+      '.HHHHHHH................D...............',
+      '.HHHHHHH...............DBD.......D......',
+      '..HHHHH................DBBD.....DBD.....',
+      '...HHH.................DBBBD..DDBBD.....',
+      '....H..................DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'sleep1',
+    rows: [
+      '...................ZZZZ.................',
+      '........................................',
+      '..............ZZZZ......D...............',
+      '................Z......DBD.......D......',
+      '...............Z.......DBBD.....DBD.....',
+      '..............ZZZZ.....DBBBD..DDBBD.....',
+      '.......................DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'sleep2',
+    rows: [
+      '........................................',
+      '...............ZZZZ.....................',
+      '.................Z......D...............',
+      '................Z......DBD.......D......',
+      '...............ZZZZ....DBBD.....DBD.....',
+      '.......................DBBBD..DDBBD.....',
+      '..........ZZZZ.........DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'sleep3',
+    rows: [
+      '................ZZZZ....................',
+      '..................Z.....................',
+      '.................Z......D...............',
+      '................ZZZZ...DBD.......D......',
+      '.......................DBBD.....DBD.....',
+      '...........ZZZZ........DBBBD..DDBBD.....',
+      '.............Z.........DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'sleep4',
+    rows: [
+      '...................Z....................',
+      '..................Z.....................',
+      '.................ZZZZ...D...............',
+      '.......................DBD.......D......',
+      '............ZZZZ.......DBBD.....DBD.....',
+      '..............Z........DBBBD..DDBBD.....',
+      '.............Z.........DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
+  {
+    name: 'sleep5',
+    rows: [
+      '...................Z....................',
+      '..................ZZZZ..................',
+      '........................D...............',
+      '.............ZZZZ......DBD.......D......',
+      '...............Z.......DBBD.....DBD.....',
+      '..............Z........DBBBD..DDBBD.....',
+      '.............ZZZZ......DBBBBDDBBBBD.....',
+      '.......DDDDDDDDD........DBBBBBBBBD......',
+      '......DBBBBBBBBBDD.......DBBBBBBBD......',
+      '.....DBBBBBBBBBBBBDD.....DBBBBBDD.......',
+      '....DBBBBBBBBBBBBBBBDD....DBBBD.........',
+      '...DDBBBBBBBBBBBBBBBBBD..DBBBBD.........',
+      '...DBBBBBBBBBBBBBBBBBBBDDBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBBD.........',
+      '...DBBBDBBBBBBDBBBBBBBBBBBBBBD..........',
+      '...DBBBBBBBBBBBBBBBBBBBBBBBBBD..........',
+      '...DBBBBWWWWWWWBBBBBBBBDBBBBD...........',
+      '...DDBWWWWWWWWWWWWBBBBBBDBBBD...........',
+      '....DLLWWWWWWWWWWWWDBBBBDDBD............',
+      '.....DLLLWWWWWWWWWWDBBBBBDD.............',
+      '......DDLLLWWWWWWLLLDBBBBBDD............',
+      '........DLLLLLLLLLLLDDBBBBBBD...........',
+      '.........DDDDDDDDDDD..DDDDDDD...........',
+      '........................................',
+      '........................................',
+    ],
+  },
 ]
 
-/** One step of the opening animation: frame index + dwell time. */
+/** One step of an opening animation: frame index + dwell time. */
 export interface OpeningStep {
   /** Index into WHALE_FRAMES. */
   readonly frame: number
@@ -415,22 +690,105 @@ export interface OpeningStep {
   readonly ms: number
 }
 
-/** Startup sequence (~3.4s), ending on the standard pose. */
-export const OPENING_SEQUENCE: readonly OpeningStep[] = [
-  { frame: 0, ms: 400 }, // standard
-  { frame: 1, ms: 250 }, // blink
-  { frame: 0, ms: 300 }, // standard
-  { frame: 4, ms: 150 }, // spout1
-  { frame: 5, ms: 150 }, // spout2
-  { frame: 6, ms: 150 }, // spout3
-  { frame: 7, ms: 150 }, // spout4
-  { frame: 8, ms: 150 }, // spout5
-  { frame: 9, ms: 150 }, // spout6
-  { frame: 0, ms: 250 }, // standard
-  { frame: 10, ms: 170 }, // tail1
-  { frame: 11, ms: 170 }, // tail2
-  { frame: 12, ms: 260 }, // tail3
-  { frame: 11, ms: 170 }, // tail2
-  { frame: 10, ms: 170 }, // tail1
-  { frame: 0, ms: 300 }, // standard
-]
+/** Named indices into WHALE_FRAMES (the order matches the source art). */
+const F = {
+  standard: 0,
+  blink: 1,
+  fin1: 2,
+  fin2: 3,
+  spout1: 4,
+  spout2: 5,
+  spout3: 6,
+  spout4: 7,
+  spout5: 8,
+  spout6: 9,
+  tail1: 10,
+  tail2: 11,
+  tail3: 12,
+  tail4: 13,
+  heart1: 14,
+  heart2: 15,
+  heart3: 16,
+  sleep1: 17,
+  sleep2: 18,
+  sleep3: 19,
+  sleep4: 20,
+  sleep5: 21,
+} as const
+
+/**
+ * The three intro animations; each one ends back on the standard pose.
+ * The base actions (blink, fin, tail, spout) stay bundled in the classic
+ * opener as they were — only the behaviors the TUI never had (heart,
+ * sleep) get their own standalone intro.
+ */
+export type WhaleIntroId = 'classic' | 'heart' | 'sleep'
+
+/** All intro ids, in a stable order (drives the random pick). */
+export const WHALE_INTRO_IDS: readonly WhaleIntroId[] = ['classic', 'heart', 'sleep']
+
+/**
+ * One startup intro per behavior, mirroring the source plugin's cadence:
+ * classic = the shipped opener (blink → one-way water-spout bloom → full
+ * 1→2→3→4→3→2→1 tail wag); heart = a pink heart growing small→large in
+ * the top-left corner; sleep = gray Z's rising above the blowhole, then
+ * settling back to rest.
+ */
+export const OPENING_SEQUENCES: Record<WhaleIntroId, readonly OpeningStep[]> = {
+  classic: [
+    { frame: F.standard, ms: 400 },
+    { frame: F.blink, ms: 250 },
+    { frame: F.standard, ms: 300 },
+    { frame: F.spout1, ms: 150 },
+    { frame: F.spout2, ms: 150 },
+    { frame: F.spout3, ms: 150 },
+    { frame: F.spout4, ms: 150 },
+    { frame: F.spout5, ms: 150 },
+    { frame: F.spout6, ms: 150 },
+    { frame: F.standard, ms: 250 },
+    { frame: F.tail1, ms: 150 },
+    { frame: F.tail2, ms: 150 },
+    { frame: F.tail3, ms: 150 },
+    { frame: F.tail4, ms: 180 },
+    { frame: F.tail3, ms: 150 },
+    { frame: F.tail2, ms: 150 },
+    { frame: F.tail1, ms: 150 },
+    { frame: F.standard, ms: 300 },
+  ],
+  heart: [
+    { frame: F.standard, ms: 400 },
+    { frame: F.heart1, ms: 350 },
+    { frame: F.heart2, ms: 350 },
+    { frame: F.heart3, ms: 450 },
+    { frame: F.heart2, ms: 350 },
+    { frame: F.heart1, ms: 350 },
+    { frame: F.standard, ms: 500 },
+  ],
+  sleep: [
+    { frame: F.standard, ms: 400 },
+    { frame: F.sleep1, ms: 250 },
+    { frame: F.sleep2, ms: 250 },
+    { frame: F.sleep3, ms: 250 },
+    { frame: F.sleep4, ms: 250 },
+    { frame: F.sleep5, ms: 300 },
+    { frame: F.sleep4, ms: 250 },
+    { frame: F.sleep3, ms: 250 },
+    { frame: F.sleep2, ms: 250 },
+    { frame: F.sleep1, ms: 250 },
+    { frame: F.standard, ms: 400 },
+  ],
+}
+
+/**
+ * Roll one intro id uniformly at random. Called once per logo header
+ * mount — the startup splash and every `/deepseek` replay each roll
+ * independently. `random` is a test seam (0-based, values in [0, 1)).
+ */
+export function pickOpeningSequence(
+  random: () => number = Math.random,
+): { id: WhaleIntroId; sequence: readonly OpeningStep[] } {
+  const roll = random()
+  const index = Math.min(WHALE_INTRO_IDS.length - 1, Math.max(0, Math.floor(roll * WHALE_INTRO_IDS.length)))
+  const id = WHALE_INTRO_IDS[index] ?? 'classic'
+  return { id, sequence: OPENING_SEQUENCES[id] }
+}


### PR DESCRIPTION
## 目标

把 [lhh010/dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale)（本地像素鲸鱼素材作者的插件仓库）里的整套手绘帧用上：开屏鲸鱼动画从「固定播经典款」改为 **每次挂载随机三选一**（启动随机、`/deepseek` 彩蛋每次重掷）。

## 设计

源仓库共 22 帧（STANDARD/BLINK/FIN_1-2/SPOUT_1-6/TAIL_1-4/HEART_1-3/SLEEP_1-5），本地帧表原本只转了 13 帧（blink/fin/spout/tail 基础动作）。按作者仓库的动画语义：

- **基础行为不单列**——眨眼/喷水/摆尾本来就是本地开场的组合体，继续捆绑在 classic 开场里（顺手把 TAIL_4 补进摆尾，wag 变完整 1→2→3→4→3→2→1）；
- **本地没有的两个行为单列为新开场**：
  - `heart`：粉爱心 `#cc3399` 在左上角从小到大再收回（repo 点击互动同款）；
  - `sleep`：灰色 `#808080` Z 在喷水孔上方升起-落下（repo 闲置睡觉同款）。

随机语义：`pickOpeningSequence()` 在 LogoV2 每次挂载时独立掷骰（`useState` 初始化器），启动 splsh 与 `/deepseek` 重挂（`key={logoNonce}`）各自随机；序列都以 standard 姿势收尾落定，settled 头部零定时器行为不变。

## 改动

- `src/components/whaleFrames.ts`：帧表 13→22 帧（新 9 帧逐字节核对过源仓库 JSON）；`OPENING_SEQUENCES`（classic/heart/sleep）+ `pickOpeningSequence(random?)`；删除旧 `OPENING_SEQUENCE` 常量
- `src/components/Whale.tsx`：调色板 + `H`（心）/`Z`（睡眠）两色
- `src/components/LogoV2.tsx`：接入随机开场，新增 `intro` 测试缝（生产不传）
- `scripts/verify-whale-intro.mjs`（新，14 断言，登记 channel-ui 组）：帧表完整性、序列合法性（standard 起止/纯自家行为帧/classic 仍捆绑三件套）、随机 API 覆盖/钳制/每次调用独立、LogoV2 渲染冒烟（粉心/灰 Z 上屏→落定消失）
- `docs/user-guide.md`：whale 设置行说明

## 验证

- `pnpm build` EXIT=0（i18n 994）
- verify-whale-intro 14/14；verify-whale-toggle 8/8；verify-tips OK
- header-probe 落定帧 6/6 次为 0（随机开场时长 1.7–3.5s，观测窗 4.1s 内落定）
- `git diff --check` 干净

注：本地预存的 `tail2` 帧与 repo 现行版差一列（作者 zip 初版 vs repo 微调），保持不动；新增 9 帧全部取自 repo 当前源。

Closes #721
