### PR TITLE
fix(adapter): 只读投影保持值语义，修复图片无法预览

### DIFF
--- a/scripts/verify-channel-ui.ts
+++ b/scripts/verify-channel-ui.ts
@@ -9,6 +9,7 @@ import { bindChannelCommands } from '../src/dsh-adapter/channel/commands.js'
 import { mountChannelUi } from '../src/dsh-adapter/channel-ui.js'
 import { registerTuiChannel } from '../src/adapter/channel/host-registry.js'
 import { CHANNEL_UI_EFFECTS } from '../src/adapter/channel/ui-policy.js'
+import { createChannelReadView } from '../src/adapter/channel/read-view.js'
 import { channelDriver } from '../src/adapter/upstream/channel-driver.js'
 import type { HostChannelPort } from '../src/adapter/ports/channel.js'
 import { TuiPluginHostRuntime, getHostFacade } from '../src/dsh-adapter/plugin-host.js'
@@ -684,6 +685,69 @@ for (const method of ['writeProfile', 'mutateProfile', 'removeProfile'] as const
   assert.ok(historicalReads <= 3, `tail stream read ${historicalReads} fold-boundary fields, not the full history`)
   assert.throws(() => { (initial[0] as { text: string }).text = 'mutate old snapshot' }, TypeError)
   assert.equal(initial[0]?.text, 'history 0', 'old detached snapshot remains immutable after later versions')
+  mount.dispose(); unregister(); raw.releaseContributions()
+}
+
+// The detached projection owns structural containers only. Every other leaf
+// keeps its own semantics: a key-by-key copy of a Uint8Array loses its type
+// (sharp then rejects it — "Input file is missing" — and every transcript
+// thumbnail renders 无法预览), and Date/Error/class instances would hollow out
+// to empty objects the same way.
+{
+  const read = createChannelReadView(() => {})
+  class Handle {
+    constructor(readonly tag: string) {}
+    greet(): string { return `hi ${this.tag}` }
+  }
+  const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+  const date = new Date(1_700_000_000_000)
+  const source = {
+    bytes,
+    view: new DataView(new ArrayBuffer(4)),
+    date,
+    pattern: /ab+c/giu,
+    error: new Error('boom'),
+    handle: new Handle('x'),
+    map: new Map<string, number>([['k', 1]]),
+    set: new Set<number>([1, 2]),
+    plain: { a: 1 },
+    list: [1, 2],
+  }
+  const projected = read(source, 1)
+  assert.ok(projected.bytes instanceof Uint8Array, 'binary keeps its type through the projection')
+  assert.equal(projected.bytes.byteLength, bytes.byteLength, 'binary byteLength survives the projection')
+  assert.equal(projected.bytes[0], 137, 'binary bytes survive the projection')
+  assert.ok(projected.view instanceof DataView, 'DataView keeps its type')
+  assert.ok(projected.date instanceof Date && projected.date.getTime() === date.getTime(), 'Date keeps its type and time')
+  assert.ok(projected.pattern instanceof RegExp && projected.pattern.source === 'ab+c' && projected.pattern.flags === 'giu', 'RegExp keeps source and flags')
+  assert.ok(projected.error instanceof Error && projected.error.message === 'boom', 'Error keeps its message')
+  assert.ok(projected.handle instanceof Handle && projected.handle.greet() === 'hi x', 'class instance keeps its prototype methods')
+  assert.equal(projected.map.get('k'), 1, 'Map stays readable')
+  assert.equal(projected.set.has(2), true, 'Set stays readable')
+  assert.equal(projected.plain.a, 1, 'plain records still project')
+  assert.notEqual(projected.plain, source.plain, 'plain records stay detached')
+  assert.equal(projected.list[1], 2, 'arrays still project')
+  assert.notEqual(projected.list, source.list, 'arrays stay detached')
+}
+
+// The same preservation holds on the production mount path: rows keep working
+// image facades so thumbnails can decode.
+{
+  const { ctx, raw } = fixture()
+  const unregister = registerTuiChannel(ctx, raw)
+  const mount = mountChannelUi(ctx, raw, undefined, 'new')
+  const bytes = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10])
+  raw.rows.push({
+    id: 1, kind: 'user', text: '[Image #1]',
+    images: [{ id: 'img-1', width: 8, height: 8, name: 'paste-6.png', read: async () => bytes }],
+  })
+  raw.emit()
+  const image = mount.channel.rows[0]?.images?.[0]
+  assert.ok(image !== undefined, 'projected user row keeps its image facade')
+  const data = await image.read()
+  assert.ok(data instanceof Uint8Array, 'read() keeps the binary type through the detached projection')
+  assert.equal(data.byteLength, bytes.byteLength, 'read() byteLength survives the projection')
+  assert.equal(data[0], 137, 'read() bytes survive the projection')
   mount.dispose(); unregister(); raw.releaseContributions()
 }
 

