### PR TITLE
fix(ink): ScrollBox 底部超滚完全惰性化——贴底 wheel-down 不再强拖/闪烁

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -123,6 +123,11 @@ const GROUPS = {
 // 一键回底回归：pill 常驻显示、End/Enter 回底、远距回底不触发空白
 // 死锁（大偏移一步到位后首帧即有内容）。
     ["verify-back-to-bottom", ['node', '--import', 'tsx/esm', 'scripts/verify-back-to-bottom.tsx']],
+// 底部超滚门控回归：已贴底时 wheel-down 必须是完全惰性的 no-op（不清
+// sticky、不积 delta、不重绘）——修复前每格 sticky flip-flop + pill 闪现
+// + 整屏重绘（流式下可感知为"强拖+闪烁"）；且滚上再滚回仍须正常（着陆
+// 格放行、at-bottom re-pin 恢复 sticky）。
+    ["verify-scrollbox-bottom-overscroll", ['node', '--import', 'tsx/esm', 'scripts/verify-scrollbox-bottom-overscroll.tsx']],
 // 时间线 rail 回归：rail 覆盖全部轮次（含折叠轮），高亮锚定视口顶、
 // ▲/▼ 目标不越过 maxScroll。
     ["verify-timeline-rail", ['node', '--import', 'tsx/esm', 'scripts/verify-timeline-rail.tsx']],

--- a/scripts/verify-scrollbox-bottom-overscroll.tsx
+++ b/scripts/verify-scrollbox-bottom-overscroll.tsx
@@ -1,0 +1,315 @@
+/**
+ * ScrollBox 底部超滚门控回归（overscroll at the bottom is a true no-op）。
+ *
+ * 用户报告：转录区已滚到最底（sticky 贴底）后继续 wheel-down 仍可见
+ * "强拖+闪烁"。根因链：每个向下 notch 走 ScrollBox.scrollBy(+3) → 无条件
+ * 清 stickyScroll → 渲染器 at-bottom re-pin 恢复 → 每格一次 sticky
+ * flip-flop（isSticky 是 React 状态）→ MessageList 虚拟化窗口/缓存
+ * churn + 「↓ 回到底部」pill 在用户已在底部时闪现 + 整屏重绘；measure
+ * 帧 innerHeight 伪影下 drain 把 scrollTop 推过 maxScroll 再拉回。
+ * 修复 = scrollBy 的底部超滚门控（dy>0 且贴底/位置在底时直接 return，
+ * 不清 sticky/不积 delta/不通知）。本脚本钉死修复后的契约：
+ *   A. 底部连续 wheel-down：零画面帧变化、零内容写入、终帧与稳定帧全等；
+ *   B. 滚轮双向未被门控误吞：wheel-up 离开底部可见滚动，wheel-down
+ *      能滚回底部（着陆格放行 + at-bottom re-pin 恢复 sticky）。
+ *
+ * Run: node --import tsx/esm scripts/verify-scrollbox-bottom-overscroll.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+process.env.DSH_TUI_LANG = 'zh'
+delete process.env.WT_SESSION
+delete process.env.TERM_PROGRAM
+delete process.env.TMUX
+
+const [
+  { PassThrough, Writable },
+  React,
+  { Terminal: XTerm },
+  { render, AlternateScreen, ScrollBox, Box, Text },
+  { Chat },
+  { QuestionStore },
+  { LOCAL_COMMANDS, completeCommands },
+  termTest,
+] = await Promise.all([
+  import('node:stream'),
+  import('react'),
+  import('@xterm/headless'),
+  import('../src/ui.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
+  import('../src/commands.js'),
+  import('./lib/term-test.mjs'),
+])
+const { default: instances } = await import('../src/ink/instances.js')
+const { sleep } = termTest
+
+const COLS = 120
+const ROWS = 36
+const BOTTOM_MARKER = '★尾行标记-在最后一条消息的最后一行★'
+
+let failures = 0
+function check(name: string, ok: boolean, extra = ''): void {
+  console.log(`${ok ? 'PASS' : 'FAIL'}: ${name}${extra ? `  (${extra})` : ''}`)
+  if (!ok) failures++
+}
+
+function makeRows(): any[] {
+  const rows: any[] = []
+  let id = 1
+  for (let turn = 0; turn < 20; turn++) {
+    rows.push({ id: id++, kind: 'user', text: `历史用户消息 ${turn}：请检查模块 ${turn} 的边界行为，这里补足一些文字。`, time: 1_700_000_000_000 + turn * 2000 })
+    const last = turn === 19
+    rows.push({
+      id: id++,
+      kind: 'assistant',
+      text: `助手回复 ${turn}：${'分析结果与建议。'.repeat(8)}${last ? `\n\n${BOTTOM_MARKER}` : ''}`,
+      time: 1_700_000_000_800 + turn * 2000,
+    })
+  }
+  return rows
+}
+
+function makeChannel(rows: any[]) {
+  const listeners = new Set<() => void>()
+  return {
+    version: 0,
+    whaleIdle: false,
+    rows,
+    status: 'idle',
+    sessionTitle: 'verify-bottom-overscroll',
+    agentId: 'probe',
+    model: 'deepseek-v4-flash',
+    provider: 'deepseek',
+    reasoningEffort: 'max',
+    effortLevels: [],
+    tokens: { input: 0, output: 0 },
+    cwd: '/tmp/demo',
+    displayCwd: '/tmp/demo',
+    gitBranch: 'main',
+    working: false,
+    spinnerMode: 'requesting',
+    responseChars: 0,
+    activeToolCount: 0,
+    turnStart: 0,
+    pending: [],
+    commandList: LOCAL_COMMANDS,
+    notifications: [],
+    mode: { plan: false, sandbox: undefined },
+    activityFrames: 'claude',
+    agentPreset: undefined,
+    subagents: [],
+    subscribe(cb: () => void) { listeners.add(cb); return () => listeners.delete(cb) },
+    submit: () => {},
+    cancel: () => {},
+    clear: () => {},
+    notify: () => {},
+    listModels: () => Promise.resolve([]),
+    listSessions: () => Promise.resolve([]),
+    deleteSession: () => Promise.resolve(true),
+    renameSessionTo: () => Promise.resolve(true),
+    setResumeTarget: () => {},
+    loadOlder: () => {},
+    mcpStatus: () => [],
+    pushLocal: () => {},
+    commandCompletions: (input: string) => completeCommands(input),
+  } as any
+}
+
+class FakeStdin extends PassThrough {
+  isTTY = true
+  setRawMode(): this { return this }
+  override ref(): this { return this }
+  override unref(): this { return this }
+}
+
+function norm(line: string): string { return line.replace(/\s+$/, '') }
+
+async function runScenario(tag: string, burstDown: number, seekUpThenDown: boolean): Promise<void> {
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  const writes: string[] = []
+  const frames: string[][] = [] // 每次 stdout 写入后的屏幕快照（去重）
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    override _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      const text = String(chunk)
+      writes.push(text)
+      term.write(text, () => {
+        const lines: string[] = []
+        for (let y = 0; y < ROWS; y++) lines.push(norm(term.buffer.active.getLine(y)?.translateToString(true) ?? ''))
+        const last = frames[frames.length - 1]
+        if (!last || last.some((l, i) => l !== lines[i]!)) frames.push(lines)
+        callback()
+      })
+    }
+  }
+  class FakeStderr extends Writable {
+    isTTY = true
+    override _write(_c: unknown, _e: BufferEncoding, cb: () => void): void { cb() }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const tree = (
+    <AlternateScreen>
+      <Chat channel={makeChannel(makeRows())} questionStore={new QuestionStore()} fullscreen />
+    </AlternateScreen>
+  )
+  const instance = await render(tree, {
+    stdout: stdout as any,
+    stdin: stdin as any,
+    stderr: new FakeStderr() as any,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  instances.set(process.stdout, instances.get(stdout)!)
+  instance.rerender(tree)
+  await sleep(900)
+
+  const wheel = (dir: 'up' | 'down', ticks: number): void => {
+    const button = dir === 'up' ? 64 : 65
+    for (let i = 0; i < ticks; i++) stdin.write(`\x1b[<${button};60;20M`)
+  }
+  const markerRow = (lines: string[]): number => lines.findIndex(l => l.includes(BOTTOM_MARKER))
+  const atBottom = () => frames.length > 0 && markerRow(frames[frames.length - 1]!) >= 0
+
+  // 新会话 sticky 应直接落在底部；保险起见 seek（seek 也是功能路径）。
+  let seek = 0
+  while (!atBottom() && seek < 120) {
+    wheel('down', 1)
+    seek++
+    await sleep(16)
+  }
+  await sleep(400)
+  if (!atBottom()) throw new Error(`${tag}: setup failed — never reached the bottom`)
+  const S0 = frames[frames.length - 1]!
+  const s0Row = markerRow(S0)
+  check(`${tag}: 稳定在底部（尾行标记可见于行 ${s0Row}）`, s0Row >= 0, `seekTicks=${seek}`)
+
+  if (seekUpThenDown) {
+    // B: 先滚上去离开底部（门控不得吞 wheel-up），再循环滚回底部——
+    // 着陆格/贴底帧必须放行并恢复 sticky（marker 重现 = 回底成功）。
+    const beforeUp = frames.length
+    wheel('up', 5)
+    await sleep(320)
+    const afterUp = frames.slice(beforeUp).find(lines => markerRow(lines) < 0)
+    check(`${tag}: wheel-up 离开底部正常滚动`, afterUp !== undefined, `marker 已滚出视口`)
+    const beforeDown = frames.length
+    let downTicks = 0
+    while (downTicks < 40 && !frames.slice(beforeDown).some(lines => markerRow(lines) >= 0)) {
+      wheel('down', 1)
+      downTicks++
+      await sleep(34)
+    }
+    await sleep(400)
+    const backFrames = frames.slice(beforeDown)
+    const back = backFrames.find(lines => markerRow(lines) >= 0)
+    check(`${tag}: wheel-down 能滚回底部（着陆格未被门控吞掉）`, back !== undefined, `downTicks=${downTicks}`)
+    if (back === undefined) {
+      const last = backFrames[backFrames.length - 1] ?? []
+      console.log(`--- B 诊断: down ${downTicks} 格后尾部 8 行 ---`)
+      console.log(last.slice(Math.max(0, ROWS - 8)).map((l, i) => `${String(i + Math.max(0, ROWS - 8)).padStart(2)}|${l}`).join('\n'))
+    }
+    await sleep(200)
+  } else {
+    // A: 底部连续 wheel-down —— 修复前的每格 sticky flip-flop / pill 闪现 /
+    // 整屏重绘帧在这里会表现为画面帧变化；修复后必须零帧、零内容写。
+    const beforeWrites = writes.length
+    const burstStart = frames.length
+    for (let i = 0; i < burstDown; i++) {
+      wheel('down', 1)
+      await sleep(30)
+    }
+    await sleep(500) // 等任何残余 drain 落定
+
+    const burstFrames = frames.slice(burstStart)
+    const changed = burstFrames.filter(lines => lines.some((l, r) => l !== S0[r]!))
+    check(`${tag}: 底部 ${burstDown} 格 wheel-down 期间零画面帧变化`, changed.length === 0, `${changed.length} 帧变化`)
+    const pillFrames = burstFrames.filter(lines => lines.some(l => l.includes('回到底部')))
+    check(`${tag}: 期间无「回到底部」pill 闪现`, pillFrames.length === 0, `${pillFrames.length} 帧含 pill`)
+    const finalFrame = burstFrames[burstFrames.length - 1] ?? S0
+    check(`${tag}: 终帧与稳定帧全等`, !finalFrame.some((l, r) => l !== S0[r]!))
+    const contentBytes = writes.slice(beforeWrites).join('').length
+    check(`${tag}: 期间无重绘级内容写入`, contentBytes <= 32, `${contentBytes} bytes`)
+  }
+
+  await instance.unmount()
+  instances.delete(process.stdout)
+  term.dispose()
+}
+
+async function runUnitScenario(tag: string): Promise<void> {
+  // C: maxScroll-1 死区回归（裸 ScrollBox 单元）。±1 行调用方（面板 ↑/↓、
+  // seek/scrollTo 落点）可以让 sticky 已破的视图静止在 maxScroll - 1
+  // （差 1 行到真底）：渲染器 re-pin 要求 scrollTop >= maxScroll，该位置
+  // 无帧可自愈——门控若在 >= maxScroll - 1 就吞 dy>0，最后一行永不可达、
+  // sticky 永不恢复。断言：+1 必须落底并把 sticky 恢复。
+  const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
+  class FakeStdout extends Writable {
+    columns = COLS
+    rows = ROWS
+    isTTY = true
+    override _write(chunk: unknown, _encoding: BufferEncoding, callback: () => void): void {
+      term.write(String(chunk), callback)
+    }
+  }
+  class FakeStderr extends Writable {
+    isTTY = true
+    override _write(_c: unknown, _e: BufferEncoding, cb: () => void): void { cb() }
+  }
+  const stdout = new FakeStdout()
+  const stdin = new FakeStdin()
+  const handleRef: { current: any } = { current: null }
+  const lines = Array.from({ length: 200 }, (_, i) => `第 ${i} 行内容-滚动单元测试`)
+  const tree = (
+    <AlternateScreen>
+      <ScrollBox ref={(h: any) => { handleRef.current = h }} stickyScroll height={30} width={COLS} flexDirection="column">
+        {lines.map((text, i) => (
+          <Box key={i} height={1} width="100%"><Text>{text}</Text></Box>
+        ))}
+      </ScrollBox>
+    </AlternateScreen>
+  )
+  const instance = await render(tree, {
+    stdout: stdout as any,
+    stdin: stdin as any,
+    stderr: new FakeStderr() as any,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  })
+  instances.set(process.stdout, instances.get(stdout)!)
+  instance.rerender(tree)
+  await sleep(500)
+  const h = handleRef.current
+  if (!h) throw new Error(`${tag}: ScrollBox handle not mounted`)
+
+  const maxScrollOf = (): number =>
+    Math.max(0, (h.getScrollHeight() ?? 0) - (h.getViewportHeight() ?? 0))
+  // 1. 跳到真底（scrollTo 越过 maxScroll，渲染帧 clamp 落底；restore 帧
+  //    会恢复 sticky——先确认工具路径本身工作）。
+  h.scrollTo(1e9)
+  await sleep(200)
+  check(`${tag}: scrollTo 落底（scrollTop == maxScroll）`, h.getScrollTop() === maxScrollOf(), `top=${h.getScrollTop()} max=${maxScrollOf()}`)
+  // 2. 打破 sticky 并停到 maxScroll - 1（差 1 行）：-1 格上滚。
+  h.scrollBy(-1)
+  await sleep(250)
+  check(`${tag}: 静止于 maxScroll - 1（sticky 已破）`, h.getScrollTop() === maxScrollOf() - 1 && !h.isSticky(), `top=${h.getScrollTop()} max=${maxScrollOf()} sticky=${h.isSticky()}`)
+  // 3. 死区核心：+1 必须放行落底并恢复 sticky（门控若含 epsilon 则在此
+  //    吞掉——最后一行永不可达）。
+  h.scrollBy(1)
+  await sleep(300)
+  check(`${tag}: maxScroll-1 的 +1 能落底`, h.getScrollTop() === maxScrollOf(), `top=${h.getScrollTop()} max=${maxScrollOf()}`)
+  check(`${tag}: 落底后 sticky 恢复`, h.isSticky() === true, `sticky=${h.isSticky()}`)
+
+  await instance.unmount()
+  instances.delete(process.stdout)
+  term.dispose()
+}
+
+await runScenario('A.贴底超滚', 12, false)
+await runScenario('B.滚上再滚回', 5, true)
+await runUnitScenario('C.maxScroll-1 死区')
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} failure(s)`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/ink/components/ScrollBox.tsx
+++ b/src/ink/components/ScrollBox.tsx
@@ -190,13 +190,54 @@ function ScrollBox({
     scrollBy(dy: number) {
       const el = domRef.current;
       if (!el) return;
+      const dyFloor = Math.floor(dy);
+      // Wheel-down / scroll-down while the view is already AT the bottom is
+      // pure overscroll: nothing left to reveal. Ignore it entirely — no
+      // sticky clear, no pending delta, no dirty mark, no subscriber
+      // notify. The old path ran every notch through sticky-break → drain →
+      // re-pin, which (with streaming content) flip-flopped the sticky flag
+      // frame by frame, remounted the virtualization window (isSticky is
+      // React state), flashed the "↓ back to bottom" pill while the user
+      // WAS at the bottom, let the drain overshoot past maxScroll on
+      // measure frames, and repainted the transcript per notch (flicker).
+      // Gate:
+      //  - sticky === true: the renderer keeps scrollTop pinned at
+      //    maxScroll each frame — a wheel-down must never unpin it
+      //    (leaving the bottom is wheel-UP's job).
+      //  - else positionally at the bottom or past it (a shrink-frozen
+      //    scrollTop can sit above the cached maxScroll): scrollTop >=
+      //    maxScroll with no in-flight scroll-UP (pending >= 0).
+      //    pending < 0 means an earlier wheel-up hasn't drained yet: a
+      //    down-notch must land so the accumulator cancels (scroll-up
+      //    followed by scroll-down naturally cancels — see the
+      //    accumulation comment below).
+      //  - Notches from ABOVE (scrollTop < maxScroll) are NOT gated —
+      //    including the landing notch that would finish the final row:
+      //    ±1-row callers (panel ↑/↓ keys) and scrollTo/seek landings can
+      //    rest at maxScroll - 1, and gating there would leave the last
+      //    row unreachable and never trigger the renderer's at-bottom
+      //    re-pin (which requires scrollTop >= maxScroll). The landing
+      //    notch drains to the bottom and the re-pin restores sticky /
+      //    clears the new-messages pill on that frame. No epsilon is
+      //    needed — the whole chain is integer rows.
+      if (dyFloor > 0) {
+        const sticky = el.stickyScroll ?? Boolean(el.attributes['stickyScroll']);
+        const pending = el.pendingScrollDelta ?? 0;
+        const maxScroll = Math.max(
+          0,
+          (el.scrollHeight ?? 0) - (el.scrollViewportHeight ?? 0),
+        );
+        if (sticky || ((el.scrollTop ?? 0) >= maxScroll && pending >= 0)) {
+          return;
+        }
+      }
       el.stickyScroll = false;
       // Wheel input cancels any in-flight anchor seek — user override.
       el.scrollAnchor = undefined;
       // Accumulate in pendingScrollDelta; renderer drains it at a capped
       // rate so fast flicks show intermediate frames. Pure accumulator:
       // scroll-up followed by scroll-down naturally cancels.
-      el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy);
+      el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + dyFloor;
       scrollMutated(el);
     },
     scrollToBottom() {


### PR DESCRIPTION
## 问题

转录区已经滚到最底部（sticky 贴底）后，继续向下滚鼠标滚轮仍会产生可见的"强拖+闪烁"。逐帧取证（headless xterm + geometry trace）确认根因链：每个向下 notch 走 `ScrollBox.scrollBy(+3)` → **无条件清 stickyScroll** → 渲染器下一帧 at-bottom re-pin 恢复 → 每格一次 sticky flip-flop（`isSticky` 是 React 状态）：

1. 「↓ 回到底部」pill 在用户**已在底部时**闪现（isSticky=false 窗口让未读计数逻辑启动）；
2. MessageList 虚拟化窗口/行高缓存 churn → 整屏重绘；
3. measure 帧 innerHeight 测量伪影（27 vs 30 行）下，drain 把 `scrollTop` 推到 **maxScroll 之上再拉回**——即可感知的"强拖"。

## 修复

`ScrollBox.scrollBy` 增加**底部超滚门控**：`dy > 0` 且满足以下任一条件时直接 return——不清 sticky、不积 delta、不标记脏、不通知订阅者：

- 该 box 正贴底（`stickyScroll === true`），或
- 位置已在/越过底部（`scrollTop >= maxScroll`）且无在途上滚（`pending >= 0`）。

刻意保留两个边界（均有回归钉死）：

- `pending < 0`（刚滚过上、未 drain 完）：向下 notch 必须落账，保持"上滚+下滚自然抵消"的累加器语义；
- 从上方落底的**着陆格**（`scrollTop < maxScroll`，含 ±1 行调用方停在 `maxScroll - 1` 的最后一格）：照常放行，由渲染器 at-bottom re-pin 恢复 sticky、清除新消息 pill——若门控含 epsilon 边界（`>= maxScroll - 1`）会形成"最后一行永不可达 + sticky 永不恢复"死区（独立审查发现，场景 C 红绿验证）。

所有滚轮路径（位置路由、时间线轨、滚动条 gutter、Chat 兜底）都汇到 `scrollBy`，一处门控全覆盖。

## 测试

新增 `scripts/verify-scrollbox-bottom-overscroll.tsx`（登记 render-scroll 组）：

- **A. 贴底超滚**：底部 12 格 wheel-down 期间零画面帧变化、零「回到底部」pill 闪现、零内容写入（修复前每格 flip-flop/pill/整屏重绘）；
- **B. 滚上再滚回**：wheel-up 离开底部正常滚动、wheel-down 能滚回底部（着陆格放行、sticky 恢复）；
- **C. maxScroll-1 死区**（裸 ScrollBox 单元）：sticky 已破且静止于差 1 行处时 `+1` 必须落底并恢复 sticky——epsilon 边界下该场景红（top 卡死、sticky 不恢复），红绿验证过。

本地验证：pnpm build 全绿、tsc 干净、verify-back-to-bottom / repro-pill / verify-wheel-selection / verify-scroll / repro-user-drag-wheel-render / verify-scrollbar-gutter 全绿、render-scroll 组 38/39（唯一失败为已登记的 Windows 预存 verify-osc8-sanitize，零文件交集）、git diff --check 干净。
