### PR TITLE
fix(streaming): smoothStreaming 长任务卡顿——20fps 降频、揭示读取记忆化、门控收敛，默认关闭

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -434,7 +434,7 @@ dsh-tui 自身区块（写入 settings.yaml 用户层，实时生效）共 21 �
 | whale | 开屏头部像素鲸鱼娘（默认开）；每次启动随机三选一开屏动画：经典组合开场（眨眼+喷水+摆尾）/ 爱心 / 睡觉，`/deepseek` 彩蛋每次重掷 |
 | diffLayout | Edit/Write diff 布局：auto（≥110 列双栏）/ split / unified |
 | thinkingFold | 思考块：preview（流式 2-3 行预览 + 落定折叠）/ full（展开到轮末） |
-| smoothStreaming | 流式平滑输出（默认开）：实时回复/展开思考/工具卡正文按 ~30fps 匀速揭示，突发送达不再跳变，一次性到达的非流式回复也平滑打出；回放/历史始终完整直出 |
+| smoothStreaming | 流式平滑输出（默认关）：实时回复/展开思考/工具卡正文按 ~20fps 匀速揭示，突发送达不再跳变，一次性到达的非流式回复也平滑打出；回放/历史始终完整直出。揭示按自身节奏持续渲染，长流式任务在较慢终端上可能感到卡顿，故默认关闭 |
 | toolBackground | 工具卡背景强调：none / subtle / strong |
 | statusBar.* | 上表全部状态栏开关（compact/model/thinking/cwd/contextUsage/cache/tokens/cost/tps/gitBranch/sessionTitle/sessionId/mode/contextBar/activity/trajectory；statusBar.sessionId 是底栏显示开关，与 cordis 的启动 sessionId 无关） |
 

--- a/scripts/verify-smooth-reveal.tsx
+++ b/scripts/verify-smooth-reveal.tsx
@@ -31,6 +31,7 @@ import {
   isRevealTimerRunning,
   revealLengthOf,
   revealLinesOf,
+  revealListenerCountForTest,
   revealStep,
   resetRevealForTest,
 } from '../src/components/smoothReveal.js'
@@ -49,6 +50,9 @@ function check(ok: boolean, label: string, detail = ''): void {
   }
 }
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+/** Catch-up sleep budget: sized for the ~20fps reveal cadence (REVEAL_FRAME_MS
+ *  50ms — a 2400-char burst needs ~48 ticks ≈ 2.4s) plus CI-load margin. */
+const CATCHUP_SLEEP_MS = 3600
 
 // ---------------------------------------------------------------------------
 // Group A — scheduler/cursor units
@@ -72,8 +76,8 @@ check(revealStep(25) === 4, 'A1 revealStep(25) = 4')
   const mid = revealLengthOf('a1', grown, { enabled: true, active: true })
   check(mid > 0 && mid < grown.length, 'A2 partial reveal mid-flight', `len=${mid}/${grown.length}`)
   // Exponential decay over the backlog (~1/8 per frame) + MIN_STEP tail: a
-  // 1200-char target needs ~1.3s to fully land.
-  await sleep(2200)
+  // 1200-char target needs ~2s to fully land at the ~20fps cadence.
+  await sleep(CATCHUP_SLEEP_MS)
   check(
     revealLengthOf('a1', grown, { enabled: true, active: true }) === grown.length,
     'A2 catch-up completes (exponential decay + MIN_STEP tail)',
@@ -100,7 +104,7 @@ check(revealStep(25) === 4, 'A1 revealStep(25) = 4')
   check(isRevealTimerRunning(), 'A3 cursor creation starts the shared timer')
   await sleep(120)
   check(getRevealVersion() > before, 'A3 ticks bump the version store')
-  await sleep(2600)
+  await sleep(CATCHUP_SLEEP_MS)
   check(!isRevealTimerRunning(), 'A3 timer retires once every cursor caught up')
 }
 
@@ -189,7 +193,7 @@ console.log('--- B: MessageList integration ---')
       const early = screen()
       check(!early.includes('omega-end'), 'B1 streaming row: tail hidden early in the reveal')
       check(early.includes('alpha-start'), 'B1 streaming row: head visible early')
-      await sleep(2600)
+      await sleep(CATCHUP_SLEEP_MS)
       check(screen().includes('omega-end'), 'B1 streaming row: tail visible after catch-up')
     },
   )
@@ -206,7 +210,7 @@ console.log('--- B: MessageList integration ---')
     async screen => {
       await sleep(80)
       check(!screen().includes('omega-end'), 'B2 settled-fresh row: tail hidden early (non-streaming becomes smooth)')
-      await sleep(2600)
+      await sleep(CATCHUP_SLEEP_MS)
       check(screen().includes('omega-end'), 'B2 settled-fresh row: complete after catch-up')
     },
   )
@@ -238,6 +242,30 @@ console.log('--- B: MessageList integration ---')
     async screen => {
       await sleep(80)
       check(screen().includes('omega-end'), 'B4 smoothStreaming=false: full text paints immediately')
+    },
+  )
+}
+
+// B5: transcript generations reuse row ids; a completed cursor from the old
+// generation must not make the new fresh row skip its reveal.
+{
+  resetRevealForTest()
+  const oldText = LONG_TEXT.replace('omega-end', 'old-generation-omega')
+  const newText = LONG_TEXT.replace('omega-end', 'new-generation-omega')
+  let rows: ChatRow[] = [
+    { id: 7, kind: 'assistant', text: oldText, streaming: false, fresh: true },
+  ]
+  await withTerminal(
+    () => <MessageList rows={rows} rowsGeneration={1} smoothStreaming {...listProps} />,
+    async (screen, rerender) => {
+      await sleep(CATCHUP_SLEEP_MS)
+      check(screen().includes('old-generation-omega'), 'B5 old generation reveal completes')
+      rows = [{ id: 7, kind: 'assistant', text: newText, streaming: false, fresh: true }]
+      rerender(<MessageList rows={rows} rowsGeneration={2} smoothStreaming {...listProps} />)
+      await sleep(80)
+      check(!screen().includes('new-generation-omega'), 'B5 reused id in a new generation reveals again')
+      await sleep(CATCHUP_SLEEP_MS)
+      check(screen().includes('new-generation-omega'), 'B5 new generation reveal completes')
     },
   )
 }
