### PR TITLE
ci: PR 白名单门禁——非名单实现 PR 自动关闭（#487）

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -1,0 +1,13 @@
+# GitHub usernames that may submit implementation PRs, one per line.
+# This does not approve feature scope or grant write access.
+# Maintainers add names; do not open an issue or discussion asking to join.
+# Collaborators with write/admin/maintain already pass the gate and need not be listed.
+# Seeded from people with 2+ merged PRs or 5+ commits on main since 2026-07-01.
+baobaolaodie
+lql341
+Qiuner
+StreamAzure
+TYCT-0926
+wusai2333
+xiaoxiaohaigui
+xuzijian2019

--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -1,12 +1,16 @@
 # GitHub usernames that may submit implementation PRs, one per line.
 # This does not approve feature scope or grant write access.
 # Maintainers add names; do not open an issue or discussion asking to join.
-# Collaborators with write/admin/maintain already pass the gate and need not be listed.
-# Seeded from people with 2+ merged PRs or 5+ commits on main since 2026-07-01.
+# Collaborators with write/admin/maintain already pass the gate even if omitted.
+# Seeded from authors with 5+ merged PRs all-time. Two merges is too weak:
+# early intake left many soft merges and stale PRs.
+AdamPlatin123
 baobaolaodie
-lql341
+ccch1mneyyy
+CikeSeven
+FUSU123fusu
+Nagi-ovo
 Qiuner
-StreamAzure
 TYCT-0926
 wusai2333
 xiaoxiaohaigui

--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -4,13 +4,18 @@
 # Collaborators with write/admin/maintain already pass the gate even if omitted.
 # Seeded from authors with 5+ merged PRs all-time. Two merges is too weak:
 # early intake left many soft merges and stale PRs.
+# Maintainer additions beyond the seed bar (2026-09): T-Auto, ShiroEirin,
+# makoMakoGo — active contributors with in-flight work under review.
 AdamPlatin123
 baobaolaodie
 ccch1mneyyy
 CikeSeven
 FUSU123fusu
+makoMakoGo
 Nagi-ovo
 Qiuner
+ShiroEirin
+T-Auto
 TYCT-0926
 wusai2333
 xiaoxiaohaigui

--- a/.github/scripts/pr-intake/allowlist.mjs
+++ b/.github/scripts/pr-intake/allowlist.mjs
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export function parseUserList(content) {
+  return new Set(content
+    .split('\n')
+    .map(line => line.trim().toLowerCase())
+    .filter(line => line && !line.startsWith('#')))
+}
+
+export async function loadApprovedContributors(workspace) {
+  try {
+    const content = await readFile(join(workspace, '.github/APPROVED_CONTRIBUTORS'), 'utf8')
+    return parseUserList(content)
+  } catch (error) {
+    if (error.code === 'ENOENT') return new Set()
+    throw error
+  }
+}

--- a/.github/scripts/pr-intake/gate.mjs
+++ b/.github/scripts/pr-intake/gate.mjs
@@ -126,9 +126,7 @@ export async function runPrGate({ github, context, core, workspace = process.env
 
   if (pr.state === 'closed') return
 
-  if (CI_ONLY_PR_AUTHOR_IDS.has(pr.user.id)
-    || pr.user.type === 'Bot'
-    || prAuthor.endsWith('[bot]')) {
+  if (CI_ONLY_PR_AUTHOR_IDS.has(pr.user.id)) {
     core.info(`Leaving CI-only bot PR open: ${prAuthor}`)
     return
   }

--- a/.github/scripts/pr-intake/gate.mjs
+++ b/.github/scripts/pr-intake/gate.mjs
@@ -1,0 +1,149 @@
+import { loadApprovedContributors } from './allowlist.mjs'
+import { detectReplyLocale } from './locale.mjs'
+import { closeMessage } from './messages.mjs'
+
+const GITHUB_ACTIONS_BOT_ID = 41898282
+const CI_ONLY_PR_AUTHOR_IDS = new Set([
+  49699333, // dependabot[bot]
+  41898282, // github-actions[bot]
+])
+const COMMENT_MARKER = '<!-- dsh-tui-pr-gate -->'
+
+export async function runPrGate({ github, context, core, workspace = process.env.GITHUB_WORKSPACE }) {
+  const pullNumber = context.payload.pull_request.number
+  const defaultBranch = context.payload.repository.default_branch
+  const { data: pr } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: pullNumber,
+  })
+  const prAuthor = pr.user.login
+  const docsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs`
+  const listUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/.github/APPROVED_CONTRIBUTORS`
+
+  async function getPermission(username) {
+    try {
+      const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        username,
+      })
+      return data.permission
+    } catch (error) {
+      // 404: 不是协作者。401/403/限流/5xx 必须抛出——吞掉会把
+      // write 协作者当成路人，reopen 例外也会失效。
+      if (error.status === 404) return null
+      throw error
+    }
+  }
+
+  async function hasWriteAccess(username) {
+    if (!username) return false
+    return ['admin', 'maintain', 'write'].includes(await getPermission(username))
+  }
+
+  async function hasVerifiedRecovery() {
+    const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pullNumber,
+      per_page: 100,
+    })
+    const latestStateEvent = events.findLast(event =>
+      ['closed', 'reopened'].includes(event.event))
+    return latestStateEvent?.event === 'reopened'
+      && await hasWriteAccess(latestStateEvent.actor?.login)
+  }
+
+  async function linkedIssueNumbers() {
+    const { repository } = await github.graphql(
+      `query($owner:String!, $repo:String!, $number:Int!) {
+        repository(owner:$owner, name:$repo) {
+          pullRequest(number:$number) {
+            closingIssuesReferences(first: 20) { nodes { number } }
+          }
+        }
+      }`,
+      { owner: context.repo.owner, repo: context.repo.repo, number: pullNumber },
+    )
+    return repository.pullRequest.closingIssuesReferences.nodes.map(node => node.number)
+  }
+
+  async function upsertGateComment(message) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pullNumber,
+      per_page: 100,
+    })
+    const existing = comments.find(comment =>
+      comment.user?.id === GITHUB_ACTIONS_BOT_ID
+      && comment.body?.includes(COMMENT_MARKER))
+    const body = `${COMMENT_MARKER}\n${message}`
+    if (existing?.body === body) return
+    if (existing) {
+      await github.rest.issues.updateComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        comment_id: existing.id,
+        body,
+      })
+      return
+    }
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: pullNumber,
+      body,
+    })
+  }
+
+  async function closePullRequest(reason) {
+    if (await hasVerifiedRecovery()) {
+      core.info(`PR #${pullNumber} was recovered by a write collaborator; leaving it open`)
+      return
+    }
+    const locale = detectReplyLocale(pr.title, pr.body)
+    core.info(`Closing PR #${pullNumber} reason=${reason} locale=${locale}`)
+    await upsertGateComment(closeMessage({
+      locale,
+      reason,
+      prAuthor,
+      docsUrl,
+      listUrl,
+    }))
+    if (await hasVerifiedRecovery()) {
+      core.info(`PR #${pullNumber} was recovered while the gate was running; leaving it open`)
+      return
+    }
+    await github.rest.pulls.update({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      pull_number: pullNumber,
+      state: 'closed',
+    })
+  }
+
+  if (pr.state === 'closed') return
+
+  if (CI_ONLY_PR_AUTHOR_IDS.has(pr.user.id)
+    || pr.user.type === 'Bot'
+    || prAuthor.endsWith('[bot]')) {
+    core.info(`Leaving CI-only bot PR open: ${prAuthor}`)
+    return
+  }
+
+  if (await hasWriteAccess(prAuthor)) {
+    core.info(`${prAuthor} has write/admin/maintain`)
+    return
+  }
+
+  const approvedContributors = await loadApprovedContributors(workspace)
+  if (approvedContributors.has(prAuthor.toLowerCase())) {
+    core.info(`${prAuthor} is in the approved contributors list`)
+    return
+  }
+
+  const linked = await linkedIssueNumbers()
+  await closePullRequest(linked.length > 0 ? 'not_approved_issue' : 'not_approved')
+}

