### PR TITLE
fix(ink): 全屏残影第三轮——最小化恢复表面重建、Windows 栈禁用 DECSTBM、背压恢复阈值

### DIFF
--- a/scripts/repro-backpressure-final-frame.tsx
+++ b/scripts/repro-backpressure-final-frame.tsx
@@ -1,0 +1,298 @@
+/**
+ * #713 backpressure × Smooth Streaming final-frame regression.
+ *
+ * A skipped terminal write must not consume the DOM renderer's dirty state.
+ * React commits and renderNodeToOutput can finish while stdout is gated; if the
+ * producer then becomes idle (a one-shot update, or a reveal cursor catching
+ * up and stopping its timer), the drain render is the ONLY remaining frame.
+ * It must rebuild from the current DOM rather than blitting the last-written
+ * frontFrame back over the skipped candidate.
+ *
+ * Run: node --import tsx/esm scripts/repro-backpressure-final-frame.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+
+const [
+  { PassThrough, Writable },
+  React,
+  { Terminal: XTerm },
+  { render, AlternateScreen, Text, useInput },
+  { default: instances },
+  { getRevealVersion, isRevealTimerRunning, resetRevealForTest, revealTextOf },
+  { useRevealVersion },
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/ink/instances.js'),
+  import('../src/components/smoothReveal.js'),
+  import('../src/hooks/useRevealVersion.js'),
+])
+
+const COLS = 100
+const ROWS = 24
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+async function until(ok: () => boolean, budgetMs = 5_000, stepMs = 25): Promise<boolean> {
+  const started = Date.now()
+  while (Date.now() - started < budgetMs) {
+    if (ok()) return true
+    await sleep(stepMs)
+  }
+  return ok()
+}
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures += 1
+}
+
+function KeepAlive(): React.ReactElement | null {
+  useInput(() => {})
+  return null
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  ref(): this { return this }
+  unref(): this { return this }
+}
+
+class ControlledStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  reportedBacklog = 0
+  readonly writes: string[] = []
+  constructor(readonly term: InstanceType<typeof XTerm>) {
+    super()
+    // Ink reads writableLength as an additional gate. Keep Node's real
+    // Writable mechanics untouched while exposing a deterministic synthetic
+    // backlog to the renderer.
+    Object.defineProperty(this, 'writableLength', {
+      configurable: true,
+      get: () => this.reportedBacklog,
+    })
+  }
+  override _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+    const text = String(chunk)
+    this.writes.push(text)
+    this.term.write(text, callback)
+  }
+}
+
+function screenText(term: InstanceType<typeof XTerm>): string {
+  const buffer = term.buffer.active
+  return Array.from({ length: term.rows }, (_, y) =>
+    buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '',
+  ).join('\n')
+}
+
+function gateRenderer(stdout: ControlledStdout, ink: any): void {
+  stdout.reportedBacklog = 9_001
+  ink.backpressured = true
+}
+
+function releaseRenderer(stdout: ControlledStdout): void {
+  stdout.reportedBacklog = 0
+  stdout.emit('drain')
+}
+
+// ---------------------------------------------------------------------------
+// A. One-shot React update: no producer exists after the skipped commit.
+// ---------------------------------------------------------------------------
+{
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const stdout = new ControlledStdout(term)
+  const stdin = new FakeStdin()
+  let updateText: React.Dispatch<React.SetStateAction<string>> = () => {}
+  function OneShot(): React.ReactElement {
+    const [value, setValue] = React.useState('BEFORE-ONE-SHOT')
+    updateText = setValue
+    return <Text>{value}</Text>
+  }
+  const instance = await render(
+    <AlternateScreen>
+      <OneShot />
+      <KeepAlive />
+    </AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stdout as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  check('A0 initial frame reached terminal', await until(() => screenText(term).includes('BEFORE-ONE-SHOT')))
+  const ink = instances.get(stdout) as any
+  check('A0 Ink instance found', ink !== undefined)
+
+  gateRenderer(stdout, ink)
+  updateText('AFTER-ONE-SHOT-FINAL')
+  await sleep(150)
+  check('A1 final commit was gated',
+    ink.backpressured === true && !screenText(term).includes('AFTER-ONE-SHOT-FINAL'))
+  check('A1 drain listener armed', stdout.listenerCount('drain') === 1,
+    `listeners=${stdout.listenerCount('drain')}`)
+
+  releaseRenderer(stdout)
+  check('A2 drain paints the one-shot final DOM',
+    await until(() => screenText(term).includes('AFTER-ONE-SHOT-FINAL'), 2_000),
+    JSON.stringify(screenText(term).slice(0, 80)))
+
+  await instance.unmount()
+  term.dispose()
+}
+
+// ---------------------------------------------------------------------------
+// B. Smooth reveal catches up while gated, then retires its only timer.
+// ---------------------------------------------------------------------------
+{
+  resetRevealForTest()
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const stdout = new ControlledStdout(term)
+  const stdin = new FakeStdin()
+  const target = 'x'.repeat(2_000)
+  function SmoothFinal(): React.ReactElement {
+    useRevealVersion()
+    const shown = revealTextOf('backpressure-final', target, { enabled: true, active: true })
+    return (
+      <>
+        <Text>STATIC-CHROME-TOP</Text>
+        <Text>{`REVEAL-LEN=${shown.length}/${target.length}`}</Text>
+        <Text>STATIC-CHROME-BOTTOM</Text>
+      </>
+    )
+  }
+  const instance = await render(
+    <AlternateScreen>
+      <SmoothFinal />
+      <KeepAlive />
+    </AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stdout as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  check('B0 initial smooth frame reached terminal',
+    await until(() => screenText(term).includes('REVEAL-LEN=')))
+  const ink = instances.get(stdout) as any
+  gateRenderer(stdout, ink)
+
+  check('B1 reveal advances while stdout is gated',
+    await until(() => getRevealVersion() > 3, 2_000),
+    `version=${getRevealVersion()}`)
+  check('B1 reveal timer retires after catching up',
+    await until(() => !isRevealTimerRunning(), 5_000),
+    `version=${getRevealVersion()}`)
+  await sleep(100)
+  check('B1 terminal still lacks the skipped final reveal',
+    !screenText(term).includes(`REVEAL-LEN=${target.length}/${target.length}`))
+
+  releaseRenderer(stdout)
+  check('B2 drain paints final reveal after its timer retired',
+    await until(() => screenText(term).includes(`REVEAL-LEN=${target.length}/${target.length}`), 2_000),
+    JSON.stringify(screenText(term).split('\n').slice(0, 4)))
+  check('B3 static chrome remains correctly placed',
+    screenText(term).includes('STATIC-CHROME-TOP') && screenText(term).includes('STATIC-CHROME-BOTTOM'))
+
+  await instance.unmount()
+  term.dispose()
+  resetRevealForTest()
+}
+
+// ---------------------------------------------------------------------------
+// C. A long blocked terminal is itself a restore/surface-uncertainty signal.
+// ---------------------------------------------------------------------------
+{
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const stdout = new ControlledStdout(term)
+  const stdin = new FakeStdin()
+  let updateText: React.Dispatch<React.SetStateAction<string>> = () => {}
+  function StaticChrome(): React.ReactElement {
+    const [value, setValue] = React.useState('DYNAMIC-BEFORE')
+    updateText = setValue
+    return (
+      <>
+        <Text>STATIC-SURFACE-TOP</Text>
+        <Text>{value}</Text>
+        <Text>STATIC-SURFACE-BOTTOM</Text>
+      </>
+    )
+  }
+  const instance = await render(
+    <AlternateScreen>
+      <StaticChrome />
+      <KeepAlive />
+    </AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stdout as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  check('C0 initial static surface reached terminal',
+    await until(() => screenText(term).includes('STATIC-SURFACE-BOTTOM')))
+  const ink = instances.get(stdout) as any
+  gateRenderer(stdout, ink)
+  updateText('DYNAMIC-AFTER')
+  check('C0 long-stall clock armed by the skipped frame',
+    await until(() => ink.backpressureStartedAt !== null, 1_000))
+  await sleep(1_200)
+  await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HPHYSICAL-SURFACE-STALE', resolve))
+  stdout.writes.length = 0
+
+  releaseRenderer(stdout)
+  check('C1 long drain triggers alt-surface health recovery',
+    await until(() => stdout.writes.some(write => write.includes('\x1b[?1049$p')), 1_000),
+    `writes=${stdout.writes.length}`)
+  // Headless xterm does not answer DECRQM/DA1. The extra DA1 covers the
+  // startup XTVERSION sentinel when it is still ahead in the querier FIFO.
+  stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c')
+  check('C2 long drain rebuilds unchanged static cells too',
+    await until(() => {
+      const text = screenText(term)
+      return text.includes('STATIC-SURFACE-TOP') &&
+        text.includes('DYNAMIC-AFTER') &&
+        text.includes('STATIC-SURFACE-BOTTOM') &&
+        !text.includes('PHYSICAL-SURFACE-STALE')
+    }, 3_000),
+    JSON.stringify(screenText(term).split('\n').slice(0, 5)))
+
+  await instance.unmount()
+  term.dispose()
+}
+
+// ---------------------------------------------------------------------------
+// D. Same-size restore must supersede a stale backpressure latch immediately.
+// ---------------------------------------------------------------------------
+{
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const stdout = new ControlledStdout(term)
+  const stdin = new FakeStdin()
+  const instance = await render(
+    <AlternateScreen>
+      <Text>SAME-SIZE-BACKPRESSURE-SURFACE</Text>
+      <KeepAlive />
+    </AlternateScreen>,
+    { stdout: stdout as any, stdin: stdin as any, stderr: stdout as any, exitOnCtrlC: false, patchConsole: false },
+  )
+  check('D0 initial same-size surface reached terminal',
+    await until(() => screenText(term).includes('SAME-SIZE-BACKPRESSURE-SURFACE')))
+  const ink = instances.get(stdout) as any
+  gateRenderer(stdout, ink)
+  await sleep(80)
+  await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HSAME-SIZE-STALE', resolve))
+  stdout.reportedBacklog = 0
+  stdout.writes.length = 0
+  stdout.emit('resize')
+  await sleep(80)
+  check('D1 same-size restore clears stale backpressure latch before repaint',
+    ink.backpressured === false,
+    `backpressured=${String(ink.backpressured)}`)
+  check('D1 same-size restore starts surface query',
+    stdout.writes.some(write => write.includes('\x1b[?1049$p')))
+  stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c')
+  check('D2 same-size restore repaints without waiting for drain backoff',
+    await until(() => {
+      const text = screenText(term)
+      return text.includes('SAME-SIZE-BACKPRESSURE-SURFACE') && !text.includes('SAME-SIZE-STALE')
+    }, 1_000))
+
+  await instance.unmount()
+  term.dispose()
+}
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} check(s) failed`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/repro-fullscreen-ghost.tsx
+++ b/scripts/repro-fullscreen-ghost.tsx
@@ -12,6 +12,9 @@
  */
 process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'WezTerm'  // DEC-2026 同步输出，使 DECSTBM 滚动优化生效