@@ -305,16 +333,32 @@ console.log('--- C: component contracts ---')
   await withTerminal(
     () => <AssistantToolUseMessage tool={runningTool} addMargin={false} verbose={false} smoothReveal fresh />,
     async (screen, rerender) => {
-      await sleep(60)
+      await sleep(160)
       const early = screen()
       check(early.includes('old line 0'), 'C2 running card: body head visible early', early)
       check(!early.includes('lines (ctrl+o to expand)'), 'C2 running card: capped tail row hidden early in the reveal', early)
-      await sleep(2200)
+      await sleep(CATCHUP_SLEEP_MS)
       check(screen().includes('lines (ctrl+o to expand)'), 'C2 running card: body complete after catch-up')
       // C3: result arriving mid/after reveal snaps complete.
       rerender(<AssistantToolUseMessage tool={doneTool} addMargin={false} verbose={false} smoothReveal fresh />)
       await sleep(80)
       check(screen().includes('settled-result-marker'), 'C3 settled result paints complete (no reveal)')
+      // A new transcript may reuse the same tool call id. Generation scope
+      // prevents the completed cursor above from suppressing the new reveal.
+      rerender(
+        <AssistantToolUseMessage
+          tool={{ ...runningTool, startedAt: Date.now() }}
+          addMargin={false}
+          verbose={false}
+          smoothReveal
+          fresh
+          revealGeneration={2}
+        />,
+      )
+      await sleep(160)
+      check(!screen().includes('lines (ctrl+o to expand)'), 'C4 reused call id reveals in a new generation')
+      await sleep(CATCHUP_SLEEP_MS)
+      check(screen().includes('lines (ctrl+o to expand)'), 'C4 new-generation tool reveal completes')
     },
   )
 }
@@ -368,9 +412,47 @@ console.log('--- D: long-session reveal subscriber fanout ---')
     () => <MessageList rows={[...historyTools, activeTool]} smoothStreaming {...listProps} />,
     async screen => {
       await sleep(120)
+      check(revealListenerCountForTest() === 1,
+        'D1 MessageList owns the only production reveal subscription',
+        `listeners=${revealListenerCountForTest()}`)
       check(screen().includes('old line 0'), 'D1 active tool remains visible with many history cards')
-      await sleep(2200)
+      await sleep(CATCHUP_SLEEP_MS)
       check(screen().includes('lines (ctrl+o to expand)'), 'D1 active tool reveal completes without nested store updates')
+    },
+  )
+}
+
+// E: inline (main-screen) scrollback is immutable — only the transcript TAIL
+// may reveal there. A fresh row that stops being the tail mid-reveal must
+// snap complete in the same commit: native scrollback cannot rewrite a
+// partially revealed row, so a lingering cursor would permanently truncate
+// it once it scrolls up (E1, the inline-truncation regression). A fresh row
+// that is never the tail paints complete from its first frame (E2).
+console.log('--- E: inline scrollback tail-only reveal ---')
+{
+  resetRevealForTest()
+  const mk = (id: number, head: string, tail: string): ChatRow => ({
+    id,
+    kind: 'assistant',
+    text: [head, 'body line one', 'body line two', 'body line three', tail].join('\n'),
+    streaming: false,
+    fresh: true,
+  })
+  const rows: ChatRow[] = [
+    mk(1, 'inline-head-early', 'inline-tail-early'),
+    mk(2, 'inline-head-late', 'inline-tail-late'),
+  ]
+  await withTerminal(
+    () => <MessageList rows={rows} smoothStreaming historyPaintEnabled rowsGeneration={1} {...listProps} />,
+    async (screen, rerender) => {
+      await sleep(80)
+      const early = screen()
+      check(early.includes('inline-tail-early'), 'E2 non-tail fresh row paints complete immediately (inline tail-only)')
+      check(!early.includes('inline-tail-late'), 'E1 tail row reveals gradually')
+      rows.push({ id: 3, kind: 'user', text: 'follow-up question' })
+      rerender(<MessageList rows={rows} smoothStreaming historyPaintEnabled rowsGeneration={1} {...listProps} />)
+      await sleep(120)
+      check(screen().includes('inline-tail-late'), 'E1 mid-reveal row snaps complete when it stops being the tail')
     },
   )
 }