--- a/.github/scripts/pr-intake/issue-link.mjs
+++ b/.github/scripts/pr-intake/issue-link.mjs
@@ -1,0 +1,41 @@
+import { detectReplyLocale } from './locale.mjs'
+import { missingIssueMessage } from './messages.mjs'
+
+const ISSUE_LINK_CUTOFF = '2026-08-25T00:00:00Z'
+
+export async function runIssueLink({ github, context, core }) {
+  if (context.eventName !== 'pull_request') {
+    core.notice('非 pull_request 事件，跳过关联 issue 检查')
+    return
+  }
+  const pr = context.payload.pull_request
+  if (new Date(pr.created_at) < new Date(ISSUE_LINK_CUTOFF)) {
+    core.notice(`PR 建于 ${pr.created_at}，早于门禁生效时间 ${ISSUE_LINK_CUTOFF}，按旧规则放行`)
+    return
+  }
+  if (pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]')) {
+    core.notice(`作者 ${pr.user.login} 是机器人，跳过`)
+    return
+  }
+  if ((pr.labels ?? []).some(label => label.name === 'no-issue-needed')) {
+    core.notice('带 no-issue-needed 标签，维护者已豁免')
+    return
+  }
+  const { repository } = await github.graphql(
+    `query($owner:String!, $repo:String!, $number:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$number) {
+          closingIssuesReferences(first: 20) { nodes { number } }
+        }
+      }
+    }`,
+    { owner: context.repo.owner, repo: context.repo.repo, number: pr.number },
+  )
+  const linked = repository.pullRequest.closingIssuesReferences.nodes.map(node => node.number)
+  if (linked.length === 0) {
+    const locale = detectReplyLocale(pr.title, pr.body)
+    core.setFailed(missingIssueMessage(locale))
+    return
+  }
+  core.notice(`已关联 issue：${linked.map(n => `#${n}`).join(' ')}`)
+}

