### PR TITLE
fix(adapter): 会话切换清理决策提示与输入 FIFO，恢复活动预设归一化

### DIFF
--- a/scripts/verify-extension-events.tsx
+++ b/scripts/verify-extension-events.tsx
@@ -62,7 +62,7 @@ process.env.DSH_TUI_LANG = 'zh'
 // 家目录隔离：touchSession/clearResumeTarget（/new 与 rewind 都会走）写
 // ~/.dsh-tui 的真实文件，必须先切到临时目录再 import src。HOME 与
 // USERPROFILE 必须成对设置（POSIX 读 HOME、Windows 读 USERPROFILE）。
-const { mkdtempSync, mkdirSync, writeFileSync } = await import('node:fs')
+const { mkdtempSync, mkdirSync, readFileSync, writeFileSync } = await import('node:fs')
 const { tmpdir } = await import('node:os')
 const { join: joinPath } = await import('node:path')
 const isolatedHome = mkdtempSync(joinPath(tmpdir(), 'dshtui-ext-events-home-'))
@@ -846,15 +846,86 @@ await sleep(800)
   check('pending session ownership: synchronous subscriber cannot send the old image to the replacement',
     probeDelivered && probeContent?.every(block => block.type !== 'image') === true,
     JSON.stringify(probeContent))
-  check('pending session ownership: session swap dismissed the old sticky indicator',
-    await settled(() => !(channel as unknown as { notifications: readonly { text: string }[] }).notifications
-      .some(item => item.text.includes('正在等待插件决定（tui/input）'))))
+  const decisionNoticeVisible = (): boolean =>
+    (channel as unknown as { notifications: readonly { text: string }[] }).notifications
+      .some(item => item.text.includes('正在等待插件决定（tui/input）'))
+  // The switch drains the session-scoped decision ledger; waiting for the
+  // decision's own deadline would make this pass without any dismissal.
+  const noticeGonePromptly = await (async () => {
+    const deadline = Date.now() + 800
+    while (Date.now() < deadline) {
+      if (!decisionNoticeVisible()) return true
+      await sleep(20)
+    }
+    return false
+  })()
+  check('pending session ownership: session swap dismissed the old sticky indicator before its deadline',
+    noticeGonePromptly, JSON.stringify({ stillVisible: decisionNoticeVisible() }))
   release({ handled: true, notice: '旧会话插件结果不应出现' })
   await sleep(150) // 固定窗:探针 陈旧 handled 结果不得吐进新会话，给它一个现身窗
   check('pending session ownership: stale handled result did not toast into the new session',
     !notified('旧会话插件结果不应出现'))
   unsubscribe()
   dispose()
