### PR TITLE
chore: 加 .coderabbit.yaml——只报正确性问题，按仓库规则给路径级指令

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,115 @@
+# CodeRabbit 配置。目标：把它当成只报正确性问题的第二双眼睛，而不是风格 lint。
+# Schema: https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# 仓库自己的规则在 AGENTS.md / ADAPTER.md / docs/contributing.md，下面的
+# path_instructions 只是把那些规则里「机器能核对」的部分复述给它。
+
+language: zh-CN
+
+tone_instructions: >-
+  用中文。只报会导致错误行为、回归或让测试假通过/假失败的问题，说明触发路径。
+  不评论格式、命名、注释措辞，不提超出本 PR 范围的重构或架构建议。不确定就不说。
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+
+  # 摘要留在 walkthrough 评论里，不改写作者写的 PR 正文
+  # （PR 入口门禁按正文判断语言与关联 issue，正文被改写会干扰它）。
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  collapse_walkthrough: true
+  review_status: true
+  poem: false
+  in_progress_fortune: false
+  sequence_diagrams: false
+  suggested_labels: false
+  suggested_reviewers: false
+  related_issues: true
+  related_prs: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # 默认只 review 目标为默认分支的 PR；stacked PR 的上层目标是下层分支，
+    # 也要 review。
+    base_branches:
+      - ".*"
+    ignore_usernames:
+      - "dependabot[bot]"
+    ignore_title_keywords:
+      - "WIP"
+
+  # 生成产物、vendored 依赖与锁文件不 review。
+  path_filters:
+    - "!lib/**"
+    - "!vendor/**"
+    - "!**/pnpm-lock.yaml"
+    - "!**/*.snapshot.json"
+    - "!docs/assets/**"
+
+  path_instructions:
+    - path: "src/dsh-adapter/**"
+      instructions: >-
+        这是唯一允许 import @deepseek-ai/* 的位置。重点核对：transcript 投影只来自
+        持久化会话事件，不插入乐观的助手/工具事实；事件顺序、seq 锚点与 call-ID
+        匹配不被打乱；注册的资源经 ctx.effect 或既有退出漏斗清理。不要建议 adapter
+        分层或 API 重构。
+    - path: "src/{screens,components,hooks,utils,cc}/**"
+      instructions: >-
+        UI 层禁止 import @deepseek-ai/*，出现即指出。终端宽度必须用仓库的显示宽度/
+        切片/换行辅助函数，直接用 .length 算宽度是 bug。TUI 活动期间不得有
+        console.log 或 stdout 诊断。相对导入必须带 .js 后缀，不引入 any。
+        不要评论格式、命名、注释语言与长度。
+    - path: "src/{ink,native-ts}/**"
+      instructions: >-
+        移植的 Ink 渲染器与 Yoga 布局引擎。只关注行为回归、帧差分正确性与终端
+        状态恢复（raw 模式、光标、alt-screen、同步输出、鼠标、焦点）。不要提类型
+        收紧、风格统一或批量重构建议。
+    - path: "scripts/**"
+      instructions: >-
+        无头回归与取证脚本。带 `固定窗:` 标签的 sleep 是有意保留的固定窗口，
+        不要建议改成轮询；term-test 的 settle 超时静默返回是既定设计，不要建议
+        改抛出。只指出会让断言假通过或假失败的问题（等待条件与断言条件分叉、
+        对已成立条件轮询、读到过期屏幕）。
+    - path: "{docs/**/*.md,README.md,README_EN.md}"
+      instructions: >-
+        只检查中文版与 .en.md/README_EN 是否同步：行为、配置项、快捷键、限制
+        必须两版一致。不做 markdown 风格、标点与语法润色。
+    - path: "{cordis.patch.yml,cordis.yml}"
+      instructions: >-
+        行序、行 ID 与 insert/override 语义关键。对官方行的改动必须同步
+        patch-surface.snapshot.json。
+    - path: ".github/**"
+      instructions: >-
+        重点看 pull_request_target 下的 checkout 与 secrets 暴露、以及门禁脚本
+        对权限判断的绕过路径。
+
+  tools:
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: "off"
+    description:
+      mode: "off"
+    issue_assessment:
+      mode: warning
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "ADAPTER.md"
+      - "docs/contributing.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,11 +3,12 @@
 # 仓库自己的规则在 AGENTS.md / ADAPTER.md / docs/contributing.md，下面的
 # path_instructions 只是把那些规则里「机器能核对」的部分复述给它。
 
