### PR TITLE
Fix/issue 770 context warning

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -415,6 +415,7 @@ const GROUPS = {
 // 防再腐烂。
     ["verify-submit", ['node', '--import', 'tsx/esm', 'scripts/verify-submit.mjs']],
     ["verify-compact", ['node', '--import', 'tsx/esm', 'scripts/verify-compact.mjs']],
+    ["verify-context-warning", ['node', '--import', 'tsx/esm', 'scripts/verify-context-warning.mjs']],
     ["verify-channel-goal-todo", ['node', '--import', 'tsx/esm', 'scripts/verify-channel-goal-todo.mjs']],
     ["verify-whale-toggle", ['node', '--import', 'tsx/esm', 'scripts/verify-whale-toggle.mjs']],
 // 开屏鲸鱼三选一（classic 组合开场/heart/sleep）：帧表完整性（22 帧

--- a/scripts/verify-channel-owner-lifecycle.ts
+++ b/scripts/verify-channel-owner-lifecycle.ts
@@ -62,7 +62,10 @@ import { createContextBookkeeping } from '../src/dsh-adapter/channel/context-boo
 // compaction checkpoint, crossing the high-water mark must warn again.
 {
   const warnings: string[] = []
-  const state = { contextWindow: 100, tokens: { input: 90 }, pending: [], emit() {} }
+  // The warning reads the last turn's billed usage (input + cache read +
+  // cache write), not the cumulative tokens counter — resumed sessions
+  // replay the counter at full size while the live turn stays small.
+  const state = { contextWindow: 100, tokens: { input: 90 }, lastUsage: { input: 90, cacheRead: 0, cacheWrite: 0 }, pending: [], emit() {} }
   const bookkeeping = createContextBookkeeping(
     () => state,
     text => { warnings.push(text) },

--- a/scripts/verify-channel-ui.ts
+++ b/scripts/verify-channel-ui.ts
@@ -133,14 +133,17 @@ function fixture(jobs?: unknown, options: { throwOnEvent?: string; effectCleanup
   const { raw, agent, listeners } = fixture()
   const route = listeners.get('session/event')!
   raw.contextWindow = 100_000
-  raw.tokens.input = 90_000
+  // The warning reads the last turn's billed usage (input + cache read +
+  // cache write), not the cumulative tokens counter — resumed sessions
+  // replay the counter at full size while the live turn stays small.
+  raw.lastUsage = { input: 90_000, cacheRead: 0, cacheWrite: 0 }
   route(agent.session, { type: 'turn/end', data: { turn: 1, reason: { kind: 'completed' } }, time: 1 })
   assert.equal(raw.notifications.length, 1)
   route(agent.session, {
     type: 'user/message', time: 2,
     data: { source: { kind: 'plugin', plugin: 'compact' }, content: [{ type: 'text', text: 'summary' }] },
   })
-  raw.tokens.input = 90_000
+  raw.lastUsage = { input: 90_000, cacheRead: 0, cacheWrite: 0 }
   route(agent.session, { type: 'turn/end', data: { turn: 2, reason: { kind: 'completed' } }, time: 3 })
   assert.equal(raw.notifications.length, 2, 'warn → compact checkpoint → warn traverses the shared reset')
   raw.releaseContributions()

--- a/scripts/verify-context-warning.mjs
+++ b/scripts/verify-context-warning.mjs
@@ -1,0 +1,172 @@
+/**
+ * Regression for #770: /resume must not raise live warnings from replayed
+ * totals, historical windows, or failed turns. Run against the compiled channel.
+ */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const isolatedHome = mkdtempSync(join(tmpdir(), 'dsh-tui-context-warning-'))
+process.env.HOME = isolatedHome
+process.env.USERPROFILE = isolatedHome
+process.on('exit', () => rmSync(isolatedHome, { recursive: true, force: true }))
+
+const [{ Context }, { createChannel }, { settled }] = await Promise.all([
+  import('@deepseek-ai/cordis'),
+  import('../lib/types/dsh-adapter/channel.js'),
+  import('./lib/term-test.mjs'),
+])
+
+let failed = 0
+function check(name, ok, extra = '') {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failed += 1
+}
+
+function makeAgent(id, sessionId, events = []) {
+  return {
+    id,
+    status: 'idle',
+    options: {},
+    ctx: { on: () => () => {} },
+    session: {
+      id: sessionId,
+      seq: events.at(-1)?.seq ?? 0,
+      events,
+      header: { cwd: '/tmp/context-warning' },
+    },
+    followup() {},
+    steer() {},
+    inbox: { remove: () => true },
+    cancel() {},
+    whenIdle: () => Promise.resolve(),
+  }
+}
+
+const usage = {
+  inputTokens: 70_000,
+  outputTokens: 1_000,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+}
+const historicalEvents = [
+  { type: 'request/context', seq: 1, time: 1, data: { contextWindow: 128_000 } },
+  { type: 'turn/start', seq: 2, time: 2, data: { turn: 1 } },
+  {
+    type: 'assistant/message',
+    seq: 3,
+    time: 3,
+    data: { turn: 1, step: 1, message: { role: 'assistant', content: [] }, usage },
+  },
+  { type: 'turn/end', seq: 4, time: 4, data: { turn: 1, reason: { kind: 'completed' } } },
+  { type: 'turn/start', seq: 5, time: 5, data: { turn: 2 } },
+  {
+    type: 'assistant/message',
+    seq: 6,
+    time: 6,
+    data: { turn: 2, step: 1, message: { role: 'assistant', content: [] }, usage },
+  },
+  { type: 'turn/end', seq: 7, time: 7, data: { turn: 2, reason: { kind: 'completed' } } },
+  { type: 'turn/start', seq: 8, time: 8, data: { turn: 3 } },
+  {
+    type: 'turn/end',
+    seq: 9,
+    time: 9,
+    data: {
+      turn: 3,
+      reason: {
+        kind: 'error',
+        error: { name: 'Error', message: 'historical provider failure' },
+      },
+    },
+  },
+]
+
+const liveModelInfo = {
+  context: { contextWindow: 150_000 },
+  reasoning: { efforts: [] },
+}
+const target = makeAgent('resumed-agent', 'resumed-session', historicalEvents)
+const ctx = new Context()
+let delayMetadata = false
+let resolveResumeInfo
+ctx.provide('llm', {
+  resolveModelInfo: () => delayMetadata
+    ? new Promise(resolve => { resolveResumeInfo = resolve })
+    : Promise.resolve(liveModelInfo),
+})
+ctx.provide('agents', {
+  resume: () => Promise.resolve({ agent: target, dispose: () => Promise.resolve() }),
+})
+
+const channel = createChannel(ctx, makeAgent('current-agent', 'current-session'), {
+  model: 'test-model',
+  provider: 'test-provider',
+  cwd: '/tmp/context-warning',
+  activity: false,
+})
+const hasLowWarning = () => channel.notifications.some(item =>
+  /Context low|上下文即将耗尽/u.test(item.text),
+)
+const hasTurnError = detail => channel.notifications.some(item =>
+  item.color === 'error' &&
+  /Turn error|回合出错/u.test(item.text) &&
+  item.text.includes(detail),
+)
+const hasErrorRow = detail => channel.rows.some(row =>
+  row.kind === 'notice' && row.text.includes(detail),
+)
+
+delayMetadata = true
+const result = await channel.resumeTo(target.session.id)
+check('/resume succeeds', result.ok === true, JSON.stringify(result))
+check('replay restores cumulative billing totals', channel.tokens.input === 140_000, String(channel.tokens.input))
+check('replay keeps the latest request usage', channel.lastUsage?.input === 70_000, JSON.stringify(channel.lastUsage))
+check('replay does not emit a stale warning', !hasLowWarning(), JSON.stringify(channel.notifications))
+check('replay keeps historical turn failure in the transcript', hasErrorRow('historical provider failure'))
+check(
+  'replay does not re-notify a historical turn failure',
+  !hasTurnError('historical provider failure'),
+  JSON.stringify(channel.notifications),
+)
+check('resume requested current route metadata', typeof resolveResumeInfo === 'function')
+
+resolveResumeInfo?.(liveModelInfo)
+check(
+  'current route replaces the historical context window',
+  await settled(() => channel.contextWindow === liveModelInfo.context.contextWindow),
+  String(channel.contextWindow),
+)
+check('current request usage avoids a cumulative-total warning', !hasLowWarning(), JSON.stringify(channel.notifications))
+
+const emit = (type, data) => {
+  const event = { type, seq: ++target.session.seq, time: target.session.seq, data }
+  target.session.events.push(event)
+  ctx.emit('session/event', target.session, event)
+}
+emit('request/context', { contextWindow: 80_000 })
+emit('turn/start', { turn: 4 })
+emit('assistant/message', {
+  turn: 4,
+  step: 1,
+  message: { role: 'assistant', content: [] },
+  usage,
+})
+emit('turn/end', { turn: 4, reason: { kind: 'completed' } })
+check('a genuinely low live context still warns', hasLowWarning(), JSON.stringify(channel.notifications))
+
+emit('turn/start', { turn: 5 })
+emit('turn/end', {
+  turn: 5,
+  reason: {
+    kind: 'error',
+    error: { name: 'Error', message: 'live provider failure' },
+  },
+})
+check(
+  'a live turn failure still notifies',
+  hasTurnError('live provider failure'),
+  JSON.stringify(channel.notifications),
+)
+
+process.exit(failed)

--- a/src/dsh-adapter/channel.ts
+++ b/src/dsh-adapter/channel.ts
@@ -670,6 +670,7 @@ function createChannelWithOwner(
     initialEffort: options.effort,
     agent: () => binding.agent,
     notify,
+    checkContextWarning,
   })
 
   commandCompletions = createCommandCompletions({

--- a/src/dsh-adapter/channel/context-bookkeeping.ts
+++ b/src/dsh-adapter/channel/context-bookkeeping.ts
@@ -5,6 +5,10 @@ export function createContextBookkeeping(
   state: () => {
     contextWindow: number | undefined
     tokens: { input: number }
+    /** Last turn's billed token shape; the honest numerator for the
+     * context-low warning (input alone misses cached reads/writes, which
+     * resumed sessions replay back at full size). */
+    lastUsage: { input: number; cacheRead: number; cacheWrite: number } | undefined
     pending: PendingMessage[]
     emit(): void
   },
@@ -15,8 +19,9 @@ export function createContextBookkeeping(
   const warning = { value: false }
   const checkContextWarning = (): void => {
     const channel = state()
-    if (warning.value || channel.contextWindow === undefined) return
-    const remaining = channel.contextWindow - channel.tokens.input
+    if (warning.value || channel.contextWindow === undefined || channel.lastUsage === undefined) return
+    const used = channel.lastUsage.input + channel.lastUsage.cacheRead + channel.lastUsage.cacheWrite
+    const remaining = channel.contextWindow - used
     if (remaining >= warningBufferTokens) return
     warning.value = true
     notify(lowContextText(Math.max(0, Math.round((remaining / channel.contextWindow) * 100))), {

--- a/src/dsh-adapter/channel/model-actions.ts
+++ b/src/dsh-adapter/channel/model-actions.ts
@@ -20,7 +20,7 @@ type Binding = ReturnType<typeof createChannelBinding>
  */
 export function createModelActions(
   ctx: Context,
-  state: Pick<ChannelState, 'provider' | 'model' | 'reasoningEffort' | 'effortLevels' | 'agentPreset' | 'working' | 'emit'>,
+  state: Pick<ChannelState, 'provider' | 'model' | 'reasoningEffort' | 'effortLevels' | 'agentPreset' | 'working' | 'contextWindow' | 'emit'>,
   deps: {
     owner: Pick<ChannelOwner, 'current'>
     binding: Pick<Binding, 'capture' | 'isCurrent'>
@@ -28,12 +28,15 @@ export function createModelActions(
     initialEffort?: string
     agent(): Agent
     notify: ChannelState['notify']
+    /** Re-check the context-low warning after a refreshed route metadata
+     * answer carries a newer contextWindow than the session started with. */
+    checkContextWarning(): void
   },
 ) {
   const { owner, selection, notify } = deps
   const llmRuntime = ctx.get('llm') as
     | {
-      resolveModelInfo(provider: string, model: string): Promise<{ reasoning?: { efforts: ReadonlyArray<{ id: string; name: string; description?: string }>; defaultEffort?: string } }>
+      resolveModelInfo(provider: string, model: string): Promise<{ context?: { contextWindow: number }; reasoning?: { efforts: ReadonlyArray<{ id: string; name: string; description?: string }>; defaultEffort?: string } }>
       listProviders(): readonly { id: string; name: string }[]
       listModels(provider: string): Promise<readonly LlmModelInfo[]>
     }
@@ -57,10 +60,22 @@ export function createModelActions(
   const effortCurrent = (capture: EffortCapture): boolean =>
     owner.current() && deps.binding.isCurrent(capture.binding) &&
     state.provider === capture.provider && state.model === capture.model && effortOperation === capture.operation
+  /** Route-level metadata shared by every resolveModelInfo consumer. The
+   * context window follows the route, not the binding: a resume rebuilds
+   * the binding (effortCurrent goes false) while the capacity answer for
+   * the same provider/model is still the live truth, so this runs before
+   * any effort freshness gate. */
+  const applyRouteMetadata = (capture: EffortCapture, info: { context?: { contextWindow: number } }): void => {
+    if (state.provider === capture.provider && state.model === capture.model && info.context !== undefined) {
+      state.contextWindow = info.context.contextWindow
+      deps.checkContextWarning()
+    }
+  }
   const resolveEfforts = async (capture: EffortCapture): Promise<EffortResult | 'unavailable' | 'error' | 'stale'> => {
     if (llmRuntime === undefined || typeof llmRuntime.resolveModelInfo !== 'function') return 'unavailable'
     try {
       const info = await llmRuntime.resolveModelInfo(capture.provider, capture.model)
+      applyRouteMetadata(capture, info)
       if (!effortCurrent(capture)) return 'stale'
       const efforts = info.reasoning?.efforts ?? []
       state.effortLevels = efforts.map(level => level.id)
@@ -87,7 +102,9 @@ export function createModelActions(
     const capture = captureEffort()
     const generation = ++effortLevelsGeneration
     void llmRuntime.resolveModelInfo(capture.provider, capture.model).then(info => {
-      if (!effortCurrent(capture) || generation !== effortLevelsGeneration) return
+      if (generation !== effortLevelsGeneration) return
+      applyRouteMetadata(capture, info)
+      if (!effortCurrent(capture)) return
       state.effortLevels = (info.reasoning?.efforts ?? []).map(level => level.id)
       state.emit()
     }).catch(() => undefined)

--- a/src/dsh-adapter/channel/projection.ts
+++ b/src/dsh-adapter/channel/projection.ts
@@ -898,7 +898,9 @@ export function createChannelProjection(state: ProjectionState, deps: Projection
         }
         const reason = event.data.reason
         if (reason.kind === 'completed') {
-          deps.checkContextWarning()
+          // Replay drains a resumed session's history through the projector;
+          // its totals describe the past, not a live context-low state.
+          if (!replaying) deps.checkContextWarning()
           break
         }
         if (reason.kind === 'aborted' || reason.kind === 'interrupted') {
@@ -920,7 +922,10 @@ export function createChannelProjection(state: ProjectionState, deps: Projection
         const detail = reason.kind === 'error' ? cleanRenderText(reason.error.message, NOTICE_CELLS) : ''
         appendRow({ id: deps.rowIds.value, kind: 'notice', text: `turn ${reason.kind}${detail ? ` · ${detail}` : ''}` })
         deps.rowIds.value += 1
-        deps.notify(
+        // Historical failure notices belong to the transcript row above;
+        // re-raising them as a live toast on every /resume re-alarmes the
+        // user over a turn that already ended.
+        if (!replaying) deps.notify(
           t('turn-failed', { detail: detail ? ` · ${detail}` : '' }),
           { color: 'error', timeoutMs: 8000 },
         )


### PR DESCRIPTION
## 问题

`/resume` 会先同步回放旧会话，再异步读取当前模型信息。

回放期间会暂时使用历史 `contextWindow`，同时原来的余量计算使用整个会话累计的 `tokens.input`。正常的长会话因此可能误报“上下文即将耗尽（剩余 0%）”。

此外，如果旧会话中存在失败回合，恢复时还会重新弹出红色错误通知。

## 修复

- 历史回放期间不触发实时上下文余量警告。
- 使用最近一次请求的 `lastUsage` 计算当前上下文占用，不再使用会话累计输入量。
- 当前模型信息返回后更新真实 `contextWindow`，再执行余量检查。
- 历史失败回合仍保留在对话记录中，但恢复时不重复弹出错误通知。
- 增加聚焦回归测试，覆盖历史窗口、累计 token、历史失败回合和真实低余量场景。

## 验证

- `pnpm compile`
- `node --import tsx/esm scripts/verify-context-warning.mjs`
- `node --import tsx/esm scripts/verify-session-reset-hygiene.tsx`
- `git diff --check`

Closes #770