### PR TITLE
fix(ui): 工具卡悬浮零打扰——内容完全可见不再弹浮层，仅真隐藏弹全文

### DIFF
--- a/scripts/verify-tool-tooltip-gating.tsx
+++ b/scripts/verify-tool-tooltip-gating.tsx
@@ -1,18 +1,21 @@
 /**
- * 工具卡头部 hover tooltip 内容回归（用户反馈：旧行为把头部已可见的
- * 文本再打印一遍——浮层没有新增详情，纯噪音）。
+ * 工具卡头部 hover tooltip 内容回归（用户反馈 v2：旧行为——内容完全
+ * 可见也弹「时刻/退出码」浮层——仍是噪音；浮层只该在内容真被隐藏时
+ * 出现）。
  *
  * 断言：
- *  A. 单行标题完整可见（Edit 卡）→ 悬停弹出**元数据**（结束时刻 + 退出码
- *     等头部没有的信息），不重复标题（标题全屏仍只出现一次）。
+ *  A. 单行标题完整可见（Edit 卡）→ 悬停**不弹任何浮层**（标题全屏只
+ *     出现一次，无时刻框）。
  *  B. 终端脚本折叠（首行 + `… +N lines`，脚本真被隐藏）→ 悬停弹出
  *     完整脚本；移开即消失（tooltip 基础设施契约不变）。
  *  C. title 缺失、args 超出头部显示预算（HEADER_ARGS_BUDGET=480）→
  *     头部裁剪；悬停弹出完整 args（含 480 字符之后才出现的标记）。
- *  D. 运行中卡片 → 悬停弹出开始时刻（时长已在 body Running… 行，不入内）。
+ *  D. 运行中卡片、标题完整可见 → 悬停**不弹**（wrap 完整显示，无隐藏
+ *     内容；时长已在头部 chip 与 body Running… 行）。
  *  E. 单行长标题被布局宽度截断（truncate-end，非 480 预算）→ 悬停弹出
- *     完整标题 + 元数据（回归：这是旧 tooltip 的原始用途）。
- *  F. 终端卡非零退出码 → 悬停元数据带「退出码 N」。
+ *     完整标题 + 元数据附注（回归：这是 tooltip 的原始用途）。
+ *  F. 折叠脚本 + 非零退出码 → 悬停弹出完整脚本，附注带「退出码 N」
+ *     （元数据只在内容真隐藏的浮层里作为附注出现）。
  *
  * Run: `node --import tsx/esm scripts/verify-tool-tooltip-gating.tsx`
  */
@@ -104,7 +107,8 @@ const base = {
 }
 
 /** Render one tool card as the whole tree (scenario swap via key). */
