### PR TITLE
fix(resume): SessionBrowser 错误 notice 多行展开——完整失败句不再截断

### DIFF
--- a/scripts/verify-session-browser.mjs
+++ b/scripts/verify-session-browser.mjs
@@ -248,7 +248,7 @@ function makeChannel() {
       return {
         ok: false,
         reason: 'failed',
-        error: 'corrupt session log: seq gap in committed region',
+        error: 'session "a1b78223-cd6d-4f1e-bafe-a4e9deeb47da" contains event type "session/color" (seq 3) unknown to this harness and not marked ignorable; refusing to interpret the log — it was likely written by a newer harness',
       }
     },
     newSession: async () => false,
@@ -675,13 +675,29 @@ check('a ghost pin never becomes a row',
 
 // ── resume failure detail ──────────────────────────────────────────────────
 stdin.write('\r')
-const failureShown = await settled(() => /corrupt session log: seq gap in committed region/.test(flat(screen())))
+const failureShown = await settled(() => /contains event type "session\/color"/.test(flat(screen())))
+// #746: the tail of the harness's failure sentence must be on screen too —
+// the old single-line truncate lost everything after "contains even…".
+const failureTailShown = failureShown && /refusing to interpret the log/.test(flat(screen()))
 s = screen()
 check('a failed resume stays in the browser', /Resume session/.test(flat(s)), flat(s).slice(0, 180))
 check(
-  'the browser shows the real resume failure',
+  'the browser shows the real resume failure (head)',
   failureShown,
-  flat(s).slice(-220),
+  flat(s).slice(-260),
+)
+check(
+  'the whole failure sentence is readable, not truncated (#746)',
+  failureTailShown,
+  flat(s).slice(-300),
+)
+check(
+  'the error notice unwraps to at most 3 rows',
+  (() => {
+    const rows = s.split('\n').filter(l => l.includes('session/color') || l.includes('refusing to interpret'))
+    return rows.length > 0 && rows.length <= 3
+  })(),
+  JSON.stringify(s.split('\n').filter(l => l.includes('session/color') || l.includes('refusing')).length),
 )
 check(
   'the browser does not misreport every failure as a running model',

--- a/src/screens/SessionBrowser.tsx
+++ b/src/screens/SessionBrowser.tsx
@@ -11,7 +11,7 @@ import { SessionPreview } from '../components/sessions/SessionPreview.js'
 import { WorkspaceListRow } from '../components/sessions/WorkspaceListRow.js'
 import { useTerminalFocus } from '../ink/hooks/use-terminal-focus.js'
 import { isMod, isPlainReturn, modLabel } from '../utils/modifiers.js'
-import { formatProject, projectName, spreadRow, tailWidth, truncateWidth } from '../sessions/format.js'
+import { formatProject, projectName, spreadRow, tailWidth, truncateWidth, wrapWidth } from '../sessions/format.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { TICK, MULTIPLICATION_X } from '../cc/figures.js'
 import {
@@ -1063,9 +1063,25 @@ export function SessionBrowser({
           delete/rename report must never shift the list by arriving. */}
       <Box flexShrink={0}>
         <Text color={notice?.tone === 'error' ? 'error' : 'success'}>
-          {notice === undefined
-            ? ' '
-            : ` ${notice.tone === 'error' ? MULTIPLICATION_X : TICK} ${truncateWidth(notice.text, Math.max(0, columns - 4))}`}
+          {notice === undefined ? ' ' : (() => {
+            // Error notices carry the harness's whole failure sentence (type
+            // name, seq, raw log path — e.g. the session/color rejection,
+            // #746); a single truncated line hid everything after "contains
+            // even…". Wrap to 3 lines CJK-aware, ellipsize only the 3rd.
+            const prefix = ` ${notice.tone === 'error' ? MULTIPLICATION_X : TICK} `
+            if (notice.tone !== 'error') {
+              return prefix + truncateWidth(notice.text, Math.max(0, columns - 4))
+            }
+            const width = Math.max(8, columns - 2)
+            const lines = wrapWidth(prefix + notice.text, width)
+            const shown = lines.slice(0, 3)
+            if (lines.length > 3 && shown.length > 0) {
+              shown[shown.length - 1] = truncateWidth(
+                (shown[shown.length - 1] + ' ' + (lines[3] ?? '')).trimEnd(), width,
+              )
+            }
+            return shown.length > 0 ? shown.join('\n') : prefix
+          })()}
         </Text>
       </Box>
       {mode === 'confirm-delete' && focused !== undefined && (


### PR DESCRIPTION
Closes #746（与 #747 同源现场，本 PR 修显示面）

## 问题

`/resume` 失败时 harness 的完整裁决句（事件类型、seq、raw log 路径、「refusing to interpret the log — it was likely written by a newer harness」）被单行 `truncateWidth` 截断——80 列终端只显示到「contains even…」，用户看不到任何裁决理由（#746 的原始报告动机）。

## 修法

错误 tone 的 notice 用 CJK 感知 `wrapWidth`（既有函数，SessionTree 同款）折到 3 行、仅末行截断省略号；成功 tone 保持单行不变（删除/改名报告本就短，不占行）。`columns` 为 0/1 的退化宽度有下限保护。

## 回归

`verify-session-browser` 的 resume 失败场景升级为 #746 真实长文本（345 列），三断言红绿验证：错误头部可见 / **尾部裁决句可见**（旧实现必丢）/ 展开不超过 3 行。改前红（尾部丢失、行计数 0）、改后全绿。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session browser error notices to clearly display unknown events.
  - Error messages now wrap across multiple lines while remaining readable within the available space.
  - Preserved browser state when session errors occur.
  - Improved truncation behavior for long notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