--- a/scripts/verify-smooth-reveal.tsx
+++ b/scripts/verify-smooth-reveal.tsx
@@ -333,10 +333,20 @@ console.log('--- C: component contracts ---')
   await withTerminal(
     () => <AssistantToolUseMessage tool={runningTool} addMargin={false} verbose={false} smoothReveal fresh />,
     async (screen, rerender) => {
-      await sleep(160)
-      const early = screen()
-      check(early.includes('old line 0'), 'C2 running card: body head visible early', early)
-      check(!early.includes('lines (ctrl+o to expand)'), 'C2 running card: capped tail row hidden early in the reveal', early)
+      // Mid-reveal must be SAMPLED, not slept past: CI tick cadence can
+      // finish a short body inside one 160ms window, but the FIRST sample
+      // where the head is visible always lands inside the reveal window on
+      // any machine speed (the cursor starts at zero and the first tick
+      // only lands ~50ms after mount).
+      let early: string | null = null
+      const c2Deadline = Date.now() + 3000
+      while (Date.now() < c2Deadline && early === null) {
+        const sample = screen()
+        if (sample.includes('old line 0')) early = sample
+        else await sleep(10)
+      }
+      check(early !== null, 'C2 running card: body head visible early', early ?? 'timeout')
+      check(early !== null && !early.includes('lines (ctrl+o to expand)'), 'C2 running card: capped tail row hidden early in the reveal', early ?? 'timeout')
       await sleep(CATCHUP_SLEEP_MS)
       check(screen().includes('lines (ctrl+o to expand)'), 'C2 running card: body complete after catch-up')
       // C3: result arriving mid/after reveal snaps complete.
@@ -355,8 +365,17 @@ console.log('--- C: component contracts ---')
           revealGeneration={2}
         />,
       )
-      await sleep(160)
-      check(!screen().includes('lines (ctrl+o to expand)'), 'C4 reused call id reveals in a new generation')
+      // Same sampling discipline as C2: the rerender recreates the cursor
+      // at zero, so the first sample where the new body head is showing
+      // (and the settled marker is gone) is inside the fresh reveal.
+      let midRegen: string | null = null
+      const c4Deadline = Date.now() + 3000
+      while (Date.now() < c4Deadline && midRegen === null) {
+        const sample = screen()
+        if (sample.includes('old line 0') && !sample.includes('settled-result-marker')) midRegen = sample
+        else await sleep(10)
+      }
+      check(midRegen !== null && !midRegen.includes('lines (ctrl+o to expand)'), 'C4 reused call id reveals in a new generation', midRegen ?? 'timeout')
       await sleep(CATCHUP_SLEEP_MS)
       check(screen().includes('lines (ctrl+o to expand)'), 'C4 new-generation tool reveal completes')
     },

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -23,7 +23,7 @@ import { stringWidth } from '../ink/stringWidth.js'
 import { truncateToWidth } from '../ink/truncateToWidth.js'
 import { clipPreview, type TimelineSnapshot, type TimelineTurn } from '../ink/timeline-rail.js'
 import type { ToolBackground } from '../tuiDisplayPrefs.js'
-import { getRevealVersion, revealLengthOf, revealTextOf } from './smoothReveal.js'
+import { getRevealVersion, hasActiveReveal, revealLengthOf, revealTextOf, splitRevealKey, toolRevealKey } from './smoothReveal.js'
 import { useRevealVersion } from '../hooks/useRevealVersion.js'
 
 /**
@@ -73,29 +73,84 @@ const NOOP_TOGGLE_STREAM_VIEW = (_rowId: number): void => {}
 // until it catches up — settling mid-reveal must not snap (that is the
 // "non-streaming delivery becomes a smooth flow" contract).
 
-function assistantRevealText(row: ChatRow, enabled: boolean): string {
-  const stripped = stripNarration(row.text)
-  return revealTextOf(`a${row.id}`, stripped, {
-    enabled,
-    active: row.streaming === true || row.fresh === true,
-  })
+function textRevealKey(kind: 'a' | 'r', rowId: number, rowsGeneration: number | undefined): string {
+  // Row ids restart from zero on /clear, rewind, and session swaps. Production
+  // channels pass rowsGeneration so an old completed/active cursor can never
+  // suppress or partially seed a fresh row with the same id. Legacy embedders
+  // without the seam retain their historical id-only namespace.
+  return rowsGeneration === undefined
+    ? `${kind}${rowId}`
+    : `${kind}${rowsGeneration}:${rowId}`
 }
 
-function reasoningRevealText(row: ChatRow, enabled: boolean): string {
-  return revealTextOf(`r${row.id}`, row.text, { enabled, active: row.streaming === true })
+/**
+ * Per-row reveal-read cache: the narration-stripped text and cursor key for
+ * the row's CURRENT text length. Every MessageList render reads these twice
+ * (layout signature + row mapping) for every visible row, and at the reveal
+ * cadence that is dozens of reads per second — recomputing stripNarration
+ * (an O(text) scan) and re-allocating the key template per read was pure
+ * waste on long sessions. Keyed by row id with an identity
+ * (`textRef`) + generation validity check — see the comment inside for why
+ * length-only validity is unsafe (channel settle replaces row.text without
+ * bumping the generation).
+ */
+type RevealRead = { textRef: string; gen: number | undefined; aKey: string; rKey: string; stripped: string }
+type RevealReadCache = Map<number, RevealRead>
+
+function revealReadFor(
+  row: ChatRow,
+  rowsGeneration: number | undefined,
+  cache: RevealReadCache,
+): RevealRead {
+  let entry = cache.get(row.id)
+  // Identity check, not length: channel settle REPLACES row.text wholesale
+  // (`row.text = text`) WITHOUT bumping rowsGeneration, so a same-length
+  // replacement must still miss — a length-only validity key would keep
+  // serving the OLD stripped text (stale row content) until the next
+  // length change. Strings are immutable (reference equality implies
+  // content equality) and every mutation path (chunk append, settle
+  // replace) allocates a new string, so this is exact AND cheaper than a
+  // length read. `gen` is defense-in-depth: the wholesale clear on
+  // generation change (in the render body below) already covers it, but a
+  // future reset-path refactor that misses a cache must degrade to a
+  // rebuild, never to stale content.
+  if (entry === undefined || entry.textRef !== row.text || entry.gen !== rowsGeneration) {
+    entry = {
+      textRef: row.text,
+      gen: rowsGeneration,
+      aKey: row.kind === 'assistant' ? textRevealKey('a', row.id, rowsGeneration) : '',
+      rKey: row.kind === 'reasoning' ? textRevealKey('r', row.id, rowsGeneration) : '',
+      stripped: row.kind === 'assistant' ? stripNarration(row.text) : row.text,
+    }
+    if (cache.size >= 5000) {
+      const oldest = cache.keys().next().value
+      if (oldest !== undefined) cache.delete(oldest)
+    }
+    cache.set(row.id, entry)
+  }
+  return entry
 }
 
 /** Display length only (layout signature; no slice allocation). */
