### PR TITLE
fix(jobs): Esc 关闭 /jobs 面板优先于中断对话

### DIFF
--- a/scripts/verify-jobs-panel.tsx
+++ b/scripts/verify-jobs-panel.tsx
@@ -8,6 +8,8 @@
  *   jobControl.kill 权限传递、无 jobs 服务降级、/new 重置投影。
  * Group C — 渲染冒烟（headless xterm）：
  *   JobCard 运行态三行瀑布（有输出时）/仅头行（无输出时）、settled 折叠、JobsPanel 标题/行/提示。
+ * Group D — 按键归属（Chat 整屏 + 假 channel）：
+ *   面板打开时 Esc 关面板而非中断对话；面板关闭后 Esc 仍能中断（防假通过）。
  *
  * 运行：node --import tsx/esm scripts/verify-jobs-panel.tsx
  */
@@ -27,11 +29,13 @@ const [
   { Context },
   { createChannel },
   { BackgroundJobStore, formatJobDuration, JOBS_MAX_TRACKED, JOBS_MAX_OUTPUT_LINES },
-  { settled, sleep },
+  { settled, settle, sleep },
   React,
   { render },
   { JobCard },
   { JobsPanel },
+  { Chat },
+  { QuestionStore },
 ] = await Promise.all([
   import('@deepseek-ai/cordis'),
   import('../src/dsh-adapter/channel.js'),
@@ -41,6 +45,8 @@ const [
   import('../src/ui.js'),
   import('../src/components/Chat/JobCard.js'),
   import('../src/components/JobsPanel.js'),
+  import('../src/screens/Chat.js'),
+  import('../src/dsh-adapter/questions.js'),
 ])
 const { Writable, PassThrough } = await import('node:stream')
 const { Terminal: XTerm } = (await import('@xterm/headless')) as unknown as {
@@ -334,20 +340,21 @@ class Input extends PassThrough {
 }
 async function withTerminal(
   make: () => React.ReactNode,
-  run: (screen: () => string, rerender: (node: React.ReactNode) => void) => Promise<void>,
+  run: (screen: () => string, rerender: (node: React.ReactNode) => void, stdin: Input) => Promise<void>,
 ): Promise<void> {
   const term = new XTerm({ cols: COLS, rows: ROWS, scrollback: 0, allowProposedApi: true })
   const stdout = new FakeStdout(term) as unknown as NodeJS.WriteStream
+  const stdin = new Input()
   const instance = await render(make(), {
     stdout,
-    stdin: new Input() as unknown as NodeJS.ReadStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
     exitOnCtrlC: false,
     patchConsole: false,
   })
   const screen = (): string =>
     Array.from({ length: ROWS }, (_, y) => term.buffer.active.getLine(y)?.translateToString(true) ?? '').join('\n')
   try {
-    await run(screen, node => instance.rerender(node))
+    await run(screen, node => instance.rerender(node), stdin)
   } finally {
     await instance.unmount()
     term.dispose()
@@ -425,6 +432,102 @@ await withTerminal(
     check('C3 非聚焦行无详情块', !text.includes('no mirrored output yet'))
   },
 )
+
+// ---------------------------------------------------------------------------
+// Group D — 按键归属：/jobs 面板打开时 Esc 关面板，不得同时中断对话
+// ---------------------------------------------------------------------------
+console.log('--- D: /jobs panel owns Esc ---')
+{
+  const cancelled: string[] = []
+  const panelJob = {
+    id: 'pwsh-7', kind: 'pwsh', label: 'gh run watch 42', status: 'running' as const,
+    command: 'gh pr checks --watch 42', startedAt: NOW - 5_000, outputLines: [],
+  }
+  const channel: Record<string, unknown> = {
+    version: 0,
+    rows: [],
+    status: 'idle',
+    sessionTitle: 'jobs esc probe',
+    agentId: 'probe',
+    provider: 'deepseek',
+    model: 'deepseek-v4-pro',
+    tokens: { input: 0, output: 0 },
+    cwd: '/tmp/demo',
+    displayCwd: '/tmp/demo',
+    // /jobs 是 idle-only 的指挥行（working 时 Enter 走插话），所以初始为 idle：
+    // 面板先打开，再让回合变成在跑（点转录任务卡进面板、或面板开着时回合起跑），
+    // 这正是 bug 的现场——面板开着 + 回合在跑。
+    working: false,
+    spinnerMode: 'idle',
+    responseChars: 0,
+    activeToolCount: 0,
+    mode: { id: 'default', plan: false },
+    modeIndex: 0,
+    cycleMode(): void {},
+    turnStart: NOW,
+    lastUserText: '',
+    pending: [],
+    commandList: [{ name: 'jobs', description: 'Show background jobs of this session' }],
+    commandCompletions: () => [{
+      name: 'jobs',
+      description: 'Show background jobs of this session',
+      replacement: '/jobs',
+      commandLine: '/jobs',
+    }],
+    notifications: [],
+    activityEnabled: false,
+    activityFrames: [],
+    backgroundJobs: [panelJob],
+    jobControl: { kill: () => true },
+    subscribe: () => () => {},
+    submit: (): void => {},
+    cancel: (): void => { cancelled.push('cancel') },
+    clear: (): void => {},
+    notify: (): void => {},
+    listModels: () => Promise.resolve([]),
+    listSessions: () => [],
+    setResumeTarget: (): void => {},
+    stageImage: () => Promise.resolve(''),
+    listSubagents: () => Promise.resolve([]),
+    lastUsage: { input: 0, cacheRead: 0, cacheWrite: 0, output: 0 },
+    contextWindow: 1_000_000,
+    contextSegments: { system: 0, prompt: 0, assistant: 0, thinking: 0, tools: 0 },
+    tps: undefined,
+    tpsSamples: [],
+    reasoningEffort: 'high',
+    agentPreset: 'standard',
+  }
+
+  await withTerminal(
+    () => React.createElement(Chat, {
+      channel: channel as never,
+      questionStore: new QuestionStore() as never,
+      onExit: () => {},
+      fullscreen: true,
+      trajectorySeen: true,
+    }),
+    async (screen, _rerender, stdin) => {
+      // 等首帧上屏（等待后操作 → settle）再发键。
+      await settle(() => screen().includes('❯'))
+      // 打开面板：整行一次写入 → PromptInput 直接派发 /jobs。
+      stdin.write('/jobs\r')
+      check('D1 /jobs 打开后台任务面板', await settled(() => screen().includes('Background Jobs')), screen().split('\n')[0] ?? '')
+      // 面板开着时回合起跑（字段按 key 时实时读取，无需重渲染）。
+      channel.working = true
+      channel.status = 'working'
+      channel.spinnerMode = 'working'
+      check('D1 面板已打开时回合在跑且未被打断', cancelled.length === 0)
+      // Esc：面板拥有键盘 → 只关面板（等待后断言 → settled 把终值直接交给 check）。
+      stdin.write('\x1b')
+      check('D2 面板打开时 Esc 关闭面板', await settled(() => !screen().includes('Background Jobs')), screen().split('\n')[0] ?? '')
+      check('D2 同一次 Esc 不中断对话', cancelled.length === 0, JSON.stringify(cancelled))
+      // 反证：无面板时同一个 Esc 仍需中断，证明 D2 不是"Esc 根本没送达"。
+      const before = cancelled.length
+      stdin.write('\x1b')
+      check('D3 面板关闭后 Esc 恢复中断对话', await settled(() => cancelled.length === before + 1), JSON.stringify(cancelled))
+    },
+  )
+}
 
 if (failed > 0) {
   console.error(`\n${failed} check(s) failed`)

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -2654,6 +2654,11 @@ export function Chat({
     if (settingsOpen) return
     // Subagent dashboard or detail scene: it owns the keyboard while open.
     if (subagentDashboardOpen || subagentDetailId !== null) return
+    // The `/jobs` panel replaces the conversation too, so it owns Esc (close)
+    // and k (kill) while open. Unguarded, Esc meant to CLOSE the panel also
+    // reached the chat:cancel branch below whenever a turn was in flight —
+    // dismissing the panel and killing the turn with one key.
+    if (jobsPanelOpen) return
     // A plugin scene (dsh-tui-scenes) or the trajectory scene owns the whole
     // screen while open: every key belongs to it. Unguarded, an Esc meant to
     // CLOSE the scene also reached the chat:cancel branch below whenever a


### PR DESCRIPTION
## 变更摘要 / Summary
`/jobs` 后台任务面板打开时，Esc 会先命中 Chat 的「中断回合」分支：面板关不掉，正在跑的回合被杀。修复为把 `jobsPanelOpen` 并入 Chat 的整屏让键守卫，Esc 只关面板。

## 关联 / Related
Closes #855

## 变更类型 / Type

- [x] fix — 修复缺陷

## 验证 / Verification

- [x] `pnpm build`（compile + 全部构建门禁）—— 未整跑；本地跑过 `pnpm compile` / `pnpm typecheck` 均 exit 0
- [x] 按改动面选的聚焦回归脚本（`scripts/verify-jobs-panel.tsx`，登记在 CI 的 `channel-ui` 组）
- [ ] 终端可见改动：在 inline 与 fullscreen 两种模式、窄终端宽度下手动演练过 —— 本次只改了按键归属，未人工演练

```text
$ node --import tsx/esm scripts/verify-jobs-panel.tsx
...
--- D: /jobs panel owns Esc ---
PASS  D1 /jobs 打开后台任务面板
PASS  D1 面板已打开时回合在跑且未被打断
PASS  D2 面板打开时 Esc 关闭面板
PASS  D2 同一次 Esc 不中断对话  ([])
PASS  D3 面板关闭后 Esc 恢复中断对话  (["cancel"])
ALL PASS

# 反向对照（把守卫改成 if (false && jobsPanelOpen) return）
FAIL  D2 面板打开时 Esc 关闭面板
FAIL  D2 同一次 Esc 不中断对话  (["cancel"])   ← Esc 杀了回合、面板还留着
2 check(s) failed
```

另在 detached worktree 里、对「只有本提交」的树跑过同一脚本（ALL PASS）与 `tsc`（exit 0），确认不依赖工作区里其它未提交改动。

## 自查 / Checklist

- [x] 只改了 `src/`，没有手改或提交 `lib/` 下的生成产物
- [x] 官方 `@deepseek-ai/*` 的 import 仍只出现在 `src/dsh-adapter/` 内
- [x] 行为、配置、快捷键与限制的改动已在 `README.md` 与 `README_EN.md` 双语同步 —— 本次未改快捷键语义（i18n 的 `jobs-panel-hint` 早已写 "Esc close"），故无需文档改动
- [x] 改了 `cordis.patch.yml` 的话，`patch-surface.snapshot.json` 已同步 —— 未改该文件
- [x] 只暂存了显式路径，没有用 `git add .` / `git add -A`（显式 `git add --` + 单 hunk `git apply --cached`）

## 关于门禁 / PR gate

作者不在 `.github/APPROVED_CONTRIBUTORS`，本 PR 会被 `pr-gate` 自动关闭。若维护者认可，**reopen 一次**即可放行：`gate.mjs` 的 `hasVerifiedRecovery()` 判定「时间线上最新的状态事件是 write 协作者触发的 `reopened`」时保留 PR。
