### PR TITLE
fix(update): 版本检查源改为 GitHub releases 最新（含预发布），修 beta 线滞后

### DIFF
--- a/scripts/verify-update-checksum.tsx
+++ b/scripts/verify-update-checksum.tsx
@@ -7,7 +7,7 @@
  *  - verifyAssetChecksum：SHA256SUMS 清单解析（`hex␣␣name` / `hex␣*name`
  *    二进制格式 / 大小写 hex / 单资产纯 digest 旁注）、篡改字节拒绝、
  *    缺条目拒绝（fail-closed）、畸形清单拒绝；
- *  - fetchGithubLatestRelease：release 资产列表中的 SHA256SUMS /
+ *  - fetchGithubNewestRelease：release 资产列表中的 SHA256SUMS /
  *    *.sha256 旁注被解析成 checksumUrl（注入 apiBaseUrl + 本地 http）；
  *  - downloadAndReplaceStandaloneBinary（本地 http server + 临时假二进制）：
  *    (a) sums 匹配 → 替换成功；篡改资产字节 → 拒绝替换且磁盘不留下载
@@ -80,9 +80,9 @@ if (typeof verifyAssetChecksum === 'function') {
   check('空清单 → 拒绝', !verifyAssetChecksum(payload, '', asset))
 }
 
-// ═══════════════ Part 2：fetchGithubLatestRelease 解析 checksumUrl ═══════════════
+// ═══════════════ Part 2：fetchGithubNewestRelease 解析 checksumUrl ═══════════════
 
-// 本地 http server 充当 GitHub：/releases/latest 返回 JSON，/asset 返回
+// 本地 http server 充当 GitHub：/releases 列表端点返回 JSON 数组，/asset 返回
 // 归档字节（tampered 标志切换内容），/SHA256SUMS 返回清单。
 let tamperAsset = false
 let omitSums = false