-language: zh-CN
-
+# 不钉死 language：PR 标题与正文用什么语言，评论就用什么语言（与 PR 入口
+# 门禁的回复语言规则一致）。
 tone_instructions: >-
-  用中文。只报会导致错误行为、回归或让测试假通过/假失败的问题，说明触发路径。
-  不评论格式、命名、注释措辞，不提超出本 PR 范围的重构或架构建议。不确定就不说。
+  Reply in the language of the PR title and body. Report only behavior bugs, regressions,
+  or tests that would pass/fail falsely, with the trigger path. No style, naming, or wording
+  comments; no refactors beyond this PR's scope. If unsure, say nothing.
 
 reviews:
   profile: chill


### PR DESCRIPTION
## 为什么

最近几个 PR 上 CodeRabbit 的意见大约五分之二有用，其余是 markdownlint 风格、超出 PR 范围的「重架构」建议和误判（#792 上那条 `--list` 会失败的判断是错的）。它在 #775 上抓到的 worker 消息处理、SGR 通道钳制那几条又确实有价值，所以目标不是关掉它，而是把它对准仓库自己的规则。

## 配置要点

- **语言与口径**：不钉死 `language`，PR 标题与正文用什么语言就用什么语言回复（与入口门禁的回复语言规则一致）；`tone_instructions` 限定只报错误行为、回归、让测试假通过/假失败的问题，不评风格、命名、注释措辞，不提超范围重构。
- **不改 PR 正文**：摘要留在 walkthrough 评论里。PR 入口门禁按正文判断语言与关联 issue，正文被它改写会干扰。
- **关掉的噪音**：markdownlint、languagetool、docstring 与 unit test 生成、诗、进度占卜、时序图、标签与 reviewer 建议、pre-merge 的标题/描述/docstring 检查。保留 issue_assessment（PR 是否真的解决了关联 issue）。
- **范围**：review 所有 base 分支（stacked PR 的上层目标是下层分支），忽略 dependabot；排除 `lib/`、`vendor/`、锁文件、`*.snapshot.json`、`docs/assets/`。
- **路径级指令**（都是 AGENTS.md 里机器能核对的条目）：
  - `src/dsh-adapter/**`：唯一允许 import `@deepseek-ai/*`；投影不插乐观事实、事件顺序与 call-ID 匹配
  - UI 层：出现上游 import 即指出；宽度必须用显示宽度辅助；渲染期间无 console.log；相对导入 `.js` 后缀；无 `any`
  - `src/ink`、`src/native-ts`：移植代码，只看行为回归与终端状态恢复，不提类型收紧与批量重构
  - `scripts/**`：带 `固定窗:` 标签的 sleep 与 `settle` 静默超时是既定设计（#569 / #568），只指出让断言假通过或假失败的问题
  - 文档：只查中英双版本同步
  - `cordis.patch.yml`：行序与快照同步
  - `.github/**`：`pull_request_target` 安全
- **知识库**：`code_guidelines` 明确读 `AGENTS.md`、`ADAPTER.md`、`docs/contributing.md`。

## 验证

按官方 `schema.v2.json` 校验：无未知键，`profile`/`language`/`mode` 枚举合法，`tone_instructions` 249 字符（上限 250）。`off` 已加引号，避免 YAML 1.1 解析器当成布尔。

配置生效后第一个被 review 的 PR 可以看下口径是否符合预期，再微调。

