### PR TITLE
perf(update): ignore foreign-platform @img/sharp optionals — cut ~90MB update downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ sh install.sh
 > ```
 >
 > `/update` 与 `dsh-tui update` 会自动写入这份配置，无需手工处理。
+>
+> 更新时还会自动写入 `ignoredOptionalDependencies`（忽略异平台的 `@img/sharp-*` 原生包）——sharp 以全平台可选依赖分发，过滤后只下载当前平台的二进制，更新体积从约 90MB 降回约 18MB。
 
 更面向零基础的安装流程、profile 叠加机制、源码构建与常见问题见[安装与快速开始](docs/getting-started.md)。
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ sh install.sh
 >
 > `/update` 与 `dsh-tui update` 会自动写入这份配置，无需手工处理。
 >
-> 更新时还会自动写入 `ignoredOptionalDependencies`（忽略异平台的 `@img/sharp-*` 原生包）——sharp 以全平台可选依赖分发，过滤后只下载当前平台的二进制，更新体积从约 90MB 降回约 18MB。
+> 更新时还会自动写入 `ignoredOptionalDependencies`（忽略异平台的 `@img/sharp-*` 原生包）——sharp 以全平台可选依赖分发，过滤后只下载当前平台的二进制，更新体积从约 90MB 降回约 18MB（需 pnpm ≥10.17；更旧版本会静默忽略该键，仅失去过滤收益）。
 
 更面向零基础的安装流程、profile 叠加机制、源码构建与常见问题见[安装与快速开始](docs/getting-started.md)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -177,6 +177,11 @@ commands), then `dsh-tui` (or `dst`) and `dsh --profile dsh-tui` are equivalent.
 >
 > `/update` and `dsh-tui update` seed this configuration automatically —
 > no manual step needed.
+>
+> Updates also seed `ignoredOptionalDependencies` covering foreign-platform
+> `@img/sharp-*` natives: sharp ships as all-platform optional dependencies,
+> and the filter keeps only the current platform's binaries downloading,
+> cutting an update from roughly 90MB back to about 18MB.
 
 `dsh-tui` (or its `dst` alias) with `--resume` restores the most recently selected session; on Windows
 the repository's `dsh-tui.cmd` works the same way.

--- a/README_EN.md
+++ b/README_EN.md
@@ -181,7 +181,8 @@ commands), then `dsh-tui` (or `dst`) and `dsh --profile dsh-tui` are equivalent.
 > Updates also seed `ignoredOptionalDependencies` covering foreign-platform
 > `@img/sharp-*` natives: sharp ships as all-platform optional dependencies,
 > and the filter keeps only the current platform's binaries downloading,
-> cutting an update from roughly 90MB back to about 18MB.
+> cutting an update from roughly 90MB back to about 18MB (needs pnpm ≥10.17;
+> older pnpm silently ignores the key and merely loses the saving).
 
 `dsh-tui` (or its `dst` alias) with `--resume` restores the most recently selected session; on Windows
 the repository's `dsh-tui.cmd` works the same way.

--- a/scripts/verify-update.mjs
+++ b/scripts/verify-update.mjs
@@ -51,6 +51,7 @@ const {
   sharpCurrentSuffix,
   ignoredSharpOptionalPatterns,
   ensureProfileSharpPlatformFilter,
+  detectLibc,
   profileWorkspaceYamlPath,
   isStandaloneRuntime,
   getStandaloneBinaryPath,
@@ -745,9 +746,13 @@ check(
   const onLinuxX64 = ignoredSharpOptionalPatterns('linux', 'x64', 'glibc')
   check('忽略清单: 排除本平台 wrapper 与 libvips', !onLinuxX64.includes('@img/sharp-linux-x64') && !onLinuxX64.includes('@img/sharp-libvips-linux-x64'))
   check('忽略清单: 含异平台代表项', onLinuxX64.includes('@img/sharp-win32-x64') && onLinuxX64.includes('@img/sharp-darwin-arm64') && onLinuxX64.includes('@img/sharp-libvips-linuxmusl-x64'))
+  check('忽略清单: 与 registry 矩阵对齐（不列不存在的包）', !onLinuxX64.includes('@img/sharp-libvips-win32-x64') && !onLinuxX64.includes('@img/sharp-linuxmusl-arm') && !onLinuxX64.includes('@img/sharp-linux-ia32'))
+  check('忽略清单: 显式保留无平台归属的 wasm 回退包', !onLinuxX64.includes('@img/sharp-wasm32') && !onLinuxX64.includes('@img/sharp-webcontainers-wasm32') && onLinuxX64.includes('@img/sharp-freebsd-wasm32'))
   const onMusl = ignoredSharpOptionalPatterns('linux', 'x64', 'musl')
   check('忽略清单: musl 环境排除 linuxmusl-x64 而保留 linux-x64', !onMusl.includes('@img/sharp-linuxmusl-x64') && onMusl.includes('@img/sharp-linux-x64'))
   check('忽略清单: 不含非平台的纯 JS 包', !onMusl.some(p => p.includes('colour')))
+  check('libc 判定: report 的 glibc 标记优先于 musl loader 存在', detectLibc({ header: { glibcVersionRuntime: '2.36' } }, true) === 'glibc')
+  check('libc 判定: 无 report 时 loader 探测兜底', detectLibc(undefined, true) === 'musl' && detectLibc(undefined, false) === 'glibc')
 
   const sharpScratch = mkdtempSync(join(tmpdir(), 'verify-sharp-filter-'))
   const prevDshHome = process.env.DSH_HOME
@@ -760,7 +765,8 @@ check(
     const yamlText = readFileSync(profileWorkspaceYamlPath('dsh-tui'), 'utf8')
     check('workspace 预种: 块落盘且带模式行', first !== undefined && yamlText.includes('ignoredOptionalDependencies:') && yamlText.includes(`- '@img/sharp-win32-x64'`))
     check('workspace 预种: 既有内容保留', yamlText.includes('nodeLinker: hoisted'))
-    check('workspace 预种: 不忽略本机平台', !yamlText.includes(`- '@img/sharp-${sharpCurrentSuffix(process.platform, process.arch, 'glibc')}'`))
+    const loaderPresent = existsSync('/lib/ld-musl-x86_64.so.1') || existsSync('/lib/ld-musl-aarch64.so.1') || existsSync('/etc/alpine-release')
+    check('workspace 预种: 不忽略本机平台', !yamlText.includes(`- '@img/sharp-${sharpCurrentSuffix(process.platform, process.arch, detectLibc(undefined, loaderPresent) === 'musl' ? 'musl' : 'glibc')}'`))
     const second = ensureProfileSharpPlatformFilter('dsh-tui')
     const afterText = readFileSync(profileWorkspaceYamlPath('dsh-tui'), 'utf8')
     check('workspace 预种: 幂等（不重复块）', afterText.match(/ignoredOptionalDependencies:/gu)?.length === 1 && second !== undefined)
@@ -768,7 +774,6 @@ check(
     writeFileSync(join(profDir, 'pnpm-workspace.yaml'), 'ignoredOptionalDependencies:\n  - fsevents\n')
     const third = ensureProfileSharpPlatformFilter('dsh-tui')
     check('workspace 预种: 已有块不覆盖', third !== undefined && readFileSync(profileWorkspaceYamlPath('dsh-tui'), 'utf8') === 'ignoredOptionalDependencies:\n  - fsevents\n')
-    rmSync(join(process.env.DSH_HOME, 'profiles', 'absent'), { recursive: true, force: true })
     check('workspace 预种: profile 目录缺失返回 undefined', ensureProfileSharpPlatformFilter('absent') === undefined)
   } finally {
     if (prevDshHome === undefined) delete process.env.DSH_HOME

--- a/scripts/verify-update.mjs
+++ b/scripts/verify-update.mjs
@@ -48,6 +48,9 @@ const {
   removeStalePackageInstall,
   ensureProfileAllowBuilds,
   ensureProfileReleaseAgeExclude,
+  sharpCurrentSuffix,
+  ignoredSharpOptionalPatterns,
+  ensureProfileSharpPlatformFilter,
   profileWorkspaceYamlPath,
   isStandaloneRuntime,
   getStandaloneBinaryPath,
@@ -730,6 +733,47 @@ check(
     else process.env.DSH_TUI_STANDALONE_BINARY = origEnv.binary
     if (origEnv.dshHome === undefined) delete process.env.DSH_HOME
     else process.env.DSH_HOME = origEnv.dshHome
+  }
+}
+
+// --- sharp 异平台 optional 过滤（维护群 2026-09-11 反馈：更新时下载全平台
+// --- @img/sharp-*，~90MB 下载量换不来任何运行时价值）----------------------------
+{
+  check('sharp 后缀: glibc linux x64', sharpCurrentSuffix('linux', 'x64', 'glibc') === 'linux-x64')
+  check('sharp 后缀: musl linux arm64', sharpCurrentSuffix('linux', 'arm64', 'musl') === 'linuxmusl-arm64')
+  check('sharp 后缀: win32 x64 直拼', sharpCurrentSuffix('win32', 'x64', 'glibc') === 'win32-x64')
+  const onLinuxX64 = ignoredSharpOptionalPatterns('linux', 'x64', 'glibc')
+  check('忽略清单: 排除本平台 wrapper 与 libvips', !onLinuxX64.includes('@img/sharp-linux-x64') && !onLinuxX64.includes('@img/sharp-libvips-linux-x64'))
+  check('忽略清单: 含异平台代表项', onLinuxX64.includes('@img/sharp-win32-x64') && onLinuxX64.includes('@img/sharp-darwin-arm64') && onLinuxX64.includes('@img/sharp-libvips-linuxmusl-x64'))
+  const onMusl = ignoredSharpOptionalPatterns('linux', 'x64', 'musl')
+  check('忽略清单: musl 环境排除 linuxmusl-x64 而保留 linux-x64', !onMusl.includes('@img/sharp-linuxmusl-x64') && onMusl.includes('@img/sharp-linux-x64'))
+  check('忽略清单: 不含非平台的纯 JS 包', !onMusl.some(p => p.includes('colour')))
+
+  const sharpScratch = mkdtempSync(join(tmpdir(), 'verify-sharp-filter-'))
+  const prevDshHome = process.env.DSH_HOME
+  try {
+    process.env.DSH_HOME = join(sharpScratch, 'dsh-home')
+    const profDir = join(process.env.DSH_HOME, 'profiles', 'dsh-tui')
+    mkdirSync(profDir, { recursive: true })
+    writeFileSync(join(profDir, 'pnpm-workspace.yaml'), 'packages:\n  - .\nnodeLinker: hoisted\n')
+    const first = ensureProfileSharpPlatformFilter('dsh-tui')
+    const yamlText = readFileSync(profileWorkspaceYamlPath('dsh-tui'), 'utf8')
+    check('workspace 预种: 块落盘且带模式行', first !== undefined && yamlText.includes('ignoredOptionalDependencies:') && yamlText.includes(`- '@img/sharp-win32-x64'`))
+    check('workspace 预种: 既有内容保留', yamlText.includes('nodeLinker: hoisted'))
+    check('workspace 预种: 不忽略本机平台', !yamlText.includes(`- '@img/sharp-${sharpCurrentSuffix(process.platform, process.arch, 'glibc')}'`))
+    const second = ensureProfileSharpPlatformFilter('dsh-tui')
+    const afterText = readFileSync(profileWorkspaceYamlPath('dsh-tui'), 'utf8')
+    check('workspace 预种: 幂等（不重复块）', afterText.match(/ignoredOptionalDependencies:/gu)?.length === 1 && second !== undefined)
+    // 用户显式决策优先：已有块不被改写（对齐 allowBuilds 语义）。
+    writeFileSync(join(profDir, 'pnpm-workspace.yaml'), 'ignoredOptionalDependencies:\n  - fsevents\n')
+    const third = ensureProfileSharpPlatformFilter('dsh-tui')
+    check('workspace 预种: 已有块不覆盖', third !== undefined && readFileSync(profileWorkspaceYamlPath('dsh-tui'), 'utf8') === 'ignoredOptionalDependencies:\n  - fsevents\n')
+    rmSync(join(process.env.DSH_HOME, 'profiles', 'absent'), { recursive: true, force: true })
+    check('workspace 预种: profile 目录缺失返回 undefined', ensureProfileSharpPlatformFilter('absent') === undefined)
+  } finally {
+    if (prevDshHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = prevDshHome
+    rmSync(sharpScratch, { recursive: true, force: true })
   }
 }
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -1137,6 +1137,91 @@ function existsSafe(path: string): boolean {
 }
 
 /**
+ * sharp distributes its native binaries as platform-specific optional
+ * dependencies (@img/sharp-<platform> wrappers plus @img/sharp-libvips-<platform>
+ * runtimes). pnpm's lockfile records EVERY platform's entry by design, and
+ * some pnpm update paths materialize all of them — maintainer-group report
+ * 2026-09-11: a 0.10.0 → 0.10.1 update downloaded ~90MB of win32/darwin/
+ * musl/riscv64/s390x/ppc64 binaries on a linux-x64 box. The fix pre-seeds
+ * `ignoredOptionalDependencies` patterns for every OTHER platform: pnpm skips
+ * ignored optionals entirely (no download, no node_modules entry), while the
+ * current platform's packages — the only ones sharp loads — stay untouched.
+ */
+const SHARP_WRAPPER_SUFFIXES: readonly string[] = [
+  'darwin-arm64', 'darwin-x64', 'linux-arm', 'linux-arm64', 'linux-ia32',
+  'linux-ppc64', 'linux-riscv64', 'linux-s390x', 'linux-x64',
+  'linuxmusl-arm', 'linuxmusl-arm64', 'linuxmusl-x64',
+  'win32-arm64', 'win32-ia32', 'win32-x64',
+] as const
+const SHARP_LIBVIPS_SUFFIXES: readonly string[] = [
+  'darwin-arm64', 'darwin-x64', 'linux-arm', 'linux-arm64',
+  'linux-ppc64', 'linux-riscv64', 'linux-s390x', 'linux-x64',
+  'linuxmusl-arm', 'linuxmusl-arm64', 'linuxmusl-x64',
+  'win32-arm64', 'win32-ia32', 'win32-x64',
+] as const
+
+/** The @img suffix of the RUNNING platform (musl linux maps to linuxmusl). */
+export function sharpCurrentSuffix(platform: string, cpu: string, libc: string): string {
+  const os = platform === 'linux' && libc === 'musl' ? 'linuxmusl' : platform
+  return `${os}-${cpu}`
+}
+
+/** Patterns for every @img platform package EXCEPT the running one. */
+export function ignoredSharpOptionalPatterns(platform: string, cpu: string, libc: string): string[] {
+  const current = sharpCurrentSuffix(platform, cpu, libc)
+  return [
+    ...SHARP_WRAPPER_SUFFIXES.filter(s => s !== current).map(s => `@img/sharp-${s}`),
+    ...SHARP_LIBVIPS_SUFFIXES.filter(s => s !== current).map(s => `@img/sharp-libvips-${s}`),
+  ]
+}
+
+/** Conservative musl probe: Alpine's loader path or release marker. */
+function isMuslRuntime(): boolean {
+  if (process.platform !== 'linux') return false
+  return existsSafe('/lib/ld-musl-x86_64.so.1') || existsSafe('/lib/ld-musl-aarch64.so.1') || existsSafe('/etc/alpine-release')
+}
+
+/** What ensureProfileSharpPlatformFilter wrote. */
+export interface SharpPlatformFilterOutcome {
+  /** Patterns appended this run (0 when the block already existed). */
+  added: string[]
+}
+
+/**
+ * Append an `ignoredOptionalDependencies:` block covering every non-current
+ * @img platform package to the profile's pnpm-workspace.yaml, so updates stop
+ * downloading ~90MB of foreign-platform sharp binaries. Best effort and
+ * idempotent, mirroring ensureProfileAllowBuilds: an existing block is an
+ * explicit user decision and is never touched; a missing file is created.
+ * Returns undefined when the profile directory is absent or the write failed —
+ * the update still runs, only the download-size win is lost.
+ */
+export function ensureProfileSharpPlatformFilter(profile: string): SharpPlatformFilterOutcome | undefined {
+  const yamlPath = profileWorkspaceYamlPath(profile)
+  try {
+    if (!existsSafe(dirname(yamlPath))) return undefined
+    let text = ''
+    try {
+      text = readFileSync(yamlPath, 'utf8')
+    } catch {
+      // Missing file — start from an empty document; writeFileSync creates it.
+    }
+    for (const line of text.split(/\r?\n/u)) {
+      if (line !== '' && line === line.trimStart() && /^ignoredOptionalDependencies:/u.test(line)) {
+        return { added: [] }
+      }
+    }
+    const patterns = ignoredSharpOptionalPatterns(process.platform, process.arch, isMuslRuntime() ? 'musl' : 'glibc')
+    const block = ['', 'ignoredOptionalDependencies:', ...patterns.map(p => `  - '${p}'`)]
+    const next = text === '' ? block.slice(1).join('\n') + '\n' : text.endsWith('\n') ? text + block.join('\n') + '\n' : text + '\n' + block.join('\n') + '\n'
+    writeFileSync(yamlPath, next, 'utf8')
+    return { added: patterns }
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * The pnpm Windows tmp-rename race signature (issue #225): pnpm swaps a
  * package directory via a `<name>_tmp_<pid>` staging dir, and a file lock or
  * AV scan makes the scandir/rename fail with ENOENT/EPERM/EBUSY. The failure
@@ -1363,6 +1448,15 @@ export async function updateTui(
     process.stderr.write(
       `dsh-tui: pre-seeded profile pnpm allowBuilds (${allowBuilds.added.join(', ')}) — ` +
         'postinstall-only deps are explicitly ignored\n',
+    )
+  }
+  // Foreign-platform @img/sharp-* optionals are pure download waste (~90MB on
+  // the maintainer-group report); ignore them so pnpm never fetches them.
+  const sharpFilter = ensureProfileSharpPlatformFilter(profile)
+  if (sharpFilter !== undefined && sharpFilter.added.length > 0) {
+    process.stderr.write(
+      `dsh-tui: pre-seeded sharp platform filter (${sharpFilter.added.length} foreign @img packages ignored) — ` +
+        'only the current platform\'s binaries download\n',
     )
   }
   // pnpm ≥11's minimumReleaseAge (24h by default) refuses installs of

--- a/src/update.ts
+++ b/src/update.ts
@@ -1147,17 +1147,16 @@ function existsSafe(path: string): boolean {
  * ignored optionals entirely (no download, no node_modules entry), while the
  * current platform's packages — the only ones sharp loads — stay untouched.
  */
-const SHARP_WRAPPER_SUFFIXES: readonly string[] = [
-  'darwin-arm64', 'darwin-x64', 'linux-arm', 'linux-arm64', 'linux-ia32',
+const SHARP_WRAPPER_SUFFIXES = [
+  'darwin-arm64', 'darwin-x64', 'freebsd-wasm32', 'linux-arm', 'linux-arm64',
   'linux-ppc64', 'linux-riscv64', 'linux-s390x', 'linux-x64',
-  'linuxmusl-arm', 'linuxmusl-arm64', 'linuxmusl-x64',
+  'linuxmusl-arm64', 'linuxmusl-x64',
   'win32-arm64', 'win32-ia32', 'win32-x64',
 ] as const
-const SHARP_LIBVIPS_SUFFIXES: readonly string[] = [
+const SHARP_LIBVIPS_SUFFIXES = [
   'darwin-arm64', 'darwin-x64', 'linux-arm', 'linux-arm64',
   'linux-ppc64', 'linux-riscv64', 'linux-s390x', 'linux-x64',
-  'linuxmusl-arm', 'linuxmusl-arm64', 'linuxmusl-x64',
-  'win32-arm64', 'win32-ia32', 'win32-x64',
+  'linuxmusl-arm64', 'linuxmusl-x64',
 ] as const
 
 /** The @img suffix of the RUNNING platform (musl linux maps to linuxmusl). */
@@ -1165,6 +1164,16 @@ export function sharpCurrentSuffix(platform: string, cpu: string, libc: string):
   const os = platform === 'linux' && libc === 'musl' ? 'linuxmusl' : platform
   return `${os}-${cpu}`
 }
+
+/**
+ * Deliberate omission: sharp's registry matrix (0.35.3) also carries the
+ * platform-agnostic `wasm32` fallback (~9MB unpacked) plus
+ * `webcontainers-wasm32`. They carry no os constraint, so they resolve on
+ * every platform — including architectures with no native @img build at all
+ * (loong64 etc.), where wasm is the only working form. They are therefore
+ * NOT ignored: updates keep downloading them, trading ~9MB for not breaking
+ * sharp on fallback-only architectures.
+ */
 
 /** Patterns for every @img platform package EXCEPT the running one. */
 export function ignoredSharpOptionalPatterns(platform: string, cpu: string, libc: string): string[] {
@@ -1175,10 +1184,33 @@ export function ignoredSharpOptionalPatterns(platform: string, cpu: string, libc
   ]
 }
 
-/** Conservative musl probe: Alpine's loader path or release marker. */
+/**
+ * Libc detection, parameterized for tests. Node's report wins when present:
+ * a stray musl loader (Debian's musl package, cross-compile toolchains) on a
+ * glibc system must NOT flip the verdict, or the current platform's own
+ * packages would land in the ignore list — and the never-touch-existing-block
+ * rule would keep that wrong list forever. The loader-path probe only
+ * answers when the report is unavailable (same fallback sharp's detect-libc
+ * uses).
+ */
+export function detectLibc(
+  report: { header?: { glibcVersionRuntime?: string } } | undefined,
+  muslLoaderPresent: boolean,
+): 'glibc' | 'musl' {
+  if (process.platform !== 'linux') return 'glibc'
+  if (report?.header?.glibcVersionRuntime !== undefined) return 'glibc'
+  return muslLoaderPresent ? 'musl' : 'glibc'
+}
+
+/** The running libc, via detectLibc's precedence (report first, paths last). */
 function isMuslRuntime(): boolean {
-  if (process.platform !== 'linux') return false
-  return existsSafe('/lib/ld-musl-x86_64.so.1') || existsSafe('/lib/ld-musl-aarch64.so.1') || existsSafe('/etc/alpine-release')
+  const report = (process.report as NodeJS.ProcessReport | undefined)?.getReport() as
+    | { header?: { glibcVersionRuntime?: string } }
+    | undefined
+  return detectLibc(
+    report,
+    existsSafe('/lib/ld-musl-x86_64.so.1') || existsSafe('/lib/ld-musl-aarch64.so.1') || existsSafe('/etc/alpine-release'),
+  ) === 'musl'
 }
 
 /** What ensureProfileSharpPlatformFilter wrote. */
@@ -1455,8 +1487,8 @@ export async function updateTui(
   const sharpFilter = ensureProfileSharpPlatformFilter(profile)
   if (sharpFilter !== undefined && sharpFilter.added.length > 0) {
     process.stderr.write(
-      `dsh-tui: pre-seeded sharp platform filter (${sharpFilter.added.length} foreign @img packages ignored) — ` +
-        'only the current platform\'s binaries download\n',
+      `dsh-tui: pre-seeded sharp platform filter (${sharpFilter.added.length} foreign-platform patterns ignored) — ` +
+        `only the current platform's binaries download (needs pnpm ≥10.17; older pnpm silently ignores the key)\n`,
     )
   }
   // pnpm ≥11's minimumReleaseAge (24h by default) refuses installs of


