### PR TITLE
perf(sixel): 量化统一走 sharp 原生 libimagequant，移除 image-q（缩略图 10–40×）

### DIFF
--- a/docs/contributing.en.md
+++ b/docs/contributing.en.md
@@ -312,6 +312,7 @@ change, also run the closest focused script:
 | Mouse pointer event pipeline (wheel coords/modifier bits, click/hover dispatch, out-of-bounds clamping, pointer-state reset) | `node --import tsx/esm scripts/verify-pointer-events.ts` |
 | Hover event performance (complete interest boundaries, no-interest rect fast path, frame/multi-root invalidation) | `node --import tsx/esm scripts/verify-hover-coalesce.tsx` |
 | Prompt-input mouse selection editing (drag/Shift+click/double-click word select, delete/replace, layered Esc, Ctrl+C copy, CJK wide cells, fold-side clamping) | `node --import tsx/esm scripts/verify-input-selection.tsx` |
+| Sixel encoding, worker cache, thumbnail/preview lifecycle | `node --import tsx/esm scripts/verify-terminal-images-sixel.tsx`, `node --import tsx/esm scripts/verify-sixel-transcript.tsx`; timing comparison `node --import tsx/esm scripts/bench-sixel-encode.tsx` |
 
 Most focused scripts invoked with plain `node` import `lib/types/`; run
 `pnpm build` first. Scripts that import TypeScript sources declare the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -233,6 +233,7 @@ CI 回归都要跑。窄改动还要跑最近的聚焦脚本：
 | 鼠标指针事件管线（滚轮坐标/修饰位、点击/hover 派发、越界 clamp、指针态重置） | `node --import tsx/esm scripts/verify-pointer-events.ts` |
 | Hover 事件性能（兴趣边界完整、无兴趣矩形快路径、帧边界/多 root 失效） | `node --import tsx/esm scripts/verify-hover-coalesce.tsx` |
 | 输入框鼠标选区编辑（拖选/Shift+click/双击选词/删除替换/Esc 分层/Ctrl+C 复制、CJK 宽字符与 fold 侧钳制） | `node --import tsx/esm scripts/verify-input-selection.tsx` |
+| Sixel 编码、worker 缓存、缩略图/预览生命周期 | `node --import tsx/esm scripts/verify-terminal-images-sixel.tsx`、`node --import tsx/esm scripts/verify-sixel-transcript.tsx`；耗时对比 `node --import tsx/esm scripts/bench-sixel-encode.tsx` |
 
 多数用普通 `node` 调用的脚本 import `lib/types/`——先跑 `pnpm build`。import
 TypeScript 源的脚本在头部声明 `node --import tsx/esm <script>` 形式。不要凭

--- a/package.json
+++ b/package.json
@@ -332,7 +332,6 @@
     "figures": "^6.1.0",
     "get-east-asian-width": "^1.0.0",
     "highlight.js": "^11.11.1",
-    "image-q": "4.0.0",
     "indent-string": "^5.0.0",
     "lodash-es": "^4.17.0",
     "marked": "^18.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,9 +116,6 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.12.0
-      image-q:
-        specifier: 4.0.0
-        version: 4.0.0
       indent-string:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2346,9 +2343,6 @@ packages:
   '@types/lodash@4.17.25':
     resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
-  '@types/node@16.9.1':
-    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
-
   '@types/node@26.4.0':
     resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
 
@@ -2616,9 +2610,6 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
-
-  image-q@4.0.0:
-    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
@@ -5029,8 +5020,6 @@ snapshots:
 
   '@types/lodash@4.17.25': {}
 
-  '@types/node@16.9.1': {}
-
   '@types/node@26.4.0':
     dependencies:
       undici-types: 8.3.0
@@ -5277,10 +5266,6 @@ snapshots:
       debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  image-q@4.0.0:
-    dependencies:
-      '@types/node': 16.9.1
 
   immer@10.2.0: {}
 