-function revealDisplayLen(row: ChatRow, enabled: boolean): number {
+function revealDisplayLen(
+  row: ChatRow,
+  enabled: boolean,
+  rowsGeneration: number | undefined,
+  cache: RevealReadCache,
+): number {
   if (row.kind === 'assistant') {
-    const stripped = stripNarration(row.text)
-    return revealLengthOf(`a${row.id}`, stripped, {
+    const read = revealReadFor(row, rowsGeneration, cache)
+    return revealLengthOf(read.aKey, read.stripped, {
       enabled,
       active: row.streaming === true || row.fresh === true,
     })
   }
   if (row.kind === 'reasoning') {
-    return revealLengthOf(`r${row.id}`, row.text, { enabled, active: row.streaming === true })
+    const read = revealReadFor(row, rowsGeneration, cache)
+    return revealLengthOf(read.rKey, row.text, {
+      enabled,
+      active: row.streaming === true,
+    })
   }
   return row.text.length
 }
@@ -135,6 +190,7 @@ function signatureParts(
   failureHintRowId: number | null | undefined,
   failureHint: string | undefined,
   displayTextLen: number,
+  smoothRevealEnabled: boolean,
 ): Array<string | number | boolean> {
   signatureScratch.length = 0
   // Universal height inputs: width reflows every row; kind switches height
@@ -164,6 +220,9 @@ function signatureParts(
         // diffLayout changes the body's — without it, a /settings toggle
         // leaves already-mounted tool cards at their stale cached height.
         foldTerminalCommand,
+        // Inline mode retires reveal as soon as a later transcript row exists:
+        // native scrollback cannot rewrite a partially revealed earlier card.
+        smoothRevealEnabled,
         tool?.status ?? '',
         tool?.resultText?.length ?? 0,
         tool?.resultFull?.length ?? 0,
@@ -588,9 +647,27 @@ export function MessageList({
   // every scroll tick) allocates nothing. A joined string per row per
   // render was O(rows) garbage per tick (3200-row session ⇒ several MB/s
   // into minor GC; the GC share of the scroll profile).
+  // Native inline scrollback is immutable. Smooth reveal may therefore run
+  // only on the transcript tail there: when a later row appears, reading the
+  // old row with enabled=false snaps its cursor before that same commit can
+  // push the row out of the writable viewport. Alt-screen has no native
+  // scrollback and can keep revealing any mounted row normally.
+  const inlineRevealTailId = historyPaintEnabled ? visibleRows.at(-1)?.id : undefined
+  const smoothRevealForRow = (row: ChatRow): boolean =>
+    smoothStreaming && (!historyPaintEnabled || row.id === inlineRevealTailId)
   const sigRef = React.useRef(new Map<number, Array<string | number | boolean>>())
+  /** Per-row reveal-read cache (see revealReadFor) + scratch bit vector of
+   *  rows whose reveal cursor is still advancing — the virtualization remount
+   *  guards below skip those rows exactly like streaming rows. */
+  const revealReadRef = React.useRef<RevealReadCache>(new Map())
+  const revealBitsRef = React.useRef<Uint8Array>(new Uint8Array(0))
+  if (revealBitsRef.current.length < visibleRows.length) {
+    revealBitsRef.current = new Uint8Array(visibleRows.length)
+  }
+  const revealBits = revealBitsRef.current
   {
     const sigs = sigRef.current
+    const reads = revealReadRef.current
     for (let i = 0; i < visibleRows.length; i++) {
       const row = visibleRows[i]!
       // Per-kind signature: only the inputs that row's OWN renderer consumes.
@@ -599,6 +676,7 @@ export function MessageList({
       // reasoning height at once, remounting the widened window over rows
       // whose rendering never changed (Yoga spike + measure churn for
       // nothing). Base parts cover the universal height inputs.
+      const rowSmoothReveal = smoothRevealForRow(row)
       const parts = signatureParts(
         row,
         columns,
@@ -612,8 +690,14 @@ export function MessageList({
         model,
         failureHintRowId,
         failureHint,
-        revealDisplayLen(row, smoothStreaming),
+        revealDisplayLen(row, rowSmoothReveal, rowsGeneration, reads),
+        rowSmoothReveal,
       )
+      revealBits[i] = rowSmoothReveal &&
+        ((row.kind === 'assistant' && hasActiveReveal(revealReadFor(row, rowsGeneration, reads).aKey)) ||
+          (row.kind === 'reasoning' && hasActiveReveal(revealReadFor(row, rowsGeneration, reads).rKey)))
+        ? 1
+        : 0
       const cachedParts = sigs.get(row.id)
       let same = false
       if (cachedParts !== undefined && cachedParts.length === parts.length) {
@@ -794,8 +878,12 @@ export function MessageList({
     // user reading history (measured: 3s of streaming while scrolled up
     // burned 2.5s of yoga and +84MB heap). Its height is in flux anyway;
     // the final settle invalidates once more and remounts exactly once.
+    // Guard 2b: rows still REVEALING (cursor active, fresh-settled rows
+    // included) get the same skip — the reveal invalidates the signature
+    // every tick for the same in-flux-height reason, and the remount-per-
+    // tick re-lex was the smooth-streaming long-task stall.
     for (let i = 0; i < start; i++) {
-      if (visibleRows[i]!.streaming === true) continue
+      if (visibleRows[i]!.streaming === true || revealBits[i] === 1) continue
       const rowId = visibleRows[i]!.id
       if (!heightsRef.current.has(rowId) && paintedOnceRef.current.has(rowId)) {
         start = i
@@ -824,12 +912,12 @@ export function MessageList({
   // for the rationale and both guards): rows BELOW the window whose height
   // was just invalidated remount to re-measure, so bottomPad keeps real
   // geometry while the user reads scrolled-up content and the tail streams.
-  // Runs for non-sticky views; sticky mounts the tail anyway. Streaming
-  // rows are skipped — THIS loop is the measured hot path of the
-  // read-while-streaming stall (the streaming tail row sits below the
+  // Runs for non-sticky views; sticky mounts the tail anyway. Streaming and
+  // still-revealing rows are skipped — THIS loop is the measured hot path of
+  // the read-while-streaming stall (the streaming tail row sits below the
   // window and invalidated per chunk).
   for (let i = end; i < visibleRows.length; i++) {
-    if (visibleRows[i]!.streaming === true) continue
+    if (visibleRows[i]!.streaming === true || revealBits[i] === 1) continue
     const rowId = visibleRows[i]!.id
     if (!heightsRef.current.has(rowId) && paintedOnceRef.current.has(rowId)) end = i + 1
   }
@@ -930,6 +1018,7 @@ export function MessageList({
     heightsRef.current.clear()
     heightsVersionRef.current++
     sigRef.current.clear()
+    revealReadRef.current.clear()
     paintedOnceRef.current = new Set()
     paintedBaseRef.current = undefined
     baseRef.current = null
@@ -1175,27 +1264,50 @@ export function MessageList({
           const tool = row.tool
           const subagent = row.kind === 'subagent' ? row.subagent : undefined
           const job = row.kind === 'job' ? row.job : undefined
-          const revealVersion = smoothStreaming && row.kind === 'tool' && row.fresh === true &&
-            row.tool?.status === 'running' && row.tool.resultView === undefined
-            ? getRevealVersion()
-            : 0
+          const rowSmoothReveal = smoothRevealForRow(row)
+          // Gate the per-tick version on the card's OWN cursor: the global
+          // reveal version advances whenever ANY row reveals, and feeding it
+          // to every running fresh card re-rendered all of them at the tick
+          // cadence (parallel tool calls: the long-task fan-out stall). The
+          // card's first render creates its cursor itself, so 0 here never
+          // blocks creation — it only keeps finished/idle cards memoized.
+          let revealVersion = 0
+          if (
+            rowSmoothReveal && row.kind === 'tool' && row.fresh === true &&
+            row.tool?.status === 'running' && row.tool.resultView === undefined &&
+            tool?.callId !== undefined
+          ) {
+            const cardKey = toolRevealKey(rowsGeneration, tool.callId)
+            if (hasActiveReveal(cardKey) || hasActiveReveal(splitRevealKey(cardKey))) {
+              revealVersion = getRevealVersion()
+            }
+          }
           // Smooth reveal feeds the SAME flattened text prop a chunk feeds,
           // and keeps the streaming layout alive until the reveal catches up
           // (settling mid-reveal must not snap — a one-shot non-streaming
-          // delivery still paints as a flow).
+          // delivery still paints as a flow). The stripped text and cursor
+          // key come from the per-row cache (revealReadFor) — the same
+          // instance the signature loop read, so the reveal's append-basis
+          // compare stays reference-equal between the two reads.
           let displayText = row.text
           let displayStreaming = row.streaming === true
-          if (row.kind === 'assistant' && smoothStreaming) {
-            const stripped = stripNarration(row.text)
-            displayText = revealTextOf(`a${row.id}`, stripped, {
-              enabled: true,
-              active: displayStreaming || row.fresh === true,
-            })
-            displayStreaming = displayStreaming || displayText.length !== stripped.length
-          } else if (row.kind === 'assistant') {
-            displayText = stripNarration(row.text)
+          if (row.kind === 'assistant') {
+            const read = revealReadFor(row, rowsGeneration, revealReadRef.current)
+            if (smoothStreaming) {
+              displayText = revealTextOf(read.aKey, read.stripped, {
+                enabled: rowSmoothReveal,
+                active: displayStreaming || row.fresh === true,
+              })
+              displayStreaming = displayStreaming || displayText.length !== read.stripped.length
+            } else {
+              displayText = read.stripped
+            }
           } else if (row.kind === 'reasoning' && smoothStreaming) {
-            displayText = revealTextOf(`r${row.id}`, row.text, { enabled: true, active: displayStreaming })
+            const read = revealReadFor(row, rowsGeneration, revealReadRef.current)
+            displayText = revealTextOf(read.rKey, row.text, {
+              enabled: rowSmoothReveal,
+              active: displayStreaming,
+            })
           }
           return (
             <MemoRow
@@ -1217,9 +1329,10 @@ export function MessageList({
               thinkingFold={thinkingFold}
               toolBackground={toolBackground}
               foldTerminalCommand={foldTerminalCommand}
-              smoothStreaming={smoothStreaming}
+              smoothStreaming={rowSmoothReveal}
               fresh={row.fresh === true}
               revealVersion={revealVersion}
+              revealGeneration={rowsGeneration}
               activityFrames={activityFrames}
               background={rowBackground(row.id)}
               toolCallId={tool?.callId}
@@ -1286,6 +1399,8 @@ type MemoRowProps = {
   fresh: boolean
   /** Version tick for active tool reveal; 0 keeps settled rows memoized. */
   revealVersion: number
+  /** Transcript generation namespace for reveal cursor keys. */
+  revealGeneration: number | undefined
   thinkingFold: 'preview' | 'full'
   toolBackground: ToolBackground
   /** Terminal-card header folding (forwarded to tool cards). */
@@ -1362,6 +1477,7 @@ function TranscriptRow({
   smoothStreaming,
   fresh,
   revealVersion,
+  revealGeneration,
   thinkingFold,
   toolBackground,
   foldTerminalCommand,
@@ -1535,6 +1651,8 @@ function TranscriptRow({
             toolBackground={toolBackground}
             smoothReveal={smoothStreaming}
             fresh={fresh}
+            revealVersion={revealVersion}
+            revealGeneration={revealGeneration}
             foldTerminalCommand={foldTerminalCommand}
             onClick={foldOnClick}
             onOpenFile={onOpenFile}

--- a/src/components/SplitDiffView.tsx
+++ b/src/components/SplitDiffView.tsx
@@ -311,7 +311,7 @@ export function SplitDiffView({
   /**
    * Smooth-streaming participation (the card owning this view computes
    * eligibility): when present, the capped row list reveals line-by-line at
-   * the shared ~30fps cadence instead of painting as one block. The `+N
+   * the shared ~20fps cadence instead of painting as one block. The `+N
    * lines` fold hint stays rendered throughout — it describes the cap, not
    * the reveal.
    */

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -14,7 +14,7 @@ import { t } from '../../i18n.js'
 import type { ToolBackground } from '../../tuiDisplayPrefs.js'
 import type { Theme } from '../../theme.js'
 import type { ClickEvent } from '../../ink/events/click-event.js'
-import { revealLinesOf, snapReveal } from '../smoothReveal.js'
+import { revealLinesOf, snapReveal, splitRevealKey, toolRevealKey } from '../smoothReveal.js'
 import { useRevealVersion } from '../../hooks/useRevealVersion.js'
 
 type Props = {
@@ -62,7 +62,7 @@ type Props = {
   /**
    * Smooth streaming reveal (settings `dsh-tui.smoothStreaming`): the card
    * BODY (diff hunks / write content — model-authored prose, not tool
-   * output) paints through an even ~30fps line reveal when it first appears,
+   * output) paints through an even ~20fps line reveal when it first appears,
    * instead of one jarring block. Only the pending CALL view animates; the
    * settled result view paints complete (real output is progress, not
    * prose), and so do replayed cards.
@@ -73,6 +73,8 @@ type Props = {
   fresh?: boolean
   /** Reveal version supplied by MessageList to avoid one store subscriber per card. */
   revealVersion?: number
+  /** Transcript generation namespace; call ids may repeat after session reset. */
+  revealGeneration?: number
 }
 
 /** Tool display names: DSH emits lowercase tool ids (`bash`); Claude Code
@@ -482,6 +484,7 @@ export function AssistantToolUseMessage({
   smoothReveal = false,
   fresh = false,
   revealVersion,
+  revealGeneration,
 }: Props): React.ReactNode {
   // MessageList owns the single production subscription and passes a version
   // prop only to active reveal rows. Standalone consumers keep the fallback
@@ -568,15 +571,23 @@ export function AssistantToolUseMessage({
   const rendered: BodyLine[] =
     footnote === undefined ? lines : [...lines, { text: footnote, tone: 'hint' }]
   // Smooth reveal (line-unit, pending CALL body only): model-authored prose
-  // (diff hunks, write content) flows in at ~30fps; the settled RESULT view,
+  // (diff hunks, write content) flows in at ~20fps; the settled RESULT view,
   // error bodies, verbose/expanded cards, and replayed (non-fresh) cards all
   // paint complete. `snapReveal` on every non-revealable render retires a
   // cursor the moment its card stops qualifying (result arrived, user
   // expanded) — idempotent, safe during render.
-  const revealKey = `tool:${tool.callId}`
+  const revealKey = toolRevealKey(revealGeneration, tool.callId)
   const revealable = smoothReveal && !isError && isRunning && view !== undefined &&
     tool.resultView === undefined && !verbose && !isExpanded && fresh
-  if (!revealable) snapReveal(revealKey)
+  if (!revealable) {
+    // Retire BOTH cursors: the body cursor and the split-diff pane cursor.
+    // SplitDiffView stops reading its key once `reveal` is gone, so an
+    // unsnapped split cursor would drain in the background for dozens of
+    // ticks, keeping the shared timer and its per-tick MessageList renders
+    // alive for nothing.
+    snapReveal(revealKey)
+    snapReveal(splitRevealKey(revealKey))
+  }
   const revealedLineCount = revealable
     ? revealLinesOf(revealKey, rendered.length, { enabled: true, active: true })
     : rendered.length
@@ -646,7 +657,7 @@ export function AssistantToolUseMessage({
               maxRows={DIFF_BODY_MAX_LINES}
               verbose={verbose}
               toolBackground={ordinaryToolBackground}
-              reveal={revealable ? { key: `${revealKey}:split` } : undefined}
+              reveal={revealable ? { key: splitRevealKey(revealKey) } : undefined}
             />
           </Box>
         ) : (

--- a/src/components/smoothReveal.ts
+++ b/src/components/smoothReveal.ts
@@ -1,7 +1,7 @@
 /**
  * Smooth streaming reveal — decouples "text the provider has delivered" from
  * "text the screen is showing" (the oh-my-pi `display.smoothStreaming` idea,
- * see their `StreamingRevealController`). A shared ~30fps scheduler advances
+ * see their `StreamingRevealController`). A shared ~20fps scheduler advances
  * each reveal cursor by an adaptive catch-up step, so burst-delivered text (a
  * slow provider dumping a large batch, or a non-streaming response arriving
  * whole) paints as a brief even flow instead of one jarring jump, while
@@ -26,7 +26,8 @@
  * live here keyed by row identity, the READS happen during render (they feed
  * the same flattened `text` prop the streaming path already uses), and the
  * WRITES happen on the scheduler tick, which bumps a version that
- * MessageList subscribes to via useSyncExternalStore. A reveal therefore
+ * MessageList subscribes to through the DefaultLane useRevealVersion hook.
+ * A reveal therefore
  * rides the exact same update pipeline as an arriving chunk: prop change →
  * memo miss → re-render → post-commit measurement. Render-phase reads are
  * idempotent and safe to re-run (a discarded concurrent render at worst
@@ -36,12 +37,18 @@
  * unit per character). Surrogate pairs are never split (see {@link
  * safeSliceEnd}); grapheme clusters longer than a surrogate pair (emoji ZWJ
  * chains) may briefly show a partial cluster mid-reveal — transient frames
- * repaint within 33ms, and settled rendering is always the full text.
+ * repaint within ~50ms, and settled rendering is always the full text.
  */
 import { registerOverflowQuench, swallowNestedUpdateOverflow } from '../ink/update-overflow-guard.js'
 
-/** Reveal tick cadence — ~30fps, matching oh-my-pi's controller. */
-export const REVEAL_FRAME_MS = 1000 / 30
+/**
+ * Reveal tick cadence — ~20fps. 30fps (oh-my-pi's controller) measured as a
+ * ~2.2× multiplier on cumulative Yoga/layout work during long streamed turns
+ * (every tick drives a full React→Yoga→diff frame regardless of chunk
+ * cadence; probe-smooth-chat-perf). 20fps keeps the typewriter visually even
+ * while cutting the tick-driven frame budget by ~40%.
+ */
+export const REVEAL_FRAME_MS = 1000 / 20
 /** Minimum units (code units or lines) advanced per tick while work remains. */
 export const REVEAL_MIN_STEP = 3
 /** Catch-up bound: the reveal settles any backlog within this many frames. */
@@ -197,6 +204,33 @@ export function snapReveal(key: string): void {
   if (textCursors.delete(key) || countCursors.delete(key)) markRevealCompleted(key)
 }
 
+/**
+ * Whether a cursor for `key` is still advancing (created and not yet caught
+ * up). Callers gate per-row work on this: a row mid-reveal re-renders every
+ * tick, while rows without a cursor must stay memoized (the reveal version
+ * prop, virtualization remount guards). O(1) map lookups, no allocation.
+ */
+export function hasActiveReveal(key: string): boolean {
+  return textCursors.has(key) || countCursors.has(key)
+}
+
+/**
+ * Cursor-key constructors — the SINGLE source of truth for tool-card reveal
+ * keys. MessageList's per-card version gating and the card's own cursor
+ * reads MUST agree on these shapes (generation prefix + `:split` suffix);
+ * a drift between duplicated copies would silently freeze a card
+ * mid-reveal (cursor active but revealVersion stuck at 0), so every
+ * construction site goes through these exports.
+ */
+export function toolRevealKey(generation: number | undefined, callId: string): string {
+  return generation === undefined ? `tool:${callId}` : `tool:${generation}:${callId}`
+}
+
+/** The split-diff pane cursor key derived from the owning card's key. */
+export function splitRevealKey(cardKey: string): string {
+  return `${cardKey}:split`
+}
+
 // ---------------------------------------------------------------------------
 // Render-phase reads
 // ---------------------------------------------------------------------------
@@ -337,4 +371,9 @@ export function resetRevealForTest(): void {
 /** Whether the shared scheduler currently runs (refcount assertions). */
 export function isRevealTimerRunning(): boolean {
   return revealTimer !== undefined
+}
+
+/** Number of mounted reveal subscribers (test-only fanout invariant). */
+export function revealListenerCountForTest(): number {
+  return revealListeners.size
 }

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -882,10 +882,11 @@ export interface Channel {
    *  `dsh-tui.expandEditor`; on by default) — gates the ⛶ affordance and
    *  the expandEditor shortcut. */
   readonly expandEditor: boolean
-  /** Smooth streaming reveal (settings `dsh-tui.smoothStreaming`; on by
-   *  default): live-arriving assistant text, expanded thinking, and tool
-   *  call bodies paint through a ~30fps reveal instead of jumping per
-   *  provider burst. */
+  /** Smooth streaming reveal (settings `dsh-tui.smoothStreaming`; off by
+   *  default — the reveal's own frame cadence measurably multiplies layout
+   *  work on long streamed turns): live-arriving assistant text, expanded
+   *  thinking, and tool call bodies paint through a ~20fps reveal instead
+   *  of jumping per provider burst. */
   readonly smoothStreaming: boolean
   /** Live status-footer visibility and compactness preferences. */
   readonly statusBar: Readonly<StatusBarConfig>
@@ -3722,7 +3723,7 @@ export function createChannel(
     foldTerminalCommand: options.foldTerminalCommand === true,
     promptSessionLabel: options.promptSessionLabel === true,
     expandEditor: options.expandEditor !== false,
-    smoothStreaming: options.smoothStreaming !== false,
+    smoothStreaming: options.smoothStreaming === true,
     statusBar: normalizeStatusBar(options.statusBar),
     whale: options.whale !== false,
     minimal: options.minimal === true,

--- a/src/dsh-adapter/index.ts
+++ b/src/dsh-adapter/index.ts
@@ -114,8 +114,11 @@ export interface Config {
   expandEditor?: boolean
   /** Smooth streaming reveal (settings `dsh-tui.smoothStreaming`): live
    *  assistant text, expanded thinking, and tool call bodies paint through
-   *  a ~30fps reveal instead of jumping per provider burst — bursty or
-   *  one-shot deliveries read as an even flow. On by default. */
+   *  a ~20fps reveal instead of jumping per provider burst — bursty or
+   *  one-shot deliveries read as an even flow. Off by default: the reveal
+   *  drives frames at its own cadence and measurably multiplies layout work
+   *  on long streamed turns (the long-task lag report); opt in for the
+   *  typewriter feel. */
   smoothStreaming?: boolean
   /** Status-footer field visibility and compact presentation preferences. */
   statusBar?: Partial<StatusBarConfig>
@@ -163,7 +166,7 @@ export const Config: Schema<Config> = Schema.object({
   foldTerminalCommand: Schema.boolean().default(false),
   promptSessionLabel: Schema.boolean().default(false),
   expandEditor: Schema.boolean().default(true),
-  smoothStreaming: Schema.boolean().default(true),
+  smoothStreaming: Schema.boolean().default(false),
   statusBar: Schema.object({
     compact: Schema.boolean().default(DEFAULT_STATUS_BAR.compact),
     model: Schema.boolean().default(DEFAULT_STATUS_BAR.model),

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -616,7 +616,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
         // resolves `?? config.expandEditor ?? true` so cordis.yml stays
         // decisive while the user layer is unset.
         expandEditor: Schema.boolean(),
-        // Same no-default rule: applyDisplay resolves `?? config.smoothStreaming ?? true`.
+        // Same no-default rule: applyDisplay resolves `?? config.smoothStreaming ?? false`.
         smoothStreaming: Schema.boolean(),
         statusBar: Schema.object({
           compact: Schema.boolean().default(DEFAULT_STATUS_BAR.compact),
@@ -718,7 +718,7 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
       channel.setFoldTerminalCommand(value.foldTerminalCommand ?? config.foldTerminalCommand ?? false)
       channel.setPromptSessionLabel(value.promptSessionLabel ?? config.promptSessionLabel ?? false)
       channel.setExpandEditor(value.expandEditor ?? config.expandEditor ?? true)
-      channel.setSmoothStreaming(value.smoothStreaming ?? config.smoothStreaming ?? true)
+      channel.setSmoothStreaming(value.smoothStreaming ?? config.smoothStreaming ?? false)
       channel.setStatusBar(normalizeStatusBar(value.statusBar ?? config.statusBar))
     }
     // Shortcut overrides resolve per action: settings user layer wins over
@@ -1036,12 +1036,12 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
           path: ['smoothStreaming'],
           label: 'Smooth streaming',
           descriptions: { zh: '流式平滑输出' },
-          hint: 'Reveal live replies, expanded thinking, and tool-call bodies through an even ~30fps flow instead of per-burst jumps; one-shot non-streaming replies paint as a flow too. Replay/history always paints complete. On by default.',
-          hintDescriptions: { zh: '把实时回复、展开的思考与工具卡正文按 ~30fps 匀速揭示，不再随供应商突发一跳一跳；一次性到达的非流式回复也会平滑打出。回放/历史内容始终完整直出。默认开启。' },
+          hint: 'Reveal live replies, expanded thinking, and tool-call bodies through an even ~20fps flow instead of per-burst jumps; one-shot non-streaming replies paint as a flow too. Replay/history always paints complete. Off by default: the reveal renders at its own cadence and can feel laggy during long streamed turns on slower terminals — turn it on for the typewriter feel.',
+          hintDescriptions: { zh: '把实时回复、展开的思考与工具卡正文按 ~20fps 匀速揭示，不再随供应商突发一跳一跳；一次性到达的非流式回复也会平滑打出。回放/历史内容始终完整直出。默认关闭：揭示按自身节奏持续渲染，长流式任务在较慢终端上可能感到卡顿；喜欢打字机效果可手动开启。' },
           kind: 'boolean',
           format(value: unknown): string {
-            // Unset in settings.yaml: the effective default is on.
-            return String(typeof value === 'boolean' ? value : config.smoothStreaming !== false)
+            // Unset in settings.yaml: the effective default is off.
+            return String(typeof value === 'boolean' ? value : config.smoothStreaming === true)
           },
         },
         {

--- a/src/hooks/useRevealVersion.ts
+++ b/src/hooks/useRevealVersion.ts
@@ -2,14 +2,14 @@ import React from 'react'
 import { getRevealVersion, subscribeReveal } from '../components/smoothReveal.js'
 
 /**
- * Reveal-frame wakeup as a React hook — bumps once per advancing ~30fps
+ * Reveal-frame wakeup as a React hook — bumps once per advancing ~20fps
  * scheduler tick so consumers re-run their render-phase cursor reads
  * ({@link revealTextOf}/{@link revealLinesOf}) and feed fresh slices through
  * the MemoRow prop pipeline. The returned number is a render trigger only;
  * its value carries no meaning.
  *
  * Deliberately NOT useSyncExternalStore: a store change forces a SYNCLANE
- * re-render (forceStoreRerender hardcodes lane 2), and at 30fps that sync
+ * re-render (forceStoreRerender hardcodes lane 2), and at 20fps that sync
  * render preempts/discards whatever DefaultLane streaming render is in
  * flight. Every such sync commit then ends with Default work still pending,
  * which React's commit-end lane accounting counts as a NESTED update —


### PR DESCRIPTION
## 根因

用户报告「长任务开启平滑流式很卡，一关马上恢复」。探针实测（scripts/probe-smooth-chat-perf，headless xterm 真管线 + onFrame 相位遥测 + 20ms 哨兵定时器）：reveal 游标以自身 30fps 节奏驱动完整 React→Yoga→diff 提交，与 chunk 节奏无关——Chat 级负载下 smooth ON 使累计 yoga 量 ×2.1（39.5s vs 18.9s）、帧数 +40%、measure 调用 +39%。行级虚拟化窗口本身无恙（帧均值 <1ms），放大器在**提交频次 × 提交成本**。

## 改动

1. **降频**：`REVEAL_FRAME_MS` 33→50ms（~20fps，tick 帧预算 -40%，打字机观感不变）
2. **揭示读取记忆化**（`revealReadFor`）：stripNarration 的 O(text) 扫描与 key 模板分配按行缓存；签名循环与行映射共享同一 stripped 实例。有效性检查用 **textRef 引用判等 + generation 双查**——channel settle 会整体替换 `row.text` 而不 bump rowsGeneration，仅按长度判等会在同长替换时持续供给旧 stripped 文本（审查修复）
3. **虚拟化重挂载守卫 2b**：游标仍在推进的行与 streaming 行同跳过重挂载（fresh-settled 行揭示期间每 tick 重挂载重测是卡顿主源）；settle 后恰好一次重挂载回正高度
4. **工具卡门控收敛**：revealVersion 只传给自身游标活跃的卡（`hasActiveReveal`，消除并行工具卡的全局版本扇出）；cursor key 构造收敛到 smoothReveal.ts 单一出口 `toolRevealKey`/`splitRevealKey`（此前三处模板漂移会静默冻结卡片）；非 revealable 时双键 snap（body + `:split`）
5. **默认关闭**（用户明示偏好「每个用户更新后默认关闭」）：Schema.default(false) + channel `===true` + plugin `??false` 三处一致；显式设置过的用户保留其选择；docs/user-guide 同步

## 验证

- `verify-smooth-reveal` 全过（含 B5/C4 generation 复用回归、D1 订阅数=1、E 组 inline tail-only snap 语义）
- channel-ui 组 55/55；render-scroll 组 41/43（2 失败为已登记预存 osc8/goal-todo，零回归）
- `pnpm build` 全绿（i18n 994 条目）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Smooth streaming is now disabled by default and can be enabled as an opt-in typewriter effect.
  - Reveal animations now run at approximately 20 FPS instead of 30 FPS.
  - Improved reveal behavior for reused transcript and tool rows, inline scrollback, virtualized content, and split-diff views.
  - Prevented stale reveal state from affecting newly generated content and improved long-session performance.

- **Documentation**
  - Updated settings and component guidance to describe the opt-in behavior, revised timing, and potential lag on slower terminals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->