--- a/src/adapter/channel/read-view.ts
+++ b/src/adapter/channel/read-view.ts
@@ -44,6 +44,19 @@ export function createChannelReadView(check: (mutation: boolean) => void) {
       return result
     }
     if (value === null || typeof value !== 'object') return value
+    // Structural containers are detached below. Every other object is a leaf
+    // with its own identity and semantics — binary buffers, Date, Error, class
+    // instances, promises — and copying one key by key silently hollows it
+    // out: a projected transcript image reached sharp as a plain object and
+    // decoded as "Input file is missing" (rendered 无法预览). Date and RegExp
+    // get a faithful detached copy; everything else is shared as-is, because
+    // no copy preserves an opaque value and a hollow one is strictly worse.
+    if (!Array.isArray(value) && !(value instanceof Map) && !(value instanceof Set)) {
+      if (value instanceof Date) return new Date(value.getTime()) as T
+      if (value instanceof RegExp) return new RegExp(value.source, value.flags) as T
+      const proto = Object.getPrototypeOf(value)
+      if (proto !== Object.prototype && proto !== null) return value
+    }
     // An inner ChannelUi projection is safe immutable data, but an outer
     // production mount must still capture its own lifetime around nested
     // callbacks. Reuse purely structural data; walk callable graphs again.


### PR DESCRIPTION
## 变更摘要 / Summary

修复 #776 引入的只读投影值语义回归：`createChannelReadView` 的 `copy()` 把非结构化叶子逐键拷成普通对象，`TranscriptImage.read()` 返回的 `Uint8Array` 因此变成 `{0:137, 1:80, …}`（`byteLength` 与原型丢失），sharp 报 `Input file is missing:`，图片缩略图 / 全屏预览 / 原图导出 / `/image` 检查全部显示「无法预览」。

用户可见差异：在本分支上图片重新正常渲染；其余行为不变。

修复方式——投影只脱离**结构化容器**（Array / 普通对象 / Map / Set）：`Date`、`RegExp` 忠实克隆；二进制、`Error`、类实例、`Promise` 原样透传（逐键拷贝无法保语义，掏空比共享更糟）。

## 关联 / Related

Fixes #820

base 指向 `refactor/adapter-channel-l4-l5`（#776 的分支）：`src/adapter/channel/read-view.ts` 与 `scripts/verify-channel-ui.ts` 只在该分支存在，`main` 与 `dev-adapter-v2` 都没有，修复无法独立落在 main 上。已在 #776 留了根因说明（[评论](https://github.com/ccch1mneyyy/dsh-TUI/pull/776#issuecomment-5590281487)）。

## 变更类型 / Type

- [x] fix — 修复缺陷

## 验证 / Verification

- [ ] `pnpm build`（compile + 全部构建门禁）——本地未跑全量；已跑 `npm run compile` + 相关门禁与两个测试组，其余交给 CI
- [x] 按改动面选的聚焦回归脚本
- [ ] 终端可见改动手动演练：本 PR 不新增 UI，图片可见性由用户实机验证（见下）

```text
npm run compile                                              → exit 0
node --import tsx/esm scripts/verify-channel-ui.ts           → verify:channel-ui OK
node scripts/run-ci-group.mjs channel-ui                     → 全部 62 项通过
node scripts/run-ci-group.mjs render-scroll                  → 全部 39 项通过
npm run verify:transcript-images                             → passed
npm run verify:image-preview                                 → all checks passed
node --import tsx/esm scripts/verify-image-inspection.tsx    → exit 0
npm run verify:boundary                                      → adapter boundary OK (540 source files)
npm run verify:adapter-ports                                 → OK (17 port files + 23 kernel files)
git diff --check                                             → clean
```

红/绿：禁用修复后新增断言红（`read() must keep the binary type through the detached projection`），恢复后绿。

端到端：真实 PNG → 投影后的 facade → `makeDecodeTier` → sharp → RGBA（16×16 / 1024 B）。

实机：用户在 Windows 终端重启后粘贴图片，缩略图正常渲染（修复前恒为「无法预览」）。

## 自查 / Checklist

- [x] 只改了 `src/` 与 `scripts/`，没有手改或提交 `lib/` 下的生成产物
- [x] 官方 `@deepseek-ai/*` 的 import 未新增到 `src/dsh-adapter/` 之外（本 PR 未新增 import）
- [x] 无行为 / 配置 / 快捷键变更，不涉及 `README.md` 双语同步
- [x] 未改 `cordis.patch.yml`
- [x] 只暂存了显式路径（`git add <path> <path>`），未用 `git add .` / `-A`
