### PR TITLE
fix(preset): en 下 PTC 预设仍显示中文——展示层按 code 键桥接 ptc

### DIFF
--- a/scripts/verify-i18n.ts
+++ b/scripts/verify-i18n.ts
@@ -23,7 +23,7 @@ import { SPINNER_VERBS } from '../src/terminal-utils/spinnerVerbs.js'
 //   spinner-verb-* src/components/WorkingSpinner.tsx tOr(`spinner-verb-${verb}`)
 //   tree-filter-* src/screens/SessionTree.tsx      t(`tree-filter-${filter}`)
 //   tree-kind-*   src/screens/SessionTree.tsx      t(`tree-kind-${entry.kind}`)
-//   preset-name-* / preset-desc-*   src/dsh-adapter/channel.ts   tOr(`preset-name-${preset.id}`) — built-in preset display text
+//   preset-name-* / preset-desc-*   src/dsh-adapter/channel/model-actions.ts   tOr(`preset-name-${presetDisplayId(preset.id)}`) — built-in preset display text
 const DYNAMIC_PREFIXES = ['cmd-desc-', 'traj-sort-', 'traj-proj-', 'logo-drift-', 'spinner-verb-', 'tree-filter-', 'tree-kind-', 'preset-name-', 'preset-desc-']
 
 let failures = 0

--- a/scripts/verify-minimal-preset-tools.mjs
+++ b/scripts/verify-minimal-preset-tools.mjs
@@ -10,6 +10,7 @@ import {
   runningPresetOf,
 } from '../lib/types/dsh-adapter/presets.js'
 import { settled } from './lib/term-test.mjs'
+import { setLang } from '../lib/types/i18n.js'
 
 const bash = { name: 'bash' }
 const editor = { name: 'str_replace_editor' }
@@ -156,6 +157,51 @@ assert.equal(directChannel.rows.some(row => row.text.includes('ptc')), true)
 assert.equal(directChannel.rows.some(row => row.text.includes('code')), false)
 assert.equal(await directChannel.switchPreset('ptc'), true)
 assert.equal(directResolveId, 'ptc')