@@ -105,8 +105,9 @@ const ASSET_NAME = 'dsh-tui-standalone-linux-x64.tar.gz'
 
 const server = http.createServer(async (req, res) => {
   const url = req.url ?? ''
-  // 注意：fetchGithubLatestRelease 请求的是 `<apiBaseUrl>/repos/<repo>/releases/latest`。
-  if (url === '/repos/ccch1mneyyy/dsh-TUI/releases/latest') {
+  // 注意：fetchGithubNewestRelease 请求的是 `<apiBaseUrl>/repos/<repo>/releases?per_page=30`（列表端点，
+  // 含预发布；最新条目由 semver gt() 选出）。
+  if (url.startsWith('/repos/ccch1mneyyy/dsh-TUI/releases')) {
     const assets: Array<Record<string, string>> = [
       { name: ASSET_NAME, browser_download_url: `http://127.0.0.1:${serverPort()}/asset` },
     ]
@@ -123,7 +124,10 @@ const server = http.createServer(async (req, res) => {
       assets.push({ name: 'dsh-tui-standalone-win-x64.zip.sha256', browser_download_url: `http://127.0.0.1:${serverPort()}/dsh-tui-standalone-win-x64.zip.sha256` })
     }
     res.writeHead(200, { 'content-type': 'application/json' })
-    res.end(JSON.stringify({ tag_name: 'v9.9.9', assets }))
+    res.end(JSON.stringify([
+      { tag_name: 'v9.9.8', assets: [] },
+      { tag_name: 'v9.9.9', assets, prerelease: true },
+    ]))
     return
   }
   if (url === '/asset') {
@@ -187,19 +191,19 @@ function serverPort(): number {
 const base = `http://127.0.0.1:${serverPort()}`
 
 {
-  const release = await updateModule.fetchGithubLatestRelease({ apiBaseUrl: base })
+  const release = await updateModule.fetchGithubNewestRelease({ apiBaseUrl: base })
   check(
-    'fetchGithubLatestRelease 解析版本号',
+    'fetchGithubNewestRelease 解析版本号',
     (release as { version?: string } | undefined)?.version === '9.9.9',
     JSON.stringify(release),
   )
   check(
-    'fetchGithubLatestRelease 从 SHA256SUMS 资产解析 checksumUrl',
+    'fetchGithubNewestRelease 从 SHA256SUMS 资产解析 checksumUrl',
     typeof (release as { checksumUrl?: string } | undefined)?.checksumUrl === 'string',
     JSON.stringify(release),
   )
   omitSums = true
-  const noSums = await updateModule.fetchGithubLatestRelease({ apiBaseUrl: base })
+  const noSums = await updateModule.fetchGithubNewestRelease({ apiBaseUrl: base })
   check(
     'release 无 SHA256SUMS 资产时 checksumUrl 缺省（走 transition 警告路径）',
     (noSums as { checksumUrl?: string } | undefined)?.checksumUrl === undefined,
@@ -208,7 +212,7 @@ const base = `http://127.0.0.1:${serverPort()}`
   // 精确旁注（<assetName>.sha256）：仍被认领——单资产 digest 旁注校验的
   // 就是伴随的那一个资产，语义无歧义。
   sidecarMode = 'exact'
-  const exactSidecar = await updateModule.fetchGithubLatestRelease({ apiBaseUrl: base })
+  const exactSidecar = await updateModule.fetchGithubNewestRelease({ apiBaseUrl: base })
   check(
     'release 只发布精确 <assetName>.sha256 旁注时解析为 checksumUrl',
     (exactSidecar as { checksumUrl?: string } | undefined)?.checksumUrl === `${base}/${ASSET_NAME}.sha256`,
@@ -219,7 +223,7 @@ const base = `http://127.0.0.1:${serverPort()}`
   // 的任意 endsWith('.sha256') 兜底会抓错清单，fail-closed 把无辜用户的
   // 更新误拒成 checksum mismatch。
   sidecarMode = 'foreign'
-  const foreignSidecar = await updateModule.fetchGithubLatestRelease({ apiBaseUrl: base })
+  const foreignSidecar = await updateModule.fetchGithubNewestRelease({ apiBaseUrl: base })
   check(
     'release 只有其他资产名的 .sha256 旁注时 checksumUrl 缺省（不抓错清单）',
     (foreignSidecar as { checksumUrl?: string } | undefined)?.checksumUrl === undefined,

--- a/src/dsh-adapter/plugin.ts
+++ b/src/dsh-adapter/plugin.ts
@@ -1491,6 +1491,9 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
           if (target.authoritative !== undefined) {
             channel.notify(t('update-mirror-lag', { latest: target.latest, authoritative: target.authoritative }))
           }
+          if (target.registryLatest !== undefined) {
+            channel.notify(t('update-registry-lag', { registry: target.registryLatest, latest: target.latest }))
+          }
           updateTargetVersion = target.latest
         }
         if (isStandaloneRuntime()) {
@@ -1573,8 +1576,14 @@ export async function apply(ctx: Context, config: Config): Promise<void> {
     const suffix = update.isStandalone && update.checksumUrl === undefined
       ? ` ${t('update-standalone-no-checksum')}`
       : ''
+    // The newest version came from a source ahead of the install's registry
+    // (GitHub releases / npmjs.org vs a lagging registry): say so, because
+    // /update can only install what that registry serves.
+    const lagSuffix = update.registryLatest === undefined
+      ? ''
+      : t('update-registry-lag', { registry: update.registryLatest, latest: update.latest })
     channel.notify(
-      `${t(key, { current: update.current, latest: update.latest })}${suffix}`,
+      `${t(key, { current: update.current, latest: update.latest })}${suffix}${lagSuffix}`,
       { color: 'warning', timeoutMs: 12000 },
     )
   })

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -398,6 +398,7 @@ const dict = {
   'update-check-failed': { zh: '无法确认新版本（网络或 registry 不可达），已尝试直接更新……', en: 'Could not confirm a newer version (network or registry unreachable); attempting the update anyway…' },
   'update-refused-deadlock': { zh: '已取消更新：镜像 registry 目前只能装到 v{{latest}}，而该版本在旧全局启动器的 patch 下会启动死锁（#183/#307）；官方最新为 v{{authoritative}}，待镜像同步后再 /update。', en: 'Update cancelled: the mirror registry can only serve v{{latest}}, which deadlocks boot under older global-launcher patches (#183/#307); official latest is v{{authoritative}} — retry /update after the mirror syncs.' },
   'update-mirror-lag': { zh: '镜像 registry 滞后：本次安装 v{{latest}}；官方最新 v{{authoritative}}，镜像同步后可再 /update。', en: 'Mirror registry lag: installing v{{latest}} now; official latest is v{{authoritative}} — run /update again once the mirror syncs.' },
+  'update-registry-lag': { zh: '（注册表尚为 v{{registry}}，/update 可能暂时装不到 v{{latest}}，稍后再试）', en: ' (the registry still serves v{{registry}}; /update may not reach v{{latest}} yet — retry later)' },
   'update-standalone-available': { zh: '发现便携包新版本：v{{latest}}（当前 v{{current}}）· 输入 /update 自动更新', en: 'New standalone version available: v{{latest}} (current v{{current}}) · type /update to update' },
   'update-standalone-no-checksum': { zh: '该版本未发布 SHA256 校验和，更新包完整性无法验证', en: 'this release publishes no SHA256 checksums; the update payload cannot be integrity-verified' },
   'update-standalone-starting': { zh: '正在下载便携包新版本并自动替换，完成后会自动重启并恢复当前会话……', en: 'Downloading and replacing standalone binary. The TUI will restart and resume this session when finished…' },

--- a/src/update.ts
+++ b/src/update.ts
@@ -104,11 +104,17 @@ export interface TuiUpdateInfo {
   downloadUrl?: string
   /** SHA256SUMS manifest URL when the release publishes one; absent = the update warning path. */
   checksumUrl?: string
+  /**
+   * What the install's registry serves when every observed source ahead of it
+   * (GitHub newest, npmjs.org) exceeds it: the update notice appends a
+   * registry-lag note so the user knows /update may not reach `latest` yet.
+   */
+  registryLatest?: string
 }
 
 /** What a fresh registry lookup says about this install. */
 export type TuiUpdateTarget =
-  | { kind: 'update'; current: string; latest: string; authoritative?: string; isStandalone?: boolean; downloadUrl?: string; checksumUrl?: string }
+  | { kind: 'update'; current: string; latest: string; authoritative?: string; registryLatest?: string; isStandalone?: boolean; downloadUrl?: string; checksumUrl?: string }
   | { kind: 'latest'; current: string; isStandalone?: boolean }
   | { kind: 'unknown'; isStandalone?: boolean }
 
@@ -274,7 +280,7 @@ export function getStandaloneAssetName(platform = process.platform, arch = proce
     : 'dsh-tui-standalone-linux-x64.tar.gz'
 }
 
-/** Options for {@link fetchGithubLatestRelease} — injectable for tests. */
+/** Options for {@link fetchGithubNewestRelease} — injectable for tests. */
 export interface GithubReleaseQuery {
   /** GitHub API base; defaults to `https://api.github.com`. */
   apiBaseUrl?: string
@@ -342,44 +348,70 @@ async function probeChecksumManifestUrl(url: string): Promise<string | undefined
 }
 
 /**
- * Fetch latest release info from GitHub Releases API for the standalone asset.
+ * Extract the standalone asset download URL and checksum manifest URL from
+ * one GitHub release payload object.
+ * @param payload - A single release object from the GitHub Releases API.
+ * @param version - The release's parsed semver version (for the fixed-name
+ *   download-URL fallback when the asset list lacks the platform asset).
+ */
+function standaloneReleaseInfo(payload: Record<string, unknown>, version: string): { downloadUrl?: string; checksumUrl?: string } {
+  const assetName = getStandaloneAssetName()
+  let downloadUrl: string | undefined
+  let checksumUrl: string | undefined
+  if (Array.isArray(payload.assets)) {
+    const asset = (payload.assets as unknown[]).find(
+      (a: unknown) => isRecord(a) && a.name === assetName && typeof a.browser_download_url === 'string',
+    ) as Record<string, unknown> | undefined
+    if (asset !== undefined && typeof asset.browser_download_url === 'string') {
+      downloadUrl = asset.browser_download_url
+    }
+    checksumUrl = findChecksumAssetUrl(payload.assets as unknown[], assetName)
+  }
+  if (downloadUrl === undefined) {
+    downloadUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${assetName}`
+  }
+  return checksumUrl === undefined ? { downloadUrl } : { downloadUrl, checksumUrl }
+}
+
+/**
+ * Fetch the NEWEST release from GitHub for the standalone asset — by semver
+ * over the releases LIST, not `/releases/latest`.
+ *
+ * `/releases/latest` returns only the newest non-prerelease, so while the
+ * project rides a prerelease line (e.g. 0.10.0-beta.*) the "latest" endpoint
+ * serves an older tag than the newest published release (measured 2026-09-04:
+ * latest = v0.10.0-beta.3 while v0.10.0-beta.5 was published) and standalone
+ * installs would never be offered the newer prereleases. The list endpoint
+ * includes prereleases; the newest entry by `gt()` is the release the
+ * updater must compare against.
  *
  * @param options - Injectable API base / fetch for tests.
- * @returns Release version tag, matching asset download URL, and the
- *   SHA256SUMS manifest URL when the release ships one, or `undefined` on any
- *   failure.
+ * @returns Release version, matching asset download URL, and the SHA256SUMS
+ *   manifest URL when the release ships one, or `undefined` on any failure.
  */
-export async function fetchGithubLatestRelease(options: GithubReleaseQuery = {}): Promise<{ version: string; downloadUrl?: string; checksumUrl?: string } | undefined> {
+export async function fetchGithubNewestRelease(options: GithubReleaseQuery = {}): Promise<{ version: string; downloadUrl?: string; checksumUrl?: string } | undefined> {
   const doFetch = options.fetchImpl ?? fetch
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), UPDATE_CHECK_TIMEOUT_MS)
   try {
-    const response = await doFetch(`${options.apiBaseUrl ?? 'https://api.github.com'}/repos/${GITHUB_REPO}/releases/latest`, {
+    const response = await doFetch(`${options.apiBaseUrl ?? 'https://api.github.com'}/repos/${GITHUB_REPO}/releases?per_page=30`, {
       headers: { accept: 'application/vnd.github.v3+json', 'user-agent': 'dsh-tui-updater' },
       signal: controller.signal,
     })
     if (!response.ok) return undefined
     const payload: unknown = await response.json()
-    if (!isRecord(payload) || typeof payload.tag_name !== 'string') return undefined
-    const rawTag = payload.tag_name.replace(/^v/, '')
-    const version = valid(rawTag)
-    if (version === null) return undefined
-    const assetName = getStandaloneAssetName()
-    let downloadUrl: string | undefined
-    let checksumUrl: string | undefined
-    if (Array.isArray(payload.assets)) {
-      const asset = (payload.assets as unknown[]).find(
-        (a: unknown) => isRecord(a) && a.name === assetName && typeof a.browser_download_url === 'string',
-      ) as Record<string, unknown> | undefined
-      if (asset !== undefined && typeof asset.browser_download_url === 'string') {
-        downloadUrl = asset.browser_download_url
+    if (!Array.isArray(payload) || payload.length === 0) return undefined
+    let newest: { version: string; payload: Record<string, unknown> } | undefined
+    for (const entry of payload as unknown[]) {
+      if (!isRecord(entry) || typeof entry.tag_name !== 'string') continue
+      const version = valid(entry.tag_name.replace(/^v/, ''))
+      if (version === null) continue
+      if (newest === undefined || gt(version, newest.version)) {
+        newest = { version, payload: entry }
       }
-      checksumUrl = findChecksumAssetUrl(payload.assets as unknown[], assetName)
     }
-    if (downloadUrl === undefined) {
-      downloadUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${version}/${assetName}`
-    }
-    return checksumUrl === undefined ? { version, downloadUrl } : { version, downloadUrl, checksumUrl }
+    if (newest === undefined) return undefined
+    return { version: newest.version, ...standaloneReleaseInfo(newest.payload, newest.version) }
   } catch {
     return undefined
   } finally {
@@ -829,7 +861,7 @@ export async function resolveTuiUpdateTarget(): Promise<TuiUpdateTarget> {
   if (currentVersion === null) return { kind: 'unknown' }
 
   if (isStandaloneRuntime()) {
-    const ghRelease = await fetchGithubLatestRelease()
+    const ghRelease = await fetchGithubNewestRelease()
     const latest = ghRelease?.version ?? (await fetchLatestVersion(resolveRegistryBase()))
     if (latest === undefined) return { kind: 'unknown' }
     if (!gt(latest, currentVersion)) return { kind: 'latest', current: currentVersion, isStandalone: true }
@@ -849,15 +881,38 @@ export async function resolveTuiUpdateTarget(): Promise<TuiUpdateTarget> {
       : { kind: 'update', current: currentVersion, latest, isStandalone: true, downloadUrl, checksumUrl }
   }
 
+  // The repository's GitHub releases are the authoritative version source
+  // (they are what the release automation publishes first); the registry
+  // decides what /update can actually install, and npmjs.org arbitrates
+  // mirror lag. The newest observable version across all three is what the
+  // user is told about — a registry that lags GitHub must not hide a
+  // published release, and a GitHub that lags npm must not hide a published
+  // package.
   const registryBase = resolveRegistryBase()
-  const [latest, official] = await Promise.all([
+  const [registryLatest, official, ghRelease] = await Promise.all([
     fetchLatestVersion(registryBase),
     registryBase === DEFAULT_REGISTRY ? undefined : fetchLatestVersion(DEFAULT_REGISTRY),
+    fetchGithubNewestRelease(),
   ])
-  if (latest === undefined) return { kind: 'unknown' }
+  const candidates = [registryLatest, official, ghRelease?.version].filter(
+    (v): v is string => v !== undefined,
+  )
+  if (candidates.length === 0) return { kind: 'unknown' }
+  const latest = candidates.reduce((a, b) => (gt(b, a) ? b : a))
   if (!gt(latest, currentVersion)) return { kind: 'latest', current: currentVersion }
   const authoritative = official !== undefined && gt(official, latest) ? official : undefined
-  return { kind: 'update', current: currentVersion, latest, ...(authoritative === undefined ? {} : { authoritative }) }
+  // GitHub ahead of every registry the install could pull from: the notice
+  // must say so, because /update on an npm install can only fetch what the
+  // registry serves — the user may see "update available" for a version
+  // /update cannot install until the npm publish catches up.
+  const registryAhead = registryLatest !== undefined && gt(latest, registryLatest) ? registryLatest : undefined
+  return {
+    kind: 'update',
+    current: currentVersion,
+    latest,
+    ...(authoritative === undefined ? {} : { authoritative }),
+    ...(registryAhead === undefined ? {} : { registryLatest: registryAhead }),
+  }
 }
 
 /**
@@ -874,6 +929,7 @@ export async function checkForTuiUpdate(): Promise<TuiUpdateInfo | undefined> {
         isStandalone: target.isStandalone,
         downloadUrl: target.downloadUrl,
         checksumUrl: target.checksumUrl,
+        registryLatest: target.registryLatest,
       }
     : undefined
 }


### PR DESCRIPTION
## 问题

版本自检与更新提示已存在（启动后台检查 + `/update`），但**版本来源**有两个缺陷：

1. **便携包（standalone）安装走 `/releases/latest`**，该端点只返回最新**非预发布** release。当前项目正处 0.10.0-beta 线，实测（2026-09-04）：`/releases/latest` = v0.10.0-beta.3，而最新已发布 v0.10.0-beta.5 —— 便携包用户永远收不到 beta.4/beta.5 的更新提示。
2. **npm 安装只查 registry**，从不参考 GitHub releases；仓库才是发版链的第一发布源，registry（尤其镜像）滞后时会掩盖已发布的新版本。

## 修复

- `fetchGithubLatestRelease` → `fetchGithubNewestRelease`：改请求 `/releases?per_page=30` 列表端点（含预发布），按 semver `gt()` 取最新条目；资产/SHA256SUMS 解析抽为共享的 `standaloneReleaseInfo()`。
- `resolveTuiUpdateTarget()` npm 路径：GitHub 最新、当前 registry、npmjs.org 三源并查，取 semver 最大者作为提示版本；GitHub 领先 registry 时通过新的 `registryLatest` 字段上报。
- 新增 i18n 键 `update-registry-lag`（中英）：启动提示与 `/update` 均附带「注册表尚为 vY，/update 可能暂时装不到 vX」说明——因为 npm 安装的 `/update` 只能装 registry 里有的版本。
- `scripts/verify-update-checksum.tsx`：mock 端点同步改为 releases 列表，并加入 [v9.9.8, v9.9.9(prerelease)] 两条目，断言 newest-pick 含预发布。

## 验证

- `tsc -p tsconfig.typecheck.json` ✓
- `npm run verify:boundary` ✓（388 文件）
- `npm run verify:i18n` ✓（995 条目）
- `verify-update-checksum.tsx`：Part 1/2（本 PR 直接相关的校验和解析与 newest-pick 断言）在本机全过；其余失败为**改动前即存在**的 Windows 平台夹具问题（mock 硬编码 linux 资产名，本机生成 win zip 直链），已用 pristine tree 对照确认失败集合一致，CI 的 Linux 跑全量。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Update checks now identify the newest valid GitHub release, including when multiple releases are available.
  - Update information includes the latest configured package registry version.
  - Notifications compare available versions across configured registries, npmjs.org, and GitHub.

- **Bug Fixes**
  - Manual and background update notifications now warn when the package registry is behind the available update.
  - Added localized guidance to retry later when registry information is delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->