### PR TITLE
perf(adapter): ChannelUi 读投影直通 traceEvents，长会话不再每帧重建事件日志（#826）

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,8 @@
     "verify:inject-channel": "node --import tsx/esm scripts/verify-inject-channel.mjs",
     "verify:background-extraction": "node --import tsx/esm scripts/verify-background-extraction.ts",
     "verify:plugin-catalog-extraction": "node --import tsx/esm scripts/verify-plugin-catalog-extraction.ts",
-    "verify:channel-composition": "node --import tsx/esm scripts/verify-channel-composition.ts"
+    "verify:channel-composition": "node --import tsx/esm scripts/verify-channel-composition.ts",
+    "verify:channel-trace-read": "node --import tsx/esm scripts/verify-channel-trace-read.ts"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",

--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -400,6 +400,11 @@ const GROUPS = {
     ["verify-channel-owner-lifecycle", ['node', '--import', 'tsx/esm', 'scripts/verify-channel-owner-lifecycle.ts']],
     ["verify-channel-router-lifecycle", ['node', '--import', 'tsx/esm', 'scripts/verify-channel-router-lifecycle.ts']],
     ["verify-reports-metadata",  ['node', '--import', 'tsx/esm', 'scripts/verify-reports-metadata.ts']],
+// ChannelUi 读投影边界：会话事件日志（traceEvents）必须零拷贝直通——它每次
+// append 都换新的快照数组，走 detached 投影会 O(events) 重建整条数组，而
+// Chat 每次渲染都读它（长会话 44 万事件实测每帧上百毫秒）。同时钉住 rows
+// 仍然是被投影的冻结副本，修复不得拆掉 detached 契约。
+    ["verify-channel-trace-read", ['node', '--import', 'tsx/esm', 'scripts/verify-channel-trace-read.ts']],
 // channel 层回归：发送链（submit/steer/撤回/打断重投）、compact 折叠、
 // goal/todo 事件回放。曾因不在 CI 而随接口演进静默失效（0.3.6 的
 // installModelSelection、#34 的投递异步化都没被它们拦下），挂进来

--- a/scripts/verify-channel-trace-read.ts
+++ b/scripts/verify-channel-trace-read.ts
@@ -1,0 +1,118 @@
+/**
+ * verify-channel-trace-read — `channel.traceEvents()` 必须是零拷贝直通。
+ *
+ * 背景（用户报告：合并 #776 后长对话卡顿，冒字/滚动都卡）：ChannelUi 的
+ * detached 读投影把整条会话事件日志也投影了一遍，而 dsh-session 每次
+ * append 都换一个新的快照数组（snapshotEvents() 的冻结缓存），读投影因此
+ * 无法按数组身份命中，每次调用都重建整条数组 —— 实测 322us @2k 事件、
+ * 2.7ms @20k、65ms @200k。Chat 在**每次渲染**都调 `channel.traceEvents()`
+ * 折叠 trajectory，44 万事件的会话于是每帧烧掉上百毫秒。
+ *
+ * 本回归钉住两条边界：
+ *  1. traceEvents 直通：返回的元素必须是会话原始事件对象（不是 detached
+ *     副本），且两次调用拿到同一批对象；lease/shadow 检查仍在该调用上生效。
+ *  2. 其余属性仍走读投影：rows 必须是冻结副本、与后端数组不同一 —— 修复
+ *     不得顺手把 detached 契约拆掉。
+ *
+ * Run: node --import tsx/esm scripts/verify-channel-trace-read.ts
+ */
+import assert from 'node:assert/strict'
+import { Context } from '@deepseek-ai/cordis'
+import { createChannel } from '../src/dsh-adapter/channel.js'
+import { mountChannelUi } from '../src/dsh-adapter/channel-ui.js'
+import { registerTuiChannel } from '../src/adapter/channel/host-registry.js'
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 40))
+
+/** Append-only live session: snapshotEvents() hands back a NEW array each call. */
+function sessionWith(events: readonly unknown[]) {
+  return {
+    id: 'trace-read-session',
+    seq: events.length,
+    events,
+    snapshotEvents: () => events.slice(),
+    requestHeader: () => undefined,
+  }
+}
+
+function fixture(eventCount: number) {
+  const events: Array<Record<string, unknown>> = []
+  for (let i = 0; i < eventCount; i++) {
+    events.push({
+      type: 'assistant/chunk', seq: i, time: 1_700_000_000_000 + i,
+      data: { turn: 1, step: 1, chunk: { type: 'text-delta', text: `字${i}` } },
+    })
+  }
+  const services: Record<string, unknown> = {
+    settings: { describe: () => [], get: () => ({}), mutate: async () => undefined },
+    credentials: { resolve: async () => undefined, set: async () => undefined, unset: async () => undefined },
+    llm: { listConfigurableProviders: () => [], discoverModels: async () => [] },
+    agents: { create: async () => { throw new Error('no create') } },
+  }
+  const ctx = {
+    on: () => () => undefined,
+    effect: () => undefined,
+    get(name: string) { return services[name] },
+    logger: { warn() {}, info() {}, debug() {} },
+  }
+  const agent = {
+    id: 'trace-read-agent', status: 'idle',
+    session: sessionWith(events),
+    ctx: { on: () => () => undefined },
+    followup() {}, steer() {}, cancel() {}, inbox: { remove: () => true },
+  }
+  const raw = createChannel(ctx as never, agent as never, { model: 'm', provider: 'p', cwd: '/tmp', activity: false })
+  return { ctx, raw, events }
+}
+
+// ── 1. traceEvents 直通（不投影、不深拷贝）──────────────────────────────
+{
+  const { ctx, raw, events } = fixture(5_000)
+  const unregister = registerTuiChannel(ctx as never, raw as never)
+  const mount = mountChannelUi(ctx as never, raw as never, undefined, 'new')
+  const first = mount.channel.traceEvents()
+  const second = mount.channel.traceEvents()
+
+  assert.equal(first.length, events.length, 'traceEvents keeps the whole log')
+  assert.notEqual(first, second, 'each call sees the session’s own fresh snapshot array')
+  assert.equal(first[0], events[0], 'event objects are handed through, not detached copies')
+  assert.equal(first[events.length - 1], events[events.length - 1], 'tail event identity survives')
+  assert.equal((first[0] as { data: unknown }).data, (events[0] as { data: unknown }).data, 'nested event data is not re-copied')
+  assert.equal(second[0], events[0], 'a second read returns the same original objects (no per-call projection)')
+  assert.notEqual(first[0], undefined, 'sanity: the log is non-empty')
+
+  // The detached read projection still owns every other property.
+  raw.rows.push({ id: 1, kind: 'assistant', text: 'hi' } as never)
+  raw.emit()
+  const rows = mount.channel.rows
+  assert.notEqual(rows, raw.rows, 'rows stay detached from the live array')
+  assert.notEqual(rows[0], raw.rows[0], 'rows stay detached row-by-row')
+  assert.equal(Object.isFrozen(rows), true, 'projected rows array is frozen')
+  assert.equal(Object.isFrozen(rows[0]), true, 'projected row is frozen')
+
+  mount.dispose(); unregister(); raw.releaseContributions()
+}
+
+// ── 2. lease/shadow 仍守在该调用上：dispose 后保留句柄必须失效 ──────────
+{
+  const { ctx, raw } = fixture(64)
+  const unregister = registerTuiChannel(ctx as never, raw as never)
+  const mount = mountChannelUi(ctx as never, raw as never, undefined, 'new')
+  const retained = mount.channel.traceEvents
+  assert.equal(retained().length, 64, 'retained handle works while the lease is live')
+  mount.dispose()
+  assert.throws(() => retained(), /lifetime/, 'retained traceEvents handle dies with the lease')
+  unregister(); raw.releaseContributions()
+}
+
+// ── 3. 空日志与单事件边界 ───────────────────────────────────────────────
+{
+  const { ctx, raw } = fixture(0)
+  const unregister = registerTuiChannel(ctx as never, raw as never)
+  const mount = mountChannelUi(ctx as never, raw as never, undefined, 'new')
+  assert.deepEqual(mount.channel.traceEvents(), [], 'empty log projects as an empty array')
+  mount.dispose(); unregister(); raw.releaseContributions()
+}
+
+await tick()
+console.log('verify:channel-trace-read OK (traceEvents direct passthrough, rows still detached, lease gated)')

