### PR TITLE
fix(questions): support paste in questionnaire custom inputs

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -535,6 +535,12 @@ const GROUPS = {
 // 提问面板 hideCustomInput 行为回归：纯选择题隐藏输入行且 Tab/打字
 // 不劫持焦点，纯文本题忽略 hide 标记，多选题默认行为不回退。
     ["verify-askpanel-hide-custom-input", ['node', '--import', 'tsx/esm', 'scripts/verify-askpanel-hide-custom-input.tsx']],
+// 问卷面板粘贴回归：bracketed paste 压平插入（纯换行块不得提交、ANSI/
+// OSC 剥净）、Ctrl+V/Alt+V 异步剪贴板插入到实时光标（读期间打字真竞态
+// 臂、busy 去重）、选项行粘贴追加+附加标签、plan-review 粘贴绝不快选/
+// 批准、隐藏输入题粘贴惰性、超长粘贴上限报错、同 chunk 批量按键经同步
+// ref 依序编辑、emoji 码点步进。
+    ["verify-question-paste", ['node', '--import', 'tsx/esm', 'scripts/verify-question-paste.tsx']],
 // 长问卷列表回归：24 行终端中的 36 个两行 provider 选项必须围绕
 // focusIndex 窗口化，初始和深度导航后焦点 label/单选标记始终可见。
     ["verify-askpanel-long-list", ['node', '--import', 'tsx/esm', 'scripts/verify-askpanel-long-list.tsx']],

--- a/scripts/verify-extension-ui.tsx
+++ b/scripts/verify-extension-ui.tsx
@@ -846,8 +846,8 @@ const screen = (back = 30) => plainText(stdout.frames.slice(-back))
 }
 
 // Bracketed paste: a chunk that is all line breaks is TEXT, not an Enter
