### PR TITLE
ci(sixel): 回归脚本首行强制 production React，修复 large preview 10 s 超时抖动

### DIFF
--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -349,7 +349,11 @@ the required credentials.
 - Preserve initialization ordering around environment-sensitive imports.
   `FORCE_COLOR`, `NODE_ENV`, and terminal capability flags are often read at
   module evaluation time; moving an import above their setup can change
-  behavior without a type error.
+  behavior without a type error. Regression scripts that import `lib/types/`
+  directly bypass the package entry, so React loads its dev build and
+  structured-clones every component's props on each commit; a script that
+  passes large image buffers as props must make
+  `lib/types/force-production-react.js` its first import.
 
 ## Architectural Invariants
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -261,6 +261,9 @@ sleep 同行尾注释或紧贴上方的注释里。`verify:fixed-window` 门禁�
   就地内联。
 - 保护环境敏感 import 的初始化顺序。`FORCE_COLOR`、`NODE_ENV`、终端能力标志
   常在模块求值时读取；把 import 移到它们初始化之前会无类型错误地改变行为。
+  直接 import `lib/types/` 的回归脚本绕过了包入口，React 会按 dev 构建加载，
+  每次 commit 都把组件 props 整份 structured-clone 一遍；把大图 buffer 当
+  props 传递的脚本要把 `lib/types/force-production-react.js` 放在第一个 import。
 
 ## 架构不变量（Architectural Invariants）
 

--- a/scripts/verify-sixel-transcript.tsx
+++ b/scripts/verify-sixel-transcript.tsx
@@ -2,6 +2,8 @@
  * Uses xterm's parser plus a pixel plane for Sixel/ECH/ED. This checks emitted
  * positions and residue, not native Windows Terminal rendering performance.
  */
+// First import on purpose: production React, see verify-terminal-images-sixel.tsx.
+import '../lib/types/force-production-react.js'
 import assert from 'node:assert/strict'
 import { PassThrough, Writable } from 'node:stream'
 import { setTimeout as delay } from 'node:timers/promises'

--- a/scripts/verify-terminal-images-sixel.tsx
+++ b/scripts/verify-terminal-images-sixel.tsx
@@ -2,6 +2,11 @@
  * Uses built modules so Worker entry resolution matches the published package.
  * Headless text/byte assertions are not native terminal visual acceptance.
  */
+// First import on purpose: the dev react-reconciler records a
+// performance.measure() per commit whose detail structured-clones the 8 MiB
+// `source` prop of every <Image>. The large preview below then needs seconds
+// and misses the 10 s deadline on CI runners. Launchers force production too.
+import '../lib/types/force-production-react.js'
 import assert from 'node:assert/strict'
 import { PassThrough, Writable } from 'node:stream'
 import { setTimeout as delay } from 'node:timers/promises'


### PR DESCRIPTION
## 变更摘要 / Summary

`verify-terminal-images-sixel` 的 "large preview" 断言在 CI 上时红时绿（09-07 main、dependabot、两个 fix 分支与 #759 attempt 1 都中过）。根因不是 Sixel 编码慢：脚本直接 import `lib/types/`，绕过了包入口的 `force-production-react`，React 按 dev 构建加载；dev reconciler 每次 commit 调 `performance.measure(detail)`，Node 把 detail 里的组件 props 整份 structured-clone，其中含 `<Image source>` 的 8 MiB RGBA buffer。主线程 profile：`structuredClone` 2.9 s、GC 1.7 s；Sixel 编码本身 40 ms。

- 两个 Sixel 回归脚本把 `lib/types/force-production-react.js` 放到第一个 import，与包入口、`bin/dsh-tui.js` 一致；同时覆盖 `verify:build` 链与 `render-scroll` 组两处调用。
- `docs/contributing.md` / `.en.md` 在"环境敏感 import 顺序"一条下补充这个契约。

## 关联 / Related

Closes #805

## 变更类型 / Type

- [x] ci / chore — 构建、工作流、仓库维护
- [x] docs — 贡献指南一句约定

## 验证 / Verification

- [x] `node --import tsx/esm scripts/verify-terminal-images-sixel.tsx`：7.7 s → 4.3 s，"large preview" 等待 4386 ms → 171 ms，通过
- [x] `node --import tsx/esm scripts/verify-sixel-transcript.tsx`：通过（该脚本的耗时由 #806 处理，与本 PR 无关）
- [ ] `pnpm build`：只改脚本与文档，未重建；CI 会跑完整门禁

```text
[+ 2431 ms] the real card close erases Sixel
[+ 6825 ms] waited  4386 ms  large preview is encoded by the compiled worker   # before
[+ 3293 ms] waited   171 ms  large preview is encoded by the compiled worker   # after
```

## 自查 / Checklist

- [x] 未改 `src/`、`lib/`、依赖或 CI 配置
- [x] 只暂存了显式路径