--- a/.github/scripts/pr-intake/locale.mjs
+++ b/.github/scripts/pr-intake/locale.mjs
@@ -1,0 +1,14 @@
+// 标题+正文里汉字占「汉字+字母」≥ 20%，或汉字 ≥ 12，回中文。
+// 先剥模板注释、代码块、URL，避免 API 名把拉丁字母撑高。
+export function detectReplyLocale(title, body) {
+  const text = `${title || ''}\n${body || ''}`
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]+`/g, ' ')
+    .replace(/https?:\/\/\S+/g, ' ')
+  const cjk = (text.match(/\p{Script=Han}/gu) || []).length
+  const latin = (text.match(/[A-Za-z]/g) || []).length
+  if (cjk === 0) return 'en'
+  if (latin === 0) return 'zh'
+  return (cjk / (cjk + latin) >= 0.2 || cjk >= 12) ? 'zh' : 'en'
+}

--- a/.github/scripts/pr-intake/messages.mjs
+++ b/.github/scripts/pr-intake/messages.mjs
@@ -1,0 +1,71 @@
+export function closeMessage({ locale, reason, prAuthor, docsUrl, listUrl }) {
+  const zh = {
+    not_approved: [
+      `Hi @${prAuthor}，感谢你愿意贡献。`,
+      '',
+      `dsh-TUI 不接受未列入 [\`.github/APPROVED_CONTRIBUTORS\`](${listUrl}) 的实现 PR。`,
+      '作者不在白名单里，所以这个 PR 会被关闭。',
+      '',
+      '可复现的 bug 请走 bug issue 表单。报告不预留实现，也不授权开 PR。',
+      '功能建议请发 GitHub Discussions。不要为已经写好的实现再开一个 issue 当通行证。',
+      '',
+      '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
+      '不要开 issue 或 Discussion 申请加入白名单。',
+      '',
+      `政策见 ${docsUrl}/contributing.md`,
+    ],
+    not_approved_issue: [
+      `Hi @${prAuthor}，感谢你愿意贡献。`,
+      '',
+      `dsh-TUI 不接受未列入 [\`.github/APPROVED_CONTRIBUTORS\`](${listUrl}) 的实现 PR。`,
+      '关联了 issue 也不授权开 PR，所以这个 PR 会被关闭。',
+      '',
+      '可复现的 bug 请走 bug issue 表单，等维护者或名单里的人修。',
+      '功能建议请发 GitHub Discussions。',
+      '',
+      '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
+      '不要开 issue 或 Discussion 申请加入白名单。',
+      '',
+      `政策见 ${docsUrl}/contributing.md`,
+    ],
+  }
+  const en = {
+    not_approved: [
+      `Hi @${prAuthor}, thanks for your interest in contributing.`,
+      '',
+      'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS`.',
+      'The author is not on that list, so this pull request is being closed.',
+      '',
+      'Report a reproducible bug through the bug issue template. A report does not reserve the work or authorize a pull request.',
+      'Feature requests belong in GitHub Discussions. Do not open an issue merely to justify an implementation that was already written.',
+      '',
+      'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
+      'Do not open an issue or discussion asking to be added to the list.',
+      '',
+      `See ${docsUrl}/contributing.en.md`,
+    ],
+    not_approved_issue: [
+      `Hi @${prAuthor}, thanks for your interest in contributing.`,
+      '',
+      'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS`.',
+      'Linking an issue does not authorize a pull request, so this one is being closed.',
+      '',
+      'Report a reproducible bug through the bug issue template and leave the fix to a maintainer or an approved contributor.',
+      'Feature requests belong in GitHub Discussions.',
+      '',
+      'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
+      'Do not open an issue or discussion asking to be added to the list.',
+      '',
+      `See ${docsUrl}/contributing.en.md`,
+    ],
+  }
+  const lines = (locale === 'zh' ? zh : en)[reason]
+  if (!lines) throw new Error(`unknown close reason: ${reason}`)
+  return lines.join('\n')
+}
+
+export function missingIssueMessage(locale) {
+  return locale === 'zh'
+    ? '代码 PR 必须关联 issue。在描述里写一行 `Closes #<issue 号>`（或用侧边栏 Development 关联）。还没有 issue：bug 用 bug 表单开一个；功能建议先发 Discussions Ideas，等维护者认可后再开跟踪 issue（见 docs/contributing.md）。'
+    : 'A code PR must link an issue. Add `Closes #<issue>` in the description (or link it in the Development sidebar). No issue yet: file a bug through the bug form; feature ideas go to Discussions Ideas and wait for a maintainer tracking issue (see docs/contributing.en.md).'
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,56 +80,17 @@ jobs:
       pull-requests: read
       issues: read
     steps:
+      - uses: actions/checkout@v7
       - uses: actions/github-script@v9
         with:
           script: |
-            // push 事件没有 PR 可查，直接放行——门禁的对象是 PR。
-            if (context.eventName !== 'pull_request') {
-              core.notice('非 pull_request 事件，跳过关联 issue 检查')
-              return
-            }
-            const pr = context.payload.pull_request
-            const CUTOFF = '2026-08-25T00:00:00Z'
-            if (new Date(pr.created_at) < new Date(CUTOFF)) {
-              core.notice(`PR 建于 ${pr.created_at}，早于门禁生效时间 ${CUTOFF}，按旧规则放行`)
-              return
-            }
-            if (pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]')) {
-              core.notice(`作者 ${pr.user.login} 是机器人，跳过`)
-              return
-            }
-            if ((pr.labels ?? []).some(l => l.name === 'no-issue-needed')) {
-              core.notice('带 no-issue-needed 标签，维护者已豁免')
-              return
-            }
-            // 查询失败时不放行（fail-closed）：github-script 默认让抛出的
-            // 异常判定 step 失败，这里不 catch，与 ci-gate 的同一姿态。
-            const { repository } = await github.graphql(
-              `query($owner:String!, $repo:String!, $number:Int!) {
-                repository(owner:$owner, name:$repo) {
-                  pullRequest(number:$number) {
-                    closingIssuesReferences(first: 20) { nodes { number } }
-                  }
-                }
-              }`,
-              { owner: context.repo.owner, repo: context.repo.repo, number: pr.number },
-            )
-            const linked = repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number)
-            if (linked.length === 0) {
-              const text = `${pr.title || ''}\n${pr.body || ''}`
-                .replace(/<!--[\s\S]*?-->/g, ' ')
-                .replace(/```[\s\S]*?```/g, ' ')
-                .replace(/`[^`]+`/g, ' ')
-                .replace(/https?:\/\/\S+/g, ' ')
-              const cjk = (text.match(/\p{Script=Han}/gu) || []).length
-              const latin = (text.match(/[A-Za-z]/g) || []).length
-              const zh = cjk > 0 && (latin === 0 || cjk / (cjk + latin) >= 0.2 || cjk >= 12)
-              core.setFailed(zh
-                ? '代码 PR 必须关联 issue。在描述里写一行 `Closes #<issue 号>`（或用侧边栏 Development 关联）。还没有 issue：bug 用 bug 表单开一个；功能建议先发 Discussions Ideas，等维护者认可后再开跟踪 issue（见 docs/contributing.md）。'
-                : 'A code PR must link an issue. Add `Closes #<issue>` in the description (or link it in the Development sidebar). No issue yet: file a bug through the bug form; feature ideas go to Discussions Ideas and wait for a maintainer tracking issue (see docs/contributing.en.md).')
-              return
-            }
-            core.notice(`已关联 issue：${linked.map(n => `#${n}`).join(' ')}`)
+            const { pathToFileURL } = await import('node:url')
+            const { join } = await import('node:path')
+            const { runIssueLink } = await import(pathToFileURL(join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/pr-intake/issue-link.mjs',
+            )).href)
+            await runIssueLink({ github, context, core })
 
   build:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,17 @@ jobs:
             )
             const linked = repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number)
             if (linked.length === 0) {
-              core.setFailed(
-                '代码 PR 必须关联 issue。在描述里写一行 `Closes #<issue 号>`（或用侧边栏 '
-                + 'Development 关联）。还没有 issue：bug 用 bug 表单开一个；功能建议先发 '
-                + 'Discussions Ideas 等维护者认可后开跟踪 issue（见 docs/contributing.md）。',
-              )
+              const text = `${pr.title || ''}\n${pr.body || ''}`
+                .replace(/<!--[\s\S]*?-->/g, ' ')
+                .replace(/```[\s\S]*?```/g, ' ')
+                .replace(/`[^`]+`/g, ' ')
+                .replace(/https?:\/\/\S+/g, ' ')
+              const cjk = (text.match(/\p{Script=Han}/gu) || []).length
+              const latin = (text.match(/[A-Za-z]/g) || []).length
+              const zh = cjk > 0 && (latin === 0 || cjk / (cjk + latin) >= 0.2 || cjk >= 12)
+              core.setFailed(zh
+                ? '代码 PR 必须关联 issue。在描述里写一行 `Closes #<issue 号>`（或用侧边栏 Development 关联）。还没有 issue：bug 用 bug 表单开一个；功能建议先发 Discussions Ideas，等维护者认可后再开跟踪 issue（见 docs/contributing.md）。'
+                : 'A code PR must link an issue. Add `Closes #<issue>` in the description (or link it in the Development sidebar). No issue yet: file a bug through the bug form; feature ideas go to Discussions Ideas and wait for a maintainer tracking issue (see docs/contributing.en.md).')
               return
             }
             core.notice(`已关联 issue：${linked.map(n => `#${n}`).join(' ')}`)

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -53,8 +53,11 @@ jobs:
                   username,
                 })
                 return data.permission
-              } catch {
-                return null
+              } catch (error) {
+                // 404: 不是协作者。401/403/限流/5xx 必须抛出——吞掉会把
+                // write 协作者当成路人，reopen 例外也会失效。
+                if (error.status === 404) return null
+                throw error
               }
             }
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,7 +1,8 @@
 # PR 白名单门禁——docs/contributing.md「如何贡献」的 CI 落地。
-# 模型抄 Herdr 的 pr-gate：默认分支上的名单 + 协作者权限，未列入者关 PR。
-# 用 pull_request_target 才能关别人仓库推过来的 PR；只经 API 读默认分支上的
-# 名单，不 checkout PR 头，避免在可信上下文里跑 fork 代码。
+# 逻辑在 .github/scripts/pr-intake/，本文件只编排。
+#
+# pull_request_target 才能关别人仓库推过来的 PR。必须 checkout 默认分支，
+# 禁止 checkout PR 头，避免在可信上下文里跑 fork 代码。
 #
 # 不追溯：只监听 opened / reopened。门禁合入前已经开着的 PR 不会收到 opened，
 # 因而不会被关掉。维护者 reopen 视为一次性放行；其他人 reopen 再关一次。
@@ -24,251 +25,20 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Checkout default branch only
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Check pull request intake policy
         uses: actions/github-script@v9
         with:
           script: |