--- a/scripts/verify-channel-trace-read.ts
+++ b/scripts/verify-channel-trace-read.ts
@@ -24,13 +24,18 @@ import { registerTuiChannel } from '../src/adapter/channel/host-registry.js'
 
 const tick = () => new Promise(resolve => setTimeout(resolve, 40))
 
-/** Append-only live session: snapshotEvents() hands back a NEW array each call. */
+/**
+ * Append-only live session: snapshotEvents() hands back a NEW array each call.
+ * Upstream caches a FROZEN snapshot per append, so the fixture freezes too —
+ * otherwise this script would pass even if traceEvents started handing out a
+ * mutable session-owned array.
+ */
 function sessionWith(events: readonly unknown[]) {
   return {
     id: 'trace-read-session',
     seq: events.length,
     events,
-    snapshotEvents: () => events.slice(),
+    snapshotEvents: () => Object.freeze(events.slice()),
     requestHeader: () => undefined,
   }
 }
@@ -75,6 +80,7 @@ function fixture(eventCount: number) {
 
   assert.equal(first.length, events.length, 'traceEvents keeps the whole log')
   assert.notEqual(first, second, 'each call sees the session’s own fresh snapshot array')
+  assert.equal(Object.isFrozen(first), true, 'traceEvents preserves the frozen session snapshot')
   assert.equal(first[0], events[0], 'event objects are handed through, not detached copies')
   assert.equal(first[events.length - 1], events[events.length - 1], 'tail event identity survives')
   assert.equal((first[0] as { data: unknown }).data, (events[0] as { data: unknown }).data, 'nested event data is not re-copied')

--- a/src/adapter/channel/ui.ts
+++ b/src/adapter/channel/ui.ts
@@ -58,7 +58,6 @@ export function createChannelUi(channel: ChannelUi, mode: AdapterMode, lease: Ch
   }
   const read = createChannelReadView(mutation => check(mutation ? 'mutate' : 'read-only'))
   const project = <T>(value: T): T => read(value, channel.version)
-  const trace = createChannelReadView(mutation => check(mutation ? 'mutate' : 'read-only'))
   const query = <T>(value: T): T => createChannelReadView(mutation => check(mutation ? 'mutate' : 'read-only'))(value, 0)
   const settle = <T>(value: T): T => {
     if (value instanceof Promise) return value.then(result => { check('read-only'); return query(result) }) as T
@@ -139,7 +138,16 @@ export function createChannelUi(channel: ChannelUi, mode: AdapterMode, lease: Ch
           ...(oauth === undefined ? {} : { oauth: methods(oauth, { providers: 'read-only', login: 'mutate', logout: 'mutate' }) }),
         })
       }
