### PR TITLE
fix(adapter): 插件存储内部入口真私有化 + 补齐 #705 审查缺失的回归

### DIFF
--- a/scripts/verify-adapter-channel-conformance.ts
+++ b/scripts/verify-adapter-channel-conformance.ts
@@ -160,6 +160,38 @@ await subscriptionConsumer.subscribe(official.snapshot.channelId, 1, value => re
 assert.deepEqual(received, [1, 2], 'subscription must deliver snapshots not earlier than afterVersion')
 checks += 1
 
+// open() → subscribe(opened.version): the provider sends `>= afterVersion`, so
+// the equal-version echo is the FIRST snapshot of that subscription and must be
+// accepted; a later duplicate version inside the same subscription still fails
+// closed (review finding: provider/consumer equal-version semantics).
+{
+  const equalConsumer = createChannelConsumer(realMethodsProvider)
+  const equalOpened = await equalConsumer.open({})
+  const echoed: number[] = []
+  await equalConsumer.subscribe(equalOpened.channelId, equalOpened.version, value => echoed.push(value.version))
+  assert.deepEqual(echoed, [equalOpened.version], 'first equal-version replay after open must be accepted')
+  checks += 1
+
+  const duplicateProvider = {
+    async open() { return snapshot1 },
+    async subscribe(_channelId: string, _afterVersion: number, listener: (snapshot: typeof snapshot1) => void) {
+      listener(snapshot1)
+      listener(snapshot1)
+      return () => undefined
+    },
+    async invoke() { throw new Error('unused') },
+    async close() { return { closed: true as const } },
+  }
+  const duplicateConsumer = createChannelConsumer(duplicateProvider)
+  await duplicateConsumer.open({})
+  await assert.rejects(
+    duplicateConsumer.subscribe(snapshot1.channelId, snapshot1.version, () => {}),
+    /version did not advance/u,
+    'a repeated version inside one subscription must still fail closed',
+  )
+  checks += 1
+}
+
 const zeroSnapshots = [
   Object.freeze({ ...snapshot1, version: 0, state: Object.freeze({ ...snapshot1.state, status: 'idle' }) }),
   Object.freeze({ ...snapshot1, version: 1, state: Object.freeze({ ...snapshot1.state, status: 'working' }) }),

--- a/scripts/verify-adapter-kernel-runtime.ts
+++ b/scripts/verify-adapter-kernel-runtime.ts
@@ -217,6 +217,25 @@ assert.notEqual(failed.currentLifecycles().find(lifecycle => lifecycle.capabilit
   assert.equal(mountCalls, 1, 'non-shadow mode may mount an effectful driver')
 }
 
+// The default production slice set (no explicit `slices` filter) must still
+// mount under passive shadow: disallowed drivers are skipped and the read-only
+// ones mount, instead of aborting the whole mount transaction (review finding:
+// the first mutate slice used to abort every later read-only slice).
+{
+  const kernel = new KernelRuntime({
+    context: {},
+    mode: 'passive-shadow',
+    generationId: 'kernel-default-slices-passive-battery',
+    kernelSlices: ADAPTER_KERNEL_SLICES,
+  })
+  await kernel.mount()
+  const drivers = kernel.diagnosticSnapshot().drivers
+  const driver = (id: string) => drivers.find(entry => entry.id === id)
+  assert.equal(driver('dsh-tui-presentation')?.mounted, false, 'mutate slice must be skipped under passive shadow')
+  assert.equal(driver('dsh-tui-channel')?.mounted, true, 'read-only slice must still mount under passive shadow')
+  checks += 1
+}
+
 // Mount is transactional: a later driver failure must roll back every
 // driver successfully mounted by the same call, in reverse order.
 {

--- a/scripts/verify-adapter-shadow.ts
+++ b/scripts/verify-adapter-shadow.ts
@@ -755,6 +755,7 @@ try {
   } = await import('../src/dsh-adapter/command-trees.js')
   const {
     TuiWorkspaceRuntime,
+    getHostWorkspaceRuntime,
   } = await import('../src/dsh-adapter/workspaces.js')
   const {
     TuiDialogRuntime,
@@ -787,6 +788,23 @@ try {
   assert.throws(() => p3Toast.show('x'), /shadow policy denies/)
   assert.throws(() => p3CommandTrees.register({ root: 'x', children: () => [] } as never), /shadow policy denies/)
   await assert.rejects(p3Workspaces.rename('x', 'y'), /shadow policy denies/)
+  // The Channel mutates workspaces through the host facade, not through the
+  // guarded public service surface, so the facade must enforce the same
+  // policy (review finding: workspace host facade bypassed shadow policy).
+  const workspaceHost = getHostWorkspaceRuntime(p3Workspaces)
+  assert.ok(workspaceHost !== undefined, 'passive root must expose the workspace host facade')
+  const denied = async (label: string, run: () => unknown): Promise<void> => {
+    let message = ''
+    try {
+      await run()
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    assert.match(message, /shadow policy denies/, `${label} must be denied by shadow policy`)
+  }
+  await denied('facade commandShell', () => workspaceHost!.commandShell(process.cwd()))
+  await denied('facade rename', () => workspaceHost!.rename(process.cwd(), 'x'))
+  await denied('facade runCommand', () => workspaceHost!.runCommand('x', '', process.cwd()))
   assert.throws(() => p3Dialogs.select({ title: 'x', options: [] } as never), /shadow policy denies/)
   assert.throws(() => p3Questions.ask({ questions: [] } as never), /shadow policy denies/)
   assert.throws(() => p3Approvals.park({ toolName: 'x' } as never), /shadow policy denies/)
@@ -897,6 +915,7 @@ try {
   } = await import('../src/dsh-adapter/command-trees.js')
   const {
     TuiWorkspaceRuntime,
+    getHostWorkspaceRuntime,
   } = await import('../src/dsh-adapter/workspaces.js')
   const {
     TuiDialogRuntime,
@@ -929,6 +948,23 @@ try {
   assert.throws(() => p3Toast.show('x'), /shadow policy denies/)
   assert.throws(() => p3CommandTrees.register({ root: 'x', children: () => [] } as never), /shadow policy denies/)
   await assert.rejects(p3Workspaces.rename('x', 'y'), /shadow policy denies/)
+  // The Channel mutates workspaces through the host facade, not through the
+  // guarded public service surface, so the facade must enforce the same
+  // policy (review finding: workspace host facade bypassed shadow policy).
+  const workspaceHost = getHostWorkspaceRuntime(p3Workspaces)
+  assert.ok(workspaceHost !== undefined, 'passive root must expose the workspace host facade')
+  const denied = async (label: string, run: () => unknown): Promise<void> => {
+    let message = ''
+    try {
+      await run()
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    assert.match(message, /shadow policy denies/, `${label} must be denied by shadow policy`)
+  }
+  await denied('facade commandShell', () => workspaceHost!.commandShell(process.cwd()))
+  await denied('facade rename', () => workspaceHost!.rename(process.cwd(), 'x'))
+  await denied('facade runCommand', () => workspaceHost!.runCommand('x', '', process.cwd()))
   assert.throws(() => p3Dialogs.select({ title: 'x', options: [] } as never), /shadow policy denies/)
   assert.throws(() => p3Questions.ask({ questions: [] } as never), /shadow policy denies/)
   assert.throws(() => p3Approvals.park({ toolName: 'x' } as never), /shadow policy denies/)

--- a/scripts/verify-plugin-storage.ts
+++ b/scripts/verify-plugin-storage.ts
@@ -133,6 +133,15 @@ while (!hostCtx.get('tuiPluginHost')?.hostDescriptor().contracts.some(contract =
 }
 check1('storage live probe is not exposed on the plugin-visible service',
   typeof (hostCtx.get('tuiPluginStorage') as { probeReversible?: unknown } | undefined)?.probeReversible === 'undefined')
+// The internal open path keeps the grant/ledger/lifecycle switches; a TS
+// `private` would still be a prototype method a plugin could reach through a
+// cast. It must be a true `#private`, i.e. absent from the service AND its
+// prototype (review finding: storage authorization bypass).
+const pluginStorageService = hostCtx.get('tuiPluginStorage') as { openInternal?: unknown } | undefined
+check1('internal storage open is unreachable on the plugin-visible service',
+  typeof pluginStorageService?.openInternal === 'undefined')
+check1('internal storage open is absent from the service prototype',
+  !Object.getOwnPropertyNames(Object.getPrototypeOf(pluginStorageService as object) ?? {}).includes('openInternal'))
 
 const handles = new Map<string, TuiPluginStorage>()
 const activations = new Map<string, { context: InstanceType<typeof Context>; fiber: { dispose(): unknown } }>()

--- a/src/dsh-adapter/plugin-storage.ts
+++ b/src/dsh-adapter/plugin-storage.ts
@@ -310,7 +310,7 @@ hostContext: compositionRoot(ctx),
    * Host-internal reversible live probe.
    *
    * This runs through the same production storage handle path as plugin
-   * storage (`openInternal`), using a random temporary namespace. It writes a
+   * storage (`#openInternal`), using a random temporary namespace. It writes a
    * tiny JSON document, reads it back, deletes it, and guarantees the file is
    * removed in a `finally`. The probe deliberately bypasses only the
    * caller-facing grant/lifecycle bookkeeping; key validation, exact-JSON
@@ -343,7 +343,7 @@ hostContext: compositionRoot(ctx),
       manifest: { id: tempNamespace } as never,
       projection: { id: tempNamespace } as never,
     }
-    const handle = this.openInternal(state.hostContext, identity, tempNamespace, {
+    const handle = concreteService(this).#openInternal(state.hostContext, identity, tempNamespace, {
       enforceGrants: false,
       bindLifecycle: false,
       recordLedger: false,
@@ -407,7 +407,10 @@ hostContext: compositionRoot(ctx),
         'storage.local requires the storage.dsh/v1alpha1#LocalStorage contract in the admitted manifest',
       )
     }
-    return this.openInternal(caller, identity, identity.componentId, {
+    // Cordis hands the service out through a Proxy, so `this` is not branded:
+    // unwrap to the concrete instance before calling the `#private` member
+    // (same pattern as message-observer's `#registerSubscription`).
+    return concreteService(this).#openInternal(caller, identity, identity.componentId, {
       enforceGrants: true,
       bindLifecycle: true,
       recordLedger: true,
@@ -421,8 +424,14 @@ hostContext: compositionRoot(ctx),
    * authorization/lifecycle bookkeeping; all key validation, exact-JSON
    * validation, namespace file handling, quota checks and read/write/delete
    * operations are exactly the production handle code.
+   *
+   * A true `#private` member, not TS `private`: the latter still compiles to a
+   * prototype method, so a plugin holding `ctx.tuiPluginStorage` could call it
+   * through `as any` with `enforceGrants: false` and a forged namespace and
+   * read another component's storage with no grant, ledger entry or unload
+   * cleanup. Only the two in-class call sites above may reach it.
    */
-  private openInternal(
+  #openInternal(
     caller: Context,
     identity: VerifiedComponentIdentity,
     plugin: string,


### PR DESCRIPTION
## 变更摘要 / Summary

跟进 #705 review（CikeSeven，CHANGES_REQUESTED）的残留项与缺失回归。

**1. 修复：插件存储内部入口仍可被绕过（与 finding 3 同类）**

`src/dsh-adapter/plugin-storage.ts` 的 `private openInternal` 在运行时仍是原型方法：持有 `ctx.tuiPluginStorage` 的插件可 `as any` 调用它并传 `enforceGrants:false` + 伪造 `plugin` 命名空间，从而**无授权读写他人组件存储、无账本记录、不随卸载清理**（唯一授权检查 `:508-509` 被该开关短路，manifest 契约检查只在公开 `open()` 里）。改为真 `#openInternal`，并经 `concreteService(this)` 调用——Cordis 把服务经 Proxy 交出，`this` 不带私有 brand，与 `message-observer` 的 `#registerSubscription` 同法。

**2. 补齐审查明确要求但缺失的回归**

- `verify-adapter-kernel-runtime.ts`：**默认 slice 集**（不传 `slices`）在 passive shadow 下不再整体中止——mutate driver 跳过、只读 slice 照常挂载（`dsh-tui-presentation` mounted=false / `dsh-tui-channel` mounted=true）；
- `verify-adapter-shadow.ts`：**host workspace facade**（Channel 的真实调用路径，非公开服务面）同样被 shadow policy 拒绝——`commandShell` / `rename` / `runCommand`，passive 与 replay 两套电池都覆盖；
- `verify-adapter-channel-conformance.ts`：`open → subscribe(opened.version)` 的**等版本首次重放**被接受，同一订阅内后续重复版本仍按连续性违规 fail closed；
- `verify-plugin-storage.ts`：内部 open 入口在服务对象与其原型上均不可见。

用户可见差异：无（尚未合并分支上的内部能力收口 + 回归覆盖）。

## 关联 / Related

base = `refactor/adapter-channel-l4-l5`（#776，内含 #705）。#705 的 review 中 finding 3 已在 message-observer 修复，但同一模式在 plugin-storage 未覆盖；本 PR 收口并补 4 项回归。无对应 issue，按仓库约定加 `no-issue-needed`。

## 变更类型 / Type

- [x] fix — 修复缺陷

## 验证 / Verification

- [ ] `pnpm build`（compile + 全部构建门禁）——本地未跑全量，交给 CI
- [x] 按改动面选的聚焦回归脚本
- [ ] 终端可见改动：无

```text
npm run typecheck                                            → exit 0
node --import tsx/esm scripts/verify-plugin-storage.ts       → plugin-storage battery OK (86 checks)
node --import tsx/esm scripts/verify-adapter-kernel-runtime.ts → OK (24 runtime checks + AST)
node --import tsx/esm scripts/verify-adapter-channel-conformance.ts → OK (33 checks)
node --import tsx/esm scripts/verify-adapter-shadow.ts       → OK (5 runtime + 112 AST + 4 handle + 79 effect + ...)
node --import tsx/esm scripts/verify-adapter-live-probes.ts  → OK (77 runtime checks)
node --import tsx/esm scripts/verify-plugin-lifecycle.ts     → plugin lifecycle battery OK (46 checks)
```

红/绿：`#openInternal` 前 `plugin-storage` 的 86 项里新增两条断言即红（服务对象上存在 `openInternal`）；改为 `#private` 后绿。kernel-runtime 的新断言在旧行为（首个 mutate slice 中止）下也拿不到 `mounted=true` 的 channel。

## 自查 / Checklist

- [x] 只改了 `src/` 与 `scripts/`，没有手改或提交 `lib/` 下的生成产物
- [x] 官方 `@deepseek-ai/*` 的 import 未新增到 `src/dsh-adapter/` 之外
- [x] 无行为 / 配置 / 快捷键变更，不涉及 `README.md` 双语同步
- [x] 未改 `cordis.patch.yml`
- [x] 只暂存了显式路径