-            const GITHUB_ACTIONS_BOT_ID = 41898282
-            const CI_ONLY_PR_AUTHOR_IDS = new Set([
-              49699333, // dependabot[bot]
-              41898282, // github-actions[bot]
-            ])
-            const COMMENT_MARKER = '<!-- dsh-tui-pr-gate -->'
-
-            const pullNumber = context.payload.pull_request.number
-            const defaultBranch = context.payload.repository.default_branch
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-            })
-            const prAuthor = pr.user.login
-            const docsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs`
-            const listUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/.github/APPROVED_CONTRIBUTORS`
-
-            // 标题+正文里汉字占「汉字+字母」≥ 20%，或汉字 ≥ 12，回中文。
-            // 先剥模板注释、代码块、URL，避免 API 名把拉丁字母撑高。
-            function detectReplyLocale(title, body) {
-              const text = `${title || ''}\n${body || ''}`
-                .replace(/<!--[\s\S]*?-->/g, ' ')
-                .replace(/```[\s\S]*?```/g, ' ')
-                .replace(/`[^`]+`/g, ' ')
-                .replace(/https?:\/\/\S+/g, ' ')
-              const cjk = (text.match(/\p{Script=Han}/gu) || []).length
-              const latin = (text.match(/[A-Za-z]/g) || []).length
-              if (cjk === 0) return 'en'
-              if (latin === 0) return 'zh'
-              return (cjk / (cjk + latin) >= 0.2 || cjk >= 12) ? 'zh' : 'en'
-            }
-
-            async function linkedIssueNumbers() {
-              const { repository } = await github.graphql(
-                `query($owner:String!, $repo:String!, $number:Int!) {
-                  repository(owner:$owner, name:$repo) {
-                    pullRequest(number:$number) {
-                      closingIssuesReferences(first: 20) { nodes { number } }
-                    }
-                  }
-                }`,
-                { owner: context.repo.owner, repo: context.repo.repo, number: pullNumber },
-              )
-              return repository.pullRequest.closingIssuesReferences.nodes.map(node => node.number)
-            }
-
-            function closeMessage(locale, reason) {
-              const zh = {
-                not_approved: [
-                  `Hi @${prAuthor}，感谢你愿意贡献。`,
-                  '',
-                  `dsh-TUI 不接受未列入 [\`.github/APPROVED_CONTRIBUTORS\`](${listUrl}) 的实现 PR。`,
-                  '作者不在白名单里，所以这个 PR 会被关闭。',
-                  '',
-                  '可复现的 bug 请走 bug issue 表单。报告不预留实现，也不授权开 PR。',
-                  '功能建议请发 GitHub Discussions。不要为已经写好的实现再开一个 issue 当通行证。',
-                  '',
-                  '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
-                  '不要开 issue 或 Discussion 申请加入白名单。',
-                  '',
-                  `政策见 ${docsUrl}/contributing.md`,
-                ],
-                not_approved_issue: [
-                  `Hi @${prAuthor}，感谢你愿意贡献。`,
-                  '',
-                  `dsh-TUI 不接受未列入 [\`.github/APPROVED_CONTRIBUTORS\`](${listUrl}) 的实现 PR。`,
-                  '关联了 issue 也不授权开 PR，所以这个 PR 会被关闭。',
-                  '',
-                  '可复现的 bug 请走 bug issue 表单，等维护者或名单里的人修。',
-                  '功能建议请发 GitHub Discussions。',
-                  '',
-                  '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
-                  '不要开 issue 或 Discussion 申请加入白名单。',
-                  '',
-                  `政策见 ${docsUrl}/contributing.md`,
-                ],
-              }
-              const en = {
-                not_approved: [
-                  `Hi @${prAuthor}, thanks for your interest in contributing.`,
-                  '',
-                  'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS`.',
-                  'The author is not on that list, so this pull request is being closed.',
-                  '',
-                  'Report a reproducible bug through the bug issue template. A report does not reserve the work or authorize a pull request.',
-                  'Feature requests belong in GitHub Discussions. Do not open an issue merely to justify an implementation that was already written.',
-                  '',
-                  'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
-                  'Do not open an issue or discussion asking to be added to the list.',
-                  '',
-                  `See ${docsUrl}/contributing.en.md`,
-                ],
-                not_approved_issue: [
-                  `Hi @${prAuthor}, thanks for your interest in contributing.`,
-                  '',
-                  'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS`.',
-                  'Linking an issue does not authorize a pull request, so this one is being closed.',
-                  '',
-                  'Report a reproducible bug through the bug issue template and leave the fix to a maintainer or an approved contributor.',
-                  'Feature requests belong in GitHub Discussions.',
-                  '',
-                  'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
-                  'Do not open an issue or discussion asking to be added to the list.',
-                  '',
-                  `See ${docsUrl}/contributing.en.md`,
-                ],
-              }
-              return (locale === 'zh' ? zh : en)[reason].join('\n')
-            }
-
-            async function getPermission(username) {
-              try {
-                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username,
-                })
-                return data.permission
-              } catch (error) {
-                // 404: 不是协作者。401/403/限流/5xx 必须抛出——吞掉会把
-                // write 协作者当成路人，reopen 例外也会失效。
-                if (error.status === 404) return null
-                throw error
-              }
-            }
-
-            async function getTextFile(path) {
-              try {
-                const { data } = await github.rest.repos.getContent({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  path,
-                  ref: defaultBranch,
-                })
-                if (!('content' in data) || typeof data.content !== 'string') {
-                  throw new Error(`Expected file content for ${path}`)
-                }
-                return Buffer.from(data.content, 'base64').toString('utf8')
-              } catch (error) {
-                if (error.status === 404) return ''
-                throw error
-              }
-            }
-
-            function parseUserList(content) {
-              return new Set(content
-                .split('\n')
-                .map(line => line.trim().toLowerCase())
-                .filter(line => line && !line.startsWith('#')))
-            }
-
-            async function hasWriteAccess(username) {
-              if (!username) return false
-              return ['admin', 'maintain', 'write'].includes(await getPermission(username))
-            }
-
-            async function hasVerifiedRecovery() {
-              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullNumber,
-                per_page: 100,
-              })
-              const latestStateEvent = events.findLast(event =>
-                ['closed', 'reopened'].includes(event.event))
-              return latestStateEvent?.event === 'reopened'
-                && await hasWriteAccess(latestStateEvent.actor?.login)
-            }
-
-            async function upsertGateComment(message) {
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullNumber,
-                per_page: 100,
-              })
-              const existing = comments.find(comment =>
-                comment.user?.id === GITHUB_ACTIONS_BOT_ID
-                && comment.body?.includes(COMMENT_MARKER))
-              const body = `${COMMENT_MARKER}\n${message}`
-              if (existing?.body === body) return
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                })
-                return
-              }
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullNumber,
-                body,
-              })
-            }
-
-            async function closePullRequest(reason) {
-              if (await hasVerifiedRecovery()) {
-                core.info(`PR #${pullNumber} was recovered by a write collaborator; leaving it open`)
-                return
-              }
-              const locale = detectReplyLocale(pr.title, pr.body)
-              core.info(`Closing PR #${pullNumber} reason=${reason} locale=${locale}`)
-              await upsertGateComment(closeMessage(locale, reason))
-              if (await hasVerifiedRecovery()) {
-                core.info(`PR #${pullNumber} was recovered while the gate was running; leaving it open`)
-                return
-              }
-              await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pullNumber,
-                state: 'closed',
-              })
-            }
-
-            if (pr.state === 'closed') return
-
-            if (CI_ONLY_PR_AUTHOR_IDS.has(pr.user.id)
-              || pr.user.type === 'Bot'
-              || prAuthor.endsWith('[bot]')) {
-              core.info(`Leaving CI-only bot PR open: ${prAuthor}`)
-              return
-            }
-
-            if (await hasWriteAccess(prAuthor)) {
-              core.info(`${prAuthor} has write/admin/maintain`)
-              return
-            }
-
-            const approvedContributors = parseUserList(
-              await getTextFile('.github/APPROVED_CONTRIBUTORS'),
-            )
-            if (approvedContributors.has(prAuthor.toLowerCase())) {
-              core.info(`${prAuthor} is in the approved contributors list`)
-              return
-            }
-
-            const linked = await linkedIssueNumbers()
-            await closePullRequest(linked.length > 0 ? 'not_approved_issue' : 'not_approved')
+            const { pathToFileURL } = await import('node:url')
+            const { join } = await import('node:path')
+            const { runPrGate } = await import(pathToFileURL(join(
+              process.env.GITHUB_WORKSPACE,
+              '.github/scripts/pr-intake/gate.mjs',
+            )).href)
+            await runPrGate({ github, context, core })

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,204 @@
+# PR 白名单门禁——docs/contributing.md「如何贡献」的 CI 落地。
+# 模型抄 Herdr 的 pr-gate：默认分支上的名单 + 协作者权限，未列入者关 PR。
+# 用 pull_request_target 才能关别人仓库推过来的 PR；只经 API 读默认分支上的
+# 名单，不 checkout PR 头，避免在可信上下文里跑 fork 代码。
+#
+# 不追溯：只监听 opened / reopened。门禁合入前已经开着的 PR 不会收到 opened，
+# 因而不会被关掉。维护者 reopen 视为一次性放行；其他人 reopen 再关一次。
+name: PR Gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  check-contributor:
+    if: github.repository == 'ccch1mneyyy/dsh-TUI'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check pull request intake policy
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const GITHUB_ACTIONS_BOT_ID = 41898282
+            const CI_ONLY_PR_AUTHOR_IDS = new Set([
+              49699333, // dependabot[bot]
+              41898282, // github-actions[bot]
+            ])
+            const COMMENT_MARKER = '<!-- dsh-tui-pr-gate -->'
+
+            const pullNumber = context.payload.pull_request.number
+            const defaultBranch = context.payload.repository.default_branch
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            })
+            const prAuthor = pr.user.login
+
+            async function getPermission(username) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username,
+                })
+                return data.permission
+              } catch {
+                return null
+              }
+            }
+
+            async function getTextFile(path) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path,
+                  ref: defaultBranch,
+                })
+                if (!('content' in data) || typeof data.content !== 'string') {
+                  throw new Error(`Expected file content for ${path}`)
+                }
+                return Buffer.from(data.content, 'base64').toString('utf8')
+              } catch (error) {
+                if (error.status === 404) return ''
+                throw error
+              }
+            }
+
+            function parseUserList(content) {
+              return new Set(content
+                .split('\n')
+                .map(line => line.trim().toLowerCase())
+                .filter(line => line && !line.startsWith('#')))
+            }
+
+            async function hasWriteAccess(username) {
+              if (!username) return false
+              return ['admin', 'maintain', 'write'].includes(await getPermission(username))
+            }
+
+            async function hasVerifiedRecovery() {
+              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                per_page: 100,
+              })
+              const latestStateEvent = events.findLast(event =>
+                ['closed', 'reopened'].includes(event.event))
+              return latestStateEvent?.event === 'reopened'
+                && await hasWriteAccess(latestStateEvent.actor?.login)
+            }
+
+            async function upsertGateComment(message) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                per_page: 100,
+              })
+              const existing = comments.find(comment =>
+                comment.user?.id === GITHUB_ACTIONS_BOT_ID
+                && comment.body?.includes(COMMENT_MARKER))
+              const body = `${COMMENT_MARKER}\n${message}`
+              if (existing?.body === body) return
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                })
+                return
+              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                body,
+              })
+            }
+
+            async function closePullRequest() {
+              if (await hasVerifiedRecovery()) {
+                core.info(`PR #${pullNumber} was recovered by a write collaborator; leaving it open`)
+                return
+              }
+              const message = [
+                `Hi @${prAuthor}，感谢你愿意贡献。`,
+                '',
+                'dsh-TUI 不接受未列入 [`.github/APPROVED_CONTRIBUTORS`]('
+                  + `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/.github/APPROVED_CONTRIBUTORS)`
+                  + ' 的实现 PR。仓库 write/admin/maintain 协作者也不在此限。',
+                '',
+                '作者不在白名单里，所以这个 PR 会被关闭。',
+                '',
+                '可复现的 bug 请走 bug issue 表单。报告不预留实现，也不授权开 PR。',
+                '功能建议、行为变更与其它提案请发 GitHub Discussions。不要为已经写好的实现再开一个 issue 当通行证。',
+                '',
+                '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
+                '不要开 issue 或 Discussion 申请加入白名单。',
+                '',
+                `政策见 https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs/contributing.md`,
+                '',
+                '---',
+                '',
+                `Hi @${prAuthor}, thanks for your interest in contributing.`,
+                '',
+                'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS` or who do not already have write/admin/maintain on this repository.',
+                '',
+                'Report a reproducible bug through the bug issue template. A report does not reserve the work or authorize a pull request.',
+                'Feature requests and other proposals belong in GitHub Discussions. Do not open an issue merely to justify an implementation that was already written.',
+                '',
+                'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
+                'Do not open an issue or discussion asking to be added to the list.',
+                '',
+                `See https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs/contributing.en.md`,
+              ].join('\n')
+              await upsertGateComment(message)
+              if (await hasVerifiedRecovery()) {
+                core.info(`PR #${pullNumber} was recovered while the gate was running; leaving it open`)
+                return
+              }
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+                state: 'closed',
+              })
+            }
+
+            if (pr.state === 'closed') return
+
+            if (CI_ONLY_PR_AUTHOR_IDS.has(pr.user.id)
+              || pr.user.type === 'Bot'
+              || prAuthor.endsWith('[bot]')) {
+              core.info(`Leaving CI-only bot PR open: ${prAuthor}`)
+              return
+            }
+
+            if (await hasWriteAccess(prAuthor)) {
+              core.info(`${prAuthor} has write/admin/maintain`)
+              return
+            }
+
+            const approvedContributors = parseUserList(
+              await getTextFile('.github/APPROVED_CONTRIBUTORS'),
+            )
+            if (approvedContributors.has(prAuthor.toLowerCase())) {
+              core.info(`${prAuthor} is in the approved contributors list`)
+              return
+            }
+
+            await closePullRequest()

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -44,6 +44,101 @@ jobs:
               pull_number: pullNumber,
             })
             const prAuthor = pr.user.login