-      if (key === 'traceEvents') return trace(result, 0)
+      // The session event log is an append-only, JSON-safe read whose snapshot
+      // array is replaced by the session on every append. Running it through
+      // the detached read projection cost O(events) per call, and Chat folds
+      // the trajectory from it on EVERY render: a long session (hundreds of
+      // thousands of chunks) paid hundreds of milliseconds per frame while
+      // streaming or scrolling — measured 322us @2k events, 2.7ms @20k,
+      // 65ms @200k. The snapshot array is already frozen by the session, so
+      // hand it back as-is; the lease/shadow `check()` above still gates the
+      // call itself (same contract as before the Channel UI split).
+      if (key === 'traceEvents') return result
       if (key === 'agentViewRows' || key === 'settingsSections') return project(result)
       return settle(result)
     }

--- a/src/dsh-adapter/channel-ui.ts
+++ b/src/dsh-adapter/channel-ui.ts
@@ -12,6 +12,9 @@ function throwCleanupFailures(failures: unknown[], message: string): void {
   if (failures.length > 1) throw new AggregateError(failures, message)
 }
 
+/** Re-probe interval while the kernel's channel slice is still absent. */
+const FACADE_PROBE_MS = 250
+
 export function mountChannelUi(
   ctx: unknown,
   channel: ChannelState,
@@ -47,9 +50,29 @@ export function mountChannelUi(
   // the identical guarded local capability. Never downgrade after binding.
   let mounted: ChannelUi | undefined
   let mountedView: ChannelUi | undefined
+  // `getHostFacade()` builds a fresh facade graph on every call (KernelRuntime
+  // facade() allocates a new descriptor port + shadow-guarded wrapper), and
+  // `resolve()` runs on EVERY `channel.X` read — Chat reads ~70-90 properties
+  // per render, so re-resolving per read cost ~2.3us each (~0.2-0.4ms/frame)
+  // for a value that only ever changes when the kernel mounts the channel
+  // slice. Probe at most every FACADE_PROBE_MS while the slice is absent;
+  // once the facade exposes the channel UI, it stays that way for the
+  // kernel's lifetime (a re-registration disposes this mount's lease).
+  let facadeProbe: ReturnType<typeof getHostFacade>
+  let facadeProbeAt = 0
+  let facadeProbeLocked = false
+  const facadeNow = (): ReturnType<typeof getHostFacade> => {
+    if (facadeProbeLocked) return facadeProbe
+    const now = Date.now()
+    if (facadeProbe !== undefined && now - facadeProbeAt < FACADE_PROBE_MS) return facadeProbe
+    facadeProbeAt = now
+    facadeProbe = getHostFacade(pluginHost as never)
+    if (facadeProbe?.channel !== undefined) facadeProbeLocked = true
+    return facadeProbe
+  }
   const resolve = (): ChannelUi => {
     lease.assertActive()
-    const facade = getHostFacade(pluginHost as never)
+    const facade = facadeNow()
     const ui = facade?.channel?.projection.ui
     if (ui === undefined) {
       if (mounted !== undefined) throw new Error('dsh-tui: mounted HostFacade lost Channel UI')


### PR DESCRIPTION
修复 #826 的 TUI 侧根因：长会话每帧重建整条事件日志。

## 现象与根因

超长对话（本次取证会话 **44 万条事件**）之后 CPU 飙高、进程无响应。

- `Chat.tsx` **每次渲染**都调 `channel.traceEvents()` 折叠 trajectory；
- #776 的 Channel UI 拆分把 `traceEvents` 也塞进了 detached 读投影（`return trace(result, 0)`），逐键深拷贝整条事件日志；
- 而 dsh-session 每次 append 都换一个新的冻结快照数组 → 读投影永远命中不了数组身份 → **每次调用重建整条数组**。

实测（裸 channel vs 生产 ChannelUi，2k / 20k / 200k 事件）：4.5us / 34us / 282us vs **322us / 2.7ms / 64.7ms**。真实会话（44 万事件，生产 mount，CPU 时间）：main 滚动 2140ms / 流式 547ms → #776 合并后 **11641ms / 17953ms** → 本修复后 1890ms / 969ms。

## 改动

1. **`src/adapter/channel/ui.ts`**：`traceEvents` 不再走 detached 读投影，直接交还会话自身的冻结快照。lease/shadow 的 `check()` 仍守在该调用上（与 #776 拆分前同一契约），其余属性（`rows` 等）照旧走投影。
2. **`src/dsh-adapter/channel-ui.ts`**：`resolve()` 里的 `getHostFacade()` 每次属性读都重建整个 facade 图（KernelRuntime `facade()` 分配新的 descriptor port + shadow-guarded wrapper），而 Chat 每帧要读 70-90 个属性、每次约 2.3us。改为 250ms 节流探测 + facade 暴露 channel UI 后锁定。单次属性读 4.2-5.6us → 0.24-0.38us。
3. **`scripts/verify-channel-trace-read.ts`**（新，登记进 `channel-ui` 组）：钉住事件对象直通、两次读拿到同批对象、lease 失效后保留句柄仍抛错，同时守住 `rows` 仍是被投影的冻结副本 —— 修复不得顺手拆掉 detached 契约。

## 验证

- `pnpm build`（编译 + 全部 verify:build 门禁）exit 0；
- `node scripts/run-ci-group.mjs channel-ui` → **65/65 通过**；
- 红绿：把 `ui.ts` 还原成修复前的版本，新门禁 exit 1（`AssertionError: event objects are handed through, not detached copies`），恢复后 exit 0；
- `git diff --check` 干净。

## 权衡与关联

- **250ms 探测窗口**：kernel 挂载 channel slice 后，最坏晚 250ms 才切到 mounted view；这之前一直使用同一份 guard 过的本地 capability（代码里 "Never downgrade after binding" 的既有语义），不存在降级。
- **与本 issue 下 @baizhu945 的 fork 方案关系**：那条路线把 trajectory 折叠移到 channel 事件入口做增量投影（并带上 rc.1 适配），与本 PR 的目标路径不同 —— 本 PR 只消掉每帧 O(events) 的投影拷贝，折叠仍留在 Chat 既有的增量 `extendTrajectory`。两者不冲突，可并存或择一。
- 若维护者认为 #826 尚有剩余项（例如内存增长另有来源），把本 PR 的 `Fixes` 降级为普通关联即可，本 PR 的收益不依赖该判定。

Fixes #826
