### PR TITLE
fix(todo): 目标行与折叠头紧贴，消除窄屏幽灵空行

### DIFF
--- a/src/components/GoalTodoPanel.tsx
+++ b/src/components/GoalTodoPanel.tsx
@@ -166,8 +166,12 @@ export function GoalTodoPanel({
   return (
     <Box flexDirection="column" paddingLeft={2} paddingRight={2} paddingTop={1}>
       {goal !== undefined && (
-        <Box flexDirection="column" marginBottom={showTodoSection ? 1 : 0}>
-          <Box flexDirection="row" width="100%">
+        <Box flexDirection="column">
+          {/* 行盒显式 height={1}：窄屏下与截断文本同行的布局会被量出虚高
+              （行内出现幽灵空行，实测窄终端里 🎯 行与折叠头之间多出空行），
+              钉死单行高度可消除；本面板各行本就设计为单行（内容均
+              truncate）。 */}
+          <Box flexDirection="row" width="100%" height={1}>
             <Text color="suggestion">🎯 </Text>
             <Box flexGrow={1} flexShrink={1}>
               <Text bold wrap="truncate">
@@ -184,7 +188,7 @@ export function GoalTodoPanel({
             </Box>
           </Box>
           {goal.phase === 'blocked' && goal.blockedReason !== undefined && (
-            <Box flexDirection="row" marginTop={1}>
+            <Box flexDirection="row" marginTop={1} height={1}>
               <Text dimColor>│ </Text>
               <Text color="error" wrap="truncate">
                 {goal.blockedReason.message}
@@ -199,6 +203,7 @@ export function GoalTodoPanel({
               collapsed line (with the live-task preview). */}
           <Box
             flexDirection="row"
+            height={1}
             onClick={onToggle}
             onMouseEnter={() => setHeaderHovered(true)}
             onMouseLeave={() => setHeaderHovered(false)}
@@ -226,7 +231,7 @@ export function GoalTodoPanel({
               {visible.map((todo, index) => {
                 const last = index === visible.length - 1 && hidden === 0
                 return (
-                  <Box key={index} flexDirection="row">
+                  <Box key={index} flexDirection="row" height={1}>
                     <BranchPrefix last={last} />
                     <TodoGlyph status={todo.status} />
                     <Text wrap="truncate" dimColor={todo.status === 'completed'}>
@@ -236,7 +241,7 @@ export function GoalTodoPanel({
                 )
               })}
               {hidden > 0 && (
-                <Box flexDirection="row">
+                <Box flexDirection="row" height={1}>
                   <BranchPrefix last />
                   <Text dimColor>… {hidden} more</Text>
                 </Box>


### PR DESCRIPTION
## 问题

1. GoalTodoPanel 目标行（🎯）下带固定 `marginBottom:1`，折叠/展开时 🎯 行与 `▾/▸ ✓` 折叠头之间始终空一行。
2. 窄屏（约 ≤50 列）下另有渲染层虚高：含截断文本（结尾 `…`）的行被量出 2~3 行高却只绘制 1 行，产生幽灵空行——表现为 🎯 行与折叠头之间、被截断的 todo 行之后凭空多出空行（此前"折叠/展开都有空行"的主因）。

## 修改

- 移除目标行容器 `marginBottom`，🎯 行与折叠头紧贴
- 面板各行（目标行/折叠头/每条 todo/blocked 原因行/… more 行）本就是单行 + truncate 设计，显式 `height={1}` 钉死行高，消除测量虚高；宽屏行高原本即 1，行为不变

## 验证

- 无头渲染 44 列与 100 列 × 展开/折叠/blocked 三种状态：结构一致、无幽灵空行、无裁剪
- `verify-goal-todo`（22 项）/ `verify-chat-overlay` / `verify-shift-tab-mode` 全绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated goal and to-do panel row sizing for more consistent one-line layouts.
  * Adjusted spacing and overflow-row dimensions to improve visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->