+
+// Display localization: the 0.1.2 roster id `ptc` must resolve the en
+// dictionary surface keyed under the legacy `code` id (preset-name-code /
+// preset-desc-code), never the Chinese roster copy — same bug as issue #8.
+setLang('en')
+const displayChannel = createChannel({
+  on() { return () => {} },
+  get(name) {
+    if (name !== 'agentPresets') return undefined
+    return {
+      defaultId: 'standard',
+      async list() {
+        return [
+          { id: 'standard', trust: 'system', name: '标准模式', description: '标准描述' },
+          { id: 'ptc', trust: 'system', name: 'PTC 模式', description: 'PTC 描述' },
+          { id: 'minimal', trust: 'system', name: '极简模式', description: '极简描述' },
+        ]
+      },
+      async resolve() { throw new Error('not used') },
+      async mount() {},
+      async recompose() { throw new Error('not used') },
+    }
+  },
+  logger: { warn() {} },
+}, {
+  id: 'preset-display-agent',
+  status: 'idle',
+  session: { id: 'preset-display-session', seq: 1, events: [] },
+  ctx: { on() { return () => {} } },
+  followup() {},
+  steer() {},
+}, {
+  model: 'deepseek-chat',
+  cwd: '/tmp',
+  provider: 'deepseek',
+  activity: false,
+  agentPreset: 'ptc',
+})
+const displayList = await displayChannel.listPresets()
+const ptcOption = displayList.find(preset => preset.id === 'ptc')
+assert.equal(ptcOption.name, 'PTC')
+assert.equal(ptcOption.description, 'Everything standard mode offers, with tools exposed through the Code Mode SDK so the model composes multi-step operations in one TypeScript program.')
+assert.equal(displayList.find(preset => preset.id === 'standard').name, 'Standard')
+assert.equal(displayList.find(preset => preset.id === 'minimal').name, 'Minimal')
+setLang('zh')
 
 const bundledSkills = [{
   name: 'audit',

--- a/src/dsh-adapter/channel/model-actions.ts
+++ b/src/dsh-adapter/channel/model-actions.ts
@@ -6,7 +6,7 @@ import { readEffortPref, resolveEffortDefault, writeEffortPref } from '../../eff
 import { snapshotLiveSessionEvents } from '../compat/liveSession.js'
 import { getLang, t, tOr, type Lang } from '../../i18n.js'
 import { migratePresetPref, writePresetPref } from '../../presetPrefs.js'
-import { resolveCompatiblePreset, rosterOf, type AgentPresetInfo } from '../preset-resolution.js'
+import { presetDisplayId, resolveCompatiblePreset, rosterOf, type AgentPresetInfo } from '../preset-resolution.js'
 import type { createChannelBinding } from './binding.js'
 import type { ChannelOwner } from './owner.js'
 import type { ChannelState, EffortOption, PresetOption } from './types.js'
@@ -180,7 +180,7 @@ export function createModelActions(
     if (presets === undefined) return []
     const localized = getLang() === 'en'
     try {
-      return (await presets.list()).map(preset => ({ id: preset.id, ...(preset.name === undefined ? {} : { name: localized ? tOr(`preset-name-${preset.id}`, preset.name) : preset.name }), ...(preset.description === undefined ? {} : { description: localized ? tOr(`preset-desc-${preset.id}`, preset.description) : preset.description }), ...(preset.broken === undefined ? {} : { broken: preset.broken }), isDefault: preset.id === presets.defaultId }))
+      return (await presets.list()).map(preset => ({ id: preset.id, ...(preset.name === undefined ? {} : { name: localized ? tOr(`preset-name-${presetDisplayId(preset.id)}`, preset.name) : preset.name }), ...(preset.description === undefined ? {} : { description: localized ? tOr(`preset-desc-${presetDisplayId(preset.id)}`, preset.description) : preset.description }), ...(preset.broken === undefined ? {} : { broken: preset.broken }), isDefault: preset.id === presets.defaultId }))
     } catch { return [] }
   }
   const switchPreset = async (presetId: string): Promise<boolean> => {

--- a/src/dsh-adapter/preset-resolution.ts
+++ b/src/dsh-adapter/preset-resolution.ts
@@ -67,3 +67,14 @@ export async function resolveCompatiblePreset(
   if (roster.some(preset => preset.id === fallback)) return presets.resolve(fallback)
   return presets.resolve(requested)
 }
+
+/**
+ * The i18n dictionary id a roster preset's localized display text resolves
+ * under. The 0.1.2 line renamed the official PTC preset `code` → `ptc`, but
+ * the dictionary keys still use the legacy `code` id (`preset-name-code` /
+ * `preset-desc-code`), so the `/preset` picker's display lookup must bridge
+ * the roster id back. User-authored ids pass through untouched.
+ */
+export function presetDisplayId(id: string): string {
+  return id === 'ptc' ? 'code' : id
+}


### PR DESCRIPTION
`/preset` 选择器与补全在 en 下对 PTC 预设回退中文：官方预设 code→ptc 改名 （0.1.2 线），但 i18n 字典键仍用旧 id（`preset-name-code` / `preset-desc-code`）。 `listPresets` 按名册实际 id 拼键，0.1.2 下拼出 `preset-name-ptc` 查不到， `tOr` 回退名册中文文案；standard/minimal/cordis/liangshen 因 id 未改正常切英文。

- `preset-resolution.ts` 新增 `presetDisplayId`：`ptc` 桥回 `code`，其余 id 透传； 旧线 `code` 直接命中字典键，新线 `ptc` 桥接回旧键，双线兼容
- `channel.ts` `listPresets` 拼字典键改用 `presetDisplayId(preset.id)`
- `verify-minimal-preset-tools` 增加 en 下 ptc/standard/minimal 显示回归
- `verify-i18n` 同步动态键拼接点注释

验证：全量 tsc 编译、verify-minimal-preset-tools、verify-i18n、verify:boundary 通过。

## 变更摘要 / Summary

<!-- 一两句说明改了什么、为什么。行为变更请写清楚用户可见的差异。 -->

## 关联 / Related

<!-- Closes #123 / Discussion 链接；纯内部改动可留空。 -->

## 变更类型 / Type

- [x] fix — 修复缺陷
- [ ] feat — 新增能力
- [ ] docs — 仅文档
- [ ] refactor / perf — 不改变外部行为
- [ ] ci / chore — 构建、工作流、仓库维护

## 验证 / Verification

<!-- 贴出实际跑过的命令与结果。没跑就别勾。 -->

- [x] `pnpm build`（compile + 全部构建门禁）
- [x] 按改动面选的聚焦回归脚本（对照表见 [docs/contributing.md](../docs/contributing.md)）
- [x] 终端可见改动：在 inline 与 fullscreen 两种模式、窄终端宽度下手动演练过

```text
<!-- 命令与输出 -->
```

## 自查 / Checklist

- [x] 只改了 `src/`，没有手改或提交 `lib/` 下的生成产物
- [x] 官方 `@deepseek-ai/*` 的 import 仍只出现在 `src/dsh-adapter/` 内
- [x] 行为、配置、快捷键与限制的改动已在 `README.md` 与 `README_EN.md` 双语同步
- [x] 改了 `cordis.patch.yml` 的话，`patch-surface.snapshot.json` 已同步
- [x] 只暂存了显式路径，没有用 `git add .` / `git add -A`