### PR TITLE
fix(sessions): /resume 识别 dsh 0.1.2 snapshot 行 + 修复 hasPrompt 冻结隐藏真实会话

### DIFF
--- a/scripts/verify-session-index.mjs
+++ b/scripts/verify-session-index.mjs
@@ -284,6 +284,30 @@ check('ordinary append growth never drops an older real title', (await listSumma
   source: 'renamed',
 })
 
+// Regression (2026-09-05): a real conversation whose FIRST listing caught the
+// log before its first human prompt (a session's header and policy rows are
+// written first) had hasPrompt=false frozen into the index via the append
+// carry-forward, so /resume counted it among "N empty" and never listed it.
+// The append forward only grows a log, and the fresh digest errs toward
+// "has a conversation" for anything past its windows — the verdict must
+// strengthen across appends, never weaken.
+const growFile = seed('grow', [], { cwd: '/proj' })
+const growSource = {
+  list: async () => [{ header: { id: 'grow', cwd: '/proj', createdAt: 1000 } }],
+  locate: () => ({ kind: 'jsonl', path: growFile }),
+}
+rmSync(INDEX_FILE, { force: true })
+const bootSighting = await listSummaries(growSource)
+check('a boot artifact is honestly empty on its first sighting', bootSighting[0].hasPrompt, false)
+const growNoise = []
+for (let i = 0; i < 400; i++) {
+  growNoise.push([{ type: 'assistant/chunk', seq: 10 + i, time: 3000 + i, data: { text: filler(500) } }])
+}
+appendFileSync(growFile, encode([[userPrompt('the conversation arrives', 1)], ...growNoise]))
+const grownSighting = await listSummaries(growSource)
+check('the grown log is never reported empty again', grownSighting.find(s => s.id === 'grow').hasPrompt, true)
+
+
 check('a missing log degrades instead of throwing', digestSession(join(root, 'nope', 'x.zstd'), '/proj'), {
   title: undefined,
   hasPrompt: false,

--- a/scripts/verify-session-index.mjs
+++ b/scripts/verify-session-index.mjs
@@ -482,6 +482,23 @@ check(
   viaSnapshots.map(s => [s.id, s.title.text]).sort(),
   fromCold.map(s => [s.id, s.title.text]).sort(),
 )
+// dsh 0.1.2+ has no listSnapshots(); it put {header, revision, sizeBytes} on
+// list() itself. Parsing those rows as bare headers drops every session.
+const listReturnsSnapshots = {
+  list: async () =>
+    allHeaders.map(header => ({
+      header,
+      revision: `rev:${header.id}:${statSync(join(root, '--proj--', header.id, 'session.jsonl.zstd')).size}`,
+      sizeBytes: 1,
+    })),
+}
+rmSync(INDEX_FILE, { force: true })
+const viaListSnapshotShape = await listSummaries(listReturnsSnapshots)
+check(
+  'list() that returns snapshots (dsh 0.1.2+) still resolves titles',
+  viaListSnapshotShape.map(s => [s.id, s.title.text]).sort(),
+  fromCold.map(s => [s.id, s.title.text]).sort(),
+)
 check('a backend that lists nothing yields nothing', (await listSummaries({})).length, 0)
 check('a backend that throws yields nothing rather than propagating', (await listSummaries({ list: async () => { throw new Error('boom') } })).length, 0)
 

--- a/src/dsh-adapter/sessions/list.ts
+++ b/src/dsh-adapter/sessions/list.ts
@@ -232,7 +232,14 @@ export async function listSummaries(
                   ? undefined
                   : { text: previous.title, source: previous.titleSource }
               }
-              hasPrompt = previous.hasPrompt
+              // The log GREW since that previous verdict; the digest above was
+              // computed on the current file, so its prompt answer is the more
+              // honest one, and a log past its head window is counted as having
+              // a conversation by construction. A verdict across an append only
+              // strengthens: carrying hasPrompt=false forward here hid real
+              // sessions from /resume as "empty" when an early listing caught
+              // the log before its first human prompt.
+              hasPrompt = previous.hasPrompt || digest.hasPrompt
               titleComplete = true
             }
           }


### PR DESCRIPTION
Two session-index fixes affecting /resume usability (both with regression coverage in scripts/verify-session-index.mjs — 58 checks, CI-gated):

- 8e611cd: dsh 0.1.2's list() returns {header, revision, sizeBytes} snapshot rows; the fallback parsed them as bare headers and /resume lost every session.
- 0ac81a9: the append carry-forward froze an old hasPrompt=false into the session index — a session first listed while still a prompt-less boot artifact stayed hidden as "empty" after its log grew, hiding real conversations from /resume.

Release: after merge, push tag v0.10.0-beta.6 (matches package.json; publish.yml is tag-driven).