### PR TITLE
fix(ink): disable DECSTBM hardware scroll inside zellij

### DIFF
--- a/scripts/verify-zellij.tsx
+++ b/scripts/verify-zellij.tsx
@@ -1,0 +1,75 @@
+/**
+ * zellij compatibility regression (DECSTBM withdrawal).
+ *
+ * Real-terminal report: inside zellij, ScrollBox scrolls leave stale rows —
+ * tearing and leftover transcript lines that accumulate as content scrolls.
+ * zellij's grid handling deviates from xterm in exactly the two sequences the
+ * hardware-scroll optimization leans on:
+ *
+ *  - `CSI T` (grid.rs rotate_scroll_region_up) shifts rows only while the
+ *    cursor sits inside the scroll region, and `CSI r` does not home the
+ *    cursor outside origin mode — but the renderer parks the cursor on the
+ *    last screen row, below every ScrollBox. The shift is silently dropped
+ *    while the diff engine assumes it happened, so stale rows survive every
+ *    scroll-up frame.
+ *  - zellij DOES implement DEC 2026 synchronized output, so only DECSTBM is
+ *    withdrawn: BSU/ESU stay on and frames remain atomic.
+ *
+ * Asserts (capability probe, same harness as verify-jediterm.tsx):
+ *  1. isZellij() reads the ZELLIJ env var.
+ *  2. Under ZELLIJ=1: sync output stays enabled (DEC 2026 kept).
+ *  3. Under ZELLIJ=1: DECSTBM is excluded even though sync is on.
+ *  4. Without ZELLIJ (plain xterm-ish env): sync + DECSTBM both stay on.
+ *
+ * Run: node --import tsx/esm scripts/verify-zellij.tsx
+ */
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+// Repo root, so `--import tsx/esm` resolves no matter where the script is
+// invoked from.
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+
+let failed = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+// ---- capability wiring (SYNC_OUTPUT_SUPPORTED is computed at import) -------
+function probeEnv(env: Record<string, string | undefined>): { zellij: boolean; sync: boolean; decstbm: boolean } {
+  const terminalUrl = new URL('../src/ink/terminal.ts', import.meta.url).href
+  const src = `
+    const { isZellij, isSynchronizedOutputSupported, isDecstbmSafe } = await import(${JSON.stringify(terminalUrl)})
+    console.log(JSON.stringify({
+      zellij: isZellij(),
+      sync: isSynchronizedOutputSupported(),
+      decstbm: isDecstbmSafe(),
+    }))
+  `
+  const res = spawnSync(process.execPath, ['--import', 'tsx/esm', '-e', src], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  })
+  if (res.status !== 0) throw new Error(`probe failed: ${res.stderr}`)
+  return JSON.parse(res.stdout.trim().split('\n').at(-1) ?? '{}') as { zellij: boolean; sync: boolean; decstbm: boolean }
+}
+
+// zellij multiplexes the outer terminal instead of emulating it, so the sync
+// probe describes the OUTER terminal's DEC 2026 support. Pin TERM_PROGRAM to
+// a known-sync terminal (vscode) as the controlled premise: that isolates the
+// zellij DECSTBM withdrawal from whatever terminal the script itself runs in.
+const zellij = probeEnv({ ZELLIJ: '1', TERM_PROGRAM: 'vscode' })
+check('zellij detected via ZELLIJ env', zellij.zellij)
+check('sync output (DEC 2026) stays enabled under zellij', zellij.zellij && zellij.sync)
+check('DECSTBM excluded under zellij', zellij.zellij && !zellij.decstbm)
+
+const plain = probeEnv({ ZELLIJ: '', TERM_PROGRAM: 'vscode' })
+check('same outer terminal without zellij keeps DECSTBM', plain.sync && plain.decstbm)
+
+if (failed > 0) {
+  console.error(`\n${failed} check(s) failed`)
+  process.exit(1)
+}
+console.log('\nzellij DECSTBM regression: all checks passed')