--- a/scripts/bench-sixel-encode.tsx
+++ b/scripts/bench-sixel-encode.tsx
@@ -1,0 +1,59 @@
+/**
+ * Sixel 编码耗时基准：量化 + sixelEncode，与 worker 内 SixelEncoderCache.render
+ * 走同一条 encodeSixel 路径。只打印数字，不做断言；用于改动前后对比。
+ *
+ * 三种图 × 三档尺寸：
+ *   flat  —— 纯色，调色板只有 1 色；
+ *   photo —— 高斯噪声 blur 8，色彩分布接近照片；
+ *   noise —— 高斯噪声，256 色都用满的最坏情况。
+ *   384×192 是 transcript 缩略图量级，1024×512 是 transcript 上限，
+ *   2048×1024 是 preview 上限（超过 4 MiB Sixel 输出预算时打印 over budget）。
+ *
+ * 先 pnpm compile；运行：node --import tsx/esm scripts/bench-sixel-encode.tsx
+ */
+import { loadSharp } from '../lib/types/dsh-adapter/sharp.js'
+import { encodeSixel } from '../lib/types/ink/sixel-codec.js'
+import type { TerminalImageSource } from '../lib/types/ink/terminal-image.js'
+
+const sharp = await loadSharp()
+if (!sharp) { console.log('SKIP bench-sixel-encode: optional sharp unavailable'); process.exit(0) }
+
+const shapes = {
+  flat: { background: { r: 0, g: 255, b: 0, alpha: 1 } },
+  photo: { noise: { type: 'gaussian', mean: 128, sigma: 40 }, blur: 8 },
+  noise: { noise: { type: 'gaussian', mean: 128, sigma: 40 } },
+} as const
+const sizes: ReadonlyArray<readonly [number, number]> = [[384, 192], [1024, 512], [2048, 1024]]
+const ROUNDS = 3
+
+async function makeSource(width: number, height: number, shape: keyof typeof shapes): Promise<TerminalImageSource> {
+  const { blur, ...create } = { blur: 0.3, ...shapes[shape] }
+  const data = await sharp({ create: { width, height, channels: 4, ...create } })
+    .blur(blur).ensureAlpha().raw().toBuffer()
+  return { data: new Uint8Array(data.buffer, data.byteOffset, data.byteLength), width, height }
+}
+
+async function median(run: () => Promise<unknown>): Promise<string> {
+  const samples: number[] = []
+  for (let round = 0; round < ROUNDS; round++) {
+    const start = performance.now()
+    try { await run() } catch (error) {
+      return (error as Error).message.includes('budget') ? 'over budget' : `error: ${(error as Error).message}`
+    }
+    samples.push(performance.now() - start)
+  }
+  samples.sort((a, b) => a - b)
+  return `${samples[Math.floor(ROUNDS / 2)]!.toFixed(0)} ms`
+}
+
+console.log('| 尺寸 | ' + Object.keys(shapes).join(' | ') + ' |')
+console.log('| --- | ' + Object.keys(shapes).map(() => '---').join(' | ') + ' |')
+for (const [width, height] of sizes) {
+  const cells: string[] = []
+  for (const shape of Object.keys(shapes) as Array<keyof typeof shapes>) {
+    const source = await makeSource(width, height, shape)
+    const presentation = width > 1024 || height > 1024 ? 'preview' : 'transcript'
+    cells.push(await median(() => encodeSixel({ source, width, height, background: '#ffffff', presentation })))
+  }
+  console.log(`| ${width}×${height} | ${cells.join(' | ')} |`)
+}