-// press (isPasted lives on the InputEvent, not the key) — the confirm must
-// survive it, on its default Yes focus.
+// press (the parsed key carries isPasted; modal confirms must survive it) —
+// the confirm must not fire on its default Yes focus.
 {
   const pending = plugin.tuiDialogs.confirm({ title: '粘贴确认' })
   await settle(() => screen().includes('粘贴确认'))

--- a/scripts/verify-question-paste.tsx
+++ b/scripts/verify-question-paste.tsx
@@ -1,0 +1,367 @@
+/**
+ * Questionnaire-panel paste regression: both free-text surfaces of the
+ * ask_user_question seam (AskUserQuestionPanel's custom input row and
+ * PlanReviewPanel's feedback row) must paste like the composer —
+ *
+ *  - a bracketed paste (terminal Ctrl+Shift+V / right-click / terminals
+ *    that intercept Ctrl+V) inserts its chunk verbatim after flattening
+ *    newlines/control chars to spaces; a chunk that is all line breaks is
+ *    TEXT, never an Enter press, so it must not submit the panel;
+ *  - Ctrl+V (0x16) / Alt+V (ESC v) — the keymap `paste` binding — reads the
+ *    clipboard ASYNCHRONOUSLY (fake reader injected through
+ *    readClipboardOverride) and lands at the live caret: typing during the
+ *    read is not clobbered, and repeat keys while a read is in flight are
+ *    ignored;
+ *  - where the text lands mirrors plain typing: at the caret on the input
+ *    row, appended at the tail on an option row (+ label attach,
+ *    single-select);
+ *  - pasted content never PICKS an option: plan-review's digit quick-pick
+ *    is keypress-only, and a pasted "1" must not approve on the default
+ *    focus;
+ *  - editing is batch-safe (several keys of one stdin chunk edit in order —
+ *    typing + Enter in the SAME chunk still submits the typed text) and
+ *    code-point-safe (an emoji is one ←/⌫ step, never a split surrogate).
+ *
+ * Drives the real useInput path with fake stdin; output is captured raw
+ * and ANSI-stripped (no xterm dependency).
+ */
+process.env.FORCE_COLOR = '3'
+
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { AskUserQuestionPanel }, { render }, { settle, settled, sleep, viewportLines }] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/components/questions/AskUserQuestionPanel.js'),
+  import('../src/ui.js'),
+  import('./lib/term-test.mjs'),
+])
+
+const COLS = 100
+const ROWS = 30
+const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+class FakeStdout extends Writable {
+  columns = COLS
+  rows = ROWS
+  isTTY = true
+  _write(chunk: unknown, _e: BufferEncoding, cb: () => void) { term.write(String(chunk), cb) }
+}
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+const stdout = new FakeStdout()
+const stdin = new FakeStdin()
+/** The real terminal screen, line by line. */
+function screen(): string {
+  return viewportLines(term, ROWS).join('\n')
+}
+
+let failures = 0
+const results: string[] = []
+const check = (name: string, ok: boolean, extra?: string) => {
+  results.push(`${ok ? 'PASS' : 'FAIL'}  ${name}`)
+  if (!ok) {
+    failures++
+    if (extra !== undefined) results.push(`      actual: ${extra.slice(0, 300)}`)
+  }
+}
+
+let lastAnswer: unknown = undefined
+let cancelCount = 0
+let mountSeq = 0
+type AppLike = { rerender(el: unknown): unknown; unmount(): void }
+let app: AppLike | null = null
+/** (Re)mount a fresh panel (new key → fresh instance + fresh editing state). */
+async function mount(question: unknown, reader?: () => Promise<unknown>): Promise<void> {
+  mountSeq++
+  const element = React.createElement(AskUserQuestionPanel, {
+    key: `paste-q${mountSeq}`,
+    question,
+    position: 1,
+    total: 1,
+    answered: 0,
+    onAnswer: (selection: unknown) => { lastAnswer = selection },
+    onCancel: () => { cancelCount++ },
+    ...(reader === undefined ? {} : { readClipboardOverride: reader }),
+  })
+  if (app === null) {
+    app = await render(element, { stdout, stdin, stderr: new FakeStdout(), debug: true, exitOnCtrlC: false }) as unknown as AppLike
+  } else {
+    await app.rerender(element)
+  }
+}
+/** A fake clipboard reader resolving after a short delay (real async gap). */
+function clipboard(content: unknown, delayMs = 30): () => Promise<unknown> {
+  return () => new Promise(resolve => setTimeout(() => resolve(content), delayMs))
+}
+const CHUNK = (text: string): string => `\x1b[200~${text}\x1b[201~`
+const answerCustom = (): string | undefined => {
+  const a = lastAnswer as { selected?: string[]; custom?: string } | undefined
+  return a?.custom
+}
+const answerSelected = (): string[] => {
+  const a = lastAnswer as { selected?: string[] } | undefined
+  return a?.selected ?? []
+}
+const textQuestion = { question: '还有别的要说吗？' }
+const optionQuestion = {
+  question: '你有 API Key 吗？',
+  options: [{ label: '我有' }, { label: '我没有' }],
+}
+const planReviewQuestion = {
+  question: '按计划执行？',
+  detail: '计划：改三处文件。',
+  options: [{ label: '批准' }, { label: '继续计划' }],
+  intent: { kind: 'plan-review', approve: '批准' },
+}
+
+// ── 1. Bracketed paste into the input row: flattened to one line. ─────
+lastAnswer = undefined
+await mount(optionQuestion)
+await settle(() => screen().includes('你有 API Key 吗？'))
+stdin.write('\t') // focus the custom input row
+await sleep(120)
+stdin.write(CHUNK('地址：\n第二行\x07带\t制表符'))
+check('1a: chunk paste flattens newlines/tabs/control chars to spaces',
+  await settled(() => screen().includes('地址： 第二行 带 制表符')), screen())
+check('1b: chunk paste alone never submits', lastAnswer === undefined)
+stdin.write('\r')
+check('1c: Enter carries the flattened text as a pure custom answer',
+  await settled(() => answerCustom() === '地址： 第二行 带 制表符' && answerSelected().length === 0),
+  JSON.stringify(lastAnswer))
+
+// ── 1d. Paste with COMPLETE ANSI/OSC sequences: stripped entirely, no
+//       `[31m` residue and no surviving control char. ──────────────────
+lastAnswer = undefined
+await mount(textQuestion)
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write(CHUNK('红\x1b[31m色\x1b[0m灯\x1b]0;标题\x07亮'))
+stdin.write('\r')
+check('1d: ANSI/OSC sequences are stripped, text survives verbatim',
+  await settled(() => answerCustom() === '红色灯亮'), JSON.stringify(answerCustom()))
+
+// ── 2. A chunk that is ALL line breaks is text: no submit, no text. ────
+lastAnswer = undefined
+cancelCount = 0
+await mount(optionQuestion)
+await settle(() => screen().includes('你有 API Key 吗？'))
+stdin.write('\t')
+await sleep(120)
+stdin.write(CHUNK('\r\n\r\n'))
+// 稳定性探针（不得被粘贴提交）：无可靠的可观察变化，保留固定窗口。
+await sleep(250)
+check('2a: pure-newline paste does NOT submit the question', lastAnswer === undefined)
+stdin.write('\r')
+check('2b: Enter on the empty answer shows the validation error (no phantom text)',
+  await settled(() => screen().includes('先输入回答内容再提交')), screen())
+
+// ── 3. Ctrl+V reads the clipboard asynchronously and lands at the LIVE
+//       caret. Two arms: (a) idle — paste lands mid-text at the caret;
+//       (b) RACE — typing continues while the read is in flight (reader
+//       delayed 400ms), so the paste must resolve AFTER that typing and
+//       land at the caret the user actually sees (never clobber it, never
+//       fall back to the keypress-time position). ───────────────────────
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'text', text: 'B' }, 80))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('ac') // text-only question: input row focused from the start
+await settle(() => screen().includes('ac'))
+stdin.write('\x1b[D') // ← caret between a and c (unobservable, keep pacing)
+await sleep(120)
+stdin.write('\x16') // Ctrl+V → async read of 'B'
+check('3a: idle paste lands at the caret',
+  await settled(() => screen().includes('aBc'), { timeoutMs: 3000 }), screen())
+stdin.write('\r')
+check('3b: idle-paste answer is in order',
+  await settled(() => answerCustom() === 'aBc'), JSON.stringify(lastAnswer))
+
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'text', text: 'B' }, 400))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('ac')
+await settle(() => screen().includes('ac'))
+stdin.write('\x1b[D')
+await sleep(120)
+stdin.write('\x16') // read starts; resolves ~400ms later
+stdin.write('tail') // typed BEFORE the read resolves (a|tail|c → 'atailc')
+check('3c: typing during the read lands first, paste follows at the LIVE caret',
+  await settled(() => screen().includes('atailBc'), { timeoutMs: 3000 }), screen())
+stdin.write('\r')
+check('3d: raced answer keeps the order (paste after the typed tail)',
+  await settled(() => answerCustom() === 'atailBc'), JSON.stringify(lastAnswer))
+
+// ── 4. Ctrl+V on an option row: append at the tail + attach the label. ─
+lastAnswer = undefined
+await mount(optionQuestion, clipboard({ kind: 'text', text: '我的密钥 sk-x' }))
+await settle(() => screen().includes('我有'))
+stdin.write('\x16')
+await settled(() => screen().includes('我的密钥 sk-x'))
+check('4a: option-row paste appends and attaches the focused label',
+  await settled(() => screen().includes('（附加：我有）')), screen())
+stdin.write('\r')
+check('4b: Enter on the option row carries BOTH the label and the pasted text',
+  await settled(() => answerSelected().join() === '我有' && answerCustom() === '我的密钥 sk-x'),
+  JSON.stringify(lastAnswer))
+
+// ── 5. Alt+V alias (ESC v) reaches the same clipboard arm. ────────────
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'text', text: 'alt-ok' }))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x1bv')
+await settled(() => screen().includes('alt-ok'))
+stdin.write('\r')
+check('5a: Alt+V pastes like Ctrl+V', await settled(() => answerCustom() === 'alt-ok'), JSON.stringify(lastAnswer))
+
+// ── 6. Clipboard content that is not text → inline error, no crash. ────
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'image', path: 'C:/shots/paste-x.png' }))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x16')
+check('6a: image clipboard shows the not-text error',
+  await settled(() => screen().includes('剪贴板内容是图片或文件，无法作为文字粘贴')), screen())
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'files', paths: ['C:/a.txt'] }))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x16')
+check('6b: file clipboard shows the same error',
+  await settled(() => screen().includes('剪贴板内容是图片或文件，无法作为文字粘贴')), screen())
+lastAnswer = undefined
+await mount(textQuestion, clipboard(null))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x16')
+check('6c: empty clipboard shows the empty error', await settled(() => screen().includes('剪贴板为空')), screen())
+lastAnswer = undefined
+await mount(textQuestion, () => Promise.reject(new Error('boom')))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x16')
+check('6d: clipboard read failure shows the failure error',
+  await settled(() => screen().includes('读取剪贴板失败')), screen())
+
+// ── 6e/6f. Over-cap paste is refused with an inline error — never
+//       truncated silently, on either transport. ────────────────────────
+const overLong = '长'.repeat(8001)
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'text', text: overLong }))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x16')
+check('6e: Ctrl+V past the cap shows the too-long error, inserts nothing',
+  await settled(() => screen().includes('粘贴内容过长')), screen())
+stdin.write('ok')
+await settle(() => screen().includes('ok'))
+stdin.write('\r')
+check('6f: …and the field still accepts typing afterwards',
+  await settled(() => answerCustom() === 'ok'), JSON.stringify(lastAnswer))
+lastAnswer = undefined
+await mount(textQuestion)
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write(CHUNK(overLong))
+check('6g: bracketed paste past the cap shows the same error',
+  await settled(() => screen().includes('粘贴内容过长')), screen())
+
+// ── 7. Batched keys in ONE stdin chunk edit through synchronous refs:
+//       a terminal delivers one chunk as several key events inside a
+//       single React batch, so the second event must see the first's
+//       result (stale closure state would misplace the insert). ─────────
+lastAnswer = undefined
+await mount(textQuestion)
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('ab') // settle the base text first
+await settle(() => screen().includes('ab'))
+stdin.write('\x1b[Dx') // ← moves the caret, x types AFTER it — one chunk
+check('7a: batched ←+x inserts at the MOVED caret',
+  await settled(() => screen().includes('axb')), screen())
+stdin.write('\r')
+check('7b: batched edit answer is in order',
+  await settled(() => answerCustom() === 'axb'), JSON.stringify(lastAnswer))
+
+// One chunk can also carry a text run followed by a bracketed-paste chunk
+// (unbracketed paste with an embedded terminal paste): both land in order.
+lastAnswer = undefined
+await mount(textQuestion)
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write(`ab${CHUNK('X')}`)
+await settled(() => screen().includes('abX'))
+stdin.write('\r')
+check('7c: text run + paste chunk in one stdin chunk land in order',
+  await settled(() => answerCustom() === 'abX'), JSON.stringify(lastAnswer))
+
+// ── 8. Plan review: pasted content never quick-picks or approves. ──────
+// The feedback row is the screen line holding the ✎ glyph; the option rows
+// always show "1. 批准" / "2. 继续计划", so a whole-screen includes('1')
+// would be vacuous — probe the feedback LINE itself.
+const feedbackRow = (): string =>
+  screen().split('\n').find(line => line.includes('✎')) ?? ''
+lastAnswer = undefined
+cancelCount = 0
+await mount(planReviewQuestion)
+await settle(() => screen().includes('批准'))
+stdin.write(CHUNK('1')) // a pasted digit must NOT pick option 1 (批准)
+await sleep(250)
+check('8a: pasted digit does NOT approve the plan', lastAnswer === undefined, JSON.stringify(lastAnswer))
+check('8b: pasted digit lands in the feedback row (focused)',
+  await settled(() => feedbackRow().trimEnd().endsWith('1')), feedbackRow())
+stdin.write('\r')
+check('8c: Enter routes it to keep-planning-with-feedback',
+  await settled(() => answerSelected().join() === '继续计划' && answerCustom() === '1'),
+  JSON.stringify(lastAnswer))
+lastAnswer = undefined
+await mount(planReviewQuestion, clipboard({ kind: 'text', text: '改成这样行吗' }))
+await settle(() => screen().includes('批准'))
+stdin.write('\x16') // Ctrl+V while Approve is focused
+await settled(() => screen().includes('改成这样行吗'))
+stdin.write('\r')
+check('8d: Ctrl+V feedback then Enter = keep-planning, never approve',
+  await settled(() => answerSelected().join() === '继续计划' && answerCustom() === '改成这样行吗'),
+  JSON.stringify(lastAnswer))
+
+// ── 9. Pure-option questions (hideCustomInput): paste is inert. ────────
+lastAnswer = undefined
+await mount({ ...optionQuestion, hideCustomInput: true }, clipboard({ kind: 'text', text: 'X' }))
+await settle(() => screen().includes('我有'))
+stdin.write(CHUNK('X'))
+await sleep(150)
+stdin.write('\x16')
+await sleep(150)
+check('9a: paste into a hideCustomInput question types nothing', !screen().includes('X'), screen())
+check('9b: …and never submits', lastAnswer === undefined)
+
+// ── 10. Repeat Ctrl+V while a read is in flight: only one insert. ──────
+lastAnswer = undefined
+await mount(textQuestion, clipboard({ kind: 'text', text: 'X' }, 150))
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write('\x16\x16') // two keys, one chunk — the busy guard drops the second
+await sleep(350)
+check('10a: double Ctrl+V inserts exactly once', screen().includes('X') && !screen().includes('XX'), screen())
+stdin.write('\r')
+check('10b: …and the answer holds the single insert',
+  await settled(() => answerCustom() === 'X'), JSON.stringify(lastAnswer))
+
+// ── 11. Code-point caret: an emoji is one ⌫ step (never a split pair). ─
+lastAnswer = undefined
+await mount(textQuestion)
+await settle(() => screen().includes('还有别的要说吗？'))
+stdin.write(CHUNK('a😀b'))
+await settled(() => screen().includes('a😀b'))
+stdin.write('\x1b[D') // ← (one code-point step)
+await sleep(120)
+stdin.write('\x7f') // backspace removes the WHOLE emoji
+await sleep(120)
+stdin.write('\r')
+check('11a: backspace deletes the full emoji as one step (no lone surrogate)',
+  await settled(() => answerCustom() === 'ab'), JSON.stringify(answerCustom()))
+
+// ── 12. Esc still cancels after all the pasting (no swallowed keys). ───
+cancelCount = 0
+await mount(optionQuestion)
+await settle(() => screen().includes('我有'))
+stdin.write('\x1b')
+await sleep(150)
+check('12a: Esc cancels a fresh panel', cancelCount === 1)
+
+app?.unmount()
+await sleep(100)
+console.log(results.join('\n'))
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURES`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/components/ExtensionDialog.tsx
+++ b/src/components/ExtensionDialog.tsx
@@ -34,12 +34,14 @@ import { t } from '../i18n.js'
 import { Box, Text, useInput, useTerminalSize } from '../ui.js'
 import { stringWidth } from '../ink/stringWidth.js'
 import { isPlainReturnInput } from '../utils/modifiers.js'
+import { actionMatches } from '../utils/keymap.js'
+import { readClipboard } from '../utils/clipboard.js'
 import { Pane } from './design-system/Pane.js'
 import { ListItem } from './design-system/ListItem.js'
 import { HintLine } from './design-system/HintLine.js'
 import { listWindow } from './listWindow.js'
 import { INPUT_CELLS, type TuiDialogAnswer, type TuiDialogSnapshot } from '../dsh-adapter/dialogs.js'
-import { capCells, flattenInline } from '../dsh-adapter/sanitize.js'
+import { capCells, flattenPasteInline } from '../dsh-adapter/sanitize.js'
 
 export type ExtensionDialogProps = {
   /** The pending dialog (TuiDialogStore snapshot; `key` remounts per dialog). */
@@ -79,7 +81,7 @@ function SelectDialog({
   }
   const { rows: terminalRows } = useTerminalSize()
 
-  useInput((input, key, event) => {
+  useInput((input, key) => {
     if (key.escape || (key.ctrl && input === 'c')) {
       onCancel()
       return
@@ -92,9 +94,10 @@ function SelectDialog({
       moveFocus(1)
       return
     }
-    // isPasted lives on the InputEvent, not the key: a bracketed paste that
-    // is all line breaks is pasted content, never an Enter press.
-    if (isPlainReturnInput(input, { ...key, isPasted: event.isPasted })) {
+    // A bracketed paste that is all line breaks is pasted content, never an
+    // Enter press — the key carries isPasted, and isPlainReturnInput
+    // refuses pastes before the plain-return test.
+    if (isPlainReturnInput(input, key)) {
       const option = dialog.options[focusRef.current]
       if (option !== undefined) onDecide(option.id)
     }
@@ -162,7 +165,7 @@ function ConfirmDialog({
     setFocusIndex(next)
   }
 
-  useInput((input, key, event) => {
+  useInput((input, key) => {
     if (key.escape || (key.ctrl && input === 'c')) {
       onCancel()
       return
@@ -175,9 +178,10 @@ function ConfirmDialog({
       moveFocus(1)
       return
     }
-    // isPasted lives on the InputEvent, not the key: a bracketed paste that
-    // is all line breaks must not confirm on the default focus.
-    if (isPlainReturnInput(input, { ...key, isPasted: event.isPasted })) {
+    // A bracketed paste that is all line breaks is pasted content, never an
+    // Enter press — the key carries isPasted, and isPlainReturnInput
+    // refuses pastes before the plain-return test.
+    if (isPlainReturnInput(input, key)) {
       onDecide(focusRef.current === 0)
     }
   }, { isActive: true })
@@ -232,15 +236,39 @@ function InputDialog({
     setValue(nextValue)
     setCursor(nextCursor)
   }
+  /** True while the component is mounted (async clipboard continuation
+   *  guard: the dialog can close before the read resolves). */
+  const mountedRef = React.useRef(true)
+  React.useEffect(() => () => { mountedRef.current = false }, [])
+  /** True while a clipboard read is in flight (ignore repeat Ctrl+V). */
+  const pasteBusyRef = React.useRef(false)
+
+  /** Insert one chunk under the single-line + cell-cap contract: content
+   *  that fits lands at the caret; oversized PASTE content is truncated
+   *  (mayCap) while oversized typing stays ignored — the value never
+   *  exceeds INPUT_CELLS cells either way. */
+  const insertChunk = (chunk: string, mayCap: boolean): void => {
+    const points = [...valueRef.current]
+    const at = cursorRef.current
+    const chunkPoints = [...chunk].length
+    const candidate = points.slice(0, at).join('') + chunk + points.slice(at).join('')
+    if (stringWidth(candidate) <= INPUT_CELLS) {
+      applyEdit(candidate, at + chunkPoints)
+    } else if (mayCap) {
+      const capped = capCells(candidate, INPUT_CELLS)
+      applyEdit(capped, Math.min(at + chunkPoints, [...capped].length))
+    }
+  }
 
   useInput((input, key, event) => {
     if (key.escape || (key.ctrl && input === 'c')) {
       onCancel()
       return
     }
-    // isPasted lives on the InputEvent, not the key: a bracketed paste that
-    // is all line breaks is inserted as text, not submitted.
-    if (isPlainReturnInput(input, { ...key, isPasted: event.isPasted })) {
+    // A bracketed paste that is all line breaks is inserted as text, never
+    // submitted — the key carries isPasted, and isPlainReturnInput refuses
+    // pastes before the plain-return test.
+    if (isPlainReturnInput(input, key)) {
       onDecide(valueRef.current)
       return
     }
@@ -277,21 +305,32 @@ function InputDialog({
       applyEdit(valueRef.current, points.length)
       return
     }
+    // Clipboard paste (default Ctrl+V / Alt+V — the keymap `paste`
+    // binding): raw mode hands the key to the app, so the clipboard is
+    // read here. Only text offers insert — files/images have no text form
+    // in a single-line value, and read failures are silently ignored (the
+    // dialog has no notice channel; repeat keys while a read is in flight
+    // are dropped by the busy guard).
+    if (actionMatches('paste', input, key)) {
+      if (!pasteBusyRef.current) {
+        pasteBusyRef.current = true
+        void readClipboard()
+          .then(content => {
+            if (!mountedRef.current) return
+            if (content?.kind === 'text' && content.text !== '') {
+              insertChunk(flattenPasteInline(content.text), true)
+            }
+          })
+          .finally(() => { pasteBusyRef.current = false })
+      }
+      return
+    }
     if (input && !key.ctrl && !key.meta && !key.super && !key.tab && !key.escape) {
       // A bracketed paste arrives as one chunk and may carry newlines/control
-      // chars — this is a single-line panel, so flatten them to spaces. Every
-      // edit path holds the value at INPUT_CELLS cells so the resolved answer
-      // keeps the documented bound: typing past the cap is ignored, an
-      // oversized paste is truncated (never silently unbounded).
-      const chunk = event.isPasted ? flattenInline(input) : input
-      const chunkPoints = [...chunk].length
-      const candidate = points.slice(0, at).join('') + chunk + points.slice(at).join('')
-      if (stringWidth(candidate) <= INPUT_CELLS) {
-        applyEdit(candidate, at + chunkPoints)
-      } else if (event.isPasted) {
-        const capped = capCells(candidate, INPUT_CELLS)
-        applyEdit(capped, Math.min(at + chunkPoints, [...capped].length))
-      }
+      // chars (even complete ANSI sequences) — this is a single-line panel,
+      // so strip ANSI and flatten controls to spaces (typed text is already
+      // control-free; mayCap only applies to paste).
+      insertChunk(event.isPasted ? flattenPasteInline(input) : input, event.isPasted === true)
     }
   }, { isActive: true })
 

--- a/src/components/questions/AskUserQuestionPanel.tsx
+++ b/src/components/questions/AskUserQuestionPanel.tsx
@@ -10,6 +10,19 @@
  * appends into that input row (single-select also attaches the option's
  * label, so the answer can carry both `selected` and `custom`); focusing
  * the input row itself and typing gives a pure custom answer.
+ *
+ * Paste works on the input row like the composer: Ctrl+V/Alt+V (the keymap
+ * `paste` binding, remappable in /settings) reads the system clipboard,
+ * and a terminal bracketed paste (Ctrl+Shift+V / right-click / terminals
+ * that intercept Ctrl+V) inserts its chunk — newlines and control chars are
+ * flattened to spaces, pasted content never submits the panel. Editing
+ * state (value + caret) lives in refs mutated synchronously per event: a
+ * terminal delivers one stdin chunk as several key events inside a single
+ * React batch, and the clipboard read resolves asynchronously — state
+ * queued by one event is invisible to the next, and a paste must land at
+ * the caret the user actually sees. The caret counts CODE POINTS (`[...s]`
+ * iteration, same contract as the plugin InputDialog), so an emoji can
+ * never be split into a lone surrogate by ←/→/⌫/Del or a paste boundary.
  */
 
 import React from 'react'
@@ -21,11 +34,25 @@ import { POINTER } from '../../cc/figures.js'
 import type { QuestionDraft, QuestionSelection } from '../../dsh-adapter/questions.js'
 import { PlanReviewPanel } from './PlanReviewPanel.js'
 import { isPlainReturnInput } from '../../utils/modifiers.js'
+import { actionMatches } from '../../utils/keymap.js'
+import { flattenPasteInline } from '../../dsh-adapter/sanitize.js'
+import { readClipboard, type ClipboardRead } from '../../utils/clipboard.js'
 import { listWindow } from '../listWindow.js'
 
 const CHECKED = '◉'
 const UNCHECKED = '○'
 const PENCIL = '✎'
+
+/**
+ * Paste cap for one answer field, in code points. Typing is naturally
+ * bounded (humans cannot type unboundedly) and the protocol places no
+ * limit on `custom`, but a stray Ctrl+V of a file/log must not inflate the
+ * panel to hundreds of wrapped rows (every keystroke then re-lays them
+ * out) or ship a megabyte answer. Deliberately generous — anything past it
+ * is an accident, and the inline error says exactly that. Twin constant in
+ * PlanReviewPanel (the two panels share the same input contract).
+ */
+const ANSWER_PASTE_MAX_POINTS = 8000
 
 export type AskUserQuestionPanelProps = {
   /** The question to render (from the QuestionStore snapshot). */
@@ -60,6 +87,12 @@ export type AskUserQuestionPanelProps = {
   readonly onCancel: () => void
   /** Esc on later questions — navigates to the previous question. */
   readonly onBack?: (draft: QuestionDraft) => void
+  /**
+   * Test seam: clipboard reader for the Ctrl+V paste arm. Defaults to the
+   * real cross-platform reader (PowerShell/pbpaste/wl-paste…); headless
+   * verification injects a fake so paste outcomes are deterministic.
+   */
+  readonly readClipboardOverride?: () => Promise<ClipboardRead>
 }
 
 export function AskUserQuestionPanel({
@@ -71,12 +104,18 @@ export function AskUserQuestionPanel({
   onAnswer,
   onCancel,
   onBack,
+  readClipboardOverride,
 }: AskUserQuestionPanelProps): React.ReactNode {
   // Plan-mode's exit_plan_mode ask carries a presentation intent: render
   // the CC-style decision card instead of the generic questionnaire. The
   // branch precedes every hook so hook order stays stable per remount key.
   if (question.intent?.kind === 'plan-review') {
-    return <PlanReviewPanel question={question} onAnswer={onAnswer} onCancel={onCancel} />
+    return <PlanReviewPanel
+      question={question}
+      onAnswer={onAnswer}
+      onCancel={onCancel}
+      readClipboardOverride={readClipboardOverride}
+    />
   }
   const options = question.options ?? []
   const multiSelect = question.multiSelect === true
@@ -102,7 +141,28 @@ export function AskUserQuestionPanel({
     () => new Set(multiSelect ? selectedIndices : []),
   )
   const [customText, setCustomText] = React.useState(initialCustom)
-  const [customCursor, setCustomCursor] = React.useState(initialCustom.length)
+  const [customCursor, setCustomCursor] = React.useState(() => [...initialCustom].length)
+  // Synchronous source of truth for the handlers (see the module header):
+  // keys of one stdin batch share a single React update, and the clipboard
+  // read resolves asynchronously — the state mirrors exist only to re-render.
+  const textRef = React.useRef(initialCustom)
+  const cursorRef = React.useRef([...initialCustom].length)
+  /** Single choke point for every text/caret mutation: refs first, then the
+   *  state mirrors so the render sees the committed value. */
+  const applyText = (nextText: string, nextCursor: number): void => {
+    textRef.current = nextText
+    cursorRef.current = nextCursor
+    setCustomText(nextText)
+    setCustomCursor(nextCursor)
+  }
+  /** True while the component is mounted (async clipboard continuation
+   *  guard: the panel can unmount when the user answers before the read
+   *  resolves). */
+  const mountedRef = React.useRef(true)
+  React.useEffect(() => () => { mountedRef.current = false }, [])
+  /** True while a clipboard read is in flight (ignore repeat Ctrl+V). */
+  const pasteBusyRef = React.useRef(false)
+  const clipboardReader = readClipboardOverride ?? readClipboard
   /** Single-select label captured by typing on a focused option — submitted
    *  together with the custom text when the input row itself is Entered. */
   const [attached, setAttached] = React.useState<string | null>(
@@ -150,20 +210,81 @@ export function AskUserQuestionPanel({
 
   /** Append at the text tail (option-row typing has no visible cursor). */
   const appendText = (text: string): void => {
-    setCustomText(previous => previous + text)
-    setCustomCursor(previous => previous + text.length)
+    applyText(textRef.current + text, cursorRef.current + [...text].length)
     setError(null)
   }
 
-  /** Drop the character before the cursor; empty text drops the attach. */
+  /** Drop the character before the caret; empty text drops the attach. */
   const backspaceText = (): void => {
-    if (customCursor <= 0) return
-    setCustomText(previous => {
-      const next = previous.slice(0, customCursor - 1) + previous.slice(customCursor)
-      if (next === '') setAttached(null)
-      return next
-    })
-    setCustomCursor(cursor => cursor - 1)
+    const points = [...textRef.current]
+    const at = cursorRef.current
+    if (at <= 0) return
+    points.splice(at - 1, 1)
+    const next = points.join('')
+    if (next === '') setAttached(null)
+    applyText(next, at - 1)
+  }
+
+  /**
+   * Paste-path entry shared by both transports (bracketed-paste chunk and
+   * the async clipboard read). Single-line field: newlines and control
+   * chars flatten to spaces; a chunk with nothing visible (blank lines or
+   * stray controls only) inserts nothing, and one past the cap is refused
+   * (never truncated — the user must see that text was dropped). Where the
+   * text lands mirrors plain typing — at the caret while the input row is
+   * focused, appended at the tail (and the option's label attached,
+   * single-select) when typing on an option row would append.
+   * @returns 'ok' | 'empty' (nothing visible to insert) | 'too-long'
+   */
+  const insertPastedText = (raw: string, atCaret: boolean): 'ok' | 'empty' | 'too-long' => {
+    const text = flattenPasteInline(raw)
+    if (text.trim() === '') return 'empty'
+    if ([...text].length > ANSWER_PASTE_MAX_POINTS) return 'too-long'
+    const points = [...textRef.current]
+    const at = atCaret ? cursorRef.current : points.length
+    points.splice(at, 0, ...text)
+    applyText(points.join(''), at + [...text].length)
+    if (!atCaret && !multiSelect) setAttached(options[focusIndex]?.label ?? null)
+    return 'ok'
+  }
+
+  /** Inline error for an over-cap paste (shared by both transports). */
+  const pasteTooLongError = (): string =>
+    t('question-paste-too-long', { n: ANSWER_PASTE_MAX_POINTS })
+
+  /** Ctrl+V/Alt+V arm: read the system clipboard and insert its text. */
+  const pasteFromClipboard = (): void => {
+    if (pasteBusyRef.current) return
+    pasteBusyRef.current = true
+    // Option-row typing appends at the tail; capture which semantics the
+    // keypress asked for — the read resolves later, after the user may
+    // have moved focus or typed (the refs make either safe).
+    const atCaret = inputFocused
+    void clipboardReader()
+      .then(content => {
+        if (!mountedRef.current) return
+        if (content === null || content.kind === 'unavailable') {
+          setError(t(content === null ? 'input-clipboard-empty' : 'input-clipboard-unavailable'))
+          return
+        }
+        if (content.kind !== 'text') {
+          // File/image offers have no text form in an answer field.
+          setError(t('question-paste-not-text'))
+          return
+        }
+        if (content.text === '') {
+          setError(t('input-clipboard-empty'))
+          return
+        }
+        const result = insertPastedText(content.text, atCaret)
+        setError(result === 'too-long' ? pasteTooLongError() : null)
+      })
+      .catch(() => {
+        if (mountedRef.current) setError(t('input-clipboard-read-failed'))
+      })
+      .finally(() => {
+        pasteBusyRef.current = false
+      })
   }
 
   const checkedLabels = (): string[] =>
@@ -172,7 +293,7 @@ export function AskUserQuestionPanel({
 
   /** Enter on a real option: the option(s) plus whatever the input row holds. */
   const submitOptions = (): void => {
-    const text = customText.trim()
+    const text = textRef.current.trim()
     if (multiSelect) {
       const selected = checkedLabels()
       if (selected.length === 0 && text === '') {
@@ -193,7 +314,7 @@ export function AskUserQuestionPanel({
   /** Enter on the input row itself: the text, plus the attached label (or
    *  the checked labels for multi-select) when there is one. */
   const submitInput = (): void => {
-    const text = customText.trim()
+    const text = textRef.current.trim()
     if (multiSelect) {
       const selected = checkedLabels()
       if (selected.length === 0 && text === '') {
@@ -222,7 +343,7 @@ export function AskUserQuestionPanel({
           })()
     return {
       selected,
-      ...(customText !== '' ? { custom: customText } : {}),
+      ...(textRef.current !== '' ? { custom: textRef.current } : {}),
     }
   }
 
@@ -234,6 +355,29 @@ export function AskUserQuestionPanel({
     if (key.escape) {
       if (onBack !== undefined) onBack(currentDraft())
       else onCancel()
+      return
+    }
+
+    // ── Paste ─────────────────────────────────────────────────────────
+    // A bracketed paste (terminal Ctrl+Shift+V / right-click / a terminal
+    // that intercepts Ctrl+V) arrives as ONE chunk flagged isPasted. Where
+    // it lands mirrors plain typing: on an option row it appends at the
+    // tail (and attaches the option's label, single-select), on the input
+    // row it inserts at the caret. It never submits — a chunk that is all
+    // line breaks is text, not an Enter press (isPlainReturnInput refuses
+    // pastes; the flattened text may also be empty → nothing to insert).
+    if (key.isPasted === true) {
+      if (!hideCustomInput && input !== '') {
+        const result = insertPastedText(input, inputFocused)
+        setError(result === 'too-long' ? pasteTooLongError() : null)
+      }
+      return
+    }
+    // Clipboard paste (default Ctrl+V / Alt+V — the keymap `paste`
+    // binding, remappable in /settings): raw mode hands the key to the
+    // app, so the clipboard is read here (mirrors the composer's arm).
+    if (actionMatches('paste', input, key)) {
+      if (!hideCustomInput) pasteFromClipboard()
       return
     }
 
@@ -255,34 +399,39 @@ export function AskUserQuestionPanel({
         return
       }
       if (key.delete) {
-        if (customCursor < customText.length) {
-          setCustomText(text => {
-            const next = text.slice(0, customCursor) + text.slice(customCursor + 1)
-            if (next === '') setAttached(null)
-            return next
-          })
+        const points = [...textRef.current]
+        const at = cursorRef.current
+        if (at < points.length) {
+          points.splice(at, 1)
+          const next = points.join('')
+          if (next === '') setAttached(null)
+          applyText(next, at)
         }
         return
       }
       if (key.leftArrow) {
-        setCustomCursor(cursor => Math.max(0, cursor - 1))
+        applyText(textRef.current, Math.max(0, cursorRef.current - 1))
         return
       }
       if (key.rightArrow) {
-        setCustomCursor(cursor => Math.min(customText.length, cursor + 1))
+        applyText(textRef.current, Math.min([...textRef.current].length, cursorRef.current + 1))
         return
       }
       if (key.home) {
-        setCustomCursor(0)
+        applyText(textRef.current, 0)
         return
       }
       if (key.end) {
-        setCustomCursor(customText.length)
+        applyText(textRef.current, [...textRef.current].length)
         return
       }
       if (!key.ctrl && !key.meta && !key.super && input) {
-        setCustomText(text => text.slice(0, customCursor) + input + text.slice(customCursor))
-        setCustomCursor(cursor => cursor + input.length)
+        // Ordinary typing at the live caret (a text run may carry several
+        // characters in one event — e.g. an unbracketed terminal paste).
+        const points = [...textRef.current]
+        const at = cursorRef.current
+        points.splice(at, 0, ...input)
+        applyText(points.join(''), at + [...input].length)
         setError(null)
       }
       return
@@ -317,7 +466,7 @@ export function AskUserQuestionPanel({
     }
     if (key.backspace) {
       // Edit the input row without leaving the option list.
-      if (!hideCustomInput && customText !== '') backspaceText()
+      if (!hideCustomInput && textRef.current !== '') backspaceText()
       return
     }
     // Typing on an option appends into the input row; single-select also
@@ -331,7 +480,11 @@ export function AskUserQuestionPanel({
   const remaining = total - answered
   const headerTitle = ` ${t('question-header-progress', { position, total, remaining: remaining > 1 ? t('question-remaining-more', { n: remaining }) : '' })} `
 
-  const cursorChar = customCursor < customText.length ? customText[customCursor] : ' '
+  // The caret counts code points (see the module header), so the caret
+  // char and the visual split index into the point array — never raw
+  // UTF-16 offsets, which could land inside a surrogate pair.
+  const textPoints = [...customText]
+  const cursorChar = customCursor < textPoints.length ? textPoints[customCursor] : ' '
   /** Mouse: click the input row to focus it (same as Tab). */
   const focusInputRow = (): void => {
     if (hideCustomInput) return
@@ -356,7 +509,7 @@ export function AskUserQuestionPanel({
     }
     const label = options[index]?.label
     if (label === undefined) return
-    const text = customText.trim()
+    const text = textRef.current.trim()
     onAnswer({ selected: [label], ...(text !== '' ? { custom: text } : {}) })
   }
   const [hoverIndex, setHoverIndex] = React.useState(-1)
@@ -389,11 +542,11 @@ export function AskUserQuestionPanel({
           <Text ref={caretRef} dimColor>{t('question-direct-input')}</Text>
         ) : (
           <>
-            <Text wrap="wrap">{customText.slice(0, customCursor)}</Text>
+            <Text wrap="wrap">{textPoints.slice(0, customCursor).join('')}</Text>
             {inputFocused
               ? <Text ref={caretRef} inverse>{cursorChar}</Text>
               : <Text ref={caretRef} color="suggestion">▏</Text>}
-            <Text wrap="wrap">{customText.slice(inputFocused ? customCursor + 1 : customCursor)}</Text>
+            <Text wrap="wrap">{textPoints.slice(inputFocused ? customCursor + 1 : customCursor).join('')}</Text>
           </>
         )}
       </Box>
@@ -461,6 +614,7 @@ export function AskUserQuestionPanel({
   const hintParts = inputFocused
     ? [
         t('question-hint-type'),
+        t('question-hint-paste'),
         t('question-hint-enter'),
         ...(options.length > 0 ? [t('question-hint-back')] : []),
         onBack === undefined ? t('question-hint-esc') : t('question-hint-previous'),
@@ -470,7 +624,7 @@ export function AskUserQuestionPanel({
     : [
         t('question-hint-select'),
         ...(multiSelect ? [t('question-hint-multi')] : []),
-        ...(hideCustomInput ? [] : [t('question-hint-attach')]),
+        ...(hideCustomInput ? [] : [t('question-hint-paste'), t('question-hint-attach')]),
         t('question-hint-enter'),
         onBack === undefined ? t('question-hint-esc') : t('question-hint-previous'),
         ...(onBack === undefined ? [] : [t('question-hint-cancel')]),

--- a/src/components/questions/PlanReviewPanel.tsx
+++ b/src/components/questions/PlanReviewPanel.tsx
@@ -13,6 +13,16 @@
  *   declineLabel is the first option that is not the approve label.
  * - Esc / Ctrl+C: the store rejects with ASK_CANCELLED, which plan-mode
  *   reads as "the user dismissed the review to speak instead".
+ *
+ * Paste works on the feedback row like the composer: Ctrl+V/Alt+V (the
+ * keymap `paste` binding) reads the system clipboard, and a bracketed
+ * paste inserts its chunk — newlines/control chars flatten to spaces, and
+ * pasted content NEVER picks an option or approves (a pasted digit or a
+ * chunk of line breaks is text, not a quick-pick or an Enter). Editing
+ * state (value + caret) lives in refs mutated synchronously per event —
+ * one stdin chunk is one React batch, and the clipboard read resolves
+ * asynchronously — with the caret counting code points so an emoji can
+ * never be split by ←/→/⌫/Del (same contract as the plugin InputDialog).
  */
 
 import React from 'react'
@@ -24,8 +34,20 @@ import { Markdown } from '../Markdown.js'
 import { POINTER } from '../../cc/figures.js'
 import type { QuestionSelection } from '../../dsh-adapter/questions.js'
 import { isPlainReturnInput } from '../../utils/modifiers.js'
+import { actionMatches } from '../../utils/keymap.js'
+import { flattenPasteInline } from '../../dsh-adapter/sanitize.js'
+import { readClipboard, type ClipboardRead } from '../../utils/clipboard.js'
 
 const PENCIL = '✎'
+
+/**
+ * Paste cap for the feedback field, in code points — twin constant of
+ * AskUserQuestionPanel's ANSWER_PASTE_MAX_POINTS (same input contract):
+ * typing is naturally bounded, but a stray Ctrl+V of a file/log must not
+ * inflate the feedback row or ship a megabyte `custom`. Generous on
+ * purpose; the inline error names the bound.
+ */
+const ANSWER_PASTE_MAX_POINTS = 8000
 
 export type PlanReviewPanelProps = {
   /** The plan-review question (intent.kind === 'plan-review'). */
@@ -39,12 +61,18 @@ export type PlanReviewPanelProps = {
   readonly onAnswer: (selection: QuestionSelection) => void
   /** Esc / Ctrl+C — dismissed to speak instead (ASK_CANCELLED). */
   readonly onCancel: () => void
+  /**
+   * Test seam: clipboard reader for the Ctrl+V paste arm. Defaults to the
+   * real cross-platform reader; headless verification injects a fake.
+   */
+  readonly readClipboardOverride?: () => Promise<ClipboardRead>
 }
 
 export function PlanReviewPanel({
   question,
   onAnswer,
   onCancel,
+  readClipboardOverride,
 }: PlanReviewPanelProps): React.ReactNode {
   const options = question.options ?? []
   const approveLabel = question.intent?.approve ?? options[0]?.label
@@ -55,6 +83,26 @@ export function PlanReviewPanel({
   const [feedback, setFeedback] = React.useState('')
   const [cursor, setCursor] = React.useState(0)
   const [error, setError] = React.useState<string | null>(null)
+  // Synchronous source of truth for the handlers (see the module header):
+  // one stdin chunk is one React batch, and the clipboard read resolves
+  // asynchronously — the state mirrors exist only to re-render.
+  const textRef = React.useRef('')
+  const cursorRef = React.useRef(0)
+  /** Single choke point for every text/caret mutation: refs first, then the
+   *  state mirrors so the render sees the committed value. */
+  const applyFeedback = (nextText: string, nextCursor: number): void => {
+    textRef.current = nextText
+    cursorRef.current = nextCursor
+    setFeedback(nextText)
+    setCursor(nextCursor)
+  }
+  /** True while the component is mounted (async clipboard continuation
+   *  guard: the panel can unmount when the user answers first). */
+  const mountedRef = React.useRef(true)
+  React.useEffect(() => () => { mountedRef.current = false }, [])
+  /** True while a clipboard read is in flight (ignore repeat Ctrl+V). */
+  const pasteBusyRef = React.useRef(false)
+  const clipboardReader = readClipboardOverride ?? readClipboard
   const { rows: terminalRows } = useTerminalSize()
   // Chat chrome (status line) + panel scaffolding (divider, question,
   // spacings, hint) consume twelve rows before the plan body — same
@@ -95,16 +143,78 @@ export function PlanReviewPanel({
   /** Typing anywhere appends to the feedback buffer and focuses the input
    *  row — plan review has no "attach" semantics: approve must be clean. */
   const appendFeedback = (text: string): void => {
-    setFeedback(previous => previous + text)
-    setCursor(previous => previous + text.length)
+    applyFeedback(textRef.current + text, cursorRef.current + [...text].length)
     setFocusIndex(options.length)
     setError(null)
   }
 
   const backspaceFeedback = (): void => {
-    if (cursor <= 0) return
-    setFeedback(previous => previous.slice(0, cursor - 1) + previous.slice(cursor))
-    setCursor(previous => previous - 1)
+    const points = [...textRef.current]
+    const at = cursorRef.current
+    if (at <= 0) return
+    points.splice(at - 1, 1)
+    applyFeedback(points.join(''), at - 1)
+  }
+
+  /**
+   * Paste-path entry shared by both transports (bracketed-paste chunk and
+   * the async clipboard read). Newlines/control chars flatten to spaces; a
+   * chunk with nothing visible inserts nothing, and one past the cap is
+   * refused (never truncated). Where the text lands mirrors plain typing:
+   * at the caret while the feedback row is focused, otherwise appended at
+   * the tail with the input row focused (typing on an option row behaves
+   * exactly that way). NEVER a quick-pick or submit.
+   * @returns 'ok' | 'empty' (nothing visible to insert) | 'too-long'
+   */
+  const insertPastedFeedback = (raw: string, atCaret: boolean): 'ok' | 'empty' | 'too-long' => {
+    const text = flattenPasteInline(raw)
+    if (text.trim() === '') return 'empty'
+    if ([...text].length > ANSWER_PASTE_MAX_POINTS) return 'too-long'
+    const points = [...textRef.current]
+    const at = atCaret ? cursorRef.current : points.length
+    points.splice(at, 0, ...text)
+    applyFeedback(points.join(''), at + [...text].length)
+    if (!atCaret) setFocusIndex(options.length)
+    return 'ok'
+  }
+
+  /** Inline error for an over-cap paste (shared by both transports). */
+  const pasteTooLongError = (): string =>
+    t('question-paste-too-long', { n: ANSWER_PASTE_MAX_POINTS })
+
+  /** Ctrl+V/Alt+V arm: read the system clipboard and insert its text. */
+  const pasteFromClipboard = (): void => {
+    if (pasteBusyRef.current) return
+    pasteBusyRef.current = true
+    // Capture which landing the keypress asked for (typing on an option
+    // row appends + focuses); the read resolves later, after the user may
+    // have moved focus or typed (the refs make either safe).
+    const atCaret = inputFocused
+    void clipboardReader()
+      .then(content => {
+        if (!mountedRef.current) return
+        if (content === null || content.kind === 'unavailable') {
+          setError(t(content === null ? 'input-clipboard-empty' : 'input-clipboard-unavailable'))
+          return
+        }
+        if (content.kind !== 'text') {
+          // File/image offers have no text form in a feedback field.
+          setError(t('question-paste-not-text'))
+          return
+        }
+        if (content.text === '') {
+          setError(t('input-clipboard-empty'))
+          return
+        }
+        const result = insertPastedFeedback(content.text, atCaret)
+        setError(result === 'too-long' ? pasteTooLongError() : null)
+      })
+      .catch(() => {
+        if (mountedRef.current) setError(t('input-clipboard-read-failed'))
+      })
+      .finally(() => {
+        pasteBusyRef.current = false
+      })
   }
 
   /** The decline answer: the other option's label when the asker named one,
@@ -116,7 +226,7 @@ export function PlanReviewPanel({
   const submitOption = (index: number): void => {
     const label = options[index]?.label
     if (label === undefined) return
-    const text = feedback.trim()
+    const text = textRef.current.trim()
     if (label === approveLabel && text !== '') {
       setError(t('plan-review-approve-needs-empty'))
       return
@@ -131,7 +241,7 @@ export function PlanReviewPanel({
   /** Enter on the feedback row: text routes to keep-planning-with-feedback;
    *  empty is a plain keep-planning. */
   const submitFeedback = (): void => {
-    const text = feedback.trim()
+    const text = textRef.current.trim()
     onAnswer({ selected: declineSelected(), ...(text !== '' ? { custom: text } : {}) })
   }
 
@@ -147,6 +257,27 @@ export function PlanReviewPanel({
     }
     if (key.escape || (key.ctrl && input === 'c')) {
       onCancel()
+      return
+    }
+
+    // ── Paste ─────────────────────────────────────────────────────────
+    // A bracketed paste arrives as ONE chunk flagged isPasted. Where it
+    // lands mirrors plain typing: at the caret on the feedback row, else
+    // appended at the tail with the feedback row focused. It NEVER picks
+    // an option — a pasted digit or an all-line-breaks chunk is text, not
+    // a quick-pick or an Enter press (isPlainReturnInput refuses pastes).
+    if (key.isPasted === true) {
+      if (input !== '') {
+        const result = insertPastedFeedback(input, inputFocused)
+        setError(result === 'too-long' ? pasteTooLongError() : null)
+      }
+      return
+    }
+    // Clipboard paste (default Ctrl+V / Alt+V — the keymap `paste`
+    // binding, remappable in /settings): raw mode hands the key to the
+    // app, so the clipboard is read here (mirrors the composer's arm).
+    if (actionMatches('paste', input, key)) {
+      pasteFromClipboard()
       return
     }
 
@@ -168,30 +299,37 @@ export function PlanReviewPanel({
         return
       }
       if (key.delete) {
-        if (cursor < feedback.length) {
-          setFeedback(text => text.slice(0, cursor) + text.slice(cursor + 1))
+        const points = [...textRef.current]
+        const at = cursorRef.current
+        if (at < points.length) {
+          points.splice(at, 1)
+          applyFeedback(points.join(''), at)
         }
         return
       }
       if (key.leftArrow) {
-        setCursor(value => Math.max(0, value - 1))
+        applyFeedback(textRef.current, Math.max(0, cursorRef.current - 1))
         return
       }
       if (key.rightArrow) {
-        setCursor(value => Math.min(feedback.length, value + 1))
+        applyFeedback(textRef.current, Math.min([...textRef.current].length, cursorRef.current + 1))
         return
       }
       if (key.home) {
-        setCursor(0)
+        applyFeedback(textRef.current, 0)
         return
       }
       if (key.end) {
-        setCursor(feedback.length)
+        applyFeedback(textRef.current, [...textRef.current].length)
         return
       }
       if (!key.ctrl && !key.meta && input) {
-        setFeedback(text => text.slice(0, cursor) + input + text.slice(cursor))
-        setCursor(value => value + input.length)
+        // Ordinary typing at the live caret (a text run may carry several
+        // characters in one event — e.g. an unbracketed terminal paste).
+        const points = [...textRef.current]
+        const at = cursorRef.current
+        points.splice(at, 0, ...input)
+        applyFeedback(points.join(''), at + [...input].length)
         setError(null)
       }
       return
@@ -211,14 +349,14 @@ export function PlanReviewPanel({
       return
     }
     if (key.backspace) {
-      if (feedback !== '') backspaceFeedback()
+      if (textRef.current !== '') backspaceFeedback()
       return
     }
     if (!key.ctrl && !key.meta && input) {
       // Number quick-pick submits the option outright — but only with an
       // empty buffer; with feedback pending, digits are feedback chars.
       const digit = /^[1-9]$/.test(input) ? Number(input) : 0
-      if (feedback === '' && digit >= 1 && digit <= options.length) {
+      if (textRef.current === '' && digit >= 1 && digit <= options.length) {
         submitOption(digit - 1)
         return
       }
@@ -226,7 +364,11 @@ export function PlanReviewPanel({
     }
   }, { isActive: true })
 
-  const cursorChar = cursor < feedback.length ? feedback[cursor] : ' '
+  // The caret counts code points (see the module header), so the caret
+  // char and the visual split index into the point array — never raw
+  // UTF-16 offsets, which could land inside a surrogate pair.
+  const feedbackPoints = [...feedback]
+  const cursorChar = cursor < feedbackPoints.length ? feedbackPoints[cursor] : ' '
   /** Mouse: click a decision row = focus it + submit (same as Enter). */
   const [hoverIndex, setHoverIndex] = React.useState(-1)
   const clickOption = (index: number): void => {
@@ -314,11 +456,11 @@ export function PlanReviewPanel({
               <Text ref={caretRef} dimColor>{t('plan-review-feedback-placeholder')}</Text>
             ) : (
               <>
-                <Text wrap="wrap">{feedback.slice(0, cursor)}</Text>
+                <Text wrap="wrap">{feedbackPoints.slice(0, cursor).join('')}</Text>
                 {inputFocused
                   ? <Text ref={caretRef} inverse>{cursorChar}</Text>
                   : <Text ref={caretRef} color="suggestion">▏</Text>}
-                <Text wrap="wrap">{feedback.slice(inputFocused ? cursor + 1 : cursor)}</Text>
+                <Text wrap="wrap">{feedbackPoints.slice(inputFocused ? cursor + 1 : cursor).join('')}</Text>
               </>
             )}
           </Box>

--- a/src/dsh-adapter/sanitize.ts
+++ b/src/dsh-adapter/sanitize.ts
@@ -68,3 +68,18 @@ export function flattenInline(value: string): string {
   // eslint-disable-next-line no-control-regex -- deliberate: sanitize untrusted render-path text
   return value.replace(/[\x00-\x1f\x7f-\x9f]/g, ' ')
 }
+
+/**
+ * Single-line field ingress for terminal/clipboard paste: strip COMPLETE
+ * ANSI/OSC sequences first (paste content is user-controlled bytes — a
+ * smuggled ESC[… would otherwise break out of the render path), then flatten
+ * every remaining C0/C1 control char to a space. Unlike {@link flattenInline},
+ * this never leaves `[31m`-style residue behind; the two regexes mirror
+ * {@link cleanRenderText}'s strip, and the final pass covers the rest.
+ */
+export function flattenPasteInline(value: string): string {
+  const withoutAnsi = value
+    .replace(/\u001B\][^\u0007]*(?:\u0007|\u001B\\)/gu, '')
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/gu, '')
+  return flattenInline(withoutAnsi)
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -989,6 +989,7 @@ const dict = {
   'question-header-progress': { zh: ' 📋 提问 · 第 {{position}}/{{total}} 题{{remaining}} ', en: ' 📋 Question {{position}}/{{total}} {{remaining}} ' },
   'question-remaining-more': { zh: ' · 还剩 {{n}} 题', en: ' · {{n}} left' },
   'question-hint-type': { zh: '输入回答', en: 'Type answer' },
+  'question-hint-paste': { zh: 'Ctrl+V 粘贴', en: 'Ctrl+V paste' },
   'question-hint-enter': { zh: 'Enter 提交', en: 'Enter submit' },
   'question-hint-back': { zh: '↑ 返回选项', en: '↑ back to options' },
   'question-hint-esc': { zh: 'Esc 中断', en: 'Esc cancel' },
@@ -1001,6 +1002,8 @@ const dict = {
   'question-custom-tab': { zh: '自定义回答', en: 'Custom answer' },
   'question-attached-label': { zh: '（附加：{{label}}）', en: '(attached: {{label}})' },
   'question-direct-input': { zh: '直接输入…', en: 'Type directly…' },
+  'question-paste-not-text': { zh: '剪贴板内容是图片或文件，无法作为文字粘贴', en: 'Clipboard holds an image or file — not pastable as text' },
+  'question-paste-too-long': { zh: '粘贴内容过长（最多 {{n}} 个字符），请精简后再试', en: 'Pasted content is too long (max {{n}} characters) — trim it and try again' },
 
   // ── components/approvals/ApprovalPanel.tsx ──────────────────────────
   'approval-waiting': { zh: ' ⏳ 等待审批 · {{tool}} ', en: ' Awaiting approval · {{tool}} ' },
@@ -1064,7 +1067,7 @@ const dict = {
   'plan-review-fallback-header': { zh: '计划评审', en: 'Plan review' },
   'plan-review-feedback-placeholder': { zh: '输入反馈，告诉模型要改什么…', en: 'Tell the model what to change…' },
   'plan-review-approve-needs-empty': { zh: '请先清空反馈再批准（或在输入行回车提交反馈）', en: 'Clear the feedback to approve (or press Enter on the input row to send it)' },
-  'plan-review-hint': { zh: '↑/↓ 选择 · 1/2 快选 · 打字输入反馈 · Enter 提交 · Esc 打断评审', en: '↑/↓ select · 1/2 quick-pick · type feedback · Enter submit · Esc dismiss' },
+  'plan-review-hint': { zh: '↑/↓ 选择 · 1/2 快选 · 打字输入反馈 · Ctrl+V 粘贴 · Enter 提交 · Esc 打断评审', en: '↑/↓ select · 1/2 quick-pick · type feedback · Ctrl+V paste · Enter submit · Esc dismiss' },
 
   // ── providerWizard.ts ────────────────────────────────────────────────
   'provider-unavailable': { zh: '/provider 需要经 dsh profile 启动（settings / credentials / llm-pi-ai 服务未挂载）', en: '/provider requires starting through a dsh profile (settings / credentials / llm-pi-ai services not mounted)' },

--- a/src/ink/events/input-event.ts
+++ b/src/ink/events/input-event.ts
@@ -35,6 +35,16 @@ export type Key = {
   mouseCol?: number
   /** Pointer row (0-indexed) when the key is a wheel event. See mouseCol. */
   mouseRow?: number
+  /**
+   * True when this input arrived as a bracketed paste (terminal paste —
+   * Ctrl+Shift+V / right-click / a terminal that intercepts Ctrl+V) rather
+   * than typed characters. Mirrors `InputEvent.isPasted` so modal handlers
+   * can treat a paste chunk as text without reaching for the third callback
+   * argument: pasted content — even a chunk that is all line breaks — is
+   * never an Enter/submit press. Optional so hand-built key literals (tests,
+   * synthetic dispatches) keep compiling; the live pipeline always sets it.
+   */
+  isPasted?: boolean
 }
 
 function parseKey(keypress: ParsedKey): [Key, string] {
@@ -68,6 +78,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
     // protocol CSI u sequences. Distinct from meta (Alt/Option) so
     // bindings like cmd+c can be expressed separately from opt+c.
     super: keypress.super,
+    isPasted: keypress.isPasted === true,
     mouseCol: keypress.mouseCol,
     mouseRow: keypress.mouseRow,
   }


### PR DESCRIPTION
## 问题
问卷（ask_user_question）的自定义输入框无法 Ctrl+V 粘贴。粘贴只实现在主输入框 PromptInput；问卷面板接管键盘后 PromptInput 被挂起（isActive:false），面板自己的按键处理没有粘贴支路，Ctrl+V 按键被兜底守卫吞掉。

## 改动
- **input-event**：`Key.isPasted` 镜像解析结果——9 处 `isPlainReturnInput` 调用点自动拒绝「纯换行粘贴块」当回车（ApprovalPanel/JobsPanel 等弹窗一并获得中央保护）
- **sanitize**：`flattenPasteInline` 先剥完整 ANSI/OSC 再压平 C0/C1
- **AskUserQuestionPanel / PlanReviewPanel**：编辑状态重构为同步 ref + 码点游标（同 stdin chunk 单 React 批次、异步剪贴板读落实时光标、emoji 永不劈半）；粘贴双路（bracketed chunk + Ctrl+V/Alt+V 异步读剪贴板）共用同一插入入口，落点镜像打字语义（输入行光标处插入 / 选项行尾部追加+附标签）；纯换行块不提交、粘贴绝不触发 plan-review 快选/批准；8000 码点粘贴上限（拒绝不静默截断）；busy/mounted 守卫 + 内联错误行
- **ExtensionDialog** InputDialog 补 Ctrl+V 支路（沿用 500 格 cap）
- i18n 3 键 + 提示文案；新增 verify-question-paste 回归 33 断言（channel-ui 组）

## 验证
pnpm build 全链绿 ×2、channel-ui 整组 58/58 ×2、独立子代理审核无必须修（4 条建议全落实）、用户重启实机验证通过（问卷自定义输入 Ctrl+V 粘贴成功）。

Fixes #787


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clipboard and bracketed-paste support for question answers and plan-review feedback.
  * Added paste sanitization, length limits, validation, and clear error messages.
  * Improved text editing for pasted content, including emoji, cursor movement, and batched input.
  * Updated keyboard hints to explain paste shortcuts.

* **Bug Fixes**
  * Prevented pasted text from accidentally selecting options or triggering modal confirmation.
  * Improved handling of duplicate, unsupported, failed, and interrupted clipboard reads.

* **Tests**
  * Added comprehensive regression coverage for questionnaire paste behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->