+// Windows 终端栈默认禁用 DECSTBM（全屏残影类）；本复现的目的正是验证
+// DECSTBM 快速路径自身的模型一致性，强制开启。
+process.env.DSH_TUI_FORCE_DECSTBM = '1'
 process.env.DSH_TUI_THEME = 'dark'
 
 const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([

--- a/scripts/repro-fullscreen-selfheal.tsx
+++ b/scripts/repro-fullscreen-selfheal.tsx
@@ -15,20 +15,26 @@
  * 用 headless xterm 验证（xterm 的 buffer.active.type 如实反映 1049 状态）：
  *   1. 挂载 AlternateScreen → xterm 进入 alternate buffer；
  *   2. term.reset() 模拟 conpty 模式重置 → buffer 掉回 normal；
- *   3. 注入 FOCUS_IN + 伪造 DECRPM "1049;2 reset" 应答 → 应用写回
- *      1049h + 2J → buffer 恢复 alternate；
- *   4. 反向：DECRPM 回答 "set"(1) 时不重进（不出现新的 2J）。
+ *   3. 发出「尺寸未变」的 resize（终端最小化→恢复的现场形态）+ 伪造
+ *      DECRPM "1049;2 reset" 应答 → 应用写回 1049h + 2J、完整重绘；
+ *   4. 查询在途的增量提交不泄漏到 main；1049=set 时原 buffer 全帧修复；
+ *   5. 0×0/FOCUS_IN/>5s gap 都能补全静态层；inline 走 viewport 重锚。
  *
  * 运行：node --import tsx/esm scripts/repro-fullscreen-selfheal.tsx
  */
 process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
+// Exercise the Windows Terminal DEC-2026 path on every CI host. The field
+// failure happens under WT_SESSION, where ED2 inside a synchronized block is
+// not equivalent to Ctrl+L's proven out-of-band clear.
+process.env.WT_SESSION ??= 'repro-fullscreen-selfheal'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen, Text, useInput }] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen, Text, useInput }, { default: instances }] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
+  import('../src/ink/instances.js'),
 ])
 
 /** 输入管线开关：App 的 stdin 读循环随 raw-mode（useInput 消费者）启用，
@@ -40,6 +46,27 @@ function KeepAlive(): React.ReactElement {
 
 const COLS = 80, ROWS = 24
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+/** Poll a positive condition (CI-load tolerant) instead of a fixed window. */
+async function until(ok: () => boolean, budgetMs = 4_000, stepMs = 30): Promise<boolean> {
+  const t0 = Date.now()
+  while (Date.now() - t0 < budgetMs) {
+    if (ok()) return true
+    await sleep(stepMs)
+  }
+  return ok()
+}
+/** Resolve the querier's pending queue (headless xterm never answers), so a
+ *  leftover query from an unanswered scenario cannot eat the next scenario's
+ *  injected DECRPM reply (querier FIFO first-match). */
+function drainQuerier(): void {
+  const q = (instances.get(stdout) as any)?.app?.querier
+  if (!q) return
+  for (const p of q.queue.splice(0)) {
+    if (p.kind === 'query') p.resolve(undefined)
+    else p.resolve()
+    p.releaseRawMode?.()
+  }
+}
 let failed = 0
 function check(name: string, ok: boolean, extra = '') {
   console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
@@ -71,18 +98,37 @@ const inst = await render(
   { stdout: stdout as any, stdin: stdin as any, stderr: stdout as any, exitOnCtrlC: false, patchConsole: false },
 )
 await sleep(500)
+const screenText = () => {
+  const buffer = term.buffer.active
+  return Array.from({ length: term.rows }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+}
 check('挂载后 xterm 进入 alternate buffer', term.buffer.active.type === 'alternate', term.buffer.active.type)
+check('挂载后内容完整', screenText().includes('probe'))
 
-// 模拟 conpty 模式重置：term.reset() 把 xterm 一切归零（含 1049）
+// 模拟 conpty 模式重置：term.reset() 把 xterm 一切归零（含 1049 / 1004 / 2004）。
 writes.length = 0
 term.reset()
 check('term.reset() 后 buffer 掉回 normal（模拟 conpty 重置）', term.buffer.active.type === 'normal', term.buffer.active.type)
 
-// 焦点回窗 → 触发探测；伪造 DECRPM 应答 1049;2（reset）
-stdin.write('\x1b[I') // FOCUS_IN
+// Windows Terminal 最小化→恢复常发出一个「尺寸未变」的 resize。若把它当
+// no-op 丢掉，1049 已掉而应用仍以为在 alt，后续增量帧就会画进 main buffer。
+stdout.emit('resize')
 await sleep(150)
-check('FOCUS_IN 后发出 DECRQM 1049 探测', writes.some(w => w.includes('\x1b[?1049$p')),
+check('同尺寸 resize 后发出 DECRQM 1049 探测', writes.some(w => w.includes('\x1b[?1049$p')),
   writes.filter(w => w.includes('$p')).map(w => JSON.stringify(w)).join(' ').slice(0, 60))
+check('同尺寸 resize 重断言 focus/paste 模式',
+  writes.some(w => w.includes('\x1b[?1004h')) && writes.some(w => w.includes('\x1b[?2004h')))
+// 查询在途期间模拟鲸鱼/状态栏动画提交。物理终端已掉进 main 时，这个
+// 增量帧必须被合并，不能把局部内容写进主屏/scrollback。
+inst.rerender(
+  <AlternateScreen>
+    <Text>probe-next</Text>
+    <KeepAlive />
+  </AlternateScreen>,
+)
+await sleep(100)
+check('1049 查询在途不向 main 泄漏增量帧',
+  term.buffer.active.type === 'normal' && !screenText().includes('probe-next') && !writes.some(w => w.includes('probe-next')))
 // DECRPM: mode 1049 status 2 (reset)。DA1 哨兵应答 ×2：第一枚被启动时
 // XTVERSION 探针的未决哨兵吃掉（headless xterm 不回 XTVERSION/DA1，
 // 真终端永远会答，故真机不堆积），第二枚才收尾本探测的 flush。
@@ -96,16 +142,341 @@ check('收到 reset 应答后重进 alt-screen（1049h + 2J）',
   term.buffer.active.type === 'alternate',
   `type=${term.buffer.active.type}`)
 check('重进时带鼠标跟踪重断言', writes.some(w => w.includes('\x1b[?1000h') || w.includes('\x1b[?1006h')))
+check('重进后同一恢复事务完整重绘最新内容', screenText().includes('probe-next'), JSON.stringify(screenText().slice(0, 80)))
 
-// 反向：再触发一次探测，应答 set(1) → 不得出现新的清屏重进
+// 1049 仍健康、但物理像素面被终端 renderer 弄脏：同尺寸 resize 应做
+// 全帧刷新，不得重进 1049（避免 iTerm2 的重复-enter 清屏副作用）。
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HSTALE-SURFACE', resolve))
+writes.length = 0
+stdout.emit('resize')
+await sleep(150)
+check('健康同尺寸 resize 仍探测 1049', writes.some(w => w.includes('\x1b[?1049$p')))
+stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c')
+await sleep(400)
+check('1049=set 时不重复进入 alt', !writes.some(w => w.includes('\x1b[?1049h')))
+check('1049=set 后全帧修复脏 surface',
+  term.buffer.active.type === 'alternate' && screenText().includes('probe-next') && !screenText().includes('STALE-SURFACE'))
+// Ctrl+L fixes the field corruption because its ED2 runs outside DEC-2026.
+// Automatic recovery must use the same WT-safe boundary: an ED2 enclosed by
+// BSU/ESU can leave the viewport/surface partially stale on Windows Terminal.
+const surfaceFrame = writes.find(w => w.includes('\x1b[2J') && w.includes('probe-next')) ?? ''
+const surfaceEraseAt = surfaceFrame.indexOf('\x1b[2J')
+const surfaceOpenBefore = surfaceFrame.lastIndexOf('\x1b[?2026h', surfaceEraseAt)
+const surfaceCloseBefore = surfaceFrame.lastIndexOf('\x1b[?2026l', surfaceEraseAt)
+check('WT surface 恢复的 ED2 位于同步块外',
+  surfaceEraseAt >= 0 && (surfaceOpenBefore < 0 || surfaceCloseBefore > surfaceOpenBefore),
+  JSON.stringify(surfaceFrame.slice(Math.max(0, surfaceEraseAt - 30), surfaceEraseAt + 30)))
+
+// 最小化期间 ConPTY 可能短暂报告 0×0。不得把它替换成构造期的 80×24
+// fallback 并画一帧；保留最后有效布局，恢复到正尺寸后再做一次完整刷新。
+writes.length = 0
+stdout.columns = 0
+stdout.rows = 0
+stdout.emit('resize')
+inst.rerender(
+  <AlternateScreen>
+    <Text>probe-after-minimize</Text>
+    <KeepAlive />
+  </AlternateScreen>,
+)
+await sleep(120)
+check('0×0 最小化窗口不写合成尺寸帧',
+  writes.length === 0 && !screenText().includes('probe-after-minimize'), `writes=${writes.length}`)
+const RESTORED_COLS = COLS + 7
+const RESTORED_ROWS = ROWS + 3
+term.resize(RESTORED_COLS, RESTORED_ROWS)
+stdout.columns = RESTORED_COLS
+stdout.rows = RESTORED_ROWS
+stdout.emit('resize')
+await sleep(150)
+check('0×0→新尺寸恢复后触发 surface 健康探测', writes.some(w => w.includes('\x1b[?1049$p')))
+stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c')
+await sleep(400)
+check('0×0→新尺寸恢复后完整绘出最新帧',
+  term.cols === RESTORED_COLS && term.rows === RESTORED_ROWS &&
+  term.buffer.active.type === 'alternate' && screenText().includes('probe-after-minimize'))
+
+// The common minimize shape is 0×0 → the SAME original dimensions. Preserve
+// bypassRefreshDedupe through the same-size branch: it must bypass the 250ms
+// benign-signal dedupe and render the React changes accumulated while writes
+// were suppressed. Pin lastSurfaceRefreshAt to expose the otherwise timing-
+// dependent loss deterministically.
+drainQuerier()
+stdout.columns = 0
+stdout.rows = 0
+stdout.emit('resize')
+inst.rerender(
+  <AlternateScreen>
+    <Text>probe-same-size-restore</Text>
+    <KeepAlive />
+  </AlternateScreen>,
+)
+await sleep(100)
+stdout.columns = RESTORED_COLS
+stdout.rows = RESTORED_ROWS
+const sameSizeInk = instances.get(stdout) as any
+sameSizeInk.lastSurfaceRefreshAt = Date.now()
+writes.length = 0
+stdout.emit('resize')
+await sleep(150)
+check('0×0→同尺寸恢复绕过去抖并触发探测', writes.some(w => w.includes('\x1b[?1049$p')))
+stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c')
+await sleep(400)
+check('0×0→同尺寸恢复绘出最小化期间最新帧', screenText().includes('probe-same-size-restore'))
+
+// 有些终端恢复焦点但尺寸完全不变、也不发 resize。FOCUS_IN 本身就是
+// surface 恢复边界：1049=set 时不重复 enter，但必须完整重绘脏像素面。
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HFOCUS-STALE', resolve))
 writes.length = 0
 stdin.write('\x1b[I')
 await sleep(150)
+check('无 resize 的 FOCUS_IN 触发 surface 健康探测', writes.some(w => w.includes('\x1b[?1049$p')))
 stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c') // status 1 = set（双 DA1 同理）
 await sleep(400)
-check('应答 set 时不重进（无 2J）', !writes.some(w => w.includes('\x1b[2J')))
-check('buffer 保持 alternate', term.buffer.active.type === 'alternate')
+check('FOCUS_IN + 1049=set 不重复进入 alt', !writes.some(w => w.includes('\x1b[?1049h')))
+check('FOCUS_IN 无 resize 仍完整修复 surface',
+  term.buffer.active.type === 'alternate' && screenText().includes('probe-same-size-restore') && !screenText().includes('FOCUS-STALE'))
+
+const ink = instances.get(stdout) as any
+// Bootstrap paradox: the terminal may deliver FOCUS_OUT, then lose DECSET
+// 1004 while minimized, so FOCUS_IN never arrives. Any later real user input
+// proves focus returned and must synthesize the missing strong surface signal.
+// Keep the stdin gap deliberately short: this exercises focus-state recovery,
+// not the independent >5s fallback below.
+drainQuerier()
+await sleep(300)
+stdin.write('\x1b[O')
+await sleep(80)
+ink.app.lastStdinTime = Date.now()
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HNO-FOCUS-KEY-STALE', resolve))
+writes.length = 0
+stdin.write('y')
+await sleep(150)
+check('FOCUS_IN 丢失后首个普通键升级为 surface 恢复',
+  (ink.app as any).pendingFocusProbe === false && (ink as any).altScreenSurfaceRecoveryPending === true)
+stdin.write('\x1b[?1049;1$y\x1b[?1049;1$y\x1b[?c\x1b[?c')
+check('FOCUS_IN 丢失后普通键完整修复 surface',
+  await until(() => screenText().includes('probe-same-size-restore') && !screenText().includes('NO-FOCUS-KEY-STALE'), 3_000))
+
+// Same bootstrap gap for mouse-only use. ParsedMouse used to continue before
+// the generic focus failsafe, so hover could probe 1049=set forever without
+// ever requesting a repaint of unchanged cells.
+drainQuerier()
+await sleep(300)
+stdin.write('\x1b[O')
+await sleep(80)
+ink.app.lastStdinTime = Date.now()
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HNO-FOCUS-MOUSE-STALE', resolve))
+writes.length = 0
+stdin.write('\x1b[<35;6;6M')
+await sleep(150)
+check('FOCUS_IN 丢失后首个 hover 升级为 surface 恢复',
+  (ink as any).altScreenSurfaceRecoveryPending === true)
+stdin.write('\x1b[?1049;1$y\x1b[?1049;1$y\x1b[?c\x1b[?c')
+check('FOCUS_IN 丢失后 hover 完整修复 surface',
+  await until(() => screenText().includes('probe-same-size-restore') && !screenText().includes('NO-FOCUS-MOUSE-STALE'), 3_000))
+drainQuerier()
+await sleep(300)
+
+// focus/resize 模式都被 renderer reset 吞掉时，最小化期间累积的 >5s stdin
+// gap 是最后信号。首个普通键会先走交互 probe，再在 batch tail 触发强制
+// surface refresh；静态输入框/Todo/页边距必须在这一拍恢复。
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HGAP-STALE', resolve))
+ink.app.lastStdinTime = Date.now() - 6_000
+writes.length = 0
+stdin.write('x')
+await sleep(150)
+check('>5s gap 后首个普通键触发 surface 健康探测', writes.some(w => w.includes('\x1b[?1049$p')))
+stdin.write('\x1b[?1049;1$y\x1b[?1049;1$y\x1b[?c\x1b[?c')
+await sleep(400)
+check('>5s gap 恢复完整重绘静态 surface',
+  screenText().includes('probe-same-size-restore') && !screenText().includes('GAP-STALE'))
+
+// 0×0 期间若 PTY 在恢复正尺寸时漏发 resize，FOCUS_IN 也必须先同步尺寸
+// 状态，再走同尺寸 surface 恢复；静态页面不能永远卡在 unavailable。
+writes.length = 0
+stdout.columns = 0
+stdout.rows = 0
+stdout.emit('resize')
+inst.rerender(
+  <AlternateScreen>
+    <Text>probe-focus-zero</Text>
+    <KeepAlive />
+  </AlternateScreen>,
+)
+await sleep(100)
+stdout.columns = RESTORED_COLS
+stdout.rows = RESTORED_ROWS
+stdin.write('\x1b[I') // 故意不 emit('resize')
+await sleep(150)
+check('0×0→正尺寸漏 resize 时 FOCUS_IN 补触发探测', writes.some(w => w.includes('\x1b[?1049$p')))
+stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c')
+await sleep(400)
+check('0×0→正尺寸漏 resize 时 FOCUS_IN 完整绘出', screenText().includes('probe-focus-zero'))
+
+// Apple Terminal 不能安全接收 DECRQM（会把尾字节 p 打到屏幕）：同尺寸
+// 恢复直接在当前 alt buffer 全绘，既不探测也不盲目重复 1049h。
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HAPPLE-STALE', resolve))
+const savedTermProgram = process.env.TERM_PROGRAM
+process.env.TERM_PROGRAM = 'Apple_Terminal'
+writes.length = 0
+stdout.emit('resize')
+await sleep(200)
+if (savedTermProgram === undefined) delete process.env.TERM_PROGRAM
+else process.env.TERM_PROGRAM = savedTermProgram
+check('不支持 DECRQM 的终端零探测字节', !writes.some(w => w.includes('\x1b[?1049$p')))
+check('不支持 DECRQM 的终端仍完整修复 surface',
+  term.buffer.active.type === 'alternate' && screenText().includes('probe-focus-zero') && !screenText().includes('APPLE-STALE'))
+
+// 失联 multiplexer 连 DA1 都不回时，surface gate 也不能永久冻结。1s
+// fallback 在当前 buffer 全绘；迟到的明确 reset 回包仍可在后续补做 re-entry。
+// （等待窗口须超出 consecutive-refresh 去抖窗口，Apple 场景刚完成一次刷新。）
+await sleep(150)
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HNO-DA1-STALE', resolve))
+writes.length = 0
+stdout.emit('resize')
+check('DECRQM/DA1 无应答时 bounded fallback 解冻并全绘',
+  await until(() => screenText().includes('probe-focus-zero') && !screenText().includes('NO-DA1-STALE'), 3_000))
+
+// 上一个场景故意不回包，其查询仍挂在 querier 队列里；排空后再注入，防止
+// FIFO first-match 吃掉本场景的健康回复（静默退化保护）。
+drainQuerier()
+// NO-DA1 的兜底刷新刚完成：越过 consecutive-refresh 去抖窗口再触发新恢复。
+await sleep(300)
+
+// 门闩自愈回归：refreshSurface 查询无应答期间，任意普通探针（hover/键）
+// 的健康回复（1049=set）必须完成在途恢复并释放渲染门闩——此前只有 reset
+// 回复或兜底计时器能清闸，健康终端上持续打字会永久冻结 UI。
+await new Promise<void>(resolve => term.write('\x1b[2J\x1b[HHEAL-STALE', resolve))
+writes.length = 0
+stdout.emit('resize')
+await sleep(150)
+check('无应答恢复期间门闩已置位', writes.some(w => w.includes('\x1b[?1049$p')))
+await sleep(300) // 越过 250ms 交互节流，让 hover 普通探针真正发出查询
+stdin.write('\x1b[<35;5;5M') // hover → 普通探针（skipMouseReassert）
+await sleep(150)
+stdin.write('\x1b[?1049;1$y\x1b[?c\x1b[?c') // set 回复完成普通探针
+check('普通探针健康回复完成在途恢复',
+  await until(() => screenText().includes('probe-focus-zero') && !screenText().includes('HEAL-STALE'), 3_000))
+writes.length = 0
+inst.rerender(
+  <AlternateScreen>
+    <Text>heal-next</Text>
+    <KeepAlive />
+  </AlternateScreen>,
+)
+check('健康回复后渲染门闩已释放',
+  await until(() => screenText().includes('heal-next'), 3_000))
+
+// A destructive/manual redraw supersedes not only an in-flight query gate but
+// also a strong probe that was deferred before it could start (for example,
+// resize during a held gesture). It must not resurrect an obsolete recovery
+// after Ctrl+L has already rebuilt the surface.
+ink.pendingProbeRequest = { refreshSurface: true, bypassRefreshDedupe: true }
+ink.forceRedraw()
+check('Ctrl+L 取消尚未启动的延期 surface probe', ink.pendingProbeRequest === undefined)
 
 await inst.unmount()
+
+// 恢复发生在「完全静态」的画面上（无动画、无 React 变化提交）：全绘的
+// erase 已就绪但没有可写的 diff。恢复必须让下一次内容帧全屏重画，而不是
+// 把屏幕留在空白（回归：帧重置后 erase 悬空、空 diff 直接跳过写）。
+const staticTerm = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+const staticWrites: string[] = []
+class StaticStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    staticWrites.push(String(chunk))
+    staticTerm.write(String(chunk), cb)
+  }
+}
+const staticStdout = new StaticStdout()
+const staticInk = await render(
+  <AlternateScreen>
+    <Text>static-probe</Text>
+    <KeepAlive />
+  </AlternateScreen>,
+  { stdout: staticStdout as any, stdin: new FakeStdin() as any, stderr: staticStdout as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(300)
+const staticText = () => {
+  const buffer = staticTerm.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+}
+check('static 挂载内容完整', staticText().includes('static-probe'))
+await new Promise<void>(resolve => staticTerm.write('\x1b[2J\x1b[HSTATIC-STALE', resolve))
+staticWrites.length = 0
+staticStdout.emit('resize')
+await sleep(200)
+check('static 同尺寸恢复发出健康探测', staticWrites.some(w => w.includes('\x1b[?1049$p')))
+// 无 DA1 应答：1s 兜底在当前 buffer 全绘（refreshAltScreenSurface）。
+check('static 空 diff 恢复后画面不空白且脏像素消失',
+  await until(() => staticText().includes('static-probe') && !staticText().includes('STATIC-STALE'), 3_000))
+
+// A genuinely blank target has zero cell diff against resetFramesForAltScreen's
+// blank baseline. needsEraseBeforePaint itself must make the frame write-worthy;
+// otherwise the physical garbage survives forever because no content patch
+// exists to enter the old `hasDiff` branch.
+staticInk.rerender(
+  <AlternateScreen>
+    <KeepAlive />
+  </AlternateScreen>,
+)
+await sleep(250)
+await new Promise<void>(resolve => staticTerm.write('\x1b[2J\x1b[HBLANK-TARGET-STALE', resolve))
+staticWrites.length = 0
+staticStdout.emit('resize')
+check('全空白目标仍消费 recovery erase',
+  await until(() => !staticText().includes('BLANK-TARGET-STALE') && staticWrites.some(w => w.includes('\x1b[2J')), 3_000))
+await staticInk.unmount()
+staticTerm.dispose()
+
+// Inline/main-screen 同样把「尺寸未变」resize 当成物理 surface 失效信号，
+// 但不能碰 1049 或清原生 scrollback：走绝对 viewport-home 重锚全绘。
+const inlineTerm = new XTerm({ cols: COLS, rows: ROWS, scrollback: 100, allowProposedApi: true })
+const inlineWrites: string[] = []
+class InlineStdout extends Writable {
+  columns = COLS; rows = ROWS; isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) {
+    inlineWrites.push(String(chunk))
+    inlineTerm.write(String(chunk), cb)
+  }
+}
+const inlineStdout = new InlineStdout()
+const inlineStdin = new FakeStdin()
+const inline = await render(
+  <>
+    <Text>inline-probe</Text>
+    <KeepAlive />
+  </>,
+  { stdout: inlineStdout as any, stdin: inlineStdin as any, stderr: inlineStdout as any, exitOnCtrlC: false, patchConsole: false },
+)
+await sleep(300)
+const inlineText = () => {
+  const buffer = inlineTerm.buffer.active
+  return Array.from({ length: ROWS }, (_, y) => buffer.getLine(buffer.baseY + y)?.translateToString(true) ?? '').join('\n')
+}
+check('inline 初始内容完整', inlineText().includes('inline-probe'))
+// FOCUS_IN is a physical-surface boundary in inline mode too. Previously the
+// Ink callback returned early outside alt-screen, even though the existing
+// viewport re-anchor is exactly the safe full-repaint primitive needed here.
+await new Promise<void>(resolve => inlineTerm.write('\x1b[2J\x1b[HINLINE-FOCUS-STALE', resolve))
+inlineWrites.length = 0
+inlineStdin.write('\x1b[I')
+await sleep(250)
+check('inline 无 resize 的 FOCUS_IN 全帧重锚',
+  inlineText().includes('inline-probe') && !inlineText().includes('INLINE-FOCUS-STALE'))
+
+await new Promise<void>(resolve => inlineTerm.write('\x1b[2J\x1b[HINLINE-STALE', resolve))
+inlineWrites.length = 0
+inlineStdout.emit('resize')
+await sleep(250)
+check('inline 同尺寸恢复用全帧重锚修复 surface',
+  inlineText().includes('inline-probe') && !inlineText().includes('INLINE-STALE'))
+check('inline 恢复不进入 1049', !inlineWrites.some(w => w.includes('\x1b[?1049h')))
+await inline.unmount()
+inlineTerm.dispose()
+term.dispose()
+
 console.log(failed === 0 ? '\nALL PASS' : `\n${failed} 项失败`)
 process.exit(failed === 0 ? 0 : 1)

--- a/scripts/repro-long-output.tsx
+++ b/scripts/repro-long-output.tsx
@@ -11,6 +11,7 @@
  */
 process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'WezTerm'  // force DEC-2026 path (SYNC_OUTPUT_SUPPORTED=true) so the DECSTBM scroll-hint optimization fires
+process.env.DSH_TUI_FORCE_DECSTBM = '1'  // Windows 终端栈默认禁用 DECSTBM；本取证脚本观测该优化路径
 
 const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
   import('node:stream'),

--- a/scripts/repro-streaming.tsx
+++ b/scripts/repro-streaming.tsx
@@ -11,6 +11,7 @@
  */
 process.env.FORCE_COLOR = '3'
 process.env.TERM_PROGRAM = 'WezTerm'  // force DEC-2026 path (SYNC_OUTPUT_SUPPORTED=true) so the DECSTBM scroll-hint optimization fires
+process.env.DSH_TUI_FORCE_DECSTBM = '1'  // Windows 终端栈默认禁用 DECSTBM；本取证脚本观测该优化路径
 
 const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render, AlternateScreen }, { Chat }, { QuestionStore }] = await Promise.all([
   import('node:stream'),

--- a/scripts/repro-user-drag-wheel-render.tsx
+++ b/scripts/repro-user-drag-wheel-render.tsx
@@ -17,6 +17,10 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 process.env.DSH_TUI_LANG = 'zh'
 process.env.WT_SESSION = 'headless-windows-terminal-probe'
+// Windows 终端栈已默认禁用 DECSTBM（全屏残影类，见 hasDecstbmScrollBug）；
+// 本复现验证的是"选区污染帧不得喂进 DECSTBM 快路径"这一独立守卫，强制
+// 开启 DECSTBM 才能观测到该守卫的效果。
+process.env.DSH_TUI_FORCE_DECSTBM = '1'
 delete process.env.TERM_PROGRAM
 delete process.env.TMUX
 

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -74,6 +74,17 @@ const GROUPS = {
 // shrunk 帧冻结的旧 scrollTop 与失准的 clamp 边界越过内容底，整屏裁剪
 // 成"只剩输入框"（Orca pane 宽度抖动的现场取证复现）。
     ["repro-resize-blank", ['node', '--import', 'tsx/esm', 'scripts/repro-resize-blank.tsx']],
+// DECSTBM Windows 终端栈门禁回归：四组 required 全跑 ubuntu（win32 半支
+// 不可测）、Windows lane 只 import、repro 全带 FORCE 绕门——删门时这里是
+// 唯一会红的防线（WT 排除 + FORCE 仅绕 Windows 门不弱化 sync/JediTerm）。
+    ["verify-decstbm-gate", ['node', '--import', 'tsx/esm', 'scripts/verify-decstbm-gate.tsx']],
+// 最小化→恢复回归：Windows Terminal/conpty 可只发「尺寸未变」resize，
+// 同时丢 1049/focus/paste 或弄脏物理 surface。恢复查询期间不得把鲸鱼/
+// 状态栏增量帧写进 main；reset→重进并立即全绘，set→原 buffer 全绘。
+    ["repro-fullscreen-selfheal", ['node', '--import', 'tsx/esm', 'scripts/repro-fullscreen-selfheal.tsx']],
+// #713 背压门控 × Smooth Streaming：跳写帧已经消费 DOM dirty，drain
+// 重试不得把旧 frontFrame blit 回去；即使 reveal 已追平并停表，终帧也要落盘。
+    ["repro-backpressure-final-frame", ['node', '--import', 'tsx/esm', 'scripts/repro-backpressure-final-frame.tsx']],
 // 空转重渲染风暴回归（issue #433）：长历史 + 30ms 空转 commit 风暴下
 // renderScrollTop / 画面 / 输入框行数必须逐帧恒定，几何不震荡。
     ["repro-idle-oscillation", ['node', '--import', 'tsx/esm', 'scripts/repro-idle-oscillation.tsx']],

--- a/scripts/verify-decstbm-gate.tsx
+++ b/scripts/verify-decstbm-gate.tsx
@@ -1,0 +1,109 @@
+/**
+ * DECSTBM Windows-terminal-stack gate — regression probes.
+ *
+ * The `win32 || WT_SESSION` exclusion in hasDecstbmScrollBug() has no other
+ * CI coverage: all four required groups run on ubuntu (process.platform is
+ * read-only, so the win32 half cannot be exercised there), the Windows
+ * platform-smoke lane only installs and imports, and every repro script
+ * sets DSH_TUI_FORCE_DECSTBM=1 — which bypasses this very gate. Deleting
+ * the gate would leave every CI run green; these probes are its defense.
+ *
+ * Env probes run in spawned subprocesses (each import re-evaluates the
+ * module-load SYNC constant and the live env reads), complete in seconds,
+ * and need no terminal UI. Inherited env keys that could skew the
+ * sync/JediTerm halves (tmux, kitty, Zed, VTE, a host WT_SESSION, leftover
+ * FORCE) are scrubbed so the probes stay honest on any host.
+ */
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+type Probe = { jet: boolean; sync: boolean; decstbm: boolean }
+
+// Keys that could skew isSynchronizedOutputSupported / JediTerm detection
+// in the child. Scrubbed before overrides are applied.
+const SCRUB_KEYS = [
+  'TMUX',
+  'KITTY_WINDOW_ID',
+  'ZED_TERM',
+  'VTE_VERSION',
+  'WT_SESSION',
+  'DSH_TUI_FORCE_DECSTBM',
+  'TERMINAL_EMULATOR',
+  'TERM_PROGRAM',
+] as const
+
+function probeEnv(overrides: Record<string, string>): Probe {
+  const terminalUrl = new URL('../src/ink/terminal.ts', import.meta.url).href
+  const src = `
+    const { isJetBrainsIdeTerminal, isSynchronizedOutputSupported, isDecstbmSafe } = await import(${JSON.stringify(terminalUrl)})
+    console.log(JSON.stringify({
+      jet: isJetBrainsIdeTerminal(),
+      sync: isSynchronizedOutputSupported(),
+      decstbm: isDecstbmSafe(),
+    }))
+  `
+  const env: NodeJS.ProcessEnv = { ...process.env, TERM: 'xterm-256color' }
+  for (const key of SCRUB_KEYS) delete env[key]
+  Object.assign(env, overrides)
+  const res = spawnSync(process.execPath, ['--import', 'tsx/esm', '-e', src], {
+    cwd: repoRoot,
+    env,
+    encoding: 'utf8',
+  })
+  if (res.status !== 0) throw new Error(`probe failed: ${res.stderr}`)
+  return JSON.parse(res.stdout.trim().split('\n').at(-1) ?? '{}') as Probe
+}
+
+// 1. The gate itself: WT_SESSION must exclude DECSTBM even with DEC 2026
+//    support — one mis-applied region scroll shifts static chrome forever
+//    (the persistent fullscreen-ghost class this gate exists to prevent).
+const wt = probeEnv({ TERM_PROGRAM: 'WezTerm', WT_SESSION: 'ci-wt-session' })
+check('WT_SESSION stack: sync on, DECSTBM excluded', wt.sync && !wt.decstbm)
+
+// 2. The bypass env re-enables the fast path on that stack …
+const wtForced = probeEnv({
+  TERM_PROGRAM: 'WezTerm',
+  WT_SESSION: 'ci-wt-session',
+  DSH_TUI_FORCE_DECSTBM: '1',
+})
+check('DSH_TUI_FORCE_DECSTBM bypasses the Windows gate', wtForced.sync && wtForced.decstbm)
+
+// 3. … WITHOUT weakening the JediTerm gate (the "only" in the bypass
+//    contract, pinned: a global FORCE would turn this red).
+const jbForced = probeEnv({
+  TERMINAL_EMULATOR: 'JetBrains-JediTerm',
+  WT_SESSION: 'ci-wt-session',
+  DSH_TUI_FORCE_DECSTBM: '1',
+})
+check('FORCE does not weaken the JediTerm gate', jbForced.sync && jbForced.jet && !jbForced.decstbm)
+
+// 4. … and without weakening the sync gate (a no-sync terminal stays
+//    excluded even with FORCE set).
+const noSyncForced = probeEnv({ DSH_TUI_FORCE_DECSTBM: '1' })
+check('FORCE does not weaken the sync gate', !noSyncForced.sync && !noSyncForced.decstbm)
+
+// 5. Baseline: a terminal without DEC 2026 never takes the fast path.
+const plain = probeEnv({})
+check('unknown terminal: no sync, no DECSTBM', !plain.sync && !plain.decstbm)
+
+// 6. The win32 half of the gate (process.platform === 'win32') cannot be
+//    asserted on linux CI — process.platform is read-only. Its coverage is
+//    the Windows platform-smoke lane importing this module plus local runs
+//    on Windows dev machines; recorded so nobody mistakes ubuntu green for
+//    full-gate coverage.
+check('win32 half documented (not assertable on this platform)', true, `platform=${process.platform}`)
+
+console.log('')
+if (failed > 0) {
+  console.error(`verify-decstbm-gate: ${failed} FAILURE(S)`)
+  process.exit(1)
+}
+console.log('verify-decstbm-gate: ALL PASS')

--- a/scripts/verify-drag-protocol.tsx
+++ b/scripts/verify-drag-protocol.tsx
@@ -644,7 +644,11 @@ type AppInternals = {
   }
 }
 type InkInternals = {
-  pendingProbeRequest: { skipMouseReassert?: boolean } | undefined
+  pendingProbeRequest: {
+    skipMouseReassert?: boolean
+    refreshSurface?: boolean
+    bypassRefreshDedupe?: boolean
+  } | undefined
   pendingAltScreenReentry: boolean
   pointerGestureActive: boolean
   protocolCandidateActive: boolean
@@ -847,7 +851,11 @@ check('场景渲染：DRAGPAD/PLAIN 标记定位', padPos.col >= 0 && plainPos.c
 }
 {
   // I6b: 松手后闩解除——FOCUS_IN 探测恢复盲写（证明闩不是永久禁用探测，
-  // conpty 自愈路径仍然可用）。
+  // conpty 自愈路径仍然可用）。I6 的 focus 已在 release tail 发出一个
+  // refreshSurface 查询；headless 不自动回答，先按测试惯例排空并让其
+  // completion 全帧刷新落定，再测下一次独立 focus。
+  drainQuerier()
+  await sleep(30)
   await sleep(300) // 再次冷却节流，确保本次 focus 必触发
   const mark = stdoutWrites.length
   stdin.write('\x1b[I')

--- a/scripts/verify-jediterm.tsx
+++ b/scripts/verify-jediterm.tsx
@@ -61,9 +61,19 @@ function probeEnv(env: Record<string, string | undefined>): { jet: boolean; sync
       decstbm: isDecstbmSafe(),
     }))
   `
+  // Scrub inherited keys that could skew the sync/JediTerm halves (tmux,
+  // kitty, Zed, VTE, a host WT_SESSION, leftover FORCE), then apply the
+  // caller's overrides — undefined values mean "leave unset".
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, TERM: 'xterm-256color' }
+  for (const key of ['TMUX', 'KITTY_WINDOW_ID', 'ZED_TERM', 'VTE_VERSION', 'WT_SESSION', 'DSH_TUI_FORCE_DECSTBM', 'TERMINAL_EMULATOR', 'TERM_PROGRAM']) {
+    delete childEnv[key]
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) childEnv[key] = value
+  }
   const res = spawnSync(process.execPath, ['--import', 'tsx/esm', '-e', src], {
     cwd: repoRoot,
-    env: { ...process.env, ...env },
+    env: childEnv,
     encoding: 'utf8',
   })
   if (res.status !== 0) throw new Error(`probe failed: ${res.stderr}`)
@@ -75,7 +85,18 @@ check('JetBrains env detected via TERMINAL_EMULATOR', jb.jet)
 check('sync output enabled for JediTerm', jb.sync)
 check('DECSTBM excluded for JediTerm', jb.sync && !jb.decstbm)
 
-const vscode = probeEnv({ TERMINAL_EMULATOR: '', TERM_PROGRAM: 'vscode' })
+// The Windows-terminal-stack gate: WT_SESSION must exclude DECSTBM even with
+// DEC 2026 support (the persistent fullscreen-ghost class — one mis-applied
+// region scroll shifts static chrome forever). The bypass env re-enables it
+// without weakening the sync/JediTerm gates.
+const wt = probeEnv({ TERMINAL_EMULATOR: '', TERM_PROGRAM: 'WezTerm', WT_SESSION: '1', DSH_TUI_FORCE_DECSTBM: undefined })
+check('Windows Terminal stack: sync on, DECSTBM excluded', wt.sync && !wt.decstbm)
+const wtForced = probeEnv({ TERMINAL_EMULATOR: '', TERM_PROGRAM: 'WezTerm', WT_SESSION: '1', DSH_TUI_FORCE_DECSTBM: '1' })
+check('DSH_TUI_FORCE_DECSTBM bypasses the Windows gate only', wtForced.sync && wtForced.decstbm)
+
+// VS Code is exercised through the force bypass: on Windows dev machines the
+// probe's real platform would otherwise (correctly) exclude DECSTBM.
+const vscode = probeEnv({ TERMINAL_EMULATOR: '', TERM_PROGRAM: 'vscode', DSH_TUI_FORCE_DECSTBM: '1' })
 check('VS Code still sync + DECSTBM', vscode.sync && vscode.decstbm)
 
 const plain = probeEnv({ TERMINAL_EMULATOR: '', TERM_PROGRAM: '' })

--- a/src/ink/components/App.tsx
+++ b/src/ink/components/App.tsx
@@ -177,9 +177,9 @@ type Props = {
 	// fullscreen) re-enters alt-screen + mouse tracking. Idempotent on the
 	// terminal side. Optional so testing.tsx doesn't need to stub it.
 	readonly onStdinResume?: () => void;
-	// Called on DECSET-1004 focus events. Ink probes the alt-screen/mouse
-	// mode state on refocus — the moment a conpty-side mode reset (DPI
-	// change, renderer restart) becomes observable — and self-heals.
+	// Called on DECSET-1004 focus events and on a synthesized refocus when
+	// real user input arrives while focus is still known blurred. Ink probes
+	// the alt-screen/mouse mode state and rebuilds the physical surface.
 	readonly onTerminalFocus?: (focused: boolean) => void;
 	// Receives the declared native-cursor position from useDeclaredCursor
 	// so ink.tsx can park the terminal cursor there after each frame.
@@ -333,6 +333,25 @@ export default class App extends PureComponent<Props, State> {
 					session.startRow,
 				),
 			);
+		}
+	}
+
+	/**
+	 * Settle pointer state owned by the OLD terminal-focus epoch. A release can
+	 * be swallowed while the window is unfocused; retaining that physical latch
+	 * would block every recovery probe forever. Call when a focus epoch ends,
+	 * or before synthetic recovery starts a new one, so a later press can
+	 * establish a fresh latch normally.
+	 */
+	settlePointerGestureForFocusBoundary(): void {
+		this.heldButtons = 0;
+		this.ambiguousHeld = false;
+		this.props.onPointerGestureChange?.(false);
+		this.finishDragSession();
+		const sel = this.props.selection;
+		if (sel.isDragging) {
+			finishSelection(sel);
+			this.props.onSelectionChange();
 		}
 	}
 
@@ -1008,6 +1027,21 @@ function processKeysInBatch(
 			continue;
 		}
 
+		// FOCUS_IN can disappear after a terminal reset drops DECSET 1004. Any
+		// subsequent real user input is equivalent proof that focus returned.
+		// Promote that first key/paste/mouse event to the same batch-tail surface
+		// recovery as an explicit FOCUS_IN. This check must precede the mouse
+		// branch: ParsedMouse used to `continue` before the old key-only failsafe,
+		// leaving mouse-only users on a stale surface indefinitely.
+		const isExplicitFocusSignal =
+			item.kind === "key" &&
+			(item.sequence === FOCUS_IN || item.sequence === FOCUS_OUT);
+		if (!isExplicitFocusSignal && !getTerminalFocused()) {
+			app.settlePointerGestureForFocusBoundary();
+			app.handleTerminalFocus(true);
+			app.pendingFocusProbe = true;
+		}
+
 		// Mouse click/drag events update selection state (fullscreen only).
 		// Terminal sends 1-indexed col/row; convert to 0-indexed for the
 		// screen buffer. Button bit 0x20 = drag (motion while button held).
@@ -1037,37 +1071,22 @@ function processKeysInBatch(
 		}
 		if (sequence === FOCUS_OUT) {
 			app.handleTerminalFocus(false);
-			// Gesture latch: focus loss means no release event is coming for
-			// a held button (released outside the window or swallowed by the
-			// OS) — clear the held-button set so the health probe may write
-			// again.
-			app.heldButtons = 0;
-			app.ambiguousHeld = false;
-			app.props.onPointerGestureChange?.(false);
-			// Drag protocol: focus loss also orphans an in-flight drag
-			// session — settle it with a dragend (if started) like the
-			// selection recovery below.
-			app.finishDragSession();
-			// Defensive: if we lost the release event (mouse released outside
-			// terminal window — some emulators drop it rather than capturing the
-			// pointer), focus-out is the next observable signal that the drag is
-			// over. Without this, drag-to-scroll's timer runs until the scroll
-			// boundary is hit.
-			if (app.props.selection.isDragging) {
-				finishSelection(app.props.selection);
-				app.props.onSelectionChange();
-			}
+			// Ink-side pointer-state reset (hover highlights, tooltip dwell,
+			// multi-click chain, no-interest cache): pointer geometry is stale
+			// once the window loses focus — minimize/alt-tab — and clearing it
+			// NOW (invisible while unfocused) keeps the restore repaint from
+			// resurrecting pre-focus-loss highlights at stale coordinates.
+			app.props.onTerminalFocus?.(false);
+			// A focus boundary terminates the old physical gesture even when
+			// its release was swallowed outside the window. Shared with synthetic
+			// focus recovery so no stale latch can strand later probes.
+			app.settlePointerGestureForFocusBoundary();
 			// Safe boundary: mark the batch for a deferred drain at the batch
 			// tail (not mid-batch — see release's finally).
 			app.pendingReleaseTail = true;
 			const event = new TerminalFocusEvent("terminalblur");
 			app.internal_eventEmitter.emit("terminalblur", event);
 			continue;
-		}
-
-		// Failsafe: if we receive input, the terminal must be focused
-		if (!getTerminalFocused()) {
-			setTerminalFocused(true);
 		}
 
 		// Handle Ctrl+Z (suspend) using parsed key to support both raw (\x1a) and

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -42,7 +42,7 @@ import { applySearchHighlight } from './searchHighlight.js';
 import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, pickFollowForSelection, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, shiftSelectionForViewportResize, shiftSelectionForViewportTranslation, startSelection, updateSelection } from './selection.js';
 import { isDecstbmSafe, SYNC_OUTPUT_SUPPORTED, serializeDiff, supportsDecrqmProbe, supportsExtendedKeys, supportsWin32InputMode, type Terminal, writeDiffToTerminal } from './terminal.js';
 import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, DISABLE_WIN32_INPUT_MODE, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ENABLE_WIN32_INPUT_MODE, ERASE_SCREEN, ERASE_SCROLLBACK, SGR_RESET } from './termio/csi.js';
-import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
+import { DBP, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec.js';
 import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, setClipboard, supportsTabStatus, wrapForMultiplexer } from './termio/osc.js';
 import { decrqm } from './terminal-querier.js';
 import { TerminalWriteProvider } from './useTerminalNotification.js';
@@ -55,13 +55,35 @@ const ALT_SCREEN_ANCHOR_CURSOR = Object.freeze({
   y: 0,
   visible: false
 });
+const ALT_SCREEN_SURFACE_RECOVERY_TIMEOUT_MS = 1000;
+/** A terminal that accepted no new frame for this long may have been hidden,
+ *  detached, or renderer-reset. Its first drain is a surface boundary, not
+ *  merely permission to resume incremental diffs.
+ *
+ *  250ms (was 1000ms): while the write gate holds, frames are SKIPPED and
+ *  the physical surface may apply partial/congested byte streams in ways the
+ *  diff baseline cannot model (ConPTY buffering while the window is hidden,
+ *  a mis-applied scroll). Resuming with an incremental delta against a
+ *  possibly-diverged surface PERSERVES that divergence forever on static
+ *  rows (the fullscreen ghost class). One full erase+repaint per congestion
+ *  episode heals it; the 250ms floor matches the surface-refresh dedupe
+ *  window so sub-second congestion bursts cannot spam full repaints. */
+const BACKPRESSURE_SURFACE_RECOVERY_MS = 250;
+/** Dedupe window for consecutive benign full-surface refresh signals
+ *  (window-settle resize bursts, resize+FOCUS_IN pairs, a stdin-gap refresh
+ *  right after either). Full restore-from-invalid refreshes bypass it. */
+const ALT_SCREEN_SURFACE_REFRESH_DEDUPE_MS = 250;
 const CURSOR_HOME_PATCH = Object.freeze({
   type: 'stdout' as const,
   content: CURSOR_HOME
 });
 const ERASE_THEN_HOME_PATCH = Object.freeze({
-  type: 'stdout' as const,
-  content: ERASE_SCREEN + CURSOR_HOME
+  // `clearTerminal` makes serializeDiff close DEC-2026 before ED2 and reopen
+  // it for the paint. Windows Terminal can leave a partially stale viewport
+  // when ED2 itself is enclosed by BSU/ESU; Ctrl+L succeeds because its clear
+  // is outside that block. Keep clear+paint in the same stdout.write call.
+  type: 'clearTerminal' as const,
+  reason: 'clear' as const,
 });
 
 // Cached per-Ink-instance, invalidated on resize. frame.cursor.y for
@@ -72,6 +94,14 @@ function makeAltScreenParkPatch(terminalRows: number) {
     content: cursorPosition(terminalRows, 1)
   });
 }
+
+/** A minimized ConPTY may temporarily report 0/undefined dimensions. */
+function positiveTerminalDimension(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
 export type Options = {
   stdout: NodeJS.WriteStream;
   stdin: NodeJS.ReadStream;
@@ -129,6 +159,9 @@ export default class Ink {
   private readonly unsubscribeTTYHandlers?: () => void;
   private terminalColumns: number;
   private terminalRows: number;
+  // Minimize can make ConPTY expose 0×0/undefined temporarily. Keep the last
+  // valid layout and suppress frame writes until a positive size returns.
+  private terminalSizeUnavailable = false;
   /** Columns the Yoga root was last constrained with (see onComputeLayout). */
   private lastLayoutColumns = -1;
   private currentNode: ReactNode = null;
@@ -143,6 +176,9 @@ export default class Ink {
   private drainListener: (() => void) | null = null;
   /** Fallback re-probe delay while backpressured (bounded backoff). */
   private drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
+  /** Start of the current uninterrupted output stall. A long stall makes the
+   *  physical terminal surface untrustworthy even when virtual frames agree. */
+  private backpressureStartedAt: number | null = null;
   // Every scheduled microtask carries the generation that created it. Immediate
   // renders invalidate older trailing work before it can append an old frame.
   private renderGeneration = 0;
@@ -208,18 +244,35 @@ export default class Ink {
     columns: number;
     rows: number;
   } | null = null;
-  // True when the previous frame's screen buffer cannot be trusted for
-  // blit — selection overlay mutated it, resetFramesForAltScreen()
-  // replaced it with blanks, or forceRedraw() reset it to 0×0. Forces
-  // one full-render frame; steady-state frames after clear it and regain
-  // the blit + narrow-damage fast path.
+  // True when renderer blitting cannot be trusted — selection overlay
+  // mutated the previous screen, a reset replaced it with blanks/0×0, or a
+  // backpressure-skipped candidate consumed DOM dirty flags without becoming
+  // the terminal baseline. Forces one full-render frame; a successful clean
+  // frame clears it and regains the blit + narrow-damage fast path.
   private prevFrameContaminated = false;
-  // Set by handleResize: prepend ERASE_SCREEN to the next onRender's patches
-  // INSIDE the BSU/ESU block so clear+paint is atomic. Writing ERASE_SCREEN
-  // synchronously in handleResize would leave the screen blank for the ~80ms
-  // render() takes; deferring into the atomic block means old content stays
-  // visible until the new frame is fully ready.
+  // Set by handleResize/recovery: prepend a `clearTerminal` patch to the next
+  // onRender. serializeDiff keeps it in the SAME stdout.write as the repaint,
+  // but executes ED2 outside DEC-2026 (Windows Terminal can leave stale cells
+  // when ED2 is enclosed by BSU/ESU), then reopens sync for the content paint.
+  // Deferring until the frame is ready also avoids a long clear→paint gap.
   private needsEraseBeforePaint = false;
+  // A same-size resize can be the only signal that Windows Terminal restored
+  // after a renderer reset. While its 1049 health query is in flight, hold
+  // incremental alt-screen writes: if the physical terminal already fell
+  // back to main, those deltas would otherwise be painted into scrollback.
+  // The recovery completion always emits one full frame and clears the gate.
+  private altScreenSurfaceRecoveryPending = false;
+  private altScreenSurfaceRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Bounded retry for a refreshSurface probe request parked behind the
+   *  gesture latch (see probeAltScreenHealth). Without it, a lost mouse
+   *  release (window unfocused at release time) plus a dropped DECSET-1004
+   *  (no FOCUS_OUT to settle the latch) could strand a required surface
+   *  refresh indefinitely while incremental frames keep painting against a
+   *  possibly-diverged surface — the exact ghost class this batch fixes. */
+  private pendingProbeRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Completion time of the last full alt-screen surface refresh (dedupe
+   *  window for consecutive benign refresh signals, see probe entry). */
+  private lastSurfaceRefreshAt = 0;
   // Native cursor positioning: a component (via useDeclaredCursor) declares
   // where the terminal cursor should be parked after each frame. Terminal
   // emulators render IME preedit text at the physical cursor position, and
@@ -255,8 +308,11 @@ export default class Ink {
       stdout: options.stdout,
       stderr: options.stderr
     };
-    this.terminalColumns = options.stdout.columns || 80;
-    this.terminalRows = options.stdout.rows || 24;
+    const initialColumns = positiveTerminalDimension(options.stdout.columns);
+    const initialRows = positiveTerminalDimension(options.stdout.rows);
+    this.terminalSizeUnavailable = initialColumns === undefined || initialRows === undefined;
+    this.terminalColumns = initialColumns ?? 80;
+    this.terminalRows = initialRows ?? 24;
     this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows);
     this.stylePool = new StylePool();
     this.charPool = new CharPool();
@@ -412,13 +468,53 @@ export default class Ink {
   // blank→paint flicker). useVirtualScroll's height scaling already bounds
   // the per-resize cost; synchronous handling keeps dimensions consistent.
   private handleResize = () => {
-    const cols = this.options.stdout.columns || 80;
-    const rows = this.options.stdout.rows || 24;
-    // Terminals often emit 2+ resize events for one user action (window
-    // settling). Same-dimension events are no-ops; skip to avoid redundant
-    // frame resets and renders.
-    if (cols === this.terminalColumns && rows === this.terminalRows) return;
+    const cols = positiveTerminalDimension(this.options.stdout.columns);
+    const rows = positiveTerminalDimension(this.options.stdout.rows);
+    // ConPTY may expose 0×0 (or undefined) while the window is minimized.
+    // 80×24 is only a construction fallback, never a real resize target:
+    // laying out and painting that synthetic size deposits a bogus frame
+    // which is replayed when the window returns.
+    if (cols === undefined || rows === undefined) {
+      if (!this.terminalSizeUnavailable) noteFrameCause('resize');
+      this.terminalSizeUnavailable = true;
+      return;
+    }
+    const restoredFromUnavailable = this.terminalSizeUnavailable;
+    this.terminalSizeUnavailable = false;
+    // Windows Terminal / conpty can emit a same-dimension resize when a
+    // minimized window is restored or its renderer restarts. That event is
+    // NOT a no-op: DEC modes (including 1049) and the physical surface may
+    // have reset while our virtual frame still claims they are intact. Use a
+    // recovery repaint instead of the ordinary geometry path. Healthy
+    // duplicate resize events stay cheap in alt-screen (one mode query, then
+    // one atomic repaint); main-screen uses its proven viewport re-anchor.
+    if (cols === this.terminalColumns && rows === this.terminalRows) {
+      noteFrameCause('resize');
+      // A real resize/restore notification is stronger than a stale output
+      // gate. Retry immediately; if the stream is still saturated, the normal
+      // backlog check re-arms the gate without losing the recovery erase.
+      this.detachDrainListener();
+      this.backpressured = false;
+      this.backpressureStartedAt = null;
+      this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
+      if (this.drainTimer !== null) {
+        clearTimeout(this.drainTimer);
+        this.drainTimer = null;
+      }
+      // Pointer coordinates are unknown after a minimize→restore (the window
+      // was gone): drop stale hover/click-chain state the same way a real
+      // resize does, so a post-restore click cannot merge with a pre-minimize
+      // one and stale highlights clear on the next motion.
+      clearHovered(this.hoveredNodes);
+      this.app?.resetPointerState();
+      invalidateNoInterestRect();
+      this.reassertTerminalModes(false, true, restoredFromUnavailable);
+      return;
+    }
     noteFrameCause('resize');
+    if (restoredFromUnavailable && !this.isPaused && this.currentNode !== null) {
+      this.reassertInputModes();
+    }
     this.terminalColumns = cols;
     this.terminalRows = rows;
     this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows);
@@ -445,6 +541,8 @@ export default class Ink {
     this.scheduleRender.cancel?.();
     this.detachDrainListener();
     this.backpressured = false;
+    this.backpressureStartedAt = null;
+    this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
@@ -460,23 +558,14 @@ export default class Ink {
     // constraint every node was measured against.
     dom.markTreeDirty(this.rootNode);
 
-    // Alt screen: reset frame buffers so the next render repaints from
-    // scratch (prevFrameContaminated → every cell written, wrapped in
-    // BSU/ESU — old content stays visible until the new frame swaps
-    // atomically). Re-assert mouse tracking (some emulators reset it on
-    // resize). Do NOT write ENTER_ALT_SCREEN: iTerm2 treats ?1049h as a
-    // buffer clear even when already in alt — that's the blank flicker.
-    // Self-healing re-entry (if something kicked us out of alt) is handled
-    // by handleResume (SIGCONT) and the sleep-wake detector; resize itself
-    // doesn't exit alt-screen. Do NOT write ERASE_SCREEN: render() below
-    // can take ~80ms; erasing first leaves the screen blank that whole time.
-    if (this.altScreenActive && !this.isPaused && this.options.stdout.isTTY) {
-      // Blind mouse re-assert + 1049 probe: conpty resets modes on resize
-      // too, and a dropped 1049 means every subsequent frame paints onto
-      // the MAIN screen (looks like the app spontaneously exited
-      // fullscreen). The probe's re-entry is gated on a positive DECRPM
-      // "reset" answer, so this stays inert on healthy terminals.
-      this.probeAltScreenHealth();
+    // Alt screen: seed a blank virtual baseline so the new-size frame paints
+    // every cell. The 1049 query starts only after the new React/Yoga layout
+    // commits below: a restore from 0×0 gates that renderer microtask until
+    // the query decides between re-entry and an in-buffer atomic repaint.
+    // Never blindly write ENTER_ALT_SCREEN here — iTerm2 clears an already-
+    // active alt buffer on repeated 1049h.
+    const recoverAltScreen = this.altScreenActive && !this.isPaused && this.options.stdout.isTTY;
+    if (recoverAltScreen) {
       this.resetFramesForAltScreen();
       this.needsEraseBeforePaint = true;
     }
@@ -488,6 +577,20 @@ export default class Ink {
     // layout is updated, causing a mismatch between viewport and content dimensions.
     if (this.currentNode !== null) {
       this.render(this.currentNode);
+    }
+    if (recoverAltScreen) {
+      // Start the mode query only AFTER the synchronous React/layout commit.
+      // A 0×0→changed-size restore gates the renderer until 1049 is known
+      // (bypassing the consecutive-refresh dedupe window) and may need a
+      // corrective re-entry. Ordinary geometry changes keep their existing
+      // eager full repaint so terminals/test harnesses that ignore DECRQM
+      // cannot freeze resize. The probe still starts before the renderer
+      // microtask; unsupported DECRQM fallback repaints against the new
+      // Yoga layout.
+      this.probeAltScreenHealth({
+        refreshSurface: restoredFromUnavailable,
+        bypassRefreshDedupe: restoredFromUnavailable,
+      });
     }
   };
   resolveExitPromise: () => void = () => {};
@@ -538,6 +641,10 @@ export default class Ink {
    * returns, fullscreen scroll is dead.
    */
   exitAlternateScreen(): void {
+    // This method performs its own full-surface re-enter/repaint (and is the
+    // editor-handoff resume): any recovery that was in flight before the
+    // handoff is void — its gate would swallow the resume repaint below.
+    this.cancelAltScreenSurfaceRecovery();
     if (this.altScreenActive) {
       // Fullscreen: re-enter alt FIRST — terminal editors (vim, nano, less)
       // write smcup/rmcup, so the editor's rmcup on exit dropped us to the
@@ -584,13 +691,9 @@ export default class Ink {
       this.prevFrameContaminated = true;
       this.resume();
     }
-    // Re-enable focus reporting and extended key reporting — terminal
-    // editors (vim, nano, etc.) write their own modifyOtherKeys level on
-    // entry and reset it on exit, leaving us unable to distinguish
-    // ctrl+shift+<letter> from ctrl+<letter>. Pop-before-push keeps the
-    // Kitty stack balanced (a well-behaved editor restores our entry, so
-    // without the pop we'd accumulate depth on each editor round-trip).
-    this.options.stdout.write('\x1b[?1004h' + (supportsWin32InputMode() ? ENABLE_WIN32_INPUT_MODE : supportsExtendedKeys() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS : ''));
+    // Editors may reset bracketed paste, focus, and extended-key reporting.
+    // Restore the complete input protocol set, with balanced Kitty depth.
+    this.reassertInputModes();
   }
   /**
    * One-shot viewport re-anchor for the NEXT main-screen frame: repaint the
@@ -630,6 +733,38 @@ export default class Ink {
     this.onRender();
   }
 
+  private noteBackpressureStart(): void {
+    if (this.backpressureStartedAt === null) {
+      this.backpressureStartedAt = performance.now();
+    }
+  }
+
+  private backpressureNeedsSurfaceRecovery(): boolean {
+    return this.backpressureStartedAt !== null &&
+      performance.now() - this.backpressureStartedAt >= BACKPRESSURE_SURFACE_RECOVERY_MS;
+  }
+
+  /** Resume output after a real drain. A short congestion window only needs
+   *  the coalesced final frame; a long one is also a terminal-visibility /
+   *  transport boundary, so incremental diffs can no longer trust the
+   *  physical surface and must take the full recovery path. */
+  private resumeAfterBackpressure(): void {
+    const recoverSurface = this.backpressureNeedsSurfaceRecovery();
+    this.backpressured = false;
+    if (recoverSurface) {
+      this.backpressureStartedAt = null;
+      if (this.options.stdout.isTTY) {
+        this.reassertTerminalModes(false, true, true);
+      } else {
+        // Non-TTY streams have no physical surface or terminal modes; they
+        // still need the coalesced final output after a long blocked write.
+        this.renderNow();
+      }
+      return;
+    }
+    this.renderNow();
+  }
+
   /**
    * Schedule the next scroll-drain frame — Grok Build's Presenter, ported.
    * Grok keeps TWO cadence knobs (min_draw_ms for renders, scroll_ms for
@@ -652,9 +787,9 @@ export default class Ink {
    *    input→paint latency, which reads as sticky, laggy scrolling on
    *    Windows terminals.
    *
-   * The gate holds only DRAIN frames; React-driven renders (keystrokes,
-   * streaming) still render via the normal throttle — user-visible updates
-   * must never wait behind scroll output.
+   * The gate holds terminal WRITES from every producer while saturated.
+   * React/streaming commits may still build candidates, so skipped candidates
+   * must poison renderer blitting until one coalesced current-DOM frame lands.
    */
   private scheduleDrain(): void {
     const stdout = this.options.stdout as Writable & { writableLength?: number };
@@ -679,6 +814,7 @@ export default class Ink {
     // write result re-asserts the true state — so a stream that silently
     // recovered resumes painting without ever busy-looping. Never a fixed
     // 4ms poll while backpressured.
+    this.noteBackpressureStart();
     this.backpressured = true;
     // ALWAYS ensure the drain listener exists while backpressured — even
     // when the fallback timer is already armed. renderNow() detaches the
@@ -697,8 +833,21 @@ export default class Ink {
           ? stdout.writableLength
           : 0;
       if (nowBacklog <= PTY_BACKLOG_BYTES) {
-        // The stream looks drained (or never reports a backlog): try a
-        // frame; the write result re-asserts the gate.
+        // The stream looks drained (or never reports a backlog). A long stall
+        // is also a restore boundary: do not resume with a local delta against
+        // a physical surface the terminal may have discarded while hidden.
+        if (this.backpressureNeedsSurfaceRecovery()) {
+          this.backpressured = false;
+          this.backpressureStartedAt = null;
+          if (this.options.stdout.isTTY) {
+            this.reassertTerminalModes(false, true, true);
+          } else {
+            this.renderNow();
+          }
+          return;
+        }
+        // Short congestion: resume at the normal quarter-frame cadence; the
+        // write result re-asserts the gate if the stream was not really ready.
         this.backpressured = false;
       }
       this.scheduleDrain();
@@ -714,10 +863,7 @@ export default class Ink {
       this.drainListener = null;
       stdout.removeListener('drain', handler);
       if (this.isUnmounted || this.isPaused) return;
-      // The stream drained: clear the gate so this render actually writes
-      // (the write result re-asserts the true backpressure state).
-      this.backpressured = false;
-      this.renderNow();
+      this.resumeAfterBackpressure();
     };
     this.drainListener = handler;
     stdout.once('drain', handler);
@@ -735,7 +881,15 @@ export default class Ink {
     if (this.isUnmounted || this.isPaused) {
       return;
     }
-    if (GEOMETRY_TRACE_ENABLED) beginGeometryFrame(this.renderGeneration);
+    // A restore health query is deciding whether the physical target is the
+    // alt buffer or main. Coalesce React/animation ticks until that answer;
+    // writing an incremental diff now is exactly how whale/status fragments
+    // leaked into main-screen scrollback after minimize → restore. Recovery
+    // completion paths always clear the gate before issuing their own
+    // full-frame repaint, so this coalescing can never starve the recovery.
+    if (this.altScreenActive && this.altScreenSurfaceRecoveryPending) {
+      return;
+    }
     // Entering a render cancels any pending drain tick — this render will
     // handle the drain (and re-schedule below if needed). Prevents a
     // wheel-event-triggered render AND a drain-timer render both firing.
@@ -763,13 +917,18 @@ export default class Ink {
     // On drift, route through the resize path (cache sync + markTreeDirty
     // + re-render) and bail: the render handleResize schedules paints the
     // correctly-laid-out frame.
-    const liveColumns = this.options.stdout.columns || 80;
-    const liveRows = this.options.stdout.rows || 24;
-    if (this.options.stdout.isTTY && (liveColumns !== this.terminalColumns || liveRows !== this.terminalRows)) {
+    const liveColumns = positiveTerminalDimension(this.options.stdout.columns);
+    const liveRows = positiveTerminalDimension(this.options.stdout.rows);
+    if (
+      this.options.stdout.isTTY &&
+      (liveColumns === undefined || liveRows === undefined || this.terminalSizeUnavailable ||
+        liveColumns !== this.terminalColumns || liveRows !== this.terminalRows)
+    ) {
       this.handleResize();
       return;
     }
 
+    if (GEOMETRY_TRACE_ENABLED) beginGeometryFrame(this.renderGeneration);
     const renderStart = performance.now();
     const terminalWidth = this.terminalColumns;
     const terminalRows = this.terminalRows;
@@ -1044,7 +1203,7 @@ export default class Ink {
     const tOptimize = performance.now();
     const optimized = optimize(diff);
     const optimizeMs = performance.now() - tOptimize;
-    const hasDiff = optimized.length > 0;
+    let hasDiff = optimized.length > 0;
     // Backpressure gate, computed BEFORE the optimized patch list is built:
     // write() === false is the authoritative signal (a stream with a small
     // high-water mark can reject writes while writableLength is still below
@@ -1052,7 +1211,7 @@ export default class Ink {
     const stdout = this.options.stdout as Writable & { writableLength?: number };
     const backlog = typeof stdout.writableLength === 'number' ? stdout.writableLength : 0;
     const writing = !this.backpressured && backlog <= PTY_BACKLOG_BYTES;
-    if (this.altScreenActive && hasDiff && writing) {
+    if (this.altScreenActive && writing && (hasDiff || this.needsEraseBeforePaint)) {
       // Prepend CSI H to anchor the physical cursor to (0,0) so
       // log-update's relative moves compute from a known spot (self-healing
       // against out-of-band cursor drift, see the ALT_SCREEN_ANCHOR_CURSOR
@@ -1064,14 +1223,13 @@ export default class Ink {
       // position independently. Parking at bottom (not 0,0) keeps the guide
       // where the user's attention is.
       //
-      // After resize, prepend ERASE_SCREEN too. The diff only writes cells
-      // that changed; cells where new=blank and prev-buffer=blank get skipped
-      // — but the physical terminal still has stale content there (shorter
-      // lines at new width leave old-width text tails visible). ERASE inside
-      // BSU/ESU is atomic: old content stays visible until the whole
-      // erase+paint lands, then swaps in one go. Writing ERASE_SCREEN
-      // synchronously in handleResize would blank the screen for the ~80ms
-      // render() takes.
+      // After resize/recovery, prepend a full ED2 clear too. The diff only
+      // writes cells that changed; cells where new=blank and virtual-prev=blank
+      // get skipped even when the PHYSICAL terminal still contains stale text.
+      // The clearTerminal patch makes serializeDiff close DEC-2026 before ED2
+      // (required by Windows Terminal), then reopen it for the full paint. It
+      // remains in this frame's single stdout.write, unlike an eager clear in
+      // handleResize that could leave a visible clear→render gap.
       if (this.needsEraseBeforePaint) {
         this.needsEraseBeforePaint = false;
         optimized.unshift(ERASE_THEN_HOME_PATCH);
@@ -1079,6 +1237,10 @@ export default class Ink {
         optimized.unshift(CURSOR_HOME_PATCH);
       }
       optimized.push(this.altScreenParkPatch);
+      // A recovery erase is itself terminal output even when the target frame
+      // is entirely blank. Carry that fact into cursor restoration and the
+      // write path instead of preserving the empty-diff fast path.
+      hasDiff = true;
     }
 
     // Native cursor positioning: park the terminal cursor at the declared
@@ -1176,18 +1338,23 @@ export default class Ink {
     }
     const tWrite = performance.now();
     // Skip THIS write while backpressured (see the gate above) and wait for
-    // the stream's own drain. The diff engine compares against frontFrame —
-    // the last frame the terminal ACTUALLY received — so a skipped frame
-    // coalesces into the next write instead of being lost (and its erase/
-    // cursor patches never reach the terminal, so needsEraseBeforePaint and
-    // displayCursor stay truthful).
+    // the stream's own drain. The diff engine keeps frontFrame at the last
+    // frame the terminal ACTUALLY received, and the skipped branch below
+    // poisons clean-subtree blits because this candidate consumed DOM dirty
+    // flags. Together those invariants make the retry rebuild current DOM and
+    // coalesce the skipped frame instead of silently restoring old content.
     let writeMs = 0;
     if (writing) {
       const flushed = writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
       writeMs = performance.now() - tWrite;
       this.backpressured = !flushed;
-      if (flushed && this.drainBackoffMs !== DRAIN_BACKOFF_BASE_MS) {
-        this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
+      if (flushed) {
+        this.backpressureStartedAt = null;
+        if (this.drainBackoffMs !== DRAIN_BACKOFF_BASE_MS) {
+          this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
+        }
+      } else {
+        this.noteBackpressureStart();
       }
       // One frame reached the terminal. Components holding a widened mount
       // window until its content is actually flushed (MessageList's paint
@@ -1201,19 +1368,22 @@ export default class Ink {
       // lost forever.
       this.backFrame = this.frontFrame;
       this.frontFrame = frame;
-
       // Update blit safety for the NEXT frame. The frame just rendered
       // becomes frontFrame (= next frame's prevScreen). If we applied the
       // selection overlay, that buffer has inverted cells. selActive/hlActive
       // are only ever true in alt-screen; in main-screen this is false→false.
       this.prevFrameContaminated = selActive || hlActive;
     } else {
-      // Skipped write: the frame never reached the terminal, so the cursor
-      // park target (displayCursor, set above) and the contamination flag
-      // must stay at their last-WRITTEN values — displayCursor was already
-      // updated for this frame, so roll it back; the next written frame
-      // recomputes both fresh from the same baseline.
+      // Skipped write: the frame never reached the terminal. Roll the cursor
+      // model back to the last-WRITTEN frame, and poison renderer blitting for
+      // the retry: renderNodeToOutput already consumed/cleared the DOM dirty
+      // flags while building this skipped candidate. Without the poison, the
+      // drain render sees a clean tree and blits `frontFrame` (the old terminal
+      // contents) over the current DOM; a one-shot update—or Smooth Streaming
+      // after its reveal timer retires—then has no producer left to repair the
+      // permanently lost final frame.
       this.displayCursor = parked;
+      this.prevFrameContaminated = true;
       this.backpressured = true;
       noteFrameCause('backpressure');
     }
@@ -1298,6 +1468,10 @@ export default class Ink {
    */
   forceRedraw(): void {
     if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) return;
+    // This path performs its own full-surface clear+repaint, so any in-flight
+    // surface recovery is superseded — its gate must not swallow the repaint
+    // below (the user just asked for a redraw; nothing to coalesce behind).
+    this.cancelAltScreenSurfaceRecovery();
     // SGR reset first — ERASE_SCREEN fills with the current background
     // (BCE); ctrl+l is exactly the recovery a user reaches for when the
     // screen is already wrecked (e.g. a stuck colored SGR after a torn
@@ -1325,6 +1499,9 @@ export default class Ink {
    */
   clearScrollbackAndRedraw(): void {
     if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) return;
+    // Same supersede rationale as forceRedraw: destructive UI boundary with
+    // its own full repaint; an in-flight recovery must not gate it.
+    this.cancelAltScreenSurfaceRecovery();
     // Keep 3J outside synchronized output. Windows Terminal can relocate the
     // viewport when erase-buffer commands execute inside BSU/ESU.
     this.options.stdout.write(
@@ -1362,6 +1539,12 @@ export default class Ink {
    */
   setAltScreenActive(active: boolean, mouseTracking = false): void {
     if (this.altScreenActive === active) return;
+    // Either transition is a full surface change: an in-flight recovery from
+    // the previous mode is void (its gate must not swallow the fresh entry's
+    // first frame, and a stale deferred re-entry must not erase an unrelated
+    // later alt screen — iTerm2 clears an already-active alt buffer on a
+    // repeated 1049h).
+    this.cancelAltScreenSurfaceRecovery();
     const resetOldPointerContext = (): void => {
       // Fire leave handlers before dropping the set — a bare clear strands
       // old rows with hovered=true. resetPointerState also emits dragend for
@@ -1412,68 +1595,75 @@ export default class Ink {
     return this.altScreenActive;
   }
 
+  /** Full input-mode restore after a terminal renderer / transport reset. */
+  private inputModeReassertion(): string {
+    // Bracketed paste and focus reporting are DECSET modes too. The former
+    // keeps pasted newlines framed; the latter is how the next minimize /
+    // restore becomes observable. The old recovery restored only keyboard +
+    // mouse, so one renderer reset permanently disabled both.
+    return EBP + EFE + (supportsWin32InputMode()
+      ? ENABLE_WIN32_INPUT_MODE
+      : supportsExtendedKeys()
+        // Kitty is a stack: pop-before-push keeps depth at one. A reset leaves
+        // an empty stack, where the pop is defined as a no-op.
+        ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS
+        : '');
+  }
+
+  private reassertInputModes(): void {
+    this.options.stdout.write(this.inputModeReassertion());
+  }
+
   /**
    * Re-assert terminal modes after a gap (>5s stdin silence or event-loop
-   * stall). Catches tmux detach→attach, ssh reconnect, and laptop
-   * sleep/wake — none of which send SIGCONT. The terminal may reset DEC
-   * private modes on reconnect; this method restores them.
+   * stall). Catches tmux detach→attach, ssh reconnect, laptop wake, and the
+   * same-size resize emitted when a minimized Windows Terminal is restored.
    *
-   * Always re-asserts extended key reporting and mouse tracking. Mouse
-   * tracking is idempotent (DEC private mode set-when-set is a no-op). The
-   * Kitty keyboard protocol is NOT — CSI >1u is a stack push, so we pop
-   * first to keep depth balanced (pop on empty stack is a no-op per spec,
-   * so after a terminal reset this still restores depth 0→1). Without the
-   * pop, each >5s idle gap adds a stack entry, and the single pop on exit
-   * or suspend can't drain them — the shell is left in CSI u mode where
-   * Ctrl+C/Ctrl+D leak as escape sequences. The alt-screen
-   * re-entry (ERASE_SCREEN + frame reset) is NOT idempotent — it blanks the
-   * screen — so it's opt-in via includeAltScreen. The stdin-gap caller fires
-   * on ordinary >5s idle + keypress and must not erase; the event-loop stall
-   * detector fires on genuine sleep/wake and opts in. tmux attach / ssh
-   * reconnect typically send a resize, which already covers alt-screen via
-   * handleResize.
+   * `refreshSurface` is reserved for a strong terminal-refresh signal. In
+   * alt-screen it holds incremental writes until DECRQM tells us whether to
+   * re-enter 1049 or repaint the healthy buffer; in main-screen the existing
+   * viewport re-anchor already provides the full repaint. A caller sets
+   * `bypassRefreshDedupe` for a distinct correctness boundary (0×0 recovery or
+   * a long output stall), so it cannot be mistaken for a duplicate signal.
    */
-  reassertTerminalModes = (includeAltScreen = false): void => {
+  private handleStdinResume = (): void => {
+    // A >5s input gap is the last recovery signal when a renderer reset also
+    // dropped focus reporting and emitted no resize. Unlike periodic health
+    // probes, this path must rebuild unchanged/static cells as well.
+    this.reassertTerminalModes(false, true);
+  };
+
+  reassertTerminalModes = (
+    includeAltScreen = false,
+    refreshSurface = false,
+    bypassRefreshDedupe = false,
+  ): void => {
     if (!this.options.stdout.isTTY) return;
     // Shutdown latch: the >5s idle-gap trigger (or an event-loop stall
-    // detector firing during the dispose window) must not re-assert mouse
-    // tracking after the exit cleanup disabled it (issue #522).
+    // detector firing during the dispose window) must not re-assert modes
+    // after the exit cleanup disabled them (issue #522).
     if (this.isUnmounted) return;
     // Don't touch the terminal during an editor handoff — re-enabling kitty
     // keyboard here would undo enterAlternateScreen's disable and nano would
     // start seeing CSI-u sequences again.
     if (this.isPaused) return;
-    // Extended keys — re-assert if enabled (App.tsx enables these on
-    // allowlisted terminals at raw-mode entry; a terminal reset clears them).
-    // Pop-before-push keeps Kitty stack depth at 1 instead of accumulating
-    // on each call. win32-input-mode is a plain DEC private mode (no stack),
-    // so a bare re-set suffices.
-    if (supportsWin32InputMode()) {
-      this.options.stdout.write(ENABLE_WIN32_INPUT_MODE);
-    } else if (supportsExtendedKeys()) {
-      this.options.stdout.write(DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS);
-    }
+    this.reassertInputModes();
     if (!this.altScreenActive) {
-      // Main-screen self-heal: alt-screen re-anchors the cursor with CSI H
-      // every frame, but inline diffs are purely relative — a third-party
-      // tty write during the idle gap (an MCP subprocess's stderr, issue
-      // #17) shifts every subsequent write by N rows and nothing detects
-      // it after the fact (see requestViewportReanchor). The same
-      // gap-then-keypress signal that re-asserts DEC modes is the natural
-      // moment to blindly re-sync: repaint the viewport from the physical
-      // cursor position. Idempotent when nothing drifted — the user sees
-      // no change, at O(viewport) bytes once per >5s idle gap.
+      // Main-screen self-heal: repaint from an absolute viewport-home anchor.
+      // This is idempotent on a healthy screen and reconstructs a surface the
+      // terminal discarded without touching native scrollback.
       this.log.requestViewportReanchor();
       this.renderNow();
       return;
     }
     // Mouse tracking + alt-screen health — the probe re-asserts mouse
     // blindly (idempotent) and re-enters alt only if the terminal answers
-    // DECRPM with "1049 reset".
-    this.probeAltScreenHealth();
-    // Drain any deferred re-entry: a >5s stdin gap is a safe boundary (no
-    // button can be held — the terminal would have sent motion events), and
-    // resume is exactly the moment a confirmed 1049 loss should heal.
+    // DECRPM with "1049 reset". A same-size resize additionally requests a
+    // full surface repaint after the answer.
+    this.probeAltScreenHealth({ refreshSurface, bypassRefreshDedupe });
+    // Try any deferred re-entry now; the drain itself preserves the gesture
+    // latch. The first post-gap input can be a mouse press, so a long silence
+    // alone is not proof that no button is currently held.
     this.drainAltScreenReentry();
     // Alt-screen re-entry — destructive (ERASE_SCREEN). Only for callers that
     // have a strong signal the terminal actually dropped mode 1049.
@@ -1568,6 +1758,7 @@ export default class Ink {
           this.drainTimer = null;
         }
         this.backpressured = false;
+        this.backpressureStartedAt = null;
         this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
       },
       () => (this.app ?? this.shutdownApp)?.beginShutdown(),
@@ -1740,12 +1931,17 @@ export default class Ink {
    * gesture's end and drained by setPointerGestureActive(false).
    */
   private pendingAltScreenReentry = false;
+  /** A same-size restore probe confirmed 1049 is still set, but its full
+   * surface repaint must wait for the active pointer gesture to finish. */
+  private pendingAltScreenSurfaceRefresh = false;
   /**
    * Set when probeAltScreenHealth was blocked by an active gesture. The
    * probe is retried at the release tail (drainAltScreenReentry) with the
    * original caller's skipMouseReassert semantics.
    */
-  private pendingProbeRequest: { skipMouseReassert?: boolean } | undefined = undefined;
+  private pendingProbeRequest:
+    | { skipMouseReassert?: boolean; refreshSurface?: boolean; bypassRefreshDedupe?: boolean }
+    | undefined = undefined;
   setPointerGestureActive = (active: boolean): void => {
     this.pointerGestureActive = active;
     // Do NOT drain pendingAltScreenReentry here: the gesture latch clears at
@@ -1758,27 +1954,23 @@ export default class Ink {
   setProtocolCandidateActive = (active: boolean): void => {
     this.protocolCandidateActive = active;
   };
-  /**
-   * Execute a deferred alt-screen re-entry, if one was confirmed while a
-   * gesture was latched. Called by App after the release tail completes.
-   * Only clears the pending flag when the re-entry actually runs — a pause
-   * or alt-screen exit during the gesture keeps the recovery signal alive
-   * for the next safe boundary (resume, focus, or a later release).
-   */
+  /** Execute a deferred alt-screen re-entry or surface repaint after the
+   * active gesture's release tail. Re-entry wins when both are pending. */
   drainAltScreenReentry = (): void => {
-    if (!this.pendingAltScreenReentry) return;
-    // Shutdown latch: beginShutdown permanently cancels the producer — a
-    // pending re-entry must never re-enter after DISABLE_MOUSE_TRACKING /
-    // EXIT_ALT_SCREEN have been written.
+    if (!this.pendingAltScreenReentry && !this.pendingAltScreenSurfaceRefresh) return;
+    // Shutdown latch: recovery must never re-enable modes after cleanup.
     if (this.isUnmounted || this.isPaused || !this.altScreenActive) return;
-    // Dual latch: never re-enter while a physical button is held OR while a
-    // protocol candidate (split SGR prefix) is in flight. The destructive
-    // re-entry (1049h + 2J + mouse DECSET) would erase the screen under the
-    // user's pointer and reset button tracking mid-drag, or corrupt a
-    // half-parsed report.
+    // Both operations reset frame buffers / terminal pixels, so wait until no
+    // physical button or split protocol candidate is in flight.
     if (this.pointerGestureActive || this.protocolCandidateActive) return;
-    this.pendingAltScreenReentry = false;
-    this.reenterAltScreen();
+    if (this.pendingAltScreenReentry) {
+      this.pendingAltScreenReentry = false;
+      this.pendingAltScreenSurfaceRefresh = false;
+      this.reenterAltScreen();
+      return;
+    }
+    this.pendingAltScreenSurfaceRefresh = false;
+    this.refreshAltScreenSurface();
   };
   /**
    * Retry a health probe that was blocked by an active gesture. Called by
@@ -1801,8 +1993,17 @@ export default class Ink {
     // protocol candidate is in flight — the probe's DECSET/DECRQM writes
     // would corrupt the stream.
     if (this.pointerGestureActive || this.protocolCandidateActive) return;
+    // Editor handoff: a probe write now would corrupt the editor's stream.
+    // Unlike the latch case, DO keep the request — a deferred surface
+    // refresh must survive the handoff (exitAlternateScreen re-asserts
+    // input modes but performs no surface refresh of its own).
+    if (this.isPaused) {
+      const retry = setTimeout(() => this.drainPendingProbe(), ALT_SCREEN_SURFACE_RECOVERY_TIMEOUT_MS);
+      retry.unref?.();
+      return;
+    }
     const now = Date.now();
-    const throttleLeft = 250 - (now - this.lastHealthProbeAt);
+    const throttleLeft = req.refreshSurface ? 0 : 250 - (now - this.lastHealthProbeAt);
     if (throttleLeft > 0) {
       // Still inside the throttle window: keep the request pending and
       // schedule the retry for when the window closes. The timer is
@@ -1813,6 +2014,7 @@ export default class Ink {
       return;
     }
     this.pendingProbeRequest = undefined;
+    this.clearPendingProbeRetryTimer();
     this.probeAltScreenHealth(req);
   };
   /**
@@ -1824,96 +2026,259 @@ export default class Ink {
     this.drainAltScreenReentry();
     this.drainPendingProbe();
   };
-  probeAltScreenHealth = (options?: { skipMouseReassert?: boolean }): void => {
+  probeAltScreenHealth = (options?: {
+    skipMouseReassert?: boolean
+    refreshSurface?: boolean
+    /** Bypass consecutive-refresh dedupe for a distinct correctness boundary
+     *  (0×0 recovery or a long output stall). */
+    bypassRefreshDedupe?: boolean
+  }): void => {
     // Shutdown latch: during the dispose window after beginShutdown (up to
     // the 5s fallback exit) stray input, focus, resize or a pending DECRPM
-    // reply would otherwise re-write ENABLE_MOUSE_TRACKING AFTER the exit
-    // cleanup's DISABLE_MOUSE_TRACKING — the mouse-reporting residue the
-    // shell then echoes as SGR garbage (issue #522). The exit funnel latches
-    // isUnmounted via beginShutdown() BEFORE any cleanup sequence is
-    // written, while raw mode is still held; the cooked-mode restore lands
-    // only in concludeShutdown() after the settle window.
+    // reply must not re-enable terminal modes after cleanup (#522).
     if (this.isUnmounted) return;
-    // Dual latch: never write while a physical button is held OR while a
-    // protocol candidate (split SGR prefix) is in flight. The physical latch
-    // covers press→release; the candidate latch covers the window between
-    // the first byte of a report and its completion — a DECSET re-assert
-    // there corrupts the stream mid-parse.
+    // Duplicate same-size resize events coalesce behind the first query. The
+    // pending recovery will end with a full repaint, so no signal is lost.
+    if (options?.refreshSurface && this.altScreenSurfaceRecoveryPending) return;
+    // Consecutive refresh signals (window-settle resize bursts, a resize
+    // followed by FOCUS_IN, a stdin-gap refresh right after either) within
+    // the window are the same restore reported twice: skip the duplicate
+    // full erase+paint cycle. Distinct correctness boundaries bypass this.
+    if (
+      options?.refreshSurface &&
+      !options.bypassRefreshDedupe &&
+      Date.now() - this.lastSurfaceRefreshAt < ALT_SCREEN_SURFACE_REFRESH_DEDUPE_MS
+    ) {
+      return;
+    }
+    // Dual latch: never write while a physical button or split protocol
+    // candidate is in flight. Merge requests so a later ordinary interaction
+    // cannot downgrade a required surface refresh.
     if (this.pointerGestureActive || this.protocolCandidateActive) {
-      this.pendingProbeRequest = { ...options };
+      const pending = this.pendingProbeRequest;
+      this.pendingProbeRequest = pending
+        ? {
+            skipMouseReassert: Boolean(pending.skipMouseReassert && options?.skipMouseReassert),
+            refreshSurface: Boolean(pending.refreshSurface || options?.refreshSurface),
+            bypassRefreshDedupe: Boolean(pending.bypassRefreshDedupe || options?.bypassRefreshDedupe),
+          }
+        : { ...options };
+      // A parked refreshSurface request is correctness work, not a periodic
+      // sample: arm a bounded retry so a stuck latch (lost release + dropped
+      // focus reporting) cannot strand the surface recovery indefinitely.
+      if (this.pendingProbeRequest.refreshSurface) this.armPendingProbeRetry();
       return;
     }
     const now = Date.now();
-    if (now - this.lastHealthProbeAt < 250) return;
+    // A physical-surface refresh is correctness work, not a periodic health
+    // sample: never drop it behind the 250ms interaction throttle.
+    if (!options?.refreshSurface && now - this.lastHealthProbeAt < 250) return;
     this.lastHealthProbeAt = now;
     if (!this.options.stdout.isTTY || this.isPaused || !this.altScreenActive) return;
-    // Mouse-driven callers pass skipMouseReassert: the event that triggered
-    // the probe already proves tracking is alive, so the blind DECSET
-    // re-assert is pure risk near gestures — only the 1049 query below is
-    // worth sending (conpty can drop 1049 while mouse tracking survives;
-    // without a mouse-path probe a mouse-only user never recovers, since
-    // mouse input keeps lastStdinTime fresh and starves the >5s gap path).
+    // Mouse-driven callers pass skipMouseReassert: the arriving report itself
+    // proves mouse tracking is alive. Resize/restore callers re-assert it.
     if (this.altScreenMouseTracking && !options?.skipMouseReassert) {
       this.options.stdout.write(ENABLE_MOUSE_TRACKING);
     }
     const querier = this.app?.querier;
-    if (querier === undefined) return;
-    // macOS Terminal.app prints the trailing `p` of `CSI ? 1049 $ p` as
-    // literal text instead of ignoring the unsupported query, leaking a
-    // visible character at the cursor on every probe. The blind
-    // mouse-tracking re-assert above still runs there — only the round trip
-    // is skipped, which costs nothing: Terminal.app never answered it.
-    if (!supportsDecrqmProbe()) return;
+    // Terminal.app is deliberately excluded because it prints the DECRQM
+    // trailing `p`. Without a safe mode query we can still repaint the buffer
+    // we are in; only a positive reset answer may perform destructive 1049h.
+    if (querier === undefined || !supportsDecrqmProbe()) {
+      if (options?.refreshSurface) this.refreshAltScreenSurface();
+      return;
+    }
+    if (options?.refreshSurface) {
+      // Coalesce animation/streaming renders until we know whether they belong
+      // in alt or main. A bounded fallback is mandatory: TerminalQuerier's DA1
+      // barrier is reliable on real VT terminals, but a broken multiplexer or
+      // test transport must never freeze rendering forever. Note the fallback
+      // can paint into main if 1049 was genuinely dropped AND the answer was
+      // lost — the accepted trade for not freezing; a later reset answer
+      // corrects via reenterAltScreen.
+      this.altScreenSurfaceRecoveryPending = true;
+      this.armAltScreenSurfaceRecoveryTimer();
+    }
     void Promise.all([querier.send(decrqm(1049)), querier.flush()]).then(([reply]) => {
-      // DECRPM status: 1/3 = set, 2/4 = reset, 0/undefined = unknown.
-      // Heal only on a POSITIVE reset — an unanswered probe must not
-      // trigger the destructive re-entry.
-      if (reply === undefined || (reply.status !== 2 && reply.status !== 4)) return;
-      // The reply resolves asynchronously: focus/keyboard/resize issued the
-      // query, but a mouse press may have latched a gesture since (or a
-      // protocol candidate may be in flight). Re-entering now would erase
-      // the screen under the user's pointer and reset button tracking
-      // mid-drag — defer to the gesture's end instead.
+      const reset = reply !== undefined && (reply.status === 2 || reply.status === 4);
+      // The reply resolves asynchronously: a press or split mouse sequence may
+      // have started since the query. Defer destructive buffer work to the
+      // release tail while keeping incremental writes gated.
       if (this.pointerGestureActive || this.protocolCandidateActive) {
-        this.pendingAltScreenReentry = true;
+        if (reset) this.pendingAltScreenReentry = true;
+        else if (this.altScreenSurfaceRecoveryPending) this.pendingAltScreenSurfaceRefresh = true;
         return;
       }
-      // Same re-check for the wider world: the probe ran with alt-screen
-      // active, but an exit or editor handoff may have landed meanwhile.
-      if (this.isUnmounted || this.isPaused || !this.altScreenActive) return;
-      this.reenterAltScreen();
+      // The probe may outlive an editor handoff, alt-screen exit, or shutdown.
+      if (this.isUnmounted || this.isPaused || !this.altScreenActive) {
+        this.cancelAltScreenSurfaceRecovery();
+        return;
+      }
+      if (reset) {
+        // 1049 was dropped: destructive re-entry is the only correct heal.
+        this.reenterAltScreen();
+      } else if (this.altScreenSurfaceRecoveryPending) {
+        // A healthy answer (1049 still set) from ANY probe — including
+        // ordinary interaction probes — completes a pending recovery: the
+        // terminal just proved the mode intact, so an in-buffer erase+paint
+        // is safe and the render gate must not outlive its healers.
+        this.refreshAltScreenSurface();
+      }
     }).catch(() => {
-      /* probe is best-effort; the next trigger retries */
+      // Query failures must not leave the render gate stuck forever. Stay in
+      // the current buffer and reconstruct it; the next signal retries 1049.
+      if (options?.refreshSurface && this.altScreenSurfaceRecoveryPending) {
+        this.refreshAltScreenSurface();
+      }
     });
   };
 
-  /** Refocus = first observable moment after a conpty-side mode reset. */
+  /** Refocus is the minimize→restore signal even when no resize is emitted. */
   handleTerminalFocusProbe = (focused: boolean): void => {
-    if (focused) {
-      this.probeAltScreenHealth();
-      // Refocus is a safe boundary: the OS delivered the focus event, so no
-      // button can be held (a held button would have generated motion or a
-      // release first). Drain any deferred re-entry confirmed while the
-      // window was unfocused.
-      this.drainAltScreenReentry();
+    if (!focused) {
+      // Window lost focus (minimize / alt-tab): pointer state is stale by
+      // the time it returns. Clear hover highlights, tooltip dwell, the
+      // multi-click chain and the no-interest rect cache NOW (invisible
+      // while unfocused) so the restore repaint starts clean instead of
+      // resurrecting pre-focus-loss highlights at stale coordinates.
+      // Doing it at blur — not in the recovery repaint — avoids tooltip
+      // flicker on every plain re-focus.
+      clearHovered(this.hoveredNodes);
+      this.app?.resetPointerState();
+      invalidateNoInterestRect();
+      return;
     }
+    // Some PTYs update rows/columns back to positive values before FOCUS_IN
+    // but omit the matching resize event. Let the normal size-recovery path
+    // consume that transition; it handles both inline and alternate screens.
+    if (this.terminalSizeUnavailable) {
+      this.handleResize();
+      return;
+    }
+    // Focus restore is a strong surface boundary in BOTH rendering modes.
+    // Alt-screen queries 1049 and either re-enters or repaints the buffer;
+    // inline mode uses LogUpdate's absolute viewport re-anchor. The previous
+    // alt-only return left a no-resize inline surface stale until Ctrl+L.
+    this.reassertTerminalModes(false, true);
+    // Try any alt recovery deferred from the blurred phase. The drain still
+    // re-checks the gesture latch: a FOCUS_IN and a fresh press may share one
+    // stdin batch, or focus can arrive while an intentional drag is active.
+    // (No-op in inline mode.)
+    this.drainAltScreenReentry();
   };
 
+  private clearAltScreenSurfaceRecoveryTimer(): void {
+    if (this.altScreenSurfaceRecoveryTimer === null) return;
+    clearTimeout(this.altScreenSurfaceRecoveryTimer);
+    this.altScreenSurfaceRecoveryTimer = null;
+  }
+
+  /** Arm the one-shot recovery fallback; re-arms itself while a pointer
+   *  gesture stays latched (a single deferral without re-arm would strand
+   *  the render gate: lost mouse release + dead focus reporting leaves no
+   *  drain to clear it). Self-terminates once the gate clears. */
+  private armAltScreenSurfaceRecoveryTimer(): void {
+    this.clearAltScreenSurfaceRecoveryTimer();
+    this.altScreenSurfaceRecoveryTimer = setTimeout(() => {
+      this.altScreenSurfaceRecoveryTimer = null;
+      if (!this.altScreenSurfaceRecoveryPending) return;
+      if (this.pointerGestureActive || this.protocolCandidateActive) {
+        this.pendingAltScreenSurfaceRefresh = true;
+        this.armAltScreenSurfaceRecoveryTimer();
+        return;
+      }
+      this.refreshAltScreenSurface();
+    }, ALT_SCREEN_SURFACE_RECOVERY_TIMEOUT_MS);
+    this.altScreenSurfaceRecoveryTimer.unref?.();
+  }
+
+  /** Arm the parked-probe retry; re-arms itself while the request stays
+   *  parked (latch still held). Self-terminates once the request is
+   *  consumed or cancelled. Idempotent while already armed. */
+  private armPendingProbeRetry(): void {
+    if (this.pendingProbeRetryTimer !== null) return;
+    const timer = setTimeout(() => {
+      this.pendingProbeRetryTimer = null;
+      if (this.pendingProbeRequest === undefined) return;
+      this.drainPendingProbe();
+      if (this.pendingProbeRequest !== undefined) this.armPendingProbeRetry();
+    }, ALT_SCREEN_SURFACE_RECOVERY_TIMEOUT_MS);
+    timer.unref?.();
+    this.pendingProbeRetryTimer = timer;
+  }
+
+  private clearPendingProbeRetryTimer(): void {
+    if (this.pendingProbeRetryTimer === null) return;
+    clearTimeout(this.pendingProbeRetryTimer);
+    this.pendingProbeRetryTimer = null;
+  }
+
+  /** Cancel an in-flight surface recovery. Callers that perform their own
+   *  full-surface reset — forceRedraw, clearScrollbackAndRedraw, alt-screen
+   *  exit/re-entry, editor handoff — supersede any pending recovery: leaving
+   *  its gate up would swallow their repaint, and a stale deferred re-entry
+   *  could erase an unrelated later alt entry. */
+  private cancelAltScreenSurfaceRecovery(): void {
+    this.clearAltScreenSurfaceRecoveryTimer();
+    this.clearPendingProbeRetryTimer();
+    this.altScreenSurfaceRecoveryPending = false;
+    this.pendingAltScreenSurfaceRefresh = false;
+    this.pendingAltScreenReentry = false;
+    // A refresh request blocked before it could start belongs to the same
+    // superseded recovery transaction. Leaving it queued would make Ctrl+L,
+    // an alt-screen transition, or editor return unexpectedly start another
+    // erase/query after the replacement surface is already authoritative.
+    this.pendingProbeRequest = undefined;
+  }
+
+  /** Reconstruct every cell in a still-active alternate buffer. */
+  private refreshAltScreenSurface(): void {
+    this.clearAltScreenSurfaceRecoveryTimer();
+    this.altScreenSurfaceRecoveryPending = false;
+    this.pendingAltScreenSurfaceRefresh = false;
+    this.lastSurfaceRefreshAt = Date.now();
+    if (this.isUnmounted || this.isPaused || !this.altScreenActive) return;
+    if (this.terminalSizeUnavailable) {
+      // Dimensions invalid: nothing can be painted right now. Keep the erase
+      // armed and poison the diff baseline so the FIRST frame painted once a
+      // valid size returns full-erases the stale surface instead of relying
+      // on a later trigger to notice it.
+      this.needsEraseBeforePaint = true;
+      this.prevFrameContaminated = true;
+      return;
+    }
+    this.resetFramesForAltScreen();
+    // The virtual blank baseline cannot prove the physical terminal is blank;
+    // the next frame clears outside DEC-2026 (WT-safe) and then reopens sync
+    // for the repaint, so stale long-line tails and renderer-loss residue go.
+    this.needsEraseBeforePaint = true;
+    this.renderNow();
+  }
+
   /**
-   * Re-enter alt-screen, clear, home, re-enable mouse tracking, and reset
-   * frame buffers so the next render repaints from scratch. Self-heal for
-   * SIGCONT, resize, and stdin-gap/event-loop-stall (sleep/wake) — any of
-   * which can leave the terminal in main-screen mode while altScreenActive
-   * stays true. ENTER_ALT_SCREEN is a terminal-side no-op if already in alt.
+   * Re-enter alt-screen, restore every input mode, and repaint immediately.
+   * Resetting only the frame buffers used to leave a static UI blank forever:
+   * no animation/React commit existed to trigger the promised "next" frame.
    */
   private reenterAltScreen(): void {
-    // Same shutdown latch as probeAltScreenHealth: a DECRPM reply resolving
-    // after detachForShutdown (or a SIGCONT racing unmount) must not re-enter
-    // the alt screen or re-enable mouse tracking past the exit cleanup
-    // (issue #522).
-    if (this.isUnmounted) return;
-    this.options.stdout.write(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME + (this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : ''));
+    this.cancelAltScreenSurfaceRecovery();
+    this.lastSurfaceRefreshAt = Date.now();
+    if (this.isUnmounted || this.isPaused || !this.altScreenActive) return;
+    if (this.terminalSizeUnavailable) {
+      // Same as refreshAltScreenSurface: cannot paint at invalid dimensions.
+      // The recovery decision itself is void until a valid size returns.
+      this.needsEraseBeforePaint = true;
+      this.prevFrameContaminated = true;
+      return;
+    }
+    this.options.stdout.write(
+      ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME +
+      this.inputModeReassertion() +
+      (this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : ''),
+    );
+    this.needsEraseBeforePaint = false;
     this.resetFramesForAltScreen();
+    this.renderNow();
   }
 
   /**
@@ -2544,7 +2909,7 @@ export default class Ink {
   };
   render(node: ReactNode): void {
     this.currentNode = node;
-    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.handleAppExit} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onContextMenuAt={this.dispatchContextMenu} onHoverAt={this.dispatchHover} onWheelAt={this.dispatchWheelAt} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onDragTargetAt={this.findDragTargetAt} onDragDispatch={this.dispatchDrag} onPointerGestureChange={this.setPointerGestureActive} onProtocolCandidateChange={this.setProtocolCandidateActive} onReleaseTail={this.drainReleaseTail} onClickProbe={this.clickProbeAtBatchTail} onStdinResume={this.reassertTerminalModes} onTerminalFocus={this.handleTerminalFocusProbe} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
+    const tree = <App ref={this.setAppRef} stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.handleAppExit} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onContextMenuAt={this.dispatchContextMenu} onHoverAt={this.dispatchHover} onWheelAt={this.dispatchWheelAt} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onDragTargetAt={this.findDragTargetAt} onDragDispatch={this.dispatchDrag} onPointerGestureChange={this.setPointerGestureActive} onProtocolCandidateChange={this.setProtocolCandidateActive} onReleaseTail={this.drainReleaseTail} onClickProbe={this.clickProbeAtBatchTail} onStdinResume={this.handleStdinResume} onTerminalFocus={this.handleTerminalFocusProbe} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
         <TerminalWriteProvider value={this.writeRaw}>
           {node}
         </TerminalWriteProvider>
@@ -2670,6 +3035,11 @@ export default class Ink {
       }
       /* eslint-enable custom-rules/no-sync-fs */
     } finally {
+      // Explicit recovery cancellation: the React teardown path also cancels
+      // via setAltScreenActive(false), but an explicit call here is robust
+      // against future teardown-order refactors (both are idempotent).
+      this.cancelAltScreenSurfaceRecovery();
+
       this.isUnmounted = true;
 
       // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
@@ -2688,6 +3058,7 @@ export default class Ink {
         this.drainTimer = null;
       }
       this.backpressured = false;
+      this.backpressureStartedAt = null;
       this.drainBackoffMs = DRAIN_BACKOFF_BASE_MS;
 
       // @ts-ignore -- ported CC build; type drift tolerated updateContainerSync exists in react-reconciler but not in @types/react-reconciler

--- a/src/ink/renderer.ts
+++ b/src/ink/renderer.ts
@@ -21,10 +21,10 @@ export type RenderOptions = {
   terminalWidth: number
   terminalRows: number
   altScreen: boolean
-  // True when the previous frame's screen buffer was mutated post-render
-  // (selection overlay), reset to blank (alt-screen enter/resize/SIGCONT),
-  // or reset to 0×0 (forceRedraw). Blitting from such a prevScreen would
-  // copy stale inverted cells, blanks, or nothing. When false, blit is safe.
+  // True when blitting from the previous screen is unsafe: it was mutated
+  // post-render (selection overlay), reset to blank/0×0, or a skipped-output
+  // render consumed the DOM dirty flags without advancing the terminal frame.
+  // Blitting then copies stale cells; false means the baseline is safe.
   prevFrameContaminated: boolean
 }
 
@@ -131,12 +131,11 @@ export default function createRenderer(
     resetScrollHint()
     resetScrollDrainNode()
 
-    // prevFrameContaminated: selection overlay mutated the returned screen
-    // buffer post-render (in ink.tsx), resetFramesForAltScreen() replaced it
-    // with blanks, or forceRedraw() reset it to 0×0. Blit on the NEXT frame
-    // would copy stale inverted cells / blanks / nothing. When clean, blit
-    // restores the O(unchanged) fast path for steady-state frames (spinner
-    // tick, text stream).
+    // prevFrameContaminated: selection overlay mutated the returned screen,
+    // a reset replaced it with blanks/0×0, or a backpressure-skipped render
+    // consumed DOM dirty flags without reaching the terminal. Blit on the
+    // NEXT frame would copy stale cells and lose the current DOM. When clean,
+    // blit restores the O(unchanged) fast path (spinner tick, text stream).
     // Removing an absolute-positioned node poisons prevScreen: it may
     // have painted over non-siblings (e.g. an overlay over a ScrollBox
     // earlier in tree order), so their blits would restore the removed

--- a/src/ink/terminal.ts
+++ b/src/ink/terminal.ts
@@ -308,9 +308,38 @@ export function hasCursorUpViewportYankBug(): boolean {
 export const SYNC_OUTPUT_SUPPORTED = isSynchronizedOutputSupported()
 
 /**
+ * True when the terminal stack must not be trusted with the DECSTBM
+ * hardware-scroll shortcut — the Windows terminal stack (ConPTY → Windows
+ * Terminal / conhost). The per-frame `CSI top;bot r + CSI n S/T + CSI r`
+ * sequence assumes the emulator applies the scroll EXACTLY inside the
+ * modeled region; when the outer stack mis-applies it even once (region
+ * dropped or deferred across a sync block, a restore-time replay, a
+ * passthrough rewrite), the terminal scrolls MORE than the model and every
+ * row OUTSIDE the region — status bar, input row, page margins — is left
+ * shifted/duplicated. Those rows are static: the diff model believes them
+ * unchanged, so nothing ever repaints them (the persistent fullscreen
+ * ghost; Ctrl+L is the only repair). Same failure class as upstream
+ * claude-code#14716 ("scroll margins not reset" on Windows Terminal) and
+ * the reason JediTerm is excluded below. Disabling trades the 12-byte
+ * scroll shortcut for the cell-by-cell fallback that every terminal renders
+ * identically; write volume during scroll drains rises but stays bounded.
+ *
+ * `DSH_TUI_FORCE_DECSTBM=1` bypasses THIS gate only (not the sync/JediTerm
+ * gates) so the fast path itself stays testable on Windows and available to
+ * users who trust their terminal stack.
+ */
+export function hasDecstbmScrollBug(): boolean {
+  if (process.env.DSH_TUI_FORCE_DECSTBM === '1') return false
+  return process.platform === 'win32' || !!process.env.WT_SESSION
+}
+
+/**
  * Whether the DECSTBM hardware-scroll optimization may be used to paint
- * ScrollBox scrolls. Called once per frame — the same env reads as the
- * SYNC_OUTPUT_SUPPORTED gate, so the extra cost is a single comparison.
+ * ScrollBox scrolls. Called once per frame; SYNC_OUTPUT_SUPPORTED is a
+ * module-load constant, so the per-call cost is two live process.env reads
+ * (DSH_TUI_FORCE_DECSTBM + WT_SESSION) plus a platform check — negligible,
+ * and deliberately un-cached so env-driven probes in verify scripts stay
+ * honest against the real gate.
  *
  * JediTerm is explicitly excluded even though it implements DEC 2026: its
  * scroll-region (DECSTBM) + CSI S/T handling deviates from xterm and, when
@@ -319,9 +348,12 @@ export const SYNC_OUTPUT_SUPPORTED = isSynchronizedOutputSupported()
  * The diff engine falls back to repainting the shifted rows cell-by-cell,
  * which every terminal renders identically. Same gate as upstream Claude
  * Code, which hard-disables DECSTBM on JetBrains terminals.
+ * The Windows terminal stack is excluded for the same reason (see
+ * {@link hasDecstbmScrollBug}).
  * @returns true when DECSTBM scroll optimization is safe on this terminal.
  */
 export function isDecstbmSafe(): boolean {
+  if (hasDecstbmScrollBug()) return false
   return SYNC_OUTPUT_SUPPORTED && !isJetBrainsIdeTerminal()
 }
 


### PR DESCRIPTION
## 根因

用户报告全屏静态区域残影再现（底栏/输入框/页边距不刷新区域重复渲染），证词定位「引入性能 PR + 平滑流式之后才有」。时间线取证：DECSTBM scrollHint 优化自 0.1.0（809591d4）就存在，**#713 性能批 + smoothStreaming 把滚动优化帧从 chunk 节奏拉到 30fps，将既有 DECSTBM 缺陷面的触发频率放大了数量级**。机制：每帧 `CSI top;bot r + CSI n S + CSI r` 假设终端精确按建模区域滚动；WT/ConPTY 栈只要错应用一次（区域丢失/隐藏期延迟应用/passthrough 改写），终端滚动范围 > 模型 → 区域外静态行错位，diff 模型认为它们未变 → **永远不重画**（Ctrl+L 是唯一修复）。同族先例：上游 claude-code#14716（WT scroll margins not reset）、JediTerm 排除。

## 改动

### A. Windows 终端栈禁用 DECSTBM（terminal.ts）
`hasDecstbmScrollBug()`（win32 || WT_SESSION；`DSH_TUI_FORCE_DECSTBM=1` 仅绕此门，不弱化 sync/JediTerm 门）→ `isDecstbmSafe()` 排除；回退路径 = tmux 用户长期运行的逐行重画。WSL-in-WT（linux + WT_SESSION）同被覆盖。

### B. 最小化/恢复表面重建（ink.tsx / App.tsx）
- **0×0 尺寸门**：ConPTY 最小化期间暴露 0×0/undefined——保持上次有效布局并抑制帧写入，杜绝 80×24 假帧沉积回放
- **altScreenSurfaceRecovery 状态机**：DECRQM 1049 查询在途时 gate 增量帧（防鲸鱼/状态栏泄漏进 main scrollback）、1s unref 兜底 timer、所有自带全量重建的入口统一 cancel 恢复事务
- **同尺寸 resize 恢复**：WT 恢复可只发「尺寸未变」resize——restoredFromUnavailable 路径 bypass 250ms 去重做全量重绘
- **FOCUS_IN / 合成焦点**：失焦后首个真实输入（含鼠标/滚轮，修了旧代码 mouse continue 跳过 key-only failsafe 的洞）即焦点证明，触发表面恢复；blur 双层清理（hover/连击链/no-interest/手势闩）
- **ED2 移出 BSU/ESU 同步块**（clearTerminal patch）：WT 在同步块内执行 ED2 会残留旧视口
- **背压恢复阈值 1000→250ms**：长拥塞以一次全量擦除+重画收尾，亚秒突发不刷屏；skip-write 帧毒化 blit 基线（跳写候选已消费 DOM dirty，防 drain 帧 blit 回旧内容）

### C. 审查修复（双代理深审 + 人工复核产出）
- **F1**：parked refreshSurface 探测请求加 1s 兜底重试——丢失鼠标 release + DECSET-1004 掉落时不再可能无限挂起；unmount finally 显式 cancel
- **M1**：新增 `verify-decstbm-gate` 登记 render-scroll——四组 required 全跑 ubuntu（win32 半支不可测）、Windows lane 只 import、repro 全带 FORCE 绕门，此前删门时 CI 全绿零防线；含「FORCE 不弱化 JediTerm/sync 门」两探针
- **S2**：verify-jediterm probeEnv 清理宿主 env（tmux/kitty/Zed/VTE/WT_SESSION 漂移不再假失败）

## 验证

- repro-fullscreen-selfheal 19 场景 ALL PASS（同尺寸/0×0/FOCUS_IN/合成焦点/5s-gap/Apple 直刷/NO-DA1 兜底/Ctrl+L supersede/inline re-anchor）
- repro-backpressure-final-frame ALL PASS；verify-decstbm-gate 6/6；verify-drag-protocol 全过
- render-scroll 组 41/43（2 失败为已登记预存 osc8/goal-todo）；pnpm build 全绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal recovery after minimization, resizing, focus changes, and alternate-screen interruptions.
  * Prevented stale pointer, selection, mouse, paste, and focus states after terminal focus is restored.
  * Improved rendering reliability during long output, blocked terminals, and skipped frames.
  * Preserved final-frame updates and corrected recovery for blank or same-size terminal surfaces.
  * Disabled problematic hardware scrolling paths on Windows terminals to prevent display corruption.

* **Tests**
  * Expanded regression coverage for Windows Terminal behavior, fullscreen recovery, scrolling, dragging, and backpressure rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->