--- a/src/ink/sixel-codec.ts
+++ b/src/ink/sixel-codec.ts
@@ -1,4 +1,3 @@
-import { applyPaletteSync, buildPaletteSync, utils } from 'image-q'
 import { FINALIZER, fromRGBA8888, introducer, PALETTE_ANSI_256, sixelEncode } from 'sixel'
 import { loadSharp } from '../dsh-adapter/sharp.js'
 import { isTerminalImageSource, TERMINAL_IMAGE_MAX_EDGE, TERMINAL_IMAGE_MAX_BYTES,
@@ -70,39 +69,33 @@ async function prepareSixel(request: SixelEncodeRequest): Promise<PreparedSixel>
   const sharp = await loadSharp()
   if (sharp === undefined) throw new Error('Image decoder unavailable')
   const fill = resolveBackground(background)
+  // The manager already fits the source aspect for large previews, so 'fill'
+  // avoids a one-pixel letterbox stripe there.
   const highResolution = width > TERMINAL_IMAGE_MAX_EDGE || height > TERMINAL_IMAGE_MAX_EDGE
-  const pipeline = sharp(source.data, {
+  // Native libimagequant for every size. A JS Wu quantizer pays a fixed 33³
+  // histogram-moment cost (about 250 ms even for a 384 px thumbnail) and builds
+  // millions of point objects for large previews; libvips does the same work
+  // in 11–133 ms. The indexed PNG round trip is how sharp exposes its palette.
+  // effort 1 keeps every colour within one level of the source, while effort
+  // 10 costs seconds on noisy images.
+  const indexed = await sharp(source.data, {
     raw: { width: source.width, height: source.height, channels: 4 },
   })
     .flatten({ background: fill })
     .resize({ width, height, fit: highResolution ? 'fill' : 'contain', background: fill })
     .toColourspace('srgb')
     .ensureAlpha()
-  if (highResolution) {
-    // The manager already fits the source aspect. Native palette conversion
-    // avoids allocating millions of JS Point objects for large previews.
-    const indexed = await pipeline.png({ palette: true, colours: 256, dither: 0, effort: 1, compressionLevel: 1 }).toBuffer()
-    const data = await sharp(indexed).ensureAlpha().raw().toBuffer()
-    if (data.byteLength !== width * height * 4) throw new Error('Invalid quantized raster size')
-    const palette = new Set<number>()
-    for (let index = 0; index < data.length; index += 4) {
-      palette.add((data[index]! << 16) | (data[index + 1]! << 8) | data[index + 2]!)
-    }
-    if (palette.size > 256) throw new Error('Native palette budget exceeded')
-    const colors = [...palette].map(color => [color >>> 16, (color >>> 8) & 255, color & 255] as [number, number, number])
-    return { width, height, data, colors }
+    .png({ palette: true, colours: 256, dither: 0, effort: 1, compressionLevel: 1 })
+    .toBuffer()
+  const data = await sharp(indexed).ensureAlpha().raw().toBuffer()
+  if (data.byteLength !== width * height * 4) throw new Error('Invalid quantized raster size')
+  const palette = new Set<number>()
+  for (let index = 0; index < data.length; index += 4) {
+    palette.add((data[index]! << 16) | (data[index + 1]! << 8) | data[index + 2]!)
   }
-  const rgba = await pipeline.raw().toBuffer()
-  const points = utils.PointContainer.fromUint8Array(rgba, width, height)
-  const palette = buildPaletteSync([points], {
-    paletteQuantization: 'wuquant', colors: 256,
-    colorDistanceFormula: 'euclidean-bt709-noalpha',
-  })
-  const quantized = applyPaletteSync(points, palette, {
-    imageQuantization: 'nearest', colorDistanceFormula: 'euclidean-bt709-noalpha',
-  })
-  const colors = palette.getPointContainer().getPointArray().map(p => [p.r, p.g, p.b] as [number, number, number])
-  return { width, height, data: quantized.toUint8Array(), colors }
+  if (palette.size > 256) throw new Error('Native palette budget exceeded')
+  const colors = [...palette].map(color => [color >>> 16, (color >>> 8) & 255, color & 255] as [number, number, number])
+  return { width, height, data, colors }
 }
 
 function encodeRegion(image: PreparedSixel, crop?: SixelCrop): SixelRaster {


### PR DESCRIPTION
## 变更摘要 / Summary

Stacked 在 #807 上。transcript 缩略图（≤1024 px）的 256 色量化从 `image-q` 的 Wu 量化器改为 sharp 原生 libimagequant，与 >1024 预览已在用的路径合一；移除 `image-q`（它只在 sharp 已加载时才被调用，无 sharp 时本就解不出图，回退行为不变，node_modules 少 1.2 MB）。新增 `scripts/bench-sixel-encode.tsx` 出下表数字；contributing 对照表补 Sixel 一行。

### 耗时（`encodeSixel` 中位数，M5 Pro）

| 尺寸 | flat | photo | noise |
| --- | --- | --- | --- |
| 384×192 缩略图 | 197 → **3 ms** | 194 → **11 ms** | 374 → **34 ms** |
| 1024×512 transcript 上限 | 293 → **12 ms** | 347 → **51 ms** | 1479 → **174 ms** |
| 2048×1024 preview | 不变 | 不变 | 不变 |

Wu 量化器的 33³ 直方图矩是固定开销，所以缩略图再小也要 250 ms；worker 串行，一屏 10 张约 2.5 s。`verify-sixel-transcript` 本地 24 s → 3.2 s（macOS 主线程空闲时 worker 被降频，CPU 开销放大成秒级等待，Mac 上的 Sixel 终端收益更大）。

### 画质

<img width="2716" height="658" alt="上排：原图 / image-q / sharp；下排：与原图差异放大 16 倍" src="https://github.com/user-attachments/assets/5b997d88-6cd4-400e-b844-bd6586dc8ee0" />

上排肉眼无差，下排是差异 ×16。256 色量化误差两者都有：平均误差 sharp 更低（插画 0.54 vs 0.72，照片 1.54 vs 1.75），单像素最大略高（24 vs 14）且集中在边缘。`effort: 1`，因为 effort 10 在噪点图 2048×1024 要 5.8 s。抖动保持关闭：Sixel 靠行程压缩，开抖动输出 +30%，更容易撞 4 MiB 预算。

### 请 @ccch1mneyyy 在 Windows Terminal 上过一遍

- [ ] 多张图的会话里缩略图是否明显更快出现
- [ ] 点开预览、滚动、关闭后无残影或色块差异
- [ ] `node --import tsx/esm scripts/bench-sixel-encode.tsx` 在 Windows 上的数字

## 关联 / Related

Closes #806。发现于 #805 的排查。大图超 4 MiB 预算后 worker 静默放弃的问题不在本 PR 范围。

## 变更类型 / Type

- [x] refactor / perf — 不改变外部行为

## 验证 / Verification

- [x] `pnpm compile` + `pnpm verify:build` 全部通过（`verify:inject-channel` 本机需 `TMPDIR=/tmp`：macOS unix socket 路径 106 字符超上限，与本 PR 无关）
- [x] `node scripts/run-ci-group.mjs render-scroll` 全部通过（askpanel 两条需 CI 同款 `DSH_TUI_LANG=zh`）
- [x] `pnpm verify:package`：package surface OK
- [ ] Sixel 真机：见上方 checklist

## 自查 / Checklist

- [x] 只改了 `src/`，没有提交 `lib/`
- [x] 只暂存了显式路径