+            const docsUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs`
+            const listUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/.github/APPROVED_CONTRIBUTORS`
+
+            // 标题+正文里汉字占「汉字+字母」≥ 20%，或汉字 ≥ 12，回中文。
+            // 先剥模板注释、代码块、URL，避免 API 名把拉丁字母撑高。
+            function detectReplyLocale(title, body) {
+              const text = `${title || ''}\n${body || ''}`
+                .replace(/<!--[\s\S]*?-->/g, ' ')
+                .replace(/```[\s\S]*?```/g, ' ')
+                .replace(/`[^`]+`/g, ' ')
+                .replace(/https?:\/\/\S+/g, ' ')
+              const cjk = (text.match(/\p{Script=Han}/gu) || []).length
+              const latin = (text.match(/[A-Za-z]/g) || []).length
+              if (cjk === 0) return 'en'
+              if (latin === 0) return 'zh'
+              return (cjk / (cjk + latin) >= 0.2 || cjk >= 12) ? 'zh' : 'en'
+            }
+
+            async function linkedIssueNumbers() {
+              const { repository } = await github.graphql(
+                `query($owner:String!, $repo:String!, $number:Int!) {
+                  repository(owner:$owner, name:$repo) {
+                    pullRequest(number:$number) {
+                      closingIssuesReferences(first: 20) { nodes { number } }
+                    }
+                  }
+                }`,
+                { owner: context.repo.owner, repo: context.repo.repo, number: pullNumber },
+              )
+              return repository.pullRequest.closingIssuesReferences.nodes.map(node => node.number)
+            }
+
+            function closeMessage(locale, reason) {
+              const zh = {
+                not_approved: [
+                  `Hi @${prAuthor}，感谢你愿意贡献。`,
+                  '',
+                  `dsh-TUI 不接受未列入 [\`.github/APPROVED_CONTRIBUTORS\`](${listUrl}) 的实现 PR。`,
+                  '作者不在白名单里，所以这个 PR 会被关闭。',
+                  '',
+                  '可复现的 bug 请走 bug issue 表单。报告不预留实现，也不授权开 PR。',
+                  '功能建议请发 GitHub Discussions。不要为已经写好的实现再开一个 issue 当通行证。',
+                  '',
+                  '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
+                  '不要开 issue 或 Discussion 申请加入白名单。',
+                  '',
+                  `政策见 ${docsUrl}/contributing.md`,
+                ],
+                not_approved_issue: [
+                  `Hi @${prAuthor}，感谢你愿意贡献。`,
+                  '',
+                  `dsh-TUI 不接受未列入 [\`.github/APPROVED_CONTRIBUTORS\`](${listUrl}) 的实现 PR。`,
+                  '关联了 issue 也不授权开 PR，所以这个 PR 会被关闭。',
+                  '',
+                  '可复现的 bug 请走 bug issue 表单，等维护者或名单里的人修。',
+                  '功能建议请发 GitHub Discussions。',
+                  '',
+                  '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
+                  '不要开 issue 或 Discussion 申请加入白名单。',
+                  '',
+                  `政策见 ${docsUrl}/contributing.md`,
+                ],
+              }
+              const en = {
+                not_approved: [
+                  `Hi @${prAuthor}, thanks for your interest in contributing.`,
+                  '',
+                  'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS`.',
+                  'The author is not on that list, so this pull request is being closed.',
+                  '',
+                  'Report a reproducible bug through the bug issue template. A report does not reserve the work or authorize a pull request.',
+                  'Feature requests belong in GitHub Discussions. Do not open an issue merely to justify an implementation that was already written.',
+                  '',
+                  'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
+                  'Do not open an issue or discussion asking to be added to the list.',
+                  '',
+                  `See ${docsUrl}/contributing.en.md`,
+                ],
+                not_approved_issue: [
+                  `Hi @${prAuthor}, thanks for your interest in contributing.`,
+                  '',
+                  'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS`.',
+                  'Linking an issue does not authorize a pull request, so this one is being closed.',
+                  '',
+                  'Report a reproducible bug through the bug issue template and leave the fix to a maintainer or an approved contributor.',
+                  'Feature requests belong in GitHub Discussions.',
+                  '',
+                  'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
+                  'Do not open an issue or discussion asking to be added to the list.',
+                  '',
+                  `See ${docsUrl}/contributing.en.md`,
+                ],
+              }
+              return (locale === 'zh' ? zh : en)[reason].join('\n')
+            }
 
             async function getPermission(username) {
               try {
@@ -133,43 +228,14 @@ jobs:
               })
             }
 