--- a/src/ink/terminal.ts
+++ b/src/ink/terminal.ts
@@ -93,6 +93,17 @@ export function isJetBrainsIdeTerminal(): boolean {
 }
 
 /**
+ * Detects zellij, which multiplexes the outer terminal instead of emulating
+ * it. Capability probes therefore describe the *outer* terminal — zellij even
+ * forwards KITTY_WINDOW_ID into the pane, so kitty detection matches — while
+ * zellij's own grid decides how control sequences actually apply.
+ * @returns true when the process runs inside a zellij pane.
+ */
+export function isZellij(): boolean {
+  return !!process.env.ZELLIJ
+}
+
+/**
  * Checks if the terminal supports DEC mode 2026 (synchronized output).
  * When supported, BSU/ESU sequences prevent visible flicker during redraws.
  * @returns true when the terminal supports DEC 2026.
@@ -318,10 +329,19 @@ export const SYNC_OUTPUT_SUPPORTED = isSynchronizedOutputSupported()
  * as content scrolls (the "JetBrains terminal slowly garbles" bug class).
  * The diff engine falls back to repainting the shifted rows cell-by-cell,
  * which every terminal renders identically. Disable DECSTBM on JetBrains terminals.
+ *
+ * zellij is excluded for the same class of reason. Its `CSI T`
+ * (grid.rs rotate_scroll_region_up) shifts rows only while the cursor sits
+ * inside the scroll region, and its `CSI r` does not home the cursor outside
+ * origin mode — but the renderer parks the cursor on the last screen row,
+ * below every ScrollBox. The shift is silently dropped while the diff assumes
+ * it happened, so stale rows survive every scroll-up frame (tearing, leftover
+ * transcript lines). Only DECSTBM is withdrawn: zellij does implement DEC
+ * 2026, so BSU/ESU stay on and frames remain atomic.
  * @returns true when DECSTBM scroll optimization is safe on this terminal.
  */
 export function isDecstbmSafe(): boolean {
-  return SYNC_OUTPUT_SUPPORTED && !isJetBrainsIdeTerminal()
+  return SYNC_OUTPUT_SUPPORTED && !isJetBrainsIdeTerminal() && !isZellij()
 }
 
 /**


### PR DESCRIPTION
## Problem

Running dsh-tui inside a [zellij](https://zellij.dev) pane, the transcript
tears on every scroll-up frame: rows are left stale and duplicated lines
survive in the scrollback. Plain kitty/alacritty in the same setup render
correctly, so the corruption only appears under the multiplexer.

## Root cause

In alt-screen the renderer shifts a ScrollBox with `CSI top;bot r` plus
`CSI n S/T`, then repaints only the rows that scrolled in.

zellij's `CSI T` (`grid.rs`, `rotate_scroll_region_up`) moves rows only while
the cursor sits inside the scroll region, and its `CSI r` does not home the
cursor outside origin mode. The renderer, however, parks the cursor on the
last screen row — below every ScrollBox. The shift is therefore silently
dropped while the diff assumes it happened, so the rows that should have
moved are never repainted.

`isDecstbmSafe()` should have caught this, but it excludes only tmux and
JediTerm. zellij additionally forwards `KITTY_WINDOW_ID` into the pane, so
`isSynchronizedOutputSupported()` concludes it is talking to kitty directly
and the DECSTBM fast path stays enabled.

## Fix

Add an `isZellij()` detector next to `isJetBrainsIdeTerminal()` and exclude it
from `isDecstbmSafe()` only.

This is deliberately narrow: zellij *does* implement DEC 2026, so BSU/ESU
remain enabled and frames stay atomic. Only the DECSTBM fast path is
withdrawn, and the diff engine falls back to repainting shifted rows
cell-by-cell — which zellij renders correctly.

## Verification

`isDecstbmSafe()` evaluated in a fresh process per environment (the gate is
computed at module load):

| env | DEC 2026 | `isZellij()` | `isDecstbmSafe()` |
| --- | --- | --- | --- |
| `TERM=xterm-kitty KITTY_WINDOW_ID=1` | true | false | true (unchanged) |
| `TERM=xterm-kitty KITTY_WINDOW_ID=1 ZELLIJ=0` | true | true | **false** |
| `TERM_PROGRAM=alacritty` | true | false | true (unchanged) |
| `TERM_PROGRAM=alacritty ZELLIJ=0` | true | true | **false** |
| `TERMINAL_EMULATOR=JetBrains-JediTerm` | true | false | false (unchanged) |

Synchronized output stays on in every zellij row, confirming the change does
not widen beyond DECSTBM. Confirmed on macOS with zellij 0.44.3 inside
alacritty: the tearing is gone and the transcript stays clean.

`npm run typecheck` reports no errors in `src/ink/terminal.ts`. (The run does
report pre-existing `TS2307` errors in `src/plugin-spec/*` for unbuilt
`@dsh-std/*` workspace packages, untouched by this change.)

Happy to add a `scripts/verify-zellij.tsx` alongside `verify-jediterm.tsx` and
wire it into `verify:build` if you'd like this covered by the regression
suite.