### PR TITLE
修复长对话流式渲染卡顿与尾部空白

### DIFF
--- a/scripts/run-ci-group.mjs
+++ b/scripts/run-ci-group.mjs
@@ -60,6 +60,10 @@ const GROUPS = {
     ["verify-thinking-preview", ['node', '--import', 'tsx/esm', 'scripts/verify-thinking-preview.tsx']],
     ["repro-thinking-stream-fold", ['node', '--import', 'tsx/esm', 'scripts/repro-thinking-stream-fold.tsx']],
     ["verify-streaming-markdown-spacing", ['node', '--import', 'tsx/esm', 'scripts/verify-streaming-markdown-spacing.tsx']],
+    ['verify-text-measure-cache', ['node', '--import', 'tsx/esm', 'scripts/verify-text-measure-cache.ts']],
+    ['verify-text-wrap-geometry', ['node', '--import', 'tsx/esm', 'scripts/verify-text-wrap-geometry.tsx']],
+    ['verify-streaming-markdown-blocks', ['node', '--import', 'tsx/esm', 'scripts/verify-streaming-markdown-blocks.tsx']],
+    ['verify-text-paint-budget', ['node', '--import', 'tsx/esm', 'scripts/verify-text-paint-budget.tsx']],
 // 流式平滑揭示回归（dsh-tui.smoothStreaming）：调度器步进/游标生命周期
 // （追加保游标、替换 snap、追平不再重打）+ MessageList 集成（流式行/
 // 非流式 fresh 行渐进揭示、回放行直出、开关关闭直出）+ 组件契约

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -18,7 +18,7 @@ process.env.FORCE_COLOR = '3'
 // locale, none of which a runner is obliged to agree with.
 process.env.DSH_TUI_LANG = 'zh'
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settled, sleep }] =
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, { render }, { Chat }, { QuestionStore }, { settled, sleep, viewportLines }] =
   await Promise.all([
     import('node:stream'),
     import('react'),
@@ -223,10 +223,10 @@ for (const pendingFrame of [false, true]) {
 
   harness.stdin.write(CTRL_P)
   check('Ctrl+P collapses the panel again', await settled(() => {
-    const text = harness.screen()
+    const text = viewportLines(harness.term).join('\n')
     return panelHeader(text).includes('Ctrl+P') && !text.includes('你是 dsh')
   }),
-    panelHeader(harness.screen()).trim())
+    panelHeader(viewportLines(harness.term).join('\n')).trim())
 
   harness.stdin.write(CTRL_T)
   check('Ctrl+T opens the trajectory even before the first message', await settled(() => isScene(harness.screen())),

--- a/scripts/verify-ctrl-t-scope.tsx
+++ b/scripts/verify-ctrl-t-scope.tsx
@@ -193,13 +193,25 @@ const panelHeader = (text: string): string =>
 
 // ── empty transcript: the panel is collapsed; Ctrl+P toggles it, Ctrl+T
 //    still opens the trajectory ────────────────────────────────────────────
-{
+for (const pendingFrame of [false, true]) {
+  console.log(`\nEmpty transcript: ${pendingFrame ? 'pending paint during collapse' : 'normal scheduling'}`)
   const harness = makeHarness(100, 30)
   const localReports: Array<{ title: string; lines: readonly string[] }> = []
   const instance = await mount(harness, makeChannel({
     rows: [],
     pushLocal: (title: string, lines: readonly string[]) => { localReports.push({ title, lines }) },
   }))
+  if (pendingFrame) {
+    const ink = instances.get(harness.stdout as never)!
+    const reanchor = ink.reanchorViewport.bind(ink)
+    let reanchors = 0
+    ink.reanchorViewport = () => {
+      reanchor()
+      // Reproduce a queued animation paint consuming the collapse request
+      // before React commits. Reanchoring must observe the new layout.
+      if (++reanchors === 2) ink.onRender()
+    }
+  }
   check('the startup context panel is on screen', await settled(() => /已加载上下文/.test(harness.screen())))
   check('the collapsed panel claims Ctrl+P', await settled(() => panelHeader(harness.screen()).includes('Ctrl+P')), panelHeader(harness.screen()).trim())
 
@@ -210,7 +222,10 @@ const panelHeader = (text: string): string =>
     harness.screen().split('\n').filter(line => line.includes('/context')).join(' | '))
 
   harness.stdin.write(CTRL_P)
-  check('Ctrl+P collapses the panel again', await settled(() => !harness.screen().includes('你是 dsh')),
+  check('Ctrl+P collapses the panel again', await settled(() => {
+    const text = harness.screen()
+    return panelHeader(text).includes('Ctrl+P') && !text.includes('你是 dsh')
+  }),
     panelHeader(harness.screen()).trim())
 
   harness.stdin.write(CTRL_T)

--- a/scripts/verify-resize-temporal.tsx
+++ b/scripts/verify-resize-temporal.tsx
@@ -117,12 +117,19 @@ function doResize(app: { stdout: any; term: typeof XTerm.prototype }, w: number,
 const app = await mountChat(makeRows())
 const composerY = (lines: string[]) => lines.findIndex(l => l.includes('╭'))
 const sentinelY = (lines: string[]) => lines.findIndex(l => l.includes('SENTINEL-TAIL'))
-// 基线就绪 = composer 与 transcript 最后一行（sentinel）都已上屏，且右缘
-// 滚动条（▴）已画上——滚动条在首个内容帧之后的一帧才出现，只等内容会把
-// 无滚动条的早帧当基线，导致回基线比对必挂。
+// 时间线高亮晚于首帧和行高校正到达；整屏稳定后再取基线，避免把
+// 尚未收敛的高亮拿去与 resize 后的稳定画面对比。
+let initialScreen = ''
+let initialScreenChangedAt = Date.now()
 const baselineReady = await settled(() => {
   const lines = screenLines(app.term)
+  const snapshot = lines.join('\n')
+  if (snapshot !== initialScreen) {
+    initialScreen = snapshot
+    initialScreenChangedAt = Date.now()
+  }
   return composerY(lines) >= 0 && sentinelY(lines) >= 0 && lines.some(l => l.endsWith('▴'))
+    && Date.now() - initialScreenChangedAt >= 100
 })
 await app.flush()
 const baseline = screenLines(app.term)

--- a/scripts/verify-streaming-markdown-blocks.tsx
+++ b/scripts/verify-streaming-markdown-blocks.tsx
@@ -1,0 +1,135 @@
+/**
+ * Long Markdown blocks must match the unsplit formatter, including spacing.
+ * Run: node --import tsx/esm scripts/verify-streaming-markdown-blocks.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_LANG = 'en'
+
+import assert from 'node:assert/strict'
+import type { Tokens } from 'marked'
+import type { DOMNode, TextNode, DOMElement } from '../src/ink/dom.js'
+import type { Frame } from '../src/ink/frame.js'
+import type { Screen } from '../src/ink/screen.js'
+
+const [React, { marked }, { Box, Text }, { Markdown }, { StreamingMarkdown }, { MarkdownTable }, { configureMarked, formatToken }, { renderToScreen }, { cellAtIndex }] = await Promise.all([
+  import('react'), import('marked'), import('../src/ui.js'),
+  import('../src/components/Markdown.js'), import('../src/components/StreamingMarkdown.js'),
+  import('../src/components/MarkdownTable.js'), import('../src/terminal-utils/markdown.js'),
+  import('../src/ink/render-to-screen.js'), import('../src/ink/screen.js'),
+])
+configureMarked()
+
+function unsplit(source: string): React.ReactElement {
+  const nodes: React.ReactNode[] = []
+  let text = ''
+  const flush = () => {
+    if (text) nodes.push(<Text key={nodes.length}>{text.trim()}</Text>)
+    text = ''
+  }
+  for (const token of marked.lexer(source.trim())) {
+    if (token.type === 'table') {
+      flush()
+      nodes.push(<MarkdownTable key={nodes.length} token={token as Tokens.Table} highlight={null} />)
+    } else text += formatToken(token)
+  }
+  flush()
+  return <Box flexDirection="column" gap={1}>{nodes}</Box>
+}
+
+function screenSnapshot(screen: Screen, height = screen.height, styles = true) {
+  return {
+    height,
+    cells: Array.from({ length: screen.width * height }, (_, index) => {
+      const cell = cellAtIndex(screen, index)
+      // wrap-ansi normalizes wrapped text; a short unwrapped suffix can
+      // retain decomposed code points for the same displayed grapheme.
+      return { char: cell.char.normalize(), width: cell.width, hyperlink: cell.hyperlink, styleId: styles ? cell.styleId : undefined }
+    }),
+  }
+}
+
+function snapshot(element: React.ReactElement, width: number, styles = true) {
+  const { screen, height } = renderToScreen(element, width)
+  return screenSnapshot(screen, height, styles)
+}
+
+const paragraph = (index: number) => `Paragraph ${index}: **bold text**, inline \`value\`, and ordinary words to exercise wrapping across the sealed boundary.\n\n`
+const prefix = Array.from({ length: 100 }, (_, index) => paragraph(index)).join('')
+const cases = [
+  prefix + 'tail',
+  prefix + '\n\n\nlast paragraph\n',
+  prefix + '```ts\nconst value = 1\n```\nprose after code\n\n',
+  prefix + '- first item\n- second item\n\nnext paragraph',
+  prefix + '> a quoted paragraph\n> another line\n\ntail',
+  prefix + '| a | b |\n| - | - |\n| 1 | 2 |\n\n| c |\n| - |\n| 3 |\n\ntail',
+  '[link][target]\n\n' + prefix + '[target]: https://example.invalid\n\ntail',
+  prefix + '<div>hidden</div>\n\nvisible tail',
+  prefix + '\u4e2d\u6587 e\u0301 \ud83d\ude00 final text',
+  prefix.slice(0, 7600) + '\n\n| a | b |\n| - | - |\n' + '| long cell content | another cell |\n'.repeat(40) + '\ntail',
+  '```\n' + 'a long code line\n'.repeat(600) + '```\n\ntail',
+]
+
+for (const width of [55, 100]) {
+  for (const [index, source] of cases.entries()) {
+    const expected = snapshot(unsplit(source), width)
+    assert.deepEqual(snapshot(<Markdown>{source}</Markdown>, width), expected, `settled case ${index}, width ${width}`)
+    assert.deepEqual(snapshot(<StreamingMarkdown>{source}</StreamingMarkdown>, width), expected, `streaming case ${index}, width ${width}`)
+  }
+}
+
+const [{ PassThrough, Writable }, { render }, { default: instances }, { settled }, { scanPositions }] = await Promise.all([
+  import('node:stream'), import('../src/ui.js'), import('../src/ink/instances.js'),
+  import('./lib/term-test.mjs'), import('../src/ink/render-to-screen.js'),
+])
+class Input extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+class Output extends Writable {
+  isTTY = true
+  columns = 55
+  rows = 1000
+  _write(_chunk: unknown, _encoding: BufferEncoding, done: () => void) { done() }
+}
+function firstParagraph(node: DOMNode): TextNode | undefined {
+  if (node.nodeName === '#text') return node.nodeValue.includes('Paragraph 0:') ? node : undefined
+  for (const child of node.childNodes) {
+    const found = firstParagraph(child)
+    if (found) return found
+  }
+  return undefined
+}
+const stdout = new Output()
+const app = await render(<StreamingMarkdown>{prefix + 'WARM-TAIL-0'}</StreamingMarkdown>, {
+  stdout: stdout as unknown as NodeJS.WriteStream, stdin: new Input() as unknown as NodeJS.ReadStream,
+  stderr: new Output() as unknown as NodeJS.WriteStream, exitOnCtrlC: false, patchConsole: false,
+})
+const ink = instances.get(stdout as unknown as NodeJS.WriteStream) as unknown as { rootNode: DOMElement; frontFrame: Frame }
+try {
+  assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'WARM-TAIL-0').length === 1))
+  const sealed = firstParagraph(ink.rootNode)!
+  const sealedText = sealed.nodeValue
+  const appended = prefix + 'WARM-TAIL-0\n\n' + paragraph(101) + 'WARM-TAIL-1'
+  app.rerender(<StreamingMarkdown>{appended}</StreamingMarkdown>)
+  assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'WARM-TAIL-1').length === 1))
+  assert.equal(firstParagraph(ink.rootNode), sealed, 'an append must retain the sealed text node')
+  assert.equal(sealed.nodeValue, sealedText, 'an append must not rewrite the sealed text')
+  // Style IDs are local to each render root. The cold comparisons above
+  // check colours; this cross-root check covers geometry, text and links.
+  assert.deepEqual(screenSnapshot(ink.frontFrame.screen, undefined, false), snapshot(unsplit(appended), 55, false))
+
+  const replacement = '[go][target]\n\n' + prefix + 'REPLACED-END'
+  app.rerender(<StreamingMarkdown>{replacement}</StreamingMarkdown>)
+  assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'REPLACED-END').length === 1))
+  assert.deepEqual(screenSnapshot(ink.frontFrame.screen, undefined, false), snapshot(unsplit(replacement), 55, false), 'replacement drops obsolete blocks')
+  const defined = replacement + '\n\n[target]: https://example.invalid\n\nLINK-END'
+  app.rerender(<StreamingMarkdown>{defined}</StreamingMarkdown>)
+  assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'LINK-END').length === 1))
+  assert.deepEqual(screenSnapshot(ink.frontFrame.screen, undefined, false), snapshot(unsplit(defined), 55, false), 'late definitions update earlier references')
+} finally {
+  await app.unmount()
+}
+
+console.log('streaming Markdown blocks passed (unsplit cell equivalence, tables, code, references and Unicode)')

--- a/scripts/verify-streaming-markdown-blocks.tsx
+++ b/scripts/verify-streaming-markdown-blocks.tsx
@@ -63,6 +63,9 @@ const cases = [
   prefix + '> a quoted paragraph\n> another line\n\ntail',
   prefix + '| a | b |\n| - | - |\n| 1 | 2 |\n\n| c |\n| - |\n| 3 |\n\ntail',
   '[link][target]\n\n' + prefix + '[target]: https://example.invalid\n\ntail',
+  '[target]: https://example.invalid\n\n' + prefix + '[go][target]',
+  prefix + '[target]: https://example.invalid\n\n[go][target]',
+  '[target]: https://example.invalid\n\n' + prefix + '[go][target] ' + 'growing tail '.repeat(400),
   prefix + '<div>hidden</div>\n\nvisible tail',
   prefix + '\u4e2d\u6587 e\u0301 \ud83d\ude00 final text',
   prefix.slice(0, 7600) + '\n\n| a | b |\n| - | - |\n' + '| long cell content | another cell |\n'.repeat(40) + '\ntail',
@@ -128,6 +131,15 @@ try {
   app.rerender(<StreamingMarkdown>{defined}</StreamingMarkdown>)
   assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'LINK-END').length === 1))
   assert.deepEqual(screenSnapshot(ink.frontFrame.screen, undefined, false), snapshot(unsplit(defined), 55, false), 'late definitions update earlier references')
+
+  const referencePrefix = '[target]: https://example.invalid\n\n' + prefix
+  for (const [index, tail] of ['[go][target]', '[go][target] more text', '[go][target]\n\n[next][target]'].entries()) {
+    const marker = `REFERENCE-END-${index}`
+    const source = referencePrefix + tail + ' ' + marker
+    app.rerender(<StreamingMarkdown>{source}</StreamingMarkdown>)
+    assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, marker).length === 1))
+    assert.deepEqual(screenSnapshot(ink.frontFrame.screen, undefined, false), snapshot(unsplit(source), 55, false), 'growing suffix resolves definitions from the stable prefix')
+  }
 } finally {
   await app.unmount()
 }

--- a/scripts/verify-text-measure-cache.ts
+++ b/scripts/verify-text-measure-cache.ts
@@ -1,0 +1,153 @@
+/**
+ * Text measurement reuse across Yoga's alternating width probes.
+ * Run: node --import tsx/esm scripts/verify-text-measure-cache.ts
+ * Checks result identity instead of wall time, plus warm/cold dimensions.
+ */
+import assert from 'node:assert/strict'
+import {
+  appendChildNode,
+  createNode,
+  createTextNode,
+  insertBeforeNode,
+  removeChildNode,
+  setStyle,
+  setTextNodeValue,
+} from '../src/ink/dom.js'
+import { YogaLayoutNode } from '../src/ink/layout/yoga.js'
+import type { Styles } from '../src/ink/styles.js'
+import { MeasureMode } from '../src/native-ts/yoga-layout/index.js'
+
+function fixture(text: string, wrap: Styles['textWrap'] = 'wrap') {
+  const node = createNode('ink-text')
+  const leaf = createTextNode(text)
+  insertBeforeNode(node, leaf, node.childNodes[0])
+  setStyle(node, { textWrap: wrap })
+  assert.ok(node.yogaNode instanceof YogaLayoutNode)
+  const measure = node.yogaNode.yoga.measureFunc
+  assert.ok(measure)
+  return {
+    node,
+    leaf,
+    measure: (width: number, mode: MeasureMode = MeasureMode.Exactly) =>
+      measure(width, mode, NaN, MeasureMode.Undefined),
+    dispose: () => node.yogaNode!.freeRecursive(),
+  }
+}
+
+const longText = Array.from({ length: 500 }, (_, i) =>
+  `Paragraph ${i}: Inspect the input, collect symbols, and transform the expression. Keep the result consistent with the recorded source.`,
+).join('\n\n')
+const probes: readonly [number, MeasureMode][] = [
+  [100, MeasureMode.AtMost],
+  [98.03921568627452, MeasureMode.AtMost],
+  [97, MeasureMode.Exactly],
+  [96.03921568627452, MeasureMode.Exactly],
+]
+
+const long = fixture(longText)
+try {
+  const first = probes.map(([width, mode]) => long.measure(width, mode))
+  for (let repeat = 0; repeat < 30; repeat++) {
+    probes.forEach(([width, mode], index) => {
+      assert.equal(long.measure(width, mode), first[index], 'repeat probe must reuse its result before scanning text')
+    })
+  }
+  setTextNodeValue(long.leaf, longText + '\n\nA new paragraph.')
+  probes.forEach(([width, mode], index) => {
+    const result = long.measure(width, mode)
+    assert.notEqual(result, first[index], 'streaming append invalidates every previous width')
+    const cold = fixture(long.leaf.nodeValue)
+    try { assert.deepEqual(result, cold.measure(width, mode)) } finally { cold.dispose() }
+    assert.equal(long.measure(width, mode), result)
+  })
+} finally {
+  long.dispose()
+}
+
+const sources = [
+  '',
+  'short',
+  'alpha beta gamma delta\n\nsecond paragraph',
+  '\x1b[31mcolored text\x1b[0m\nnext line',
+  '\u4e2d\u6587 e\u0301 \ud83d\ude00 \ud83d\udc69\u200d\ud83d\udcbb\nwide characters',
+  'first\tsecond\n\tindented',
+  'a long line with words '.repeat(6),
+  'first\n\nlast\n',
+]
+const widths = [60, 10, 1, 0.5, 0, NaN, Infinity, 100]
+const modes = [MeasureMode.AtMost, MeasureMode.Exactly, MeasureMode.Undefined]
+const wraps: Styles['textWrap'][] = ['wrap', 'wrap-trim', 'truncate', 'truncate-start', 'truncate-middle']
+const warm = fixture('initial')
+try {
+  for (const wrap of wraps) {
+    setStyle(warm.node, { textWrap: wrap })
+    let text = 'one two three four five six\n'
+    for (const suffix of ['', 'tail', '\n', '\nnext', '\t', '\u4e2d\u6587']) {
+      text += suffix
+      setTextNodeValue(warm.leaf, text)
+      const cold = fixture(text, wrap)
+      try {
+        assert.deepEqual(warm.measure(8), cold.measure(8), 'appending after a newline must match a fresh measurement')
+      } finally {
+        cold.dispose()
+      }
+    }
+  }
+  for (const wrap of wraps) {
+    setStyle(warm.node, { textWrap: wrap })
+    for (const text of sources) {
+      setTextNodeValue(warm.leaf, text)
+      for (const width of widths) {
+        for (const mode of modes) {
+          const cold = fixture(text, wrap)
+          try {
+            const result = warm.measure(width, mode)
+            assert.deepEqual(result, cold.measure(width, mode), `${wrap}/${width}/${mode}: ${JSON.stringify(text)}`)
+            assert.equal(warm.measure(width, mode), result, 'unchanged measurement must reuse its result')
+          } finally {
+            cold.dispose()
+          }
+        }
+      }
+    }
+  }
+
+  setStyle(warm.node, { textWrap: 'wrap' })
+  setTextNodeValue(warm.leaf, 'alpha beta gamma delta\nsecond line')
+  const wrapped = warm.measure(8)
+  setStyle(warm.node, { textWrap: 'truncate' })
+  const truncated = warm.measure(8)
+  assert.notEqual(truncated, wrapped, 'wrap-mode changes invalidate unchanged text')
+  const truncatedCold = fixture(warm.leaf.nodeValue, 'truncate')
+  try { assert.deepEqual(truncated, truncatedCold.measure(8)) } finally { truncatedCold.dispose() }
+  setStyle(warm.node, { textWrap: 'wrap' })
+  assert.deepEqual(warm.measure(8), wrapped)
+  const intrinsic = warm.measure(8, MeasureMode.Undefined)
+  assert.notDeepEqual(intrinsic, wrapped, 'intrinsic and constrained probes must not share a result')
+  assert.deepEqual(warm.measure(8), wrapped, 'intrinsic probe cannot overwrite constrained result')
+
+  setTextNodeValue(warm.leaf, 'iiii')
+  const narrow = warm.measure(3)
+  setTextNodeValue(warm.leaf, '\u4e2d\u6587\u4e2d\u6587')
+  assert.notEqual(warm.measure(3), narrow, 'same-length text replacement invalidates the cache')
+
+  const previous = warm.measure(20)
+  const nested = createNode('ink-virtual-text')
+  const nestedLeaf = createTextNode(' nested child content')
+  insertBeforeNode(nested, nestedLeaf, nested.childNodes[0])
+  appendChildNode(warm.node, nested)
+  assert.notEqual(warm.measure(20), previous, 'nested text insertion invalidates the cache')
+  setTextNodeValue(nestedLeaf, ' changed nested content')
+  const cold = fixture(warm.leaf.nodeValue + nestedLeaf.nodeValue)
+  try { assert.deepEqual(warm.measure(20), cold.measure(20)) } finally { cold.dispose() }
+  removeChildNode(warm.node, nested)
+  assert.deepEqual(warm.measure(20), previous, 'nested text removal restores dimensions')
+
+  const old = warm.measure(20)
+  for (let width = 30; width < 70; width++) warm.measure(width)
+  assert.notEqual(warm.measure(20), old, 'old width entries are evicted instead of growing without bound')
+} finally {
+  warm.dispose()
+}
+
+console.log('text measurement cache passed (reuse, append, replacement, nesting, modes, resize and eviction)')

--- a/scripts/verify-text-paint-budget.tsx
+++ b/scripts/verify-text-paint-budget.tsx
@@ -6,13 +6,14 @@ process.env.FORCE_COLOR = '3'
 process.env.DSH_TUI_THEME = 'dark'
 import assert from 'node:assert/strict'
 
-const [React, { PassThrough, Writable }, { Box, Text, ScrollBox, AlternateScreen, render }, { default: Output }, { createNode, createTextNode, insertBeforeNode }, { default: renderNode, resetLayoutShifted, didLayoutShift }, { createScreen, StylePool, CharPool, HyperlinkPool }, { scanPositions }, { default: instances }, { settled }] = await Promise.all([
+const [React, { PassThrough, Writable }, { Box, Text, ScrollBox, AlternateScreen, render }, { default: Output }, { createNode, createTextNode, insertBeforeNode, appendChildNode }, { default: renderNode, resetLayoutShifted, didLayoutShift }, { createScreen, StylePool, CharPool, HyperlinkPool }, { scanPositions }, { default: instances }, { settled }] = await Promise.all([
   import('react'), import('node:stream'), import('../src/ui.js'),
   import('../src/ink/output.js'), import('../src/ink/dom.js'), import('../src/ink/render-node-to-output.js'),
   import('../src/ink/screen.js'), import('../src/ink/render-to-screen.js'),
   import('../src/ink/instances.js'), import('./lib/term-test.mjs'),
 ])
 import type { Frame } from '../src/ink/frame.js'
+import type { Screen } from '../src/ink/screen.js'
 
 const node = createNode('ink-text')
 const leaf = createTextNode('VISIBLE-TEXT')
@@ -27,6 +28,7 @@ const output = new Output({ width: 40, height: 20, stylePool, screen: blank })
 try {
   renderNode(node, output, { offsetY: 30, prevScreen: undefined })
   assert.equal(reads, 0, 'a fully offscreen text leaf must not be read for paint')
+  assert.equal(node.dirty, false, 'culling must finish the text paint lifecycle')
   output.get()
   const next = createScreen(40, 20, stylePool, blank.charPool, blank.hyperlinkPool)
   output.reset(40, 20, next)
@@ -40,6 +42,40 @@ try {
   assert.ok(didLayoutShift(), 'culling moved text must retain old-position invalidation')
 } finally {
   node.yogaNode!.freeRecursive()
+}
+
+const parent = createNode('ink-box')
+parent.yogaNode!.setWidth(40)
+parent.yogaNode!.setHeight(20)
+parent.yogaNode!.setFlexDirection('column')
+const offscreen = createNode('ink-text')
+insertBeforeNode(offscreen, createTextNode('OFFSCREEN'), offscreen.childNodes[0])
+offscreen.yogaNode!.setPosition('top', 30)
+const sibling = createNode('ink-text')
+const siblingText = createTextNode('CACHED-SIBLING')
+insertBeforeNode(sibling, siblingText, sibling.childNodes[0])
+appendChildNode(parent, offscreen)
+appendChildNode(parent, sibling)
+parent.yogaNode!.calculateLayout(40)
+let siblingReads = 0
+Object.defineProperty(siblingText, 'nodeValue', { get() { siblingReads++; return 'CACHED-SIBLING' } })
+let previous: Screen | undefined
+try {
+  for (let frame = 0; frame < 3; frame++) {
+    // An unrelated parent repaint must not make a clean visible sibling
+    // inherit the culled text's dirty state on every following frame.
+    parent.dirty = true
+    siblingReads = 0
+    output.reset(40, 20, createScreen(40, 20, stylePool, blank.charPool, blank.hyperlinkPool))
+    renderNode(parent, output, { prevScreen: previous })
+    previous = output.get()
+    assert.equal(offscreen.dirty, false)
+    assert.equal(scanPositions(previous, 'CACHED-SIBLING').length, 1)
+    if (frame === 0) assert.ok(siblingReads > 0)
+    else assert.equal(siblingReads, 0, 'a culled text leaf must not disable later sibling blits')
+  }
+} finally {
+  parent.yogaNode!.freeRecursive()
 }
 
 class Input extends PassThrough {

--- a/scripts/verify-text-paint-budget.tsx
+++ b/scripts/verify-text-paint-budget.tsx
@@ -1,0 +1,87 @@
+/**
+ * Offscreen text and scroll repair must not format a whole long transcript.
+ * Run: node --import tsx/esm scripts/verify-text-paint-budget.tsx
+ */
+process.env.FORCE_COLOR = '3'
+process.env.DSH_TUI_THEME = 'dark'
+import assert from 'node:assert/strict'
+
+const [React, { PassThrough, Writable }, { Box, Text, ScrollBox, AlternateScreen, render }, { default: Output }, { createNode, createTextNode, insertBeforeNode }, { default: renderNode, resetLayoutShifted, didLayoutShift }, { createScreen, StylePool, CharPool, HyperlinkPool }, { scanPositions }, { default: instances }, { settled }] = await Promise.all([
+  import('react'), import('node:stream'), import('../src/ui.js'),
+  import('../src/ink/output.js'), import('../src/ink/dom.js'), import('../src/ink/render-node-to-output.js'),
+  import('../src/ink/screen.js'), import('../src/ink/render-to-screen.js'),
+  import('../src/ink/instances.js'), import('./lib/term-test.mjs'),
+])
+import type { Frame } from '../src/ink/frame.js'
+
+const node = createNode('ink-text')
+const leaf = createTextNode('VISIBLE-TEXT')
+insertBeforeNode(node, leaf, node.childNodes[0])
+node.yogaNode!.setWidth(40)
+node.yogaNode!.calculateLayout(40)
+let reads = 0
+Object.defineProperty(leaf, 'nodeValue', { get() { reads++; return 'VISIBLE-TEXT' } })
+const stylePool = new StylePool()
+const blank = createScreen(40, 20, stylePool, new CharPool(), new HyperlinkPool())
+const output = new Output({ width: 40, height: 20, stylePool, screen: blank })
+try {
+  renderNode(node, output, { offsetY: 30, prevScreen: undefined })
+  assert.equal(reads, 0, 'a fully offscreen text leaf must not be read for paint')
+  output.get()
+  const next = createScreen(40, 20, stylePool, blank.charPool, blank.hyperlinkPool)
+  output.reset(40, 20, next)
+  renderNode(node, output, { offsetY: 0, prevScreen: blank })
+  assert.ok(reads > 0, 'a re-entering text leaf must paint instead of blitting its old blank area')
+  const visible = output.get()
+  assert.equal(scanPositions(visible, 'VISIBLE-TEXT').length, 1)
+  output.reset(40, 20, createScreen(40, 20, stylePool, blank.charPool, blank.hyperlinkPool))
+  resetLayoutShifted()
+  renderNode(node, output, { offsetY: 30, prevScreen: visible })
+  assert.ok(didLayoutShift(), 'culling moved text must retain old-position invalidation')
+} finally {
+  node.yogaNode!.freeRecursive()
+}
+
+class Input extends PassThrough {
+  isTTY = true
+  setRawMode() { return this }
+  ref() { return this }
+  unref() { return this }
+}
+class Sink extends Writable {
+  isTTY = true
+  columns = 40
+  rows = 20
+  _write(_chunk: unknown, _encoding: BufferEncoding, done: () => void) { done() }
+}
+const stdout = new Sink()
+const text = Array.from({ length: 1000 }, (_, i) => `history ${i}`).join('\n')
+const tree = (tail: string) => (
+  <AlternateScreen>
+    <ScrollBox height={20} flexDirection="column" stickyScroll>
+      <Box flexDirection="column"><Text>{text}</Text><Text>{tail}</Text></Box>
+    </ScrollBox>
+  </AlternateScreen>
+)
+const app = await render(tree('TAIL-0'), {
+  stdout: stdout as unknown as NodeJS.WriteStream, stdin: new Input() as unknown as NodeJS.ReadStream,
+  stderr: new Sink() as unknown as NodeJS.WriteStream, exitOnCtrlC: false, patchConsole: false,
+})
+const ink = instances.get(stdout as unknown as NodeJS.WriteStream) as unknown as { frontFrame: Frame }
+const originalWrite = Output.prototype.write
+let largestBlankFill = 0
+try {
+  assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'TAIL-0').length === 1))
+  Output.prototype.write = function (x, y, value, softWrap) {
+    if (value !== '' && value.trim() === '') largestBlankFill = Math.max(largestBlankFill, value.split('\n').length)
+    return originalWrite.call(this, x, y, value, softWrap)
+  }
+  app.rerender(tree('TAIL-0\nTAIL-1'))
+  assert.ok(await settled(() => scanPositions(ink.frontFrame.screen, 'TAIL-1').length === 1))
+  assert.ok(largestBlankFill <= 20, `scroll repair allocated ${largestBlankFill} blank rows for a 20-row viewport`)
+} finally {
+  Output.prototype.write = originalWrite
+  await app.unmount()
+}
+
+console.log('text paint budget passed (offscreen culling, re-entry and bounded scroll repair)')

--- a/scripts/verify-text-wrap-geometry.tsx
+++ b/scripts/verify-text-wrap-geometry.tsx
@@ -1,0 +1,47 @@
+/**
+ * Fractional Yoga constraints must paint exactly the rows measurement reserves.
+ * Run: node --import tsx/esm scripts/verify-text-wrap-geometry.tsx
+ */
+process.env.FORCE_COLOR = '3'
+import assert from 'node:assert/strict'
+
+const [React, { default: Box }, { default: Text }, { renderToScreen, scanPositions }, { default: wrapText }, { createNode, createTextNode, insertBeforeNode, setTextNodeValue }, { YogaLayoutNode }] = await Promise.all([
+  import('react'), import('../src/ink/components/Box.js'),
+  import('../src/ink/components/Text.js'), import('../src/ink/render-to-screen.js'),
+  import('../src/ink/wrap-text.js'), import('../src/ink/dom.js'), import('../src/ink/layout/yoga.js'),
+])
+
+const text = Array.from({ length: 200 }, (_, i) =>
+  `Paragraph ${i}: Inspect the input, collect symbols, and transform the expression. Keep the result consistent with the recorded source.`,
+).join('\n\n') + '\nTAIL-END'
+
+for (const width of [20, 20.25, 20.75, 59.5, 96.03921568627452, 97]) {
+  const expectedRows = wrapText(text, width, 'wrap').split('\n').length
+  const rendered = renderToScreen(<Box width={width}><Text>{text}</Text></Box>, 100)
+  assert.equal(rendered.height, expectedRows, `height at ${width} columns`)
+  assert.deepEqual(scanPositions(rendered.screen, 'TAIL-END'), [{ row: expectedRows - 1, col: 0, len: 8 }], `painted tail at ${width} columns`)
+}
+
+const parent = createNode('ink-box')
+const node = createNode('ink-text')
+const leaf = createTextNode(text)
+insertBeforeNode(node, leaf, node.childNodes[0])
+insertBeforeNode(parent, node, parent.childNodes[0])
+assert.ok(node.yogaNode instanceof YogaLayoutNode)
+try {
+  for (const width of [96.03921568627452, 60.5, 100, 96.03921568627452]) {
+    parent.yogaNode!.setWidth(width)
+    for (let pass = 0; pass < 4; pass++) {
+      parent.yogaNode!.calculateLayout(width)
+      const measuredWidth = node.yogaNode.getComputedMeasureWidth()
+      assert.ok(Number.isFinite(measuredWidth))
+      const paintedRows = wrapText(leaf.nodeValue, measuredWidth, 'wrap').split('\n').length
+      assert.equal(node.yogaNode.getComputedHeight(), paintedRows, 'warm layout must restore both height and its measurement width')
+    }
+    setTextNodeValue(leaf, leaf.nodeValue + '\nappended tail')
+  }
+} finally {
+  parent.yogaNode!.freeRecursive()
+}
+
+console.log('text wrap geometry passed (fractional columns, tail visibility, cached layouts and resize)')

--- a/scripts/verify-text-wrap-geometry.tsx
+++ b/scripts/verify-text-wrap-geometry.tsx
@@ -28,17 +28,39 @@ const leaf = createTextNode(text)
 insertBeforeNode(node, leaf, node.childNodes[0])
 insertBeforeNode(parent, node, parent.childNodes[0])
 assert.ok(node.yogaNode instanceof YogaLayoutNode)
+const yoga = node.yogaNode.yoga
+const measure = yoga.measureFunc
+assert.ok(measure)
+let measureCalls = 0
+yoga.measureFunc = (...args) => {
+  measureCalls++
+  return measure(...args)
+}
+const originalWidth = 96.03921568627452
 try {
-  for (const width of [96.03921568627452, 60.5, 100, 96.03921568627452]) {
+  // Each width needs two Yoga cache slots. A third distinct width would
+  // evict the first one before the return, silently testing a cache miss.
+  for (const [index, width] of [originalWidth, 60.5, originalWidth].entries()) {
+    const before = measureCalls
     parent.yogaNode!.setWidth(width)
     for (let pass = 0; pass < 4; pass++) {
       parent.yogaNode!.calculateLayout(width)
-      const measuredWidth = node.yogaNode.getComputedMeasureWidth()
-      assert.ok(Number.isFinite(measuredWidth))
+      const measuredWidth: number = node.yogaNode.getComputedMeasureWidth()
+      assert.equal(measuredWidth, width)
       const paintedRows = wrapText(leaf.nodeValue, measuredWidth, 'wrap').split('\n').length
       assert.equal(node.yogaNode.getComputedHeight(), paintedRows, 'warm layout must restore both height and its measurement width')
     }
-    setTextNodeValue(leaf, leaf.nodeValue + '\nappended tail')
+    if (index === 2) assert.equal(measureCalls, before, 'the width round trip must restore a cached measurement')
+    else assert.ok(measureCalls > before)
+  }
+  const beforeAppend = measureCalls
+  setTextNodeValue(leaf, leaf.nodeValue + '\nappended tail')
+  for (const width of [originalWidth, 100]) {
+    parent.yogaNode!.setWidth(width)
+    parent.yogaNode!.calculateLayout(width)
+    assert.ok(measureCalls > beforeAppend, 'appending invalidates cached text dimensions')
+    assert.equal(node.yogaNode.getComputedMeasureWidth(), width)
+    assert.equal(node.yogaNode.getComputedHeight(), wrapText(leaf.nodeValue, width, 'wrap').split('\n').length, 'appended text must be measured at the current width')
   }
 } finally {
   parent.yogaNode!.freeRecursive()

--- a/src/components/Chat/JobCard.tsx
+++ b/src/components/Chat/JobCard.tsx
@@ -84,6 +84,13 @@ export function JobCard({ job, marginTopOnTurn, onClick }: {
   // A settled job's terminal detail ('exit code: 0') rides the header; a
   // failed/killed one also keeps it as the explanatory tail line.
   const headerDetail = job.detail !== undefined && job.detail !== '' ? job.detail : undefined
+  const headerName = `${t('jobs-card-prefix')}${job.id}`
+  const duration = formatJobDuration(job)
+  const fixedHeader = [
+    info.glyph, headerName, '·', job.kind, '·', '', '·', duration,
+    ...(headerDetail === undefined ? [] : ['·', headerDetail]), '·', info.label,
+  ].join(' ')
+  const labelWidth = Math.max(0, (columns ?? 80) - stringWidth(fixedHeader))
 
   // 点击打开 /jobs 面板；hover 不刷整行背景（转录视觉保持安静），只把
   // 状态 glyph 提亮为品牌色作为可点指示。无外层缩进：任务卡是上方工具
@@ -101,14 +108,14 @@ export function JobCard({ job, marginTopOnTurn, onClick }: {
     <Box flexDirection="row" gap={1}>
       <Text color={hovered && clickable ? 'accent' : info.color}>{info.glyph}</Text>
       <Text bold color={hovered && clickable ? 'accent' : undefined}>
-        {`${t('jobs-card-prefix')}${job.id}`}
+        {headerName}
       </Text>
       <Text dimColor>·</Text>
       <Text dimColor>{job.kind}</Text>
       <Text dimColor>·</Text>
-      <Text>{clipLine(job.label, Math.max(10, rowWidth - 30))}</Text>
+      <Text>{clipLine(job.label, labelWidth)}</Text>
       <Text dimColor>·</Text>
-      <Text dimColor>{formatJobDuration(job)}</Text>
+      <Text dimColor>{duration}</Text>
       {headerDetail !== undefined && <><Text dimColor>·</Text><Text dimColor>{headerDetail}</Text></>}
       <Text dimColor>·</Text>
       <Text color={info.color}>{info.label}</Text>

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -9,8 +9,8 @@ import { MarkdownTable } from './MarkdownTable.js'
  * Markdown 渲染组件：marked 分词 + ANSI 格式化。
  *
  * 表格 token 交给 MarkdownTable 渲染为带边框的 flexbox 布局；
- * 其余块级内容由 formatToken 转成 ANSI 字符串，合并后包进单个
- * Text（整段去首尾空白）。代码块高亮由 cli-highlight 异步提供，
+ * 其余块级内容由 formatToken 转成 ANSI 字符串，按块边界分批放进
+ * Text（只去整段首尾空白）。代码块高亮由 cli-highlight 异步提供，
  * 加载完成后自动触发一次重渲染。无 markdown 语法的纯文本走快速
  * 路径，直接合成段落 token，省掉 lexer 调用。
  */
@@ -36,6 +36,7 @@ type Props = {
 const TOKEN_CACHE_CAPACITY = 200
 const TOKEN_CACHE_CHAR_BUDGET = 200_000
 const TOKEN_CACHE_MAX_SOURCE_LENGTH = 20_000
+const TEXT_BLOCK_BUDGET = 8192
 const tokenCache = new Map<string, Token[]>()
 let tokenCacheChars = 0
 
@@ -98,7 +99,7 @@ function lexWithCache(content: string, allowCache: boolean): Token[] {
 
 /**
  * 把 lexer 产出的 token 列表转成 React 节点序列：table 独立渲染，
- * 其余 token 的 ANSI 文本先累积拼接，再统一包成 Text（去除首尾空白）。
+ * 其余 token 的 ANSI 文本按完整块分批拼接，只去整段首尾空白。
  */
 function renderTokensToNodes(
   tokens: Token[],
@@ -107,15 +108,32 @@ function renderTokensToNodes(
 ): React.ReactNode[] {
   const nodes: React.ReactNode[] = []
   let ansiText = ''
+  let textParts: string[] = []
 
   const flushAnsiText = (): void => {
-    if (!ansiText) return
-    nodes.push(
-      <Text key={nodes.length} dimColor={dimColor}>
-        {ansiText.trim()}
-      </Text>,
-    )
+    if (!ansiText && textParts.length === 0) return
+    if (textParts.length === 0) {
+      nodes.push(<Text key={nodes.length} dimColor={dimColor}>{ansiText.trim()}</Text>)
+    } else {
+      textParts.push(ansiText)
+      let first = 0
+      let last = textParts.length - 1
+      while (first < last && textParts[first]!.trimStart() === '') first++
+      while (last > first && textParts[last]!.trimEnd() === '') last--
+      textParts[first] = textParts[first]!.trimStart()
+      textParts[last] = textParts[last]!.trimEnd()
+      // Each internal boundary replaces exactly one source newline with a
+      // column-child boundary. Only the whole text span trims outer space.
+      nodes.push(
+        <Box key={nodes.length} flexDirection="column">
+          {textParts.slice(first, last + 1).map((part, index) => (
+            <Text key={index} dimColor={dimColor}>{index + first < last ? part.slice(0, -1) : part}</Text>
+          ))}
+        </Box>,
+      )
+    }
     ansiText = ''
+    textParts = []
   }
 
   for (const token of tokens) {
@@ -130,6 +148,12 @@ function renderTokensToNodes(
       )
     } else {
       ansiText += formatToken(token, 0, null, null, highlight)
+      // A top-level token boundary keeps inline formatting and code fences
+      // intact while letting the painter cull finished offscreen text blocks.
+      if (ansiText.length >= TEXT_BLOCK_BUDGET && ansiText.endsWith('\n')) {
+        textParts.push(ansiText)
+        ansiText = ''
+      }
     }
   }
 

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -235,8 +235,8 @@ export function StreamingMarkdown({
   const boundary = prefixRef.current.length
   const tokens = marked.lexer(stripped.substring(boundary))
   const blocks = blocksRef.current
-  // Reference definitions have document-wide scope. Keep the original
-  // whole-prefix parser when they occur, including definitions arriving late.
+  // Reference definitions have document-wide scope, including references
+  // in the growing suffix. These documents cannot use independent parsers.
   if (!blocks.definitions && Object.keys(tokens.links).length > 0) {
     blocks.definitions = true
     blocks.blocks = []
@@ -288,8 +288,12 @@ export function StreamingMarkdown({
     }
   }
 
+  if (blocks.definitions) {
+    return <Markdown dimColor={dimColor} cacheTokens={false}>{stripped}</Markdown>
+  }
+
   const stablePrefix = prefixRef.current
-  const prefixTail = blocks.definitions ? stablePrefix : blocks.tail
+  const prefixTail = blocks.tail
   const suffixSource = stripped.substring(stablePrefix.length)
   const unstableSuffix = clipSuffixTail(suffixSource, cutRef)
   const suffixStart = cutRef.current > 0
@@ -323,7 +327,7 @@ export function StreamingMarkdown({
         </Box>
       ))}
       {prefixTail && (
-        <Box key="prefix" flexDirection="column" marginTop={blocks.definitions ? 0 : blocks.tailGap}>
+        <Box key="prefix" flexDirection="column" marginTop={blocks.tailGap}>
           <Markdown dimColor={dimColor}>{prefixTail}</Markdown>
         </Box>
       )}

--- a/src/components/StreamingMarkdown.tsx
+++ b/src/components/StreamingMarkdown.tsx
@@ -6,10 +6,10 @@ import { t } from '../i18n.js'
 import { Markdown } from './Markdown.js'
 
 /**
- * Renders markdown during streaming by splitting at the last top-level block
- * boundary: everything before is stable (memoized, never re-parsed), only the
- * final block is re-parsed per delta. marked.lexer() correctly handles unclosed code
- * fences as a single token, so block boundaries are always safe.
+ * Renders streaming markdown in sealed groups of completed top-level blocks.
+ * Only the unsealed group and growing final block change as text arrives.
+ * marked.lexer() keeps unclosed fences inside one token, and the boundary
+ * analysis below preserves the whole-document formatter's row spacing.
  */
 /**
  * Tail budget for the unstable suffix during streaming. The sticky view only
@@ -28,6 +28,7 @@ import { Markdown } from './Markdown.js'
 const SUFFIX_TAIL_BUDGET = 3584
 const SUFFIX_BOUNDARY_LOOKBACK = 2048
 const SUFFIX_CUT_STEP = 1024
+const STABLE_BLOCK_BUDGET = 8192
 
 function clipSuffixTail(suffix: string, cut: { current: number }): string {
   const total = suffix.length
@@ -176,6 +177,24 @@ function analyzeSuffixStart(tokens: readonly Token[], startIndex: number): Suffi
   return { kind: undefined, leadingNewlines }
 }
 
+function gapBetween(boundary: StableBoundary, start: SuffixStart): number {
+  if (start.kind === undefined) return 0
+  if (boundary.endsWithTable) {
+    return start.kind === 'table' && (boundary.trailingEmptyTextNode || start.leadingNewlines > 0) ? 2 : 1
+  }
+  return start.kind === 'table' ? 1 : boundary.gap + start.leadingNewlines
+}
+
+type StableBlocks = {
+  blocks: Array<{ text: string; gap: number }>
+  end: number
+  tokens: Token[]
+  tail: string
+  tailGap: number
+  boundary: StableBoundary | undefined
+  definitions: boolean
+}
+
 export function StreamingMarkdown({
   children,
   dimColor = false,
@@ -183,11 +202,13 @@ export function StreamingMarkdown({
   children: string
   dimColor?: boolean
 }): React.ReactNode {
-  // The stable prefix is kept as ONE string identity across renders: a
-  // fresh substring per render would break Markdown's React.memo and
-  // re-layout the entire finished transcript tail on every token. The
-  // identity only changes when a new block boundary advances the prefix.
+  // The prefix tracks source offsets; its rendered blocks are sealed once
+  // so an advancing boundary never reparses the entire accumulated answer.
   const prefixRef = React.useRef('')
+  const blocksRef = React.useRef<StableBlocks>({
+    blocks: [], end: 0, tokens: [], tail: '', tailGap: 0,
+    boundary: undefined, definitions: false,
+  })
   const cutRef = React.useRef(0)
   const boundaryGapRef = React.useRef(0)
   const prefixVisibleRef = React.useRef(false)
@@ -204,11 +225,25 @@ export function StreamingMarkdown({
     prefixVisibleRef.current = false
     prefixEndsWithTableRef.current = false
     prefixTrailingEmptyTextRef.current = false
+    blocksRef.current = {
+      blocks: [], end: 0, tokens: [], tail: '', tailGap: 0,
+      boundary: undefined, definitions: false,
+    }
   }
 
   // Lex only from current boundary — O(unstable length), not O(full text)
   const boundary = prefixRef.current.length
   const tokens = marked.lexer(stripped.substring(boundary))
+  const blocks = blocksRef.current
+  // Reference definitions have document-wide scope. Keep the original
+  // whole-prefix parser when they occur, including definitions arriving late.
+  if (!blocks.definitions && Object.keys(tokens.links).length > 0) {
+    blocks.definitions = true
+    blocks.blocks = []
+    blocks.tokens = []
+    blocks.end = 0
+    blocks.boundary = undefined
+  }
 
   // Last non-space token is the growing block; everything before is final
   let lastContentIdx = tokens.length - 1
@@ -223,6 +258,27 @@ export function StreamingMarkdown({
   if (advance > 0) {
     const stableBoundary = analyzeStableBoundary(tokens, lastContentIdx)
     if (stableBoundary.safe) {
+      if (!blocks.definitions) {
+        let end = boundary
+        for (let index = 0; index < lastContentIdx; index++) {
+          const token = tokens[index]!
+          blocks.tokens.push(token)
+          end += token.raw.length
+          if (end - blocks.end < STABLE_BLOCK_BUDGET) continue
+          const blockBoundary = analyzeStableBoundary(blocks.tokens, blocks.tokens.length)
+          if (!blockBoundary.safe) continue
+          const gap = blocks.boundary === undefined ? 0 : gapBetween(blocks.boundary, analyzeSuffixStart(blocks.tokens, 0))
+          // Detach the sealed slice from the growing source buffer, preserving
+          // UTF-16 code units rather than pinning every historical full reply.
+          const text = Buffer.from(stripped.substring(blocks.end, end), 'utf16le').toString('utf16le')
+          blocks.blocks.push({ text, gap })
+          blocks.end = end
+          blocks.boundary = blockBoundary
+          blocks.tokens = []
+        }
+        blocks.tail = stripped.substring(blocks.end, boundary + advance)
+        blocks.tailGap = blocks.boundary === undefined ? 0 : gapBetween(blocks.boundary, analyzeSuffixStart(blocks.tokens, 0))
+      }
       prefixRef.current = stripped.substring(0, boundary + advance)
       boundaryGapRef.current = stableBoundary.gap
       prefixVisibleRef.current = true
@@ -233,6 +289,7 @@ export function StreamingMarkdown({
   }
 
   const stablePrefix = prefixRef.current
+  const prefixTail = blocks.definitions ? stablePrefix : blocks.tail
   const suffixSource = stripped.substring(stablePrefix.length)
   const unstableSuffix = clipSuffixTail(suffixSource, cutRef)
   const suffixStart = cutRef.current > 0
@@ -259,9 +316,22 @@ export function StreamingMarkdown({
     (stablePrefix === '' || !unstableSuffix.startsWith(stablePrefix))
 
   return (
-    <Box flexDirection="column" gap={boundaryGap}>
-      {stablePrefix && <Markdown dimColor={dimColor}>{stablePrefix}</Markdown>}
-      {hasDistinctSuffix && <Markdown dimColor={dimColor} cacheTokens={false}>{unstableSuffix}</Markdown>}
+    <Box flexDirection="column">
+      {blocks.blocks.map((block, index) => (
+        <Box key={index} flexDirection="column" marginTop={block.gap}>
+          <Markdown dimColor={dimColor}>{block.text}</Markdown>
+        </Box>
+      ))}
+      {prefixTail && (
+        <Box key="prefix" flexDirection="column" marginTop={blocks.definitions ? 0 : blocks.tailGap}>
+          <Markdown dimColor={dimColor}>{prefixTail}</Markdown>
+        </Box>
+      )}
+      {hasDistinctSuffix && (
+        <Box key="suffix" flexDirection="column" marginTop={boundaryGap}>
+          <Markdown dimColor={dimColor} cacheTokens={false}>{unstableSuffix}</Markdown>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/src/ink/dom.ts
+++ b/src/ink/dom.ts
@@ -416,34 +416,20 @@ export const createTextNode = (text: string): TextNode => {
   return node
 }
 
-/**
- * Per-node incremental wrap cache for measureTextNode. A streaming text
- * node grows by append every chunk; without a cache each yoga pass re-wraps
- * the full text (wrapAnsi tokenizes + measures every word — the dominant
- * SLOW_YOGA cost at 20ms+ per frame on long code blocks).
- *
- * Greedy wrapping has no cross-line state, so a text's wrapped height equals
- * the sum of its logical lines' wrapped heights. We therefore commit
- * completed logical lines (everything before the last '\n') into `headHeight`
- * and only re-wrap the growing tail line each pass — O(current line) instead
- * of O(whole text). Cache validity requires same width/wrap mode and the
- * cached text to be a pure prefix of the new text.
- */
-type MeasureWrapCache = {
-  /** Full text as measured last time (post tab-expansion). */
+type TextMeasureCache = {
+  rawText: string
   text: string
-  width: number
   wrap: NonNullable<Styles['textWrap']>
-  /** Wrapped height of text.slice(0, tailStart) — the committed head. */
-  headHeight: number
-  /** Start offset of the uncommitted tail (just past the last '\n'). */
-  tailStart: number
-  /** Wrapped height of text.slice(tailStart). */
-  tailHeight: number
-  /** Last returned dimensions. */
-  result: { width: number; height: number }
+  entries: Array<{
+    width: number
+    widthMode: LayoutMeasureMode
+    result: { width: number; height: number }
+  }>
 }
-const measureWrapCache = new WeakMap<DOMNode, MeasureWrapCache>()
+const textMeasureCache = new WeakMap<DOMNode, TextMeasureCache>()
+// Yoga probes several widths/modes repeatedly in one layout. Retain only
+// the current text's results so streaming cannot accumulate old snapshots.
+const TEXT_MEASURE_CACHE_SIZE = 8
 
 const measureTextNode = function (
   node: DOMNode,
@@ -453,10 +439,30 @@ const measureTextNode = function (
   const rawText =
     node.nodeName === '#text' ? node.nodeValue : squashTextNodes(node)
 
-  // Expand tabs for measurement (worst case: 8 spaces each).
-  // Actual tab expansion happens in output.ts based on screen position.
-  const text = expandTabs(rawText)
+  const textWrap = node.style.textWrap ?? 'wrap'
+  let cache = textMeasureCache.get(node)
+  if (cache === undefined || cache.rawText !== rawText || cache.wrap !== textWrap) {
+    // Tabs use the same measurement expansion as the uncached path.
+    cache = { rawText, text: expandTabs(rawText), wrap: textWrap, entries: [] }
+    textMeasureCache.set(node, cache)
+  }
+  for (const entry of cache.entries) {
+    if (Object.is(entry.width, width) && entry.widthMode === widthMode) return entry.result
+  }
 
+  // Check above before measureText walks every line, even on a wrap-cache hit.
+  const result = measureTextDimensions(cache.text, width, widthMode, textWrap)
+  if (cache.entries.length === TEXT_MEASURE_CACHE_SIZE) cache.entries.shift()
+  cache.entries.push({ width, widthMode, result })
+  return result
+}
+
+function measureTextDimensions(
+  text: string,
+  width: number,
+  widthMode: LayoutMeasureMode,
+  textWrap: NonNullable<Styles['textWrap']>,
+): { width: number; height: number } {
   const dimensions = measureText(text, width)
 
   // Text fits into container, no need to wrap
@@ -483,70 +489,10 @@ const measureTextNode = function (
     return measureText(text, effectiveWidth)
   }
 
-  const textWrap = node.style.textWrap ?? 'wrap'
-
-  // Incremental path: same node, same width/wrap, text grew by append.
-  const cached = measureWrapCache.get(node)
-  if (cached !== undefined && cached.width === width && cached.wrap === textWrap) {
-    if (cached.text === text) {
-      // Same-frame repeat measure (yoga min/max probing) — free.
-      return cached.result
-    }
-    if (text.startsWith(cached.text)) {
-      const tail = text.slice(cached.tailStart)
-      const tailWrapped = wrapText(tail, width, textWrap)
-      const tailDim = measureText(tailWrapped, width)
-      // Commit fully-terminated logical lines into the head so the tail
-      // stays bounded at one line of source text.
-      const lastNewline = tail.lastIndexOf('\n')
-      let { headHeight, tailStart } = cached
-      let tailHeight = tailDim.height
-      if (lastNewline > 0) {
-        const committed = wrapText(tail.slice(0, lastNewline + 1), width, textWrap)
-        headHeight += measureText(committed, width).height
-        tailStart += lastNewline + 1
-        tailHeight = measureText(wrapText(tail.slice(lastNewline + 1), width, textWrap), width).height
-      }
-      const result = {
-        width: Math.max(cached.result.width, tailDim.width),
-        height: headHeight + tailHeight,
-      }
-      measureWrapCache.set(node, {
-        text,
-        width,
-        wrap: textWrap,
-        headHeight,
-        tailStart,
-        tailHeight,
-        result,
-      })
-      return result
-    }
-    // Text replaced or shrunk (node reuse for a different message): fall
-    // through to the full path and overwrite the cache below.
-  }
-
   const wrappedText = wrapText(text, width, textWrap)
-  const fullResult = measureText(wrappedText, width)
-
-  // Seed the incremental cache: commit everything before the last newline.
-  const lastNewline = text.lastIndexOf('\n')
-  const tailStart = lastNewline === -1 ? 0 : lastNewline + 1
-  const headHeight =
-    tailStart === 0
-      ? 0
-      : measureText(wrapText(text.slice(0, tailStart), width, textWrap), width).height
-  measureWrapCache.set(node, {
-    text,
-    width,
-    wrap: textWrap,
-    headHeight,
-    tailStart,
-    tailHeight: fullResult.height - headHeight,
-    result: fullResult,
-  })
-
-  return fullResult
+  // The wrapper has already chosen physical rows. Reapplying width-based
+  // row counting here double-counts trailing spaces at fractional widths.
+  return measureText(wrappedText, Infinity)
 }
 
 // ink-raw-ansi nodes hold pre-rendered ANSI strings with known dimensions.

--- a/src/ink/get-max-width.ts
+++ b/src/ink/get-max-width.ts
@@ -1,29 +1,15 @@
-import { LayoutEdge, type LayoutNode } from './layout/node.js'
+import type { LayoutNode } from './layout/node.js'
 
 /**
- * Returns the yoga node's content width (computed width minus padding and
- * border).
- *
- * Warning: can return a value WIDER than the parent container. In a
- * column-direction flex parent, width is the cross axis — align-items:
- * stretch never shrinks children below their intrinsic size, so the text
- * node overflows (standard CSS behavior). Yoga measures leaf nodes in two
- * passes: the AtMost pass determines width, the Exactly pass determines
- * height. getComputedWidth() reflects the wider AtMost result while
- * getComputedHeight() reflects the narrower Exactly result. Callers that
- * use this for wrapping should clamp to actual available screen space so
- * the rendered line count stays consistent with the layout height.
- * @param yogaNode - the laid-out node to measure.
- * @returns the node's content width: computed width minus padding and border.
+ * Return the text constraint that produced the laid-out height. Pixel-grid
+ * rounding can widen the painted box; wrapping at that rounded width would
+ * produce fewer rows than Yoga reserved and leave blank space at the bottom.
+ * The layout engine retains this constraint through its cache-hit paths.
+ * @param yogaNode - a laid-out text node with a measure function.
+ * @returns content width, already excluding padding and border.
  */
 const getMaxWidth = (yogaNode: LayoutNode): number => {
-  return (
-    yogaNode.getComputedWidth() -
-    yogaNode.getComputedPadding(LayoutEdge.Left) -
-    yogaNode.getComputedPadding(LayoutEdge.Right) -
-    yogaNode.getComputedBorder(LayoutEdge.Left) -
-    yogaNode.getComputedBorder(LayoutEdge.Right)
-  )
+  return yogaNode.getComputedMeasureWidth()
 }
 
 export default getMaxWidth

--- a/src/ink/layout/node.ts
+++ b/src/ink/layout/node.ts
@@ -132,6 +132,8 @@ export type LayoutNode = {
   getComputedLeft(): number
   getComputedTop(): number
   getComputedWidth(): number
+  /** Text's content constraint before layout rounds its painted box. */
+  getComputedMeasureWidth(): number
   getComputedHeight(): number
   getComputedBorder(edge: LayoutEdge): number
   getComputedPadding(edge: LayoutEdge): number

--- a/src/ink/layout/yoga.ts
+++ b/src/ink/layout/yoga.ts
@@ -125,6 +125,10 @@ export class YogaLayoutNode implements LayoutNode {
     return this.yoga.getComputedWidth()
   }
 
+  getComputedMeasureWidth(): number {
+    return this.yoga.getComputedMeasureWidth()
+  }
+
   getComputedHeight(): number {
     return this.yoga.getComputedHeight()
   }

--- a/src/ink/output.ts
+++ b/src/ink/output.ts
@@ -840,6 +840,15 @@ export default class Output {
     })
   }
 
+  /** Whether a rectangle can contribute cells under the current paint clip. */
+  isRectVisible(x: number, y: number, width: number, height: number): boolean {
+    const clip = this.imageClips.at(-1)
+    return x < Math.min(this.width, clip?.x2 ?? this.width) &&
+      x + width > Math.max(0, clip?.x1 ?? 0) &&
+      y < Math.min(this.height, clip?.y2 ?? this.height) &&
+      y + height > Math.max(0, clip?.y1 ?? 0)
+  }
+
   /**
    * Push a clip region; subsequent writes are restricted to it.
    * @param clip - the clip region to apply.

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -936,6 +936,7 @@ function renderNodeToOutput(
     // Keep the old-position cleanup above, but cull before squash/wrap/style.
     if (node.nodeName === 'ink-text' && width > 0 && height > 0 && !output.isRectVisible(x, y, width, height)) {
       nodeCache.delete(node)
+      node.dirty = false
       return
     }
 

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -932,6 +932,13 @@ function renderNodeToOutput(
       return
     }
 
+    // Text is a paint leaf: unlike boxes, it cannot own an escaping overlay.
+    // Keep the old-position cleanup above, but cull before squash/wrap/style.
+    if (node.nodeName === 'ink-text' && width > 0 && height > 0 && !output.isRectVisible(x, y, width, height)) {
+      nodeCache.delete(node)
+      return
+    }
+
     if (node.nodeName === 'ink-raw-ansi') {
       // Pre-rendered ANSI content. The producer already wrapped to width and
       // emitted terminal-ready escape codes. Skip squash, measure, wrap, and
@@ -952,13 +959,8 @@ function renderNodeToOutput(
       const plainText = segments.map(s => s.text).join('')
 
       if (plainText.length > 0) {
-        // Upstream Ink uses getMaxWidth(yogaNode) unclamped here. That
-        // width comes from Yoga's AtMost pass and can exceed the actual
-        // screen space (see getMaxWidth docstring). Yoga's height for this
-        // node already reflects the constrained Exactly pass, so clamping
-        // the wrap width here keeps line count consistent with layout.
-        // Without this, characters past the screen edge are dropped by
-        // setCellAt's bounds check.
+        // Use the same content constraint as measurement, not the rounded
+        // pixel-grid box. Offscreen overflow still clips at the terminal edge.
         const maxWidth = Math.min(getMaxWidth(yogaNode), output.width - x)
         const textWrap = node.style.textWrap ?? 'wrap'
 
@@ -1643,11 +1645,12 @@ function renderNodeToOutput(
                   Math.floor(contentY + childBottom),
                   Math.floor((y1 ?? y) + padTop + innerHeight),
                 )
-                if (screenY < screenBottom) {
-                  const fill = Array(screenBottom - screenY)
+                const fillTop = Math.max(screenY, top)
+                if (fillTop < screenBottom) {
+                  const fill = Array(screenBottom - fillTop)
                     .fill(spaces)
                     .join('\n')
-                  output.write(Math.floor(x), screenY, fill)
+                  output.write(Math.floor(x), fillTop, fill)
                   output.clip({
                     x1: undefined,
                     x2: undefined,

--- a/src/ink/wrap-text.ts
+++ b/src/ink/wrap-text.ts
@@ -10,8 +10,8 @@ const ELLIPSIS = '…'
 // output string. Yet before this cache every consumer re-wrapped from
 // scratch:
 //
-//  - dom.ts measureTextNode seeds its per-NODE incremental cache on first
-//    measure; virtualization unmounts scrolled-away rows, so scrolling back
+//  - dom.ts measureTextNode caches dimensions per node; virtualization
+//    unmounts scrolled-away rows, so scrolling back
 //    re-mounts the row's Text nodes and re-runs the FULL wrap (wrap-ansi
 //    tokenizes + string-width-measures every word — 100-300ms single-frame
 //    yoga spikes when a row of large settled text scrolls in, the dominant

--- a/src/native-ts/yoga-layout/index.ts
+++ b/src/native-ts/yoga-layout/index.ts
@@ -126,6 +126,7 @@ type Layout = {
   top: number
   width: number
   height: number
+  measuredWidth: number
   // Computed per-edge values (resolved to physical edges)
   border: [number, number, number, number] // left, top, right, bottom
   padding: [number, number, number, number]
@@ -508,6 +509,7 @@ export class Node {
   _lOutW = NaN
   /** Cached layout-pass output height restored on a cache hit. */
   _lOutH = NaN
+  _lOutMeasuredWidth = NaN
   /** Whether the single-slot layout cache holds a valid entry. */
   _hasL = false
   /** Cached available width of the last measure call. */
@@ -526,6 +528,7 @@ export class Node {
   _mOutW = NaN
   /** Cached measure-pass output height restored on a cache hit. */
   _mOutH = NaN
+  _mOutMeasuredWidth = NaN
   /** Whether the single-slot measure cache holds a valid entry. */
   _hasM = false
   /**
@@ -563,11 +566,11 @@ export class Node {
    * w,h) so hits with different inputs than _hasL can restore the right
    * dimensions. Upstream yoga uses 16; 4 covers Ink's dirty-chain depth.
    * Packed as flat arrays to avoid per-entry object allocs. Slot i uses
-   * indices [i*8, i*8+8) in _cIn (aW,aH,wM,hM,oW,oH,fW,fH) and [i*2, i*2+2)
-   * in _cOut (w,h).
+   * indices [i*8, i*8+8) in _cIn (aW,aH,wM,hM,oW,oH,fW,fH) and [i*3, i*3+3)
+   * in _cOut (w,h,measuredWidth).
    */
   _cIn: Float64Array | null = null
-  /** Cached output width/height pairs, two slots per entry. */
+  /** Cached dimensions and the leaf width used to measure them. */
   _cOut: Float64Array | null = null
   /** Generation at which the multi-entry cache was last written. */
   _cGen = -1
@@ -594,6 +597,7 @@ export class Node {
       top: 0,
       width: 0,
       height: 0,
+      measuredWidth: NaN,
       border: [0, 0, 0, 0],
       padding: [0, 0, 0, 0],
       margin: [0, 0, 0, 0],
@@ -681,6 +685,7 @@ export class Node {
    */
   reset(): void {
     this.style = defaultStyle()
+    this.layout.measuredWidth = NaN
     this.children = []
     this.parent = null
     this.measureFunc = null
@@ -765,6 +770,10 @@ export class Node {
    */
   getComputedWidth(): number {
     return this.layout.width
+  }
+  /** Content width used by the leaf measure function, before pixel rounding. */
+  getComputedMeasureWidth(): number {
+    return this.layout.measuredWidth
   }
   /**
    * Get the computed height.
@@ -1451,7 +1460,7 @@ function cacheWrite(
 ): void {
   if (!node._cIn) {
     node._cIn = new Float64Array(CACHE_SLOTS * 8)
-    node._cOut = new Float64Array(CACHE_SLOTS * 2)
+    node._cOut = new Float64Array(CACHE_SLOTS * 3)
   }
   // First write after a dirty clears stale entries from before the dirty.
   // _cGen < _generation means entries are from a previous calculateLayout;
@@ -1477,8 +1486,9 @@ function cacheWrite(
   cIn[o + 5] = oH
   cIn[o + 6] = fW ? 1 : 0
   cIn[o + 7] = fH ? 1 : 0
-  node._cOut![i * 2] = node.layout.width
-  node._cOut![i * 2 + 1] = node.layout.height
+  node._cOut![i * 3] = node.layout.width
+  node._cOut![i * 3 + 1] = node.layout.height
+  node._cOut![i * 3 + 2] = node.layout.measuredWidth
   node._cGen = _generation
 }
 
@@ -1494,6 +1504,7 @@ function commitCacheOutputs(node: Node, performLayout: boolean): void {
   if (performLayout) {
     node._lOutW = node.layout.width
     node._lOutH = node.layout.height
+    node._lOutMeasuredWidth = node.layout.measuredWidth
     // A completed layout pass re-laid the whole subtree at the final
     // constraints — any measure-pass scratch below has been overwritten,
     // so this node may serve layout-cache hits again.
@@ -1501,6 +1512,7 @@ function commitCacheOutputs(node: Node, performLayout: boolean): void {
   } else {
     node._mOutW = node.layout.width
     node._mOutH = node.layout.height
+    node._mOutMeasuredWidth = node.layout.measuredWidth
     // This measure call actually computed: its recursion overwrote the
     // subtree's layout.* as scratch for the probed size. Until a layout
     // pass re-lays this subtree, layout-cache hits here must be refused
@@ -1589,6 +1601,7 @@ function layoutNode(
       _yogaCacheHits++
       layout.width = node._lOutW
       layout.height = node._lOutH
+      layout.measuredWidth = node._lOutMeasuredWidth
       return
     }
     // Multi-entry cache: scan for matching inputs, restore cached w/h on hit.
@@ -1620,8 +1633,9 @@ function layoutNode(
           sameFloat(cIn[o + 4]!, ownerWidth) &&
           sameFloat(cIn[o + 5]!, ownerHeight)
         ) {
-          layout.width = node._cOut![i * 2]!
-          layout.height = node._cOut![i * 2 + 1]!
+          layout.width = node._cOut![i * 3]!
+          layout.height = node._cOut![i * 3 + 1]!
+          layout.measuredWidth = node._cOut![i * 3 + 2]!
           _yogaCacheHits++
           return
         }
@@ -1640,6 +1654,7 @@ function layoutNode(
     ) {
       layout.width = node._mOutW
       layout.height = node._mOutH
+      layout.measuredWidth = node._mOutMeasuredWidth
       _yogaCacheHits++
       return
     }
@@ -1742,6 +1757,7 @@ function layoutNode(
         : Math.max(0, height - paddingBorderHeight)
     _yogaMeasureCalls++
     const measured = node.measureFunc(innerW, wMode, innerH, hMode)
+    node.layout.measuredWidth = wMode === MeasureMode.Undefined ? measured.width : innerW
     node.layout.width =
       wMode === MeasureMode.Exactly
         ? width

--- a/src/screens/Chat.tsx
+++ b/src/screens/Chat.tsx
@@ -769,18 +769,20 @@ export function Chat({
   const loadedContextVisible = channel.rows.length === 0 && channel.loadedContext !== undefined
   /** Startup context panel: collapsed by default, toggled with Ctrl+P. */
   const [loadedContextOpen, setLoadedContextOpen] = React.useState(false)
-  /**
-   * The context panel changes the height of the main-screen transcript by a
-   * large amount. In inline mode that invalidates the renderer's previous
-   * scrollback/layout correspondence; asking it to repaint from the physical
-   * viewport prevents the collapsed frame from reusing stale blank cells.
-   */
   const toggleLoadedContext = React.useCallback(() => {
     setLoadedContextOpen(previous => !previous)
+  }, [])
+  const renderedLoadedContextOpen = React.useRef(loadedContextOpen)
+  React.useLayoutEffect(() => {
+    if (renderedLoadedContextOpen.current === loadedContextOpen) return
+    renderedLoadedContextOpen.current = loadedContextOpen
+    // Reanchor after the new panel geometry commits. Requesting it in the
+    // key handler lets a pending paint consume it on the old tall layout,
+    // leaving the collapsed summary stranded outside the physical viewport.
     const ink = instances.get(process.stdout) ?? instances.values().next().value
     ink?.invalidatePrevFrame()
     ink?.reanchorViewport()
-  }, [])
+  }, [loadedContextOpen])
 
   /**
    * Click-to-act targets: the Ink instance's hyperlink-open callback (wired


### PR DESCRIPTION
## 变更摘要 / Summary

修复 fullscreen 长对话流式输出时，累计正文反复参与测量和绘制造成的输入、滚动卡顿，并修复同一路径中的尾部空白。保留完整历史和上游会话事实，不增加限流、依赖或配置。

- 文本测量在全文扫描前复用当前文本的最多 8 组宽度/模式结果；去掉有高度偏差的旧单槽增量缓存。
- 流式 Markdown 在完整、安全的块边界封存约 8 KiB 的稳定组，后续只更新未封存部分；已结束 Markdown 也按完整 token 分组。保留跨块引用、表格、样式和空行语义，封存字符串断开对历史整段字符串的引用。
- 屏外文本叶子在旧位置清理后跳过格式化，容器仍保留越界浮层遍历；滚动补白只分配可见区域。
- Yoga 保存并恢复产生高度的测量宽度，绘制使用同一约束；已换行文本按实际物理行计高，消除小数宽度和尾空格导致的重复计行。
- 同步修正 JobCard 标题的显示单元宽度预算；resize 时序回归等待初始画面稳定再取基线，保持完整往返画面断言。新增 4 个专用回归并登记到 CI。

## 关联 / Related

Closes #872

## 变更类型 / Type

- [x] fix - 修复缺陷
- [x] refactor / perf - 优化既有渲染路径

## 性能对比

生产 React、100x40 fullscreen、600 条历史行、合成段落正文、renderer-facing `createChannelReadView` 投影，35ms 名义更新间隔。下表关闭 smooth reveal 保持前后可比；字符数是 UTF-16 字符，延迟是更新到下一终端帧，不是模型或网络延迟。

| 回复字符数 | 修复前 p50 | 修复后 p50 | 修复后 p95 | 事件循环延迟 max |
| ---: | ---: | ---: | ---: | ---: |
| 281,690 | 101.2ms | 8.9ms | 14.5ms | 1.1ms |
| 700,990 | 271.8ms | 13.8ms | 29.8ms | 8.8ms |

额外开启默认 smoothStreaming 的 700,990 字符验证，更新到帧 p50 约 15.6ms。基线约 28 万字符案例中布局 6,931 行、实际绘制 6,031 行的尾部空白问题已消除。

## 验证 / Verification

- [x] `pnpm build`，源码类型检查及新增脚本单独类型检查。
- [x] 按 `scripts/run-ci-group.mjs` 与 `verify:build` 的登记逐项执行，共 246/246 通过、0 超时，约 644 秒；不是把 `scripts/` 中的交互/取证工具全跑。
- [x] `verify:package`、Bun 1.3.14 包安装/import、`smoke`、上游源码兼容与 auth smoke。
- [x] 真实 Linux PTY + xterm 自动化：fullscreen/inline、70x24/100x40；流式输出、真实 stdin 打字、翻页、resize、结束后的尾部、Ctrl+C 退出与光标/备用屏恢复。

| 本地验证组 | 结果 |
| --- | ---: |
| render-scroll | 47/47 |
| input-terminal | 22/22 |
| session-workspace | 35/35 |
| channel-ui | 66/66 |
| flaky-observation | 2/2 |
| build gates | 69/69 |
| package/Bun/smoke/upstream/auth | 5/5 |

新增聚焦回归可直接重跑：

```sh
NODE_ENV=production node --import tsx/esm scripts/verify-text-measure-cache.ts
NODE_ENV=production node --import tsx/esm scripts/verify-text-wrap-geometry.tsx
NODE_ENV=production node --import tsx/esm scripts/verify-streaming-markdown-blocks.tsx
NODE_ENV=production node --import tsx/esm scripts/verify-text-paint-budget.tsx
```

覆盖缓存复用/失效、分数宽度、精确尾行、分块与原 formatter 的 cell 等价、ANSI/Unicode/表格/晚到引用、稳定节点复用、替换、屏外重入/旧位置失效与补白上限。上游 `0.1.5-rc.1`（`183f08e9`）和 `0.1.5-alpha.2`（`b2e3b2a0`）的 TUI/auth 源码类型检查，以及真实上游 Session 兼容回归均通过。

验证在 Linux x64、Node v26.8.1 进行；各项独立进程和隔离配置目录，剪贴板测试使用固定 `wl-paste` fixture，不读个人剪贴板。未进行人工终端演练、Windows/macOS 原生终端运行或真实模型 API 请求；PTY 覆盖为自动化验证。

## 自查 / Checklist

- [x] 产品代码只改 `src/`；回归只改 `scripts/`。不手改或提交 `lib/` 生成产物、临时探针和日志。
- [x] 官方 `@deepseek-ai/*` import 边界不变，无上游核心或依赖版本改动。
- [x] 无新增行为、配置、快捷键或限制需双语说明；README 和 patch surface 不涉及。
- [x] 仅暂存 17 个显式路径，`git diff --cached --check` 通过。