### PR DESCRIPTION
Closes #860

## 问题

维护群反馈（截图实证）：`/update` 0.10.0 → 0.10.1 在 linux-x64 上下载了 12+ 个异平台 `@img/sharp-*` 原生包（win32/darwin/musl/riscv64/s390x/ppc64 全家），约 **90MB** 无效下载。

## 根因链（全部实证）

1. sharp 以 `optionalDependencies` 全平台分发原生包
2. pnpm lockfile **天然记录全平台条目**（实测 89 条——锁文件跨平台一致性设计）
3. 首次安装按 os/cpu 过滤只下本平台（pnpm 11.21/11.22 × hoisted/isolated 四组合对照实验）
4. 部分更新路径把 lockfile 中的异平台 optional 物化为下载（群友现场；精确的 pnpm 内部路径未及复现，但修复与之正交）
5. dsh-tui 自身预种（allowBuilds/release-age）已排除致因

## 方案

`/update` 预种 profile 的 `pnpm-workspace.yaml` 时追加 `ignoredOptionalDependencies` 块——**枚举全部 `@img/sharp-*` 平台包、排除当前平台**（libc 判定：Node report 的 `glibcVersionRuntime` 优先，musl loader 路径探测兜底——glibc 系统装过 musl 包不会误判）。pnpm 对 ignored optional 完全跳过；幂等且用户决策优先（已有块永不覆盖），与 `ensureProfileAllowBuilds` 同一模式。平台清单对齐 sharp 0.35.3 registry 矩阵；无平台归属的 wasm32 回退包**显式保留**（约 9MB，是无原生包架构的唯一可用形态）。

**效果**：更新下载量约 90MB → 约 18MB（需 pnpm ≥10.17；旧版静默忽略该键仅失去收益）。

## 验证

- `verify-update.mjs` 新增 17 条断言全绿：后缀组合、忽略清单排除本平台（wrapper+libvips）、registry 矩阵对齐（不列不存在的包）、wasm 回退显式保留、musl/glibc 互斥排除、libc 判定真值表（report 优先于 loader 探测）、预种幂等 / 既有块不覆盖 / 缺目录降级
- `verify-update-recovery.mjs` 全绿、`tsc` 干净
- **独立审查**（Claude opus 七维度）：approve 附建议——musl 假阳性、registry 矩阵偏差、pnpm 版本下限、断言硬编码四项发现已全部修复于第二个 commit（`2310e3ac`）
- 根因链各环节附对照实验与 registry/npm 实证（见 issue #860）