+}
+
+// ── 9bb2. A notice must never be raised for a session that has already been
+// replaced: park a decision, switch sessions before the 400 ms threshold, then
+// assert no indicator appears afterwards (the switch cancels the replaced
+// session's timer instead of letting it flash into the new session). ──────
+{
+  let releaseLate: (value: { handled: true; notice: string }) => void = () => {}
+  const lateGate = new Promise<{ handled: true; notice: string }>(resolve => { releaseLate = resolve })
+  const disposeLate = decisionCtx.on('tui/input', event => {
+    if (event.text !== '切换前挂起') return undefined
+    return lateGate
+  })
+  channel.submit('切换前挂起')
+  await sleep(50) // well under DECISION_PENDING_MS (400 ms)
+  await channel.newSession()
+  await sleep(600) // past the threshold, inside the replacement session
+  const lateVisible = (channel as unknown as { notifications: readonly { text: string }[] }).notifications
+    .some(item => item.text.includes('正在等待插件决定（tui/input）'))
+  check('pending session ownership: replaced session never raises a late indicator', !lateVisible)
+  releaseLate({ handled: true, notice: '迟到的结果不应出现' })
+  await sleep(100)
+  disposeLate()
+}
+
+// ── 9bb3. A retired activity preset id normalizes in the channel state too
+// (main's normalizeActivityPreset parity): the in-memory value must agree with
+// the persisted preference instead of diverging until restart. ────────────
+{
+  const state = channel as unknown as { activityFrames?: string; setActivityFrames(name: string): boolean }
+  const before = state.activityFrames
+  const applied = state.setActivityFrames('claude')
+  check('activity preset: retired id normalizes to the current default',
+    applied === true && state.activityFrames === 'moon8',
+    JSON.stringify({ before, applied, after: state.activityFrames }))
+  state.setActivityFrames(before ?? 'moon8')
+}
+
+// ── 9bb4. Every adoption tail must reset the input FIFO BEFORE its first emit
+// (main's bind → clear → refresh order): a subscriber that submits during the
+// session-changed emit must not chain onto the replaced session's parked
+// promise. Ordering is asserted on the source, because the emit/submit timing
+// inside the real channel makes a runtime probe non-discriminating. ────────
+{
+  const tails: readonly (readonly [string, string])[] = [
+    ['session-resume.ts', 'resetAndBind('],
+    ['session-adoption.ts', 'deps.bindAgent()'],
+    ['session-live-adoption.ts', 'deps.bindAgent()'],
+    ['model-switch.ts', 'deps.bindAgent()'],
+    ['background-action.ts', 'deps.bindAgent()'],
+  ]
+  const misplaced = tails.filter(([file, marker]) => {
+    const source = readFileSync(joinPath(import.meta.dirname, '..', 'src', 'dsh-adapter', 'channel', file), 'utf8')
+    const clear = source.indexOf('deps.clearStagedImages()')
+    const first = source.indexOf(marker)
+    return clear === -1 || first === -1 || clear > first
+  })
+  check('pending session ownership: every adoption tail resets the FIFO before its first emit',
+    misplaced.length === 0, JSON.stringify(misplaced))
 }
 
 // ── 9c. rewind-prompt stale-drop: a parked rewind decision cancels when the

--- a/scripts/verify-extension-events.tsx
+++ b/scripts/verify-extension-events.tsx
@@ -855,7 +855,7 @@ await sleep(800)
     const deadline = Date.now() + 800
     while (Date.now() < deadline) {
       if (!decisionNoticeVisible()) return true
-      await sleep(20)
+      await sleep(20) // 固定窗:pacing 轮询间隔
     }
     return false
   })()
@@ -881,14 +881,14 @@ await sleep(800)
     return lateGate
   })
   channel.submit('切换前挂起')
-  await sleep(50) // well under DECISION_PENDING_MS (400 ms)
+  await sleep(50) // 固定窗:pacing 让 400ms 阈值计时器仍处于等待中
   await channel.newSession()
-  await sleep(600) // past the threshold, inside the replacement session
+  await sleep(600) // 固定窗:探针 越过 400ms 阈值，断言替换会话不冒出提示
   const lateVisible = (channel as unknown as { notifications: readonly { text: string }[] }).notifications
     .some(item => item.text.includes('正在等待插件决定（tui/input）'))
   check('pending session ownership: replaced session never raises a late indicator', !lateVisible)
   releaseLate({ handled: true, notice: '迟到的结果不应出现' })
-  await sleep(100)
+  await sleep(100) // 固定窗:pacing 给陈旧结果一个现身窗再清理监听
   disposeLate()
 }
 

