### PR TITLE
fix(resume): session/color 登记进 LEGACY 白名单——/color 会话不再被整份拒绝

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "verify:boundary": "node --import tsx/esm scripts/verify-adapter-boundary.ts",
     "verify:i18n": "node --import tsx/esm scripts/verify-i18n.ts",
     "verify:contract": "node --import tsx/esm scripts/verify-upstream-contract.ts",
+    "verify:session-append-registry": "node scripts/verify-session-append-registry.mjs",
     "verify:alpha-source": "node scripts/verify-alpha-source.mjs",
     "verify:herdr": "node --import tsx/esm scripts/verify-herdr-integration.ts",
     "verify:manifest-deps": "node --import tsx/esm scripts/verify-manifest-deps.ts",

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -249,6 +249,9 @@ const GROUPS = {
 // 放行；日志字节与 0600 权限绝不被改写；非白名单未知类型保持拒读
 // （上游 fail-closed 新格式保护不破）。
     ["verify-resume-legacy-events", ['node', 'scripts/verify-resume-legacy-events.mjs']],
+// 写端漂移门：session.append 持久化的自有事件类型必须在 LEGACY 注册
+// （/color 事故的制度化防复发——写入端与登记端自此被 CI 强制联动）。
+    ["verify-session-append-registry", ['node', 'scripts/verify-session-append-registry.mjs']],
 // 会话 cwd 回归（issue #96）：启动目录向上解析 git 仓库根（普通克隆
 // 与 .git 文件 worktree 均覆盖、dotfiles ~/.git 守卫），/resume 过滤
 // 双向兼容升级前记录的子目录会话，$HOME/盘符根容器目录只精确匹配

--- a/scripts/verify-resume-legacy-events.mjs
+++ b/scripts/verify-resume-legacy-events.mjs
@@ -49,9 +49,9 @@ const {
 } = await import('../lib/types/dsh-adapter/compat/sessionLog.js')
 
 /** Hand-craft one pre-#143 shaped log: header frame + one event frame. */
-function writeTaintedLog(id, eventType) {
+function writeTaintedLog(id, eventType, data = {}) {
   const header = { type: 'session', version: SESSION_FORMAT_VERSION, id, createdAt: 1, cwd: '/tmp/verify', delegationDepth: 0 }
-  const event = { type: eventType, seq: 0, time: 2, data: {} }
+  const event = { type: eventType, seq: 0, time: 2, data }
   const dir = join(root, '--tmp-verify--', id)
   mkdirSync(dir, { recursive: true })
   const file = join(dir, 'session.jsonl.zstd')
@@ -120,6 +120,20 @@ for (const type of LEGACY_SESSION_EVENT_TYPES) {
 assert.ok(!KNOWN_SESSION_EVENT_TYPES.has('acme/required-policy'), 'unknown stays unknown')
 ensureLegacySessionEventTypes() // second call: no-op, never throws
 assert.equal((await persistence.load(legacyId)).events.length, 1, 'still loads after re-ensure')
+
+// 6. `session/color` (the /color persistence; unlisted until 2026-09-04,
+// which made every colored session un-resumable — user-reported). The
+// whitelist-coherence loop in step 5 already proves it registered in every
+// reachable KNOWN copy; here prove the payload itself survives the strict
+// read with the real shape ({ color: string }).
+{
+  const colorId = 'aaaaaaa1-bbbb-cccc-dddd-eeeeeeeeeeee'
+  writeTaintedLog(colorId, 'session/color', { color: 'red' })
+  const loaded = await persistence.load(colorId)
+  assert.equal(loaded.events.length, 1, 'colored session loads after registration')
+  assert.equal(loaded.events[0].type, 'session/color')
+  assert.deepEqual(loaded.events[0].data, { color: 'red' }, 'color payload survives the strict read')
+}
 
 // --- part 2: split CLI/profile trees ---------------------------------------
 // Three PHYSICAL dsh-session copies (stub packages — anchor coverage is

--- a/scripts/verify-session-append-registry.mjs
+++ b/scripts/verify-session-append-registry.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Write-side drift gate: every dsh-tui-private event type persisted through
+ * `session.append('<type>', …)` must be registered for strict reads — either
+ * in dsh-session's KNOWN_SESSION_EVENT_TYPES (upstream builtin) or in our
+ * LEGACY_SESSION_EVENT_TYPES (compat/sessionLog.ts). The upstream append API
+ * has no `ignorable` flag, so an unlisted own type makes /resume, rewind,
+ * fork and --resume reject the whole log (the /color incident: session/color
+ * shipped unlisted and every colored session became un-resumable).
+ *
+ * Static scan of src/ (source of truth for the npm package), so it fails in
+ * CI the moment a new append lands without its registry entry.
+ *
+ * Run: node scripts/verify-session-append-registry.mjs
+ */
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const srcDir = join(root, 'src')
+
+const { KNOWN_SESSION_EVENT_TYPES } = await import('@deepseek-ai/dsh-session')
+const { LEGACY_SESSION_EVENT_TYPES } = await import('../lib/types/dsh-adapter/compat/sessionLog.js')
+
+const appended = new Set()
+function walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name)
+    if (statSync(p).isDirectory()) { walk(p); continue }
+    if (!/\.tsx?$/.test(name)) continue
+    const sf = ts.createSourceFile(p, readFileSync(p, 'utf8'), ts.ScriptTarget.ESNext, true)
+    const visit = (node) => {
+      // .append('ns/type', …) — string-literal first arg only; dynamic types
+      // are out of scope for a static gate (none exist as of this writing).
+      if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)
+        && node.expression.name.text === 'append' && node.arguments.length > 0
+        && ts.isStringLiteral(node.arguments[0])) {
+        const type = node.arguments[0].text
+        // Session event types are namespaced ('ns/type'); other .append APIs
+        // (promptController.append(''), injectController.append(text)) are
+        // not session persistence and must not trip the gate.
+        if (/^[a-z0-9-]+\/[a-z0-9/-]+$/.test(type)) appended.add(type)
+      }
+      ts.forEachChild(node, visit)
+    }
+    visit(sf)
+  }
+}
+walk(srcDir)
+
+const unregistered = [...appended].filter(
+  (t) => !KNOWN_SESSION_EVENT_TYPES.has(t) && !LEGACY_SESSION_EVENT_TYPES.includes(t),
+)
+console.log(`session.append types: ${[...appended].sort().join(', ')}`)
+console.log(`upstream builtin: ${[...appended].filter((t) => KNOWN_SESSION_EVENT_TYPES.has(t)).length}, TUI-registered: ${[...appended].filter((t) => LEGACY_SESSION_EVENT_TYPES.includes(t)).length}`)
+assert.deepEqual(unregistered, [],
+  `event types persisted by session.append but NOT registered for strict reads (add to LEGACY_SESSION_EVENT_TYPES in src/dsh-adapter/compat/sessionLog.ts or stop persisting them): ${unregistered.join(', ')}
+An unlisted own type makes every strict read (/resume, rewind, fork, --resume) reject the whole session log — see the /color incident (session/color, fixed 2026-09-04).`)
+console.log('verify-session-append-registry: OK')

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -6584,8 +6584,11 @@ export function createChannel(
     setSessionColor(color) {
       // `session/color` is a dsh-tui plugin event — not in dsh-session's
       // typed union, so appended through the same cast applyMode uses for
-      // its sandbox/approval overrides. It replays on resume/rewind like
-      // session/title, keeping each session's accent color its own.
+      // its sandbox/approval overrides. Strict reads only accept it via the
+      // LEGACY_SESSION_EVENT_TYPES registration (compat/sessionLog.ts) —
+      // upstream's whitelist does NOT know this type the way it knows
+      // session/title, so resume/rewind survive solely through that
+      // registration; new persisted own types must be listed there.
       ;(agent.session as unknown as { append(type: string, data: Record<string, unknown>): unknown })
         .append('session/color', { color })
       state.sessionColor = color

--- a/src/dsh-adapter/compat/sessionLog.ts
+++ b/src/dsh-adapter/compat/sessionLog.ts
@@ -69,8 +69,19 @@ import { homeDir } from '../../utils/paths.js'
  * UI frames — safe for the strict read path to accept and skip. Exported
  * for the regression verifier; grow it only with proof the type was always
  * inert (never load-bearing for session reconstruction).
+ *
+ * Registration discipline: every event type this TUI persists through
+ * `session.append` MUST be listed here (or already be in dsh-session's
+ * KNOWN_SESSION_EVENT_TYPES) — the upstream append API exposes no
+ * `ignorable` flag, so an unlisted own type makes every strict read
+ * (/resume, rewind, fork, --resume) reject the whole log with
+ * SessionFormatUnsupportedError. `session/color` was written since /color
+ * shipped but unlisted, so any colored session became un-resumable
+ * (user-reported, root-caused end-to-end 2026-09-04): payload is a bare
+ * `{ color: string }`, folded last-write-wins by the projection, never
+ * load-bearing for session reconstruction.
  */
-export const LEGACY_SESSION_EVENT_TYPES: readonly string[] = ['activity/status']
+export const LEGACY_SESSION_EVENT_TYPES: readonly string[] = ['activity/status', 'session/color']
 
 /** Zstd frame magic number, little-endian (0xFD2FB528). */
 const ZSTD_MAGIC = 0xfd2fb528


### PR DESCRIPTION
Closes #746

## 根因（216-agent 诊断，逐字证据链）

`/color` 经 `session.append('session/color', {color})` 持久化 TUI 私有事件（上游 append 无 ignorable 通道）；恢复时 dsh-session 白名单 48 项不含它 → **整份日志 fail-closed 拒绝**。兼容注册缝 `ensureLegacySessionEventTypes()` 存在且三条读路径（/resume 选择器、rewind/fork、--resume）都在调——但白名单只有 `activity/status`，漏登记自家事件。

用户实测被截断的错误完整文本（500 列 PTY 抓取）见 #746。

## 改动

| 项 | 内容 |
|---|---|
| **白名单** | `LEGACY_SESSION_EVENT_TYPES` 加 `'session/color'`（对存量污染日志同样生效——实测 170 个日志中 1 个受染，注册后直接可恢复，零迁移） |
| **注释修正** | 写入端「replays like session/title」的错误假设（session/title 是上游内置，session/color 不是）改为如实说明依赖 compat 注册 |
| **写端漂移门** | 新增 `verify-session-append-registry`：AST 扫描 src/ 全部 `session.append` 的 ns/type 字面量，断言每个要么上游内置要么已登记——**写入端与登记端自此被 CI 强制联动**（本次事故的制度化防复发）。红绿双向验证：临时移除登记 → 门禁红并点名；恢复 → 绿 |
| **回归扩展** | `verify-resume-legacy-events` 补 session/color 载荷场景（真实 SessionStore 严格读，`{color:'red'}` 存活） |

## 不选方案（均有实测背书）

升级 dsh 无效（0.1.0-rc.7/0.1.1-rc.2/0.1.2-rc.1/alpha.1 四版白名单均不含）；数据迁移不必要（注册对存量生效）且改写用户历史风险高；写端补 ignorable 走不通（API 无此参数）。

注：错误单行截断（Bug 2）另行 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session logs now preserve and correctly process the `session/color` event during strict reads.
  * Added compatibility support for persisted color events that do not affect session loading.

* **Tests**
  * Added automated verification to detect session append event types missing from approved registries.
  * Integrated registry consistency checks into the session workspace CI group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->