-            async function closePullRequest() {
+            async function closePullRequest(reason) {
               if (await hasVerifiedRecovery()) {
                 core.info(`PR #${pullNumber} was recovered by a write collaborator; leaving it open`)
                 return
               }
-              const message = [
-                `Hi @${prAuthor}，感谢你愿意贡献。`,
-                '',
-                'dsh-TUI 不接受未列入 [`.github/APPROVED_CONTRIBUTORS`]('
-                  + `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/.github/APPROVED_CONTRIBUTORS)`
-                  + ' 的实现 PR。仓库 write/admin/maintain 协作者也不在此限。',
-                '',
-                '作者不在白名单里，所以这个 PR 会被关闭。',
-                '',
-                '可复现的 bug 请走 bug issue 表单。报告不预留实现，也不授权开 PR。',
-                '功能建议、行为变更与其它提案请发 GitHub Discussions。不要为已经写好的实现再开一个 issue 当通行证。',
-                '',
-                '维护者如果明确要这份实现，可以 reopen；其他人 reopen 会被再次关闭。',
-                '不要开 issue 或 Discussion 申请加入白名单。',
-                '',
-                `政策见 https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs/contributing.md`,
-                '',
-                '---',
-                '',
-                `Hi @${prAuthor}, thanks for your interest in contributing.`,
-                '',
-                'dsh-TUI does not accept unsolicited implementation pull requests from people who are not listed in `.github/APPROVED_CONTRIBUTORS` or who do not already have write/admin/maintain on this repository.',
-                '',
-                'Report a reproducible bug through the bug issue template. A report does not reserve the work or authorize a pull request.',
-                'Feature requests and other proposals belong in GitHub Discussions. Do not open an issue merely to justify an implementation that was already written.',
-                '',
-                'If a maintainer explicitly wants this implementation, they can reopen the pull request. Reopening by anyone else will be closed again automatically.',
-                'Do not open an issue or discussion asking to be added to the list.',
-                '',
-                `See https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${defaultBranch}/docs/contributing.en.md`,
-              ].join('\n')
-              await upsertGateComment(message)
+              const locale = detectReplyLocale(pr.title, pr.body)
+              core.info(`Closing PR #${pullNumber} reason=${reason} locale=${locale}`)
+              await upsertGateComment(closeMessage(locale, reason))
               if (await hasVerifiedRecovery()) {
                 core.info(`PR #${pullNumber} was recovered while the gate was running; leaving it open`)
                 return
@@ -204,4 +270,5 @@ jobs:
               return
             }
 
-            await closePullRequest()
+            const linked = await linkedIssueNumbers()
+            await closePullRequest(linked.length > 0 ? 'not_approved_issue' : 'not_approved')

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -8,15 +8,28 @@ development contract for humans and coding agents working on `@deepseek-harness-
 ## How To Contribute
 
 - **Report bugs** through the bug issue form: version, terminal environment,
-  and a minimal reproduction.
+  and a minimal reproduction. A report does not reserve the implementation or
+  authorize a pull request.
 - **Request features** in [Discussions Ideas](https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas).
   Issues do not accept feature requests. Accepted proposals get a tracking issue,
   and its assignee owns the implementation. **Do not start writing code before the
   proposal is accepted** — OAuth, `/cost`, notifications, a plugin API and a remote
   runtime were each written in full and then closed.
-  If a maintainer has not responded within 14 days, you may open a PR directly; it
-  gets the `unreviewed-proposal` label and is treated as unreviewed.
-- **Open a pull request** against `main`. Keep changes focused: one logical
+  A discussion, issue, comment, or a claim that a maintainer agreed does not
+  authorize a pull request.
+- **Open a pull request** only if you have write/admin/maintain on this
+  repository, or your GitHub username is listed in
+  [`.github/APPROVED_CONTRIBUTORS`](../.github/APPROVED_CONTRIBUTORS).
+  Unsolicited implementation pull requests from everyone else are closed by
+  `pr-gate`, regardless of size, title, test results, or whether a human or an
+  agent wrote the code.
+  Maintainers add names based on trusted prior work. It is not an application
+  program — do not open an issue or discussion asking to be added. Membership
+  permits a pull request; it grants no write access and does not pre-approve
+  feature scope.
+  A write collaborator may reopen a closed pull request as a one-off exception.
+  Reopening by anyone else is closed again.
+  Open the pull request against `main`. Keep changes focused: one logical
   change per PR, with a Chinese or bilingual title and a description that
   covers motivation, what changed, and how it was verified.
   **A pull request that changes code must link an issue**: add a `Closes #<issue>`
@@ -29,11 +42,19 @@ development contract for humans and coding agents working on `@deepseek-harness-
   the same commands.
 - New features should include or extend a focused regression script.
 
-### When the feature proposal flow takes effect
+Before opening an implementation pull request, confirm the authenticated GitHub
+account has write access or appears in `.github/APPROVED_CONTRIBUTORS`. If
+neither is true, refuse to open the pull request and point at the bug form or
+Discussions. A human cannot bypass this with a private approval, an issue link,
+or a pasted maintainer comment.
 
-It applies only to pull requests opened on or after 2026-08-24. Pull requests
-already open before that date follow the previous rules and need no Discussion
-or tracking issue.
+### When the gates take effect
+
+The feature proposal flow applies only to pull requests opened on or after
+2026-08-24. The pull-request allowlist applies only to pull requests opened
+(or reopened) after the gate lands. Pull requests already open before that
+follow the previous rules: they are not closed retroactively and need no
+Discussion or tracking issue.
 
 
 
@@ -421,6 +442,7 @@ the required credentials.
 | Renderer/layout behavior | `src/ink/` or Yoga source, compiled output, CI regressions, focused scroll/resize/PTY probe |
 | Skill discovery or presentation | DSH adapter, slash-command merge, `/skills`, and focused regressions; maintainer-only skills live in `.agents/skills/` and must stay out of npm |
 | User-facing documented behavior | Chinese and English READMEs, plus config comments/help text where applicable |
+| Contribution intake or PR gate | `docs/contributing.md`, `docs/contributing.en.md`, `.github/workflows/pr-gate.yml`, `.github/APPROVED_CONTRIBUTORS` |
 | Package version or dependency | `package.json`, `pnpm-lock.yaml`, generated/published artifacts as applicable; do not churn the legacy npm lock incidentally |
 | Upstream validated-line bump | `src/dsh-adapter/contract.ts`, both peer and dev ranges in `package.json`, bundled `dsh-auth/package.json` and `dsh-auth/pnpm-lock.yaml`, `pnpm-workspace.yaml`, the upstream SHA in the `alpha-compat` job of `.github/workflows/ci.yml`, the version constants in `scripts/verify-{alpha-source,patch-surface,web-coexistence,upstream-contract}`, `patch-surface.snapshot.json`, `ADAPTER.md`, `docs/user-guide.md`; steps in the upgrade section of [ADAPTER.md](../ADAPTER.md) |
 

--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -123,6 +123,9 @@ boundaries and helpers over introducing parallel abstractions.
 - `cordis.yml`: full bare-composition example for direct Cordis/DSH startup.
 - `scripts/`: headless regressions, reproduction harnesses, probes, and
   diagnostics. Read each script's header before running it.
+- `.github/scripts/pr-intake/`: PR intake gate (locale, close copy, allowlist,
+  issue-link). Workflows only orchestrate; `pr-gate.yml` must check out the
+  default branch and must not run the PR head.
 - `lib/`: ignored JavaScript, declarations, and declaration maps generated from
   `src/` and shipped to npm. `./invariant` uses the compiled
   `lib/types/dsh-adapter/invariant.js` entry as well.
@@ -442,7 +445,7 @@ the required credentials.
 | Renderer/layout behavior | `src/ink/` or Yoga source, compiled output, CI regressions, focused scroll/resize/PTY probe |
 | Skill discovery or presentation | DSH adapter, slash-command merge, `/skills`, and focused regressions; maintainer-only skills live in `.agents/skills/` and must stay out of npm |
 | User-facing documented behavior | Chinese and English READMEs, plus config comments/help text where applicable |
-| Contribution intake or PR gate | `docs/contributing.md`, `docs/contributing.en.md`, `.github/workflows/pr-gate.yml`, `.github/APPROVED_CONTRIBUTORS` |
+| Contribution intake or PR gate | `docs/contributing.md`, `docs/contributing.en.md`, `.github/workflows/pr-gate.yml`, `.github/scripts/pr-intake/`, `.github/APPROVED_CONTRIBUTORS` |
 | Package version or dependency | `package.json`, `pnpm-lock.yaml`, generated/published artifacts as applicable; do not churn the legacy npm lock incidentally |
 | Upstream validated-line bump | `src/dsh-adapter/contract.ts`, both peer and dev ranges in `package.json`, bundled `dsh-auth/package.json` and `dsh-auth/pnpm-lock.yaml`, `pnpm-workspace.yaml`, the upstream SHA in the `alpha-compat` job of `.github/workflows/ci.yml`, the version constants in `scripts/verify-{alpha-source,patch-surface,web-coexistence,upstream-contract}`, `patch-surface.snapshot.json`, `ADAPTER.md`, `docs/user-guide.md`; steps in the upgrade section of [ADAPTER.md](../ADAPTER.md) |
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,13 +8,20 @@
 ## 如何贡献
 
 - **报告 bug**：用 bug 表单提交 issue，填写版本、终端环境与最短复现步骤。
+  报告不预留实现，也不授权开 PR。
 - **提功能建议**：发到 [Discussions Ideas](https://github.com/ccch1mneyyy/dsh-TUI/discussions/new?category=ideas)。
   Issues 不接受功能请求。维护者认可后会开一个 issue 跟踪实现，实现由该 issue
   的 assignee 负责。**拿到认可之前不要开始写代码**——被否的提案里已经有 OAuth、
   `/cost`、通知、插件 API、remote runtime 几套写完整才被关掉的实现。
-  发出后 14 天没有维护者回应，可以直接提 PR，会被打上 `unreviewed-proposal`
-  标签，按未经审阅处理。
-- **提交 PR**：base 指向 `main`。保持改动聚焦——一个 PR 只做一个逻辑改动，
+  Discussion、issue、评论或「维护者同意了」的转述，都不构成开 PR 的许可。
+- **提交 PR**：只有仓库 write/admin/maintain 协作者，或
+  [`.github/APPROVED_CONTRIBUTORS`](../.github/APPROVED_CONTRIBUTORS) 名单中的
+  用户，可以提交实现 PR。其余人的实现 PR 会被 `pr-gate` 自动关闭，不论体积、
+  标题、测试结果，也不论是人还是 Agent 写的。
+  名单由维护者按既有信任添加，不是申请制——不要开 issue 或 Discussion 申请加入。
+  名单只允许提交 PR，不授予 write，也不预审功能范围。
+  维护者 reopen 一次已关闭的 PR 可作为例外；其他人 reopen 会被再次关闭。
+  base 指向 `main`。保持改动聚焦——一个 PR 只做一个逻辑改动，
   标题用中文或中英对照，描述写清动机、改动点与验证方式。
   **改动代码的 PR 必须关联 issue**：描述里写一行 `Closes #<issue 号>`，或用
   侧边栏 Development 关联。CI 的 `issue-link` 组会检查，没有关联即判失败。
@@ -23,10 +30,15 @@
 - **请求 review 前先跑验证矩阵**：CI 运行的就是下面这些命令。
 - 新功能应附带或扩展一个聚焦的回归脚本。
 
-### 功能提案流程的生效时间
+开实现 PR 之前，确认当前 GitHub 账号是 write 协作者或出现在
+`.github/APPROVED_CONTRIBUTORS`。两者都不是就拒绝开 PR，引导去 bug 表单或
+Discussions。人不能用「私下批准」、关联 issue 或粘贴维护者评论来绕过。
 
-该流程只对 2026-08-24 起新建的 PR 生效。在此之前开着的 PR 按旧规则处理，
-不需要补 Discussion 或跟踪 issue。
+### 门禁与提案流程的生效时间
+
+功能提案流程只对 2026-08-24 起新建的 PR 生效。PR 白名单门禁只对门禁合入后
+新开（或被 reopen）的 PR 生效。在此之前开着的 PR 按旧规则处理，不会被追溯关闭，
+也不需要补 Discussion 或跟踪 issue。
 
 ## 范围（Scope）
 
@@ -326,6 +338,7 @@ TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式�
 | 渲染器/布局行为 | `src/ink/` 或 Yoga 源、编译产物、CI 回归、聚焦滚动/resize/PTY 探针 |
 | 技能发现或呈现 | DSH adapter、slash 命令合并、`/skills` 与相关回归；项目维护技能放 `.agents/skills/` 且不得加入 npm 包 |
 | 用户可见的文档化行为 | 中英文 README，外加适用的配置注释/帮助文本 |
+| 贡献入口或 PR 门禁 | `docs/contributing.md`、`docs/contributing.en.md`、`.github/workflows/pr-gate.yml`、`.github/APPROVED_CONTRIBUTORS` |
 | 包版本或依赖 | `package.json`、`pnpm-lock.yaml`、适用时的生成/发布产物；不要顺手搅动旧 npm 锁文件 |
 | 上游验证线 bump | `src/dsh-adapter/contract.ts`、`package.json` peer+dev 两组范围、随包内置的 `dsh-auth/package.json` 与 `dsh-auth/pnpm-lock.yaml`、`pnpm-workspace.yaml`、`.github/workflows/ci.yml` alpha-compat 的上游 SHA、`scripts/verify-{alpha-source,patch-surface,web-coexistence,upstream-contract}` 内的版本常量、`patch-surface.snapshot.json`、`ADAPTER.md`、`docs/user-guide.md`；步骤见 [ADAPTER.md](../ADAPTER.md) 升级流程 |
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -92,6 +92,8 @@ DeepSeek Harness 拥有，TUI 只消费它们。
   被禁用的 host 行、insert/override 语义都很关键。
 - `cordis.yml`：直接 Cordis/DSH 启动的完整裸组合示例。
 - `scripts/`：无头回归、复现环境、探针与诊断。运行前先读脚本头部说明。
+- `.github/scripts/pr-intake/`：PR 入口门禁（语言、关单文案、白名单、issue-link）。
+  workflow 只编排；`pr-gate.yml` 必须 checkout 默认分支，不能跑 PR 头。
 - `lib/`：由 `src/` 生成、忽略入库并随 npm 分发的 JavaScript、声明与声明映射。
   `./invariant` 也直接使用 `lib/types/dsh-adapter/invariant.js` 的编译结果。
 - `README.md` 与 `README_EN.md`：中英文用户文档。行为、配置、快捷键与限制
@@ -338,7 +340,7 @@ TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式�
 | 渲染器/布局行为 | `src/ink/` 或 Yoga 源、编译产物、CI 回归、聚焦滚动/resize/PTY 探针 |
 | 技能发现或呈现 | DSH adapter、slash 命令合并、`/skills` 与相关回归；项目维护技能放 `.agents/skills/` 且不得加入 npm 包 |
 | 用户可见的文档化行为 | 中英文 README，外加适用的配置注释/帮助文本 |
-| 贡献入口或 PR 门禁 | `docs/contributing.md`、`docs/contributing.en.md`、`.github/workflows/pr-gate.yml`、`.github/APPROVED_CONTRIBUTORS` |
+| 贡献入口或 PR 门禁 | `docs/contributing.md`、`docs/contributing.en.md`、`.github/workflows/pr-gate.yml`、`.github/scripts/pr-intake/`、`.github/APPROVED_CONTRIBUTORS` |
 | 包版本或依赖 | `package.json`、`pnpm-lock.yaml`、适用时的生成/发布产物；不要顺手搅动旧 npm 锁文件 |
 | 上游验证线 bump | `src/dsh-adapter/contract.ts`、`package.json` peer+dev 两组范围、随包内置的 `dsh-auth/package.json` 与 `dsh-auth/pnpm-lock.yaml`、`pnpm-workspace.yaml`、`.github/workflows/ci.yml` alpha-compat 的上游 SHA、`scripts/verify-{alpha-source,patch-surface,web-coexistence,upstream-contract}` 内的版本常量、`patch-surface.snapshot.json`、`ADAPTER.md`、`docs/user-guide.md`；步骤见 [ADAPTER.md](../ADAPTER.md) 升级流程 |
 


### PR DESCRIPTION
## Summary
- 落地 #487 未做的第二步：`.github/APPROVED_CONTRIBUTORS` + `pr-gate.yml`。按 [Herdr 现网](https://github.com/herdrdev/herdr/blob/master/.github/workflows/pr-gate.yml) 的模型——write/admin/maintain 协作者或名单用户才能开实现 PR，其余人打开即关并留言。
- 只抄门禁本身：`pull_request_target` + API 读默认分支名单（不 checkout PR 头）；维护者 reopen 放行、其他人 reopen 再关；dependabot 等 bot 放行。不搬 Herdr 的 kangal token、AI review 评论、`MAINTAINERS` 双重校验。
- 双语 contributing 同步。**删掉了「Discussion 14 天无回应可直接提 PR」**——那条和白名单互斥；#500 当时写它是因为白名单还没做。不追溯：只监听 `opened` / `reopened`，已经开着的 PR 不会被关。

Closes #487

## 合并前请拍板
名单现在是空的。有 write 的人不用写进去。合并前要把要继续收 PR 的外部贡献者（#487 里点名的如 Qiuner）加进 `APPROVED_CONTRIBUTORS`，否则他们之后新开的 PR 会被自动关。

## Test plan
- [ ] 看 `pr-gate.yml`：没有 `actions/checkout`，只 `getContent(..., ref: default_branch)`
- [ ] 合入后用一个**不在名单、没有 write** 的号开测试 PR，应被关掉并留下中英说明
- [ ] 维护者 reopen 该 PR，应保持打开
- [ ] 非维护者再 reopen，应再次关闭
- [ ] 本 PR 合入前已开着的 PR 仍保持打开（不追溯）
- [ ] dependabot PR 不被关


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated screening for newly opened or reopened implementation pull requests.
  * Approved contributors and repository collaborators can submit implementation pull requests under the updated intake rules.
  * Unauthorized submissions are closed with localized guidance.
  * Eligible pull requests must link to a closing issue, with guidance provided when no issue is linked.

* **Documentation**
  * Updated contribution guides with proposal, bug report, implementation, approval, issue tracking, reopening, target-branch, effective-date, and allowlist rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->