--- a/src/dsh-adapter/channel/background-action.ts
+++ b/src/dsh-adapter/channel/background-action.ts
@@ -94,6 +94,9 @@ export function createBackgroundCurrentAction(
         state.effortLevels = undefined
         state.reasoningEffort = undefined
         deps.refreshEffortLevels()
+        // Reset the input FIFO and pending-decision indicators BEFORE the first
+        // emit (main's bind → clear → refresh order).
+        deps.clearStagedImages()
         deps.bindAgent()
         deps.refreshCommands()
         void deps.refreshLoadedContext()
@@ -102,7 +105,6 @@ export function createBackgroundCurrentAction(
         touchSession(handle.agent.id)
         touchAgentViewSession(previousSessionId)
         touchAgentViewSession(String(handle.agent.id))
-        deps.clearStagedImages()
         deps.notifySessionSwitched('background', String(handle.agent.id), previousSessionId)
         deps.notifyAgentView()
         return { ok: true, backgroundedSessionId: previousSessionId }

--- a/src/dsh-adapter/channel/input-delivery.ts
+++ b/src/dsh-adapter/channel/input-delivery.ts
@@ -139,9 +139,27 @@ export function createInputDelivery(
    * ate the input.
    */
   const DECISION_PENDING_MS = 400
-  const withDecisionPending = <T>(name: string, pending: Promise<T>): Promise<T> => {
+  /**
+   * Session-scoped ledger of live pending-decision indicators. A session
+   * replacement must cancel the notice timer and dismiss an already-visible
+   * sticky notice even when the plugin's decision promise never settles; the
+   * owner-scoped release alone would keep it up until channel teardown, and a
+   * timer firing after the switch would raise the notice into the session that
+   * replaced the one which parked the input (review finding: stale decision
+   * notices were no longer dismissed or suppressed on session change).
+   */
+  const pendingDecisionCleanups = new Set<() => void>()
+  const withDecisionPending = <T>(name: string, pending: Promise<T>, origin?: UserTextOrigin): Promise<T> => {
     let dismiss: (() => void) | undefined
-    const timer = setTimeout(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const cleanup = (): void => {
+      if (timer !== undefined) { clearTimeout(timer); timer = undefined }
+      const raised = dismiss
+      dismiss = undefined
+      raised?.()
+      pendingDecisionCleanups.delete(cleanup)
+    }
+    timer = setTimeout(() => {
       // Sticky (timeoutMs 0), D-8: the indicator must cover the WHOLE wait —
       // an auto-expiring notice would vanish after ~4s while the decision,
       // the delivery and every queued FIFO task behind them stay parked,
@@ -149,12 +167,18 @@ export function createInputDelivery(
       // down only when the decision settles (finally below); a decision
       // that never settles keeps its indicator up, which is the truthful
       // state.
+      // A notice must never be raised for a session that has already been
+      // replaced: the switch drains this ledger, and the origin fence covers
+      // a timer that fires before that drain lands.
+      if (origin !== undefined && !current(origin)) { cleanup(); return }
       if (!owner.current()) return
       dismiss = notify(t('ext-decision-pending', { event: name }), { timeoutMs: 0 })
     }, DECISION_PENDING_MS)
+    pendingDecisionCleanups.add(cleanup)
     // Both exits are covered: a fast decision clears the timer before it
-    // fires; a slow one dismisses the indicator it raised.
-    const release = owner.own(() => { clearTimeout(timer); dismiss?.() })
+    // fires; a slow one dismisses the indicator it raised. The owner release
+    // keeps the channel-teardown path working on top of the session drain.
+    const release = owner.own(cleanup)
     return pending.finally(release)
   }
   /**
@@ -199,7 +223,7 @@ export function createInputDelivery(
       delivery: placement === 'steer' ? 'steer' : 'followup',
       sessionId: origin.agentId,
       cwd: origin.cwd,
-    }, normalizeInputDecision))
+    }, normalizeInputDecision), origin)
     // Staleness wins over cancel/handled: an old plugin result must neither
     // toast into nor claim input from the replacement session.
     if (dropIfStale()) return
@@ -248,10 +272,12 @@ export function createInputDelivery(
     images: readonly ComposerImageRef[] = [],
   ): void => dispatchUserText(text, placement, images)
   /** Main's `clearStagedImages`: revoke capabilities AND release the FIFO so
-   *  a task parked on the replaced session cannot wedge the new one. */
+   *  a task parked on the replaced session cannot wedge the new one, and drop
+   *  every pending-decision indicator owned by the session being replaced. */
   const clearStagedImages = (): void => {
     composer.clearStagedImages()
     inputChain = Promise.resolve()
+    for (const cleanup of [...pendingDecisionCleanups]) cleanup()
   }
 
   return {

--- a/src/dsh-adapter/channel/local-actions.ts
+++ b/src/dsh-adapter/channel/local-actions.ts
@@ -2,7 +2,7 @@ import { createUserMessage } from '@deepseek-ai/dsh-llm'
 import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { markChannelReadDirty } from '../../adapter/channel/read-view.js'
 import { writeActivityFrames } from '../../activityPrefs.js'
-import { isPresetName } from '../../components/activityFrames.js'
+import { isPresetName, normalizeActivityPreset } from '../../components/activityFrames.js'
 import { t } from '../../i18n.js'
 import { snapshotLiveSessionEvents } from '../compat/liveSession.js'
 import { LOCAL_OUTPUT_LIMIT, preview, type foldBack as FoldBack } from './transcript.js'
@@ -58,12 +58,16 @@ export function createLocalActions(deps: {
       state.emit()
     },
     setActivityFrames(name: string): boolean {
-      if (!isPresetName(name)) { notify(t('unknown-activity-preset', { name }), { color: 'error' }); return false }
-      if (name === state.activityFrames) { notify(t('activity-indicator-already', { name }), { color: 'success' }); return true }
-      if (!writeActivityFrames(name)) { notify(t('activity-pref-write-failed'), { color: 'error' }); return false }
-      state.activityFrames = name
+      // A retired id (e.g. `claude`) normalizes to the current default, so the
+      // in-memory state, the persisted preference and the toast agree instead
+      // of diverging until restart.
+      const preset = normalizeActivityPreset(name) ?? name
+      if (!isPresetName(preset)) { notify(t('unknown-activity-preset', { name }), { color: 'error' }); return false }
+      if (preset === state.activityFrames) { notify(t('activity-indicator-already', { name: preset }), { color: 'success' }); return true }
+      if (!writeActivityFrames(preset)) { notify(t('activity-pref-write-failed'), { color: 'error' }); return false }
+      state.activityFrames = preset
       state.emit()
-      notify(t('activity-indicator-switched', { name }))
+      notify(t('activity-indicator-switched', { name: preset }))
       return true
     },
     async listSubagents(): Promise<string[]> {

--- a/src/dsh-adapter/channel/model-switch.ts
+++ b/src/dsh-adapter/channel/model-switch.ts
@@ -88,6 +88,11 @@ export function createModelSwitchAction(
       deps.replay(seed)
       deps.settleReplay()
       state.working = handle.agent.status === 'running'
+      // Reset the input FIFO and pending-decision indicators BEFORE the first
+      // emit: a submit from a session-changed subscriber must not chain onto
+      // the replaced session's parked promise (main's bind → clear → refresh
+      // order).
+      deps.clearStagedImages()
       deps.bindAgent()
       deps.onModelSwitch(model)
       deps.refreshCommands()
@@ -96,7 +101,6 @@ export function createModelSwitchAction(
       touchSession(childId)
       state.emit()
       disposePrevious('dispose')
-      deps.clearStagedImages()
       if (!writeModelPref(provider, model)) deps.notify(t('model-pref-write-failed'), { color: 'warning' })
       return true
     })

--- a/src/dsh-adapter/channel/session-adoption.ts
+++ b/src/dsh-adapter/channel/session-adoption.ts
@@ -56,6 +56,10 @@ export function createSessionAdoption(
     deps.replay(seed)
     deps.settleReplay()
     state.working = handle.agent.status === 'running'
+    // Reset the input FIFO and pending-decision indicators BEFORE the first
+    // emit: a submit from a session-changed subscriber must not chain onto the
+    // replaced session's parked promise (main's bind → clear → refresh order).
+    deps.clearStagedImages()
     deps.bindAgent()
     deps.refreshCommands()
     void deps.refreshLoadedContext()
@@ -63,7 +67,6 @@ export function createSessionAdoption(
     deps.touchSession(childId)
     state.emit()
     disposePrevious('dispose')
-    deps.clearStagedImages()
     return sourceSessionId
   })
 

--- a/src/dsh-adapter/channel/session-live-adoption.ts
+++ b/src/dsh-adapter/channel/session-live-adoption.ts
@@ -79,6 +79,11 @@ export function createLiveAgentAdoption(
       deps.replay(snapshotLiveSessionEvents(target.session))
       deps.settleReplay()
       state.working = target.status === 'running'
+      // Reset the input FIFO and pending-decision indicators BEFORE the first
+      // emit: a submit from a session-changed subscriber must not chain onto
+      // the replaced session's parked promise (main's bind → clear → refresh
+      // order).
+      deps.clearStagedImages()
       deps.bindAgent()
       deps.refreshCommands()
       void deps.refreshLoadedContext()
@@ -99,7 +104,6 @@ export function createLiveAgentAdoption(
       }
       touchAgentViewSession(String(target.id))
       touchAgentViewSession(previousSessionId)
-      deps.clearStagedImages()
       deps.notifySessionSwitched('agent-view', String(target.id), previousSessionId)
       deps.notifyAgentView()
       return { ok: true }

--- a/src/dsh-adapter/channel/session-resume.ts
+++ b/src/dsh-adapter/channel/session-resume.ts
@@ -167,6 +167,9 @@ export function createSessionResumeActions(
       state.cwd = handle.agent.session.header.cwd ?? state.cwd
       state.displayCwd = deps.describeWorkspace(state.cwd).description ?? state.cwd
       deps.refreshGitBranch()
+      // Reset the input FIFO and pending-decision indicators BEFORE the first
+      // emit (main's bind → clear → refresh order); see the /new tail.
+      deps.clearStagedImages()
       resetAndBind(handle, composed.agentPreset, explicitRoute ?? recordedModelRoute(snapshotLiveSessionEvents(handle.agent.session)), true)
       writeResumeTarget(sessionId)
       touchSession(sessionId)
@@ -185,7 +188,6 @@ export function createSessionResumeActions(
         touchAgentViewSession(sessionId)
         touchAgentViewSession(previousSessionId)
       }
-      deps.clearStagedImages()
       deps.notifySessionSwitched(kind, sessionId, previousSessionId)
       return { ok: true }
     })
@@ -294,11 +296,15 @@ export function createSessionResumeActions(
       // roll back another workspace's cwd.
       state.cwd = targetCwd
       state.displayCwd = targetDisplayCwd ?? deps.describeWorkspace(targetCwd).description ?? targetCwd
+      // Reset the input FIFO and the pending-decision indicators BEFORE the
+      // first emit: a submit enqueued from a session-changed subscriber must
+      // land on a fresh chain instead of behind the replaced session's parked
+      // promise (main's bind → clear → refresh order).
+      deps.clearStagedImages()
       resetAndBind(handle, composed.agentPreset, route, false)
       clearResumeTarget()
       touchSession(handle.agent.id)
       disposePrevious('dispose')
-      deps.clearStagedImages()
       deps.notifySessionSwitched('new', String(handle.agent.id), previousSessionId)
       return true
     })

--- a/src/dsh-adapter/channel/state.ts
+++ b/src/dsh-adapter/channel/state.ts
@@ -1,6 +1,7 @@
 import type { AgentHandle } from '@deepseek-ai/dsh-agent'
 import type { SessionModeSpec } from '../../sessionModes.js'
 import { normalizePageMargin, normalizeScrollGutter, normalizeStatusBar, normalizeToolBackground, type PageMarginSetting, type ScrollGutterMode, type StatusBarConfig, type ToolBackground } from '../../tuiDisplayPrefs.js'
+import { normalizeActivityPreset } from '../../components/activityFrames.js'
 import type { ChannelState } from './types.js'
 
 /** Launch configuration belongs to channel construction, not the composition root. */
@@ -65,7 +66,7 @@ export function createInitialChannelView(
     cancelPending: false, spinnerMode: 'requesting', responseChars: 0, activeToolCount: 0,
     turnStart: 0, lastUserText: '', notifications: [], contextWindow: undefined,
     reasoningEffort: options.effort, mode: input.mode, modeIndex: 0, workingActivity: undefined,
-    activityFrames: options.activityFrames, configuredProvider: options.configuredProvider,
+    activityFrames: normalizeActivityPreset(options.activityFrames), configuredProvider: options.configuredProvider,
     configuredModel: options.configuredModel, configuredPreset: options.configuredPreset,
     configuredActivityFrames: options.configuredActivityFrames, configuredLang: options.configuredLang,
     diffLayout: options.diffLayout ?? 'auto', thinkingFold: options.thinkingFold ?? 'preview',


### PR DESCRIPTION
## 变更摘要 / Summary

跟进**会话生命周期审查**（把 `ea88f22b` 的单体 `channel.ts` 与拆分后的模块逐流程对比）发现的三处行为回归，全部修复并配回归断言。

**F1 会话级决策提示不随会话替换清理（中低）**

`withDecisionPending` 的清理只挂在 channel owner 上：切换会话（/new、/resume、/rewind、/model、live adoption）既不取消 400 ms 计时器、也不关闭已显示的 sticky 提示，于是被替换会话的提示会在**新会话**里冒出来，直到决策自身超时（~1 s 处理超时 / ~5 s 总超时）。修复：恢复会话级 ledger——清理项登记进 `Set`，`clearStagedImages()` 排空；计时器再按 enqueue 时捕获的 origin 做一次 D-6 判定，过期即自清。

**F2 输入 FIFO 重置晚于 emit（低中）**

`deps.clearStagedImages()` 排在 `resetAndBind` / `deps.bindAgent()` / `deps.refreshCommands()` 之后，切换期间由 session-changed 订阅者提交的消息会挂到**被替换会话**的 parked promise 上。修复：恢复主干的 bind → clear → refresh 顺序（session-resume 的两条尾链、session-adoption、session-live-adoption、model-switch、background-action）。

**F3 `normalizeActivityPreset` 丢失（低）**

`state.activityFrames` 与 `setActivityFrames` 不再归一化：`cordis.yml` 里 `activityFrames: claude` 或 `/activity claude` 会让内存值停在 `claude`（toast 也说 claude、选择器没有当前项），而持久化值是 `moon8`，两者到重启才一致。修复：初始化与设置入口恢复归一化。

用户可见差异：会话切换后不再出现属于旧会话的「正在等待插件决定」提示；切换瞬间提交的消息不再被旧会话的挂起决策拖住；`/activity` 的退役预设 id 归一化后提示与持久化一致。

## 关联 / Related

base = `refactor/adapter-channel-l4-l5`（#776，内含 #705）。无对应 issue，按仓库约定加 `no-issue-needed`。

## 变更类型 / Type

- [x] fix — 修复缺陷

## 验证 / Verification

- [ ] `pnpm build`（compile + 全部构建门禁）——本地未跑全量，交给 CI
- [x] 按改动面选的聚焦回归脚本
- [ ] 终端可见改动：切换会话时的提示行为由用户实机确认

```text
npm run typecheck                                    → exit 0
node scripts/run-ci-group.mjs channel-ui             → 全部 62 项通过
node scripts/run-ci-group.mjs session-workspace      → 31/35 通过
node --import tsx/esm scripts/verify-extension-events.tsx → extension decision-event seam verified
```

session-workspace 的 4 项失败（verify-keymap / verify-update-extract / verify-update-checksum / verify-standalone-cache-guard）在**基线工作区（未含本 PR 改动）同样失败**，属本地环境依赖（剪贴板图片 / update 资产），与本改动零文件交集。

**红/绿**（把 8 个源文件回退到 `af98708a` 后重跑）：

```text
FAIL pending session ownership: replaced session never raises a late indicator
FAIL activity preset: retired id normalizes to the current default — {"applied":true,"after":"claude"}
FAIL pending session ownership: every adoption tail resets the FIFO before its first emit — [["session-resume.ts","resetAndBind("],["session-adoption.ts","deps.bindAgent()"],["session-live-adoption.ts","deps.bindAgent()"],["model-switch.ts","deps.bindAgent()"],["background-action.ts","deps.bindAgent()"]]
3 check(s) failed
```

F2 的断言取**源码顺序**而非运行时探针：真实 channel 里 emit 与订阅者提交的时序让运行时探针在旧代码下也通过（不可区分），源码顺序断言是确定性的。

## 自查 / Checklist

- [x] 只改了 `src/` 与 `scripts/`，没有手改或提交 `lib/` 下的生成产物
- [x] 官方 `@deepseek-ai/*` 的 import 未新增到 `src/dsh-adapter/` 之外
- [x] 无行为 / 配置 / 快捷键变更，不涉及 `README.md` 双语同步
- [x] 未改 `cordis.patch.yml`
- [x] 只暂存了显式路径