-function cardTree(key: string, tool: Record<string, unknown>, foldTerminalCommand = false): React.ReactElement {
+function cardTree(key: string, tool: Record<string, unknown>, foldTerminalCommand = false,
+  onClick?: () => void): React.ReactElement {
   return (
     <AlternateScreen>
       <Box flexDirection="column">
@@ -115,6 +119,7 @@ function cardTree(key: string, tool: Record<string, unknown>, foldTerminalComman
           addMargin={false}
           verbose={false}
           foldTerminalCommand={foldTerminalCommand}
+          onClick={onClick}
         />
         <tooltip.TooltipLayer />
       </Box>
@@ -143,16 +148,16 @@ try {
 
   const { term, stdin } = rig
 
-  // --- A. 完整可见的单行标题：悬停弹元数据，不重复标题 -------------------
+  // --- A. 完整可见的单行标题：悬停不弹任何浮层 --------------------------
   const TITLE_A = 'Edit /tmp/a.ts (1 - 100)'
   check('场景 A 就绪：标题在屏', await settled(() => rowCount(term, TITLE_A) === 1))
   hoverText(stdin, term, TITLE_A)
-  check('A 完整标题悬停后弹出元数据（结束时刻）',
-    await settled(() => screenHas(term, '结束')))
-  check('A 元数据浮层不重复标题文本', rowCount(term, TITLE_A) === 1,
-    `rows=${rowCount(term, TITLE_A)}`)
+  await sleep(800) // 越过 600ms dwell：若会弹此刻已弹
+  check('A 完整标题悬停后不弹浮层', tooltip.getTooltipSnapshot() === null)
+  check('A 无时刻框上屏', !screenHas(term, '结束'))
   hover(stdin, 1, 1)
-  check('A 移开即隐藏工具提示', await settled(() => !screenHas(term, '结束')))
+  await sleep(100)
+  check('A 移开后仍无浮层', tooltip.getTooltipSnapshot() === null)
 
   // --- B. 折叠的终端脚本：真隐藏内容 → 悬停弹出完整脚本 ------------------
   const script = [
@@ -187,7 +192,7 @@ try {
   hover(stdin, 1, 1)
   check('C 移开即隐藏工具提示', await settled(() => !screenHas(term, 'END-MARKER-98765')))
 
-  // --- D. 运行中卡片：悬停弹开始时刻（时长在 body Running… 行，不入内） ----
+  // --- D. 运行中卡片、标题完整可见：悬停不弹任何浮层 ---------------------
   instance.rerender(cardTree('running', {
     name: 'bash',
     status: 'running',
@@ -196,21 +201,24 @@ try {
   }))
   check('场景 D 就绪：运行中卡片渲染', await settled(() => screenHas(term, 'sleep 300')))
   hoverText(stdin, term, 'sleep 300')
-  check('D 运行中悬停弹开始时刻', await settled(() => screenHas(term, '开始')))
+  await sleep(800)
+  check('D 完整可见运行中标题不弹浮层', tooltip.getTooltipSnapshot() === null)
+  check('D 无开始时刻框上屏', !screenHas(term, '开始'))
   hover(stdin, 1, 1)
-  check('D 移开即隐藏工具提示', await settled(() => !screenHas(term, '开始')))
+  await sleep(100)
+  check('D 移开后仍无浮层', tooltip.getTooltipSnapshot() === null)
 
   // --- E. 单行长标题被布局宽度截断：悬停弹完整标题（回归：宽截断是旧
-  //       tooltip 的原始用途，布局截断 ≠ 480 预算截断）。只有非终端卡的
-  //       标题 Text 是 truncate-end（终端卡默认 wrap 不截断）；断言走
-  //       tooltip store——长标题在浮层内换行会劈开尾部标记。
+  //       tooltip 的原始用途，布局截断 ≠ 480 预算截断）。真实 Chat 的
+  //       工具卡是可点击行（hover 时 ▾ 指示器占位）——传 onClick 走交互
+  //       预算（扣 ▾ 2 列），确保交互路径的截断判定也弹。
   const LONG_TITLE = 'Edit ' + 'x'.repeat(110) + ' TAIL-END-9900'
   instance.rerender(cardTree('wide', {
     name: 'edit',
     startedAt: Date.now() - 6_000,
     durationMs: 5_000,
     callView: { card: 'diff', title: LONG_TITLE, diffs: [] },
-  }))
+  }, false, () => {}))
   check('场景 E 就绪：宽截断卡片渲染', await settled(() => screenHas(term, 'xxx')))
   check('场景 E 就绪：宽截断标题尾部未上屏', !screenHas(term, 'TAIL-END-9900'))
   hoverText(stdin, term, 'Edit')
@@ -221,18 +229,28 @@ try {
   hover(stdin, 1, 1)
   check('E 移开即隐藏工具提示', await settled(() => tooltip.getTooltipSnapshot() === null))
 
-  // --- F. 终端卡非零退出码：悬停元数据带退出码 ---------------------------
+  // --- F. 折叠脚本 + 非零退出码：悬停弹完整脚本，附注带退出码 ----------
+  //     （元数据只在内容真隐藏的浮层里出现；完全可见时退出码由 body
+  //       的 `Exit code N` 行本身呈现，不重复。）
+  const scriptF = [
+    '$items = Get-ChildItem -Recurse',
+    '$items | Where-Object { $_.Length -gt 1kb }',
+    '$items | Select-Object -First 10 Name',
+  ].join('\n')
   instance.rerender(cardTree('exit7', {
     name: 'bash',
     startedAt: Date.now() - 3_000,
     durationMs: 3_000,
-    callView: { card: 'terminal', title: 'false' },
+    callView: { card: 'terminal', title: scriptF },
     resultView: { card: 'terminal', output: '', exitCode: 7 },
     resultFull: '',
-  }))
-  check('场景 F 就绪：结果卡渲染', await settled(() => screenHas(term, 'Bash(false)')))
-  hoverText(stdin, term, 'false')
-  check('F 非零退出码悬停弹出元数据带退出码', await settled(() => screenHas(term, '退出码 7')))
+  }, true))
+  check('场景 F 就绪：折叠脚本首行可见', await settled(() => screenHas(term, 'Get-ChildItem -Recurse')))
+  check('场景 F 就绪：折叠隐藏了其余行', !screenHas(term, 'Select-Object -First 10 Name'))
+  check('场景 F 就绪：body 直接呈现退出码', await settled(() => screenHas(term, 'Exit code 7')))
+  hoverText(stdin, term, '$items')
+  check('F 折叠脚本悬停弹完整命令（含末行）', await settled(() => screenHas(term, 'Select-Object -First 10 Name')))
+  check('F 浮层附注带本地化退出码', await settled(() => screenHas(term, '退出码 7')))
   hover(stdin, 1, 1)
   check('F 移开即隐藏工具提示', await settled(() => !screenHas(term, '退出码 7')))
 

--- a/src/components/messages/AssistantToolUseMessage.tsx
+++ b/src/components/messages/AssistantToolUseMessage.tsx
@@ -299,13 +299,16 @@ function foldTerminalTitle(title: string): FoldedTitle | undefined {
   return { first, hidden }
 }
 
-/** Metadata line for the header hover tooltip when the header itself is
- *  complete: start/finish wall-clock and the terminal result's exit code /
- *  signal — everything the header's relative `· 2m` chip and the body's
+/** Addendum line appended to the header hover tooltip when the header hides
+ *  content (folded script / clipped args / width-truncated title): start or
+ *  finish wall-clock and the terminal result's exit code / signal —
+ *  everything the header's relative `· 2m` chip and the body's
  *  `Running… (…)` line do NOT say. Durations stay out on purpose: showing
  *  a value twice, once on the card and once in the float, is exactly the
- *  noise class this tooltip exists to avoid. Returns '' when the row
- *  carries no timing data. */
+ *  noise class this tooltip exists to avoid. A fully visible header pops
+ *  NOTHING (meta included) — a float that repeats or annotates content
+ *  already on screen is noise, not detail. Returns '' when the row carries
+ *  no timing data. */
 function toolCardMetaTooltip(tool: ToolRow, isRunning: boolean, isError: boolean): string {
   const parts: string[] = []
   const startedAt = tool.startedAt
@@ -342,42 +345,44 @@ function HeaderTitle({ name, title, isTerminal, folded, displayArgs, argsLanguag
    *  segment renders underlined and clickable (opens the file menu). */
   filePath?: string
   onOpenFile?: (path: string) => void
-  /** Metadata line shown on hover when the header is complete: start/finish
-   *  wall-clock, terminal exit code/signal — everything the relative chip
-   *  and the body's Running… line do NOT say. Lazy getter, resolved at
-   *  show time so a running card's start stays fresh. '' = nothing. */
+  /** Addendum line for the header hover tooltip when the header HIDES
+   *  content (folded script / clipped args / width-truncated title):
+   *  start/finish wall-clock, terminal exit code/signal — everything the
+   *  relative chip and the body's Running… line do NOT say. Lazy getter,
+   *  resolved at show time so a running card's start stays fresh. '' =
+   *  nothing. A fully visible header pops no tooltip at all. */
   metaTooltip: () => string
   /**
-   * Column budget for `name + (title)` on the header line — what
+   * Column budget for the NON-terminal one-line title on the header line —
    * `useTerminalSize().columns` (already margin-adjusted) minus the fixed
-   * header chrome (loader, hover ▾ indicator, settled chip, gutter slack).
-   * When the wrapped text exceeds it, ink's truncate-end CUTS the title on
-   * the screen and the tooltip must prefer the complete text over the
-   * metadata; otherwise the metadata is everything the float adds.
+   * chrome of the row: loader dot 2 + hover ▾ indicator 2 (present while
+   * the pointer dwells) + the settled elapsed chip + slack for the
+   * transcript gutter. Only this title renders in a truncate-end Text, so
+   * only it can be cut by layout width (terminal titles wrap; args are
+   * clipped by the 480-char budget) — this budget gates just that cut.
    */
   headerTextBudget: number
 }): React.ReactNode {
-  // Hover tooltip priority: genuinely HIDDEN content first — a folded
-  // terminal script, args clipped past the 480-char budget, or a single-line
-  // title cut by layout width (truncate-end). Only a header that really
-  // fits its row offers just the metadata, and stays silent when the row
-  // has no timing data. Empty content is a no-op inside the hook.
+  // Hover tooltip rule: pop ONLY when the header genuinely hides content —
+  // a folded terminal script, args clipped past the 480-char budget, or a
+  // non-terminal one-line title cut by layout width (truncate-end). A header
+  // that fully fits its row stays silent: a float that repeats or annotates
+  // text already visible next to the pointer is noise, not detail. Empty
+  // content is a no-op inside the hook.
   const headerTooltip = useTooltip(() => {
     const meta = metaTooltip()
     const withMeta = (full: string): string => (meta === '' ? full : `${full}\n${meta}`)
     if (folded !== undefined) return withMeta(title ?? '')
     if (title === undefined && clipHeaderArgs(displayArgs) !== displayArgs) return withMeta(displayArgs)
-    // Width truncation: the truncate-end Text cuts long one-line titles by
-    // layout, not by a budget — same hidden-content rule as above.
-    const wrapped = title === undefined
-      ? `(${clipHeaderArgs(displayArgs)})`
-      : isTerminal
-        ? `(${title})`
-        : title.trim()
-    if (stringWidth(name) + stringWidth(wrapped) > headerTextBudget) {
-      return withMeta(title === undefined ? displayArgs : title.trim())
+    // Width truncation: only the non-terminal title Text is truncate-end —
+    // a long one-line title is really cut by layout when it overflows the
+    // row. Terminal titles WRAP instead (default Text wrap, nothing hidden)
+    // and args within the 480 budget wrap too; they never reach this gate.
+    if (title !== undefined && !isTerminal && stringWidth(title.trim()) > headerTextBudget) {
+      return withMeta(title.trim())
     }
-    return meta
+    // Header fully visible: nothing hidden, nothing to add — stay silent.
+    return ''
   })
   if (title === undefined) {
     return (
@@ -535,16 +540,23 @@ export function AssistantToolUseMessage({
   // source line per terminal row (truncate) keeps the panes row-aligned,
   // which the flat add/del line model cannot express.
   const { columns } = useTerminalSize()
+  // Interactive rows grow a ▾/▴ disclose column while the pointer dwells
+  // (fixed, no layout shift elsewhere). The tooltip resolves at show time —
+  // i.e. exactly while that column is present — so the budget must reserve
+  // it for clickable cards only; non-interactive rows never render it.
+  const interactive = onClick !== undefined
   // Header-row budget for the title Text. useTerminalSize() already reports
   // the margin-adjusted content width, so this is the fixed chrome of the
-  // line only: loader dot 2 + hover ▾ indicator 2 (present while the pointer
-  // dwells) + the settled elapsed chip + slack for the transcript gutter.
-  // Over the budget ink's truncate-end cuts the title on screen (a *layout*
-  // truncation, not the 480-char budget) — HeaderTitle then prefers the
-  // complete text.
-  const headerTextBudget = Math.max(0, columns - 2 - 2 - stringWidth(name)
-    - (!isRunning && elapsedText !== '' ? stringWidth(elapsedText) : 0)
-    - 4)
+  // line only: loader dot 2 + hover ▾ indicator 2 (interactive rows, present
+  // while the pointer dwells) + the settled elapsed chip. Calibrated against
+  // the renderer (probe-tooltip-truncation): a truncate-end title whose
+  // width exceeds columns − loader − ▾ − chip is really cut on screen at
+  // tooltip time; anything at or under the budget fits fully and must NOT
+  // pop a tooltip. No extra slack, and the tool name is NOT deducted — a
+  // non-terminal title carries its own first word, so double-counting name
+  // pushed the gate ~10 cols too tight and floated fully visible titles.
+  const headerTextBudget = Math.max(0, columns - 2 - (interactive ? 2 : 0)
+    - (!isRunning && elapsedText !== '' ? stringWidth(elapsedText) : 0))
   const useSplitDiff = !isError && view?.card === 'diff' &&
     (diffLayout === 'split' || (diffLayout !== 'unified' && columns >= SPLIT_DIFF_MIN_COLS))
   let body: BodyLine[] = []
@@ -598,7 +610,6 @@ export function AssistantToolUseMessage({
   // No layout change: the indicator is a fixed column on the header line, the
   // body never moves.
   const [hovered, setHovered] = React.useState(false)
-  const interactive = onClick !== undefined
   const hoverTint = interactive && hovered && !isSelected
 
   return (


### PR DESCRIPTION
## 问题

用户反馈：工具卡内容明明完整显示，悬停仍弹「完成于 xx:xx」时刻框——纯噪音。#719 把 Beta4 的无条件弹全文改成「可见→弹时刻框」，但时刻框本身仍是打扰。本次把门控再收紧一步：**内容完全可见 → 悬浮零弹框**。

## 改动

`AssistantToolUseMessage.tsx`（HeaderTitle hover 门控）：

1. **完全可见 → 不弹任何浮层**：getter 只有三种「真隐藏」才弹全文——折叠终端脚本、超 480 字符被裁剪的 args、非终端标题被布局宽度截断（truncate-end）。时刻/退出码降级为真隐藏浮层的附注尾行。
2. **预算公式修正（实测校准）**：旧式 `columns-2-2-name-elapsed-4` 双扣工具名 + 固定 slack，把截断判定阈值压紧约 10 列——64~73 列宽的标题明明完整显示却误判截断弹框。新式 `columns-2-(interactive?2:0)-elapsed`：不扣 name、▾ 指示器列只对可点击卡预留。
3. **终端卡/args 不再误弹**：探针实证超宽是 wrap 完整显示（非截断），只有折叠/480 裁剪才算真隐藏。

## 验证

- `verify-tool-tooltip-gating` 28/28（A/D 完整可见不弹，B/C/E 真隐藏仍弹，F 折叠+退出码附注；A/D/F 断言按新语义反转）
- `verify-tooltip`、`verify-hover-details` 19/19、`verify-smooth-reveal` 全过
- tsc 全绿，`git diff --check` 干净

> 注：`verify-display-settings` 的 `DEFAULT_STATUS_BAR` 失败为预存过期断言（actual 多 `cost:true` 系 #573 引入），与本改动无关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now appear only when tool-card or header content is hidden, such as truncated titles, folded commands, or clipped arguments.
  * Fully visible tool details no longer display unnecessary metadata-only tooltips.
  * Improved tooltip behavior for interactive tool cards and terminal commands, including localized exit-code information for failed commands.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->