### PR TITLE
fix(sessions): 已被固化的 hasPrompt 错判需要重算才能自愈

### DIFF
--- a/scripts/verify-session-index.mjs
+++ b/scripts/verify-session-index.mjs
@@ -461,6 +461,81 @@ check(
 check('a backend that lists nothing yields nothing', (await listSummaries({})).length, 0)
 check('a backend that throws yields nothing rather than propagating', (await listSummaries({ list: async () => { throw new Error('boom') } })).length, 0)
 
+// ── 7. A wrong verdict already committed to the index must not be served ─
+// A session first listed before its first human prompt was written derives
+// honestly as "no conversation". Once it grew, a build that carried that
+// verdict across the append — or that read a recovered title without treating
+// it as evidence — committed `hasPrompt: false` alongside a revision the log
+// still reports. The entry and the log agree on the token precisely because
+// the log is no longer written, so the cache-hit path served the wrong verdict
+// forever and /resume counted a real conversation among its empties. The
+// re-derivation below is the whole repair: nothing rewrites the file.
+const staleRevision = 'rev:stale-verdict'
+const staleFile = seed('stale-verdict', [[userPrompt('the only thing ever asked')]])
+const staleSource = {
+  listSnapshots: async () => [{ header: { id: 'stale-verdict', cwd: '/proj', createdAt: 1000 }, revision: staleRevision }],
+  locate: () => ({ kind: 'jsonl', path: staleFile }),
+}
+
+// The entry has to exist before it can be poisoned, so the session is listed
+// once, and only then is the committed verdict overwritten with the wrong one.
+await listSummaries(staleSource)
+const staleIndex = JSON.parse(readFileSync(INDEX_FILE, 'utf8'))
+staleIndex.entries['stale-verdict'].derived.hasPrompt = false
+writeFileSync(INDEX_FILE, JSON.stringify(staleIndex))
+check(
+  'the fixture poisons the cached verdict the way an older build committed it',
+  readIndex().get('stale-verdict').derived.hasPrompt,
+  false,
+)
+
+const repaired = await listSummaries(staleSource)
+check('a cached "no conversation" is not served when a title says otherwise', repaired[0].hasPrompt, true)
+check('and the index is rewritten with the verdict the log supports', readIndex().get('stale-verdict').derived.hasPrompt, true)
+
+// The repaired entry is then reused rather than re-derived: an identical
+// boundary keeps the steady state at zero log reads per listing.
+const repairedAnchor = readIndex().get('stale-verdict').derived.anchor
+await listSummaries(staleSource)
+check(
+  'the repaired entry is reused rather than re-written on every open',
+  readIndex().get('stale-verdict').derived.anchor,
+  repairedAnchor,
+)
+
+// The same shape with no title evidence at all: a boot artifact that outgrew
+// the head window keeps its honest emptiness instead of being listed.
+const bootOverflow = seed('boot-overflow', [])
+appendFileSync(
+  bootOverflow,
+  encode(Array.from({ length: 60 }, (_, i) => [{ type: 'assistant/chunk', seq: 10 + i, time: 3000 + i, data: { text: filler(2000) } }])),
+)
+const bootOverflowSize = statSync(bootOverflow).size
+ok('the artifact fixture outgrows the head window', bootOverflowSize > 64 * 1024, `${bootOverflowSize} bytes`)
+const bootOverflowSource = {
+  listSnapshots: async () => [{ header: { id: 'boot-overflow', cwd: '/proj', createdAt: 1000 }, revision: 'rev:boot-overflow' }],
+  locate: () => ({ kind: 'jsonl', path: bootOverflow }),
+}
+await listSummaries(bootOverflowSource)
+check('a log with no conversation anywhere is still empty', (await listSummaries(bootOverflowSource))[0].hasPrompt, false)
+
+// Control: a small boot artifact carries no evidence against its own cached
+// "empty" verdict, so it must stay on the fast path — otherwise every boot
+// artifact in a long history would be re-read on every open.
+const bootTiny = seed('boot-tiny', [])
+const bootTinySource = {
+  listSnapshots: async () => [{ header: { id: 'boot-tiny', cwd: '/proj', createdAt: 1000 }, revision: 'rev:boot-tiny' }],
+  locate: () => ({ kind: 'jsonl', path: bootTiny }),
+}
+await listSummaries(bootTinySource)
+const bootTinyAnchor = readIndex().get('boot-tiny').derived.anchor
+check('a boot artifact small enough to judge keeps its cached verdict', (await listSummaries(bootTinySource))[0].hasPrompt, false)
+check(
+  'and is never re-derived once cached',
+  readIndex().get('boot-tiny').derived.anchor,
+  bootTinyAnchor,
+)
+
 rmSync(root, { recursive: true, force: true })
 rmSync(home, { recursive: true, force: true })
 console.log(`verify-session-index: OK (${checks} checks)`)

--- a/src/dsh-adapter/sessions/list.ts
+++ b/src/dsh-adapter/sessions/list.ts
@@ -21,6 +21,7 @@
 import { basename } from 'node:path'
 import {
   digestSession,
+  HEAD_WINDOW_BYTES,
   recoverAppendedTitle,
   recoverSessionTitle,
   sessionTitleAnchor,
@@ -188,11 +189,26 @@ export async function listSummaries(
     const token = revision ?? (facts === undefined ? undefined : `${facts.bytes}:${facts.modifiedAt}`)
 
     let derived: DerivedEntry | undefined
+    // A cached entry claiming no conversation cannot be believed when the file
+    // itself carries evidence of one: a title that is not the log's own
+    // basename fallback, or a log too large for the head window to have judged
+    // empty (`digestSession` answers hasPrompt for anything past its window by
+    // construction). Such an entry was derived by a build whose verdict was
+    // wrong, and the cache-hit path below would serve it forever — entry and
+    // log agree on the revision precisely because the log is no longer being
+    // written, which is exactly the state a hidden session is in. A genuine
+    // boot artifact keeps its cached verdict here, so the steady state stays
+    // one read per listing.
+    const untrustworthy =
+      cached?.derived !== undefined &&
+      cached.derived.hasPrompt === false &&
+      (cached.derived.titleSource !== 'fallback' || (facts?.bytes ?? 0) > HEAD_WINDOW_BYTES)
     if (
       cached?.derived !== undefined &&
       token !== undefined &&
       cached.derived.revision === token &&
-      cached.derived.titleComplete
+      cached.derived.titleComplete &&
+      !untrustworthy
     ) {
       derived = cached.derived
     } else if (path !== undefined && token !== undefined) {


### PR DESCRIPTION
## 问题

`/resume` 会把一些**真实会话永久隐藏**，只在底部计入「N 个空会话」；重启、重开 `/resume` 都不会恢复，只有手动删掉 `~/.dsh-tui/session-index.json` 才能找回。

触发链（每一步单独看都是合理的）：

1. 会话在首条人类 prompt 落盘之前被首次 listing——此时 `hasPrompt: false` 是**诚实**的；
2. 这条判定带着 `titleComplete: true` 写进索引（`titleSource` 可以是 `auto`/`renamed`，而 provider 标题与重命名标题都只可能出现在会话跑过之后）；
3. 日志继续增长时，append 分支把 `hasPrompt = previous.hasPrompt` 带了过去；
4. 日志停止增长后，条目与日志在 revision 上完全一致——因为日志已经不再被写入了，而这正是被隐藏会话的状态——缓存命中永远复用这条错误记录。

实测（一台真实机器，dsh-tui 0.10.1 + dsh 0.1.5，69 个 session）：**5 条真实会话**处于该状态，其中最大的日志 4.9 MB，带 provider 标题与人类 prompt；`/resume` 修复前只列出部分会话。

## 为什么仅修 append 分支不够

这类日志已经不再增长，`if (!titleComplete && … facts.bytes > previous.bytes)` 分支对它们**不可达**，因此已经被固化的条目不会自愈。修复必须发生在缓存命中处。

## 改动

`src/dsh-adapter/sessions/list.ts`：缓存命中前判断当前条目是否与**文件自身携带的证据**矛盾。

- `titleSource !== 'fallback'`——标题不是日志目录名兜底，说明日志里存在 `session/title` 事件；
- `bytes > HEAD_WINDOW_BYTES`——`digestSession` 对任何超出 HEAD 窗口的日志必然回答 `hasPrompt: true`，所以「空」的判定与日志大小矛盾。

两者都不成立时（真正的启动残留）条目照旧复用，稳定态仍是每次 listing 零日志读取——这也是这里用**矛盾判据**而不是无条件重算的原因：启动残留多的历史不会被反复重读。

## 回归用例

`scripts/verify-session-index.mjs` 新增一节，覆盖三件事：

1. 被写坏的条目在下次 listing 时按日志证据重算为 `hasPrompt: true`，索引被改写为正确判定，**不依赖日志再次增长**；
2. 重算后的条目重新走缓存命中（anchor 不变），不会每次打开都重算；
3. 反例：超出 HEAD 窗口但日志中确实没有对话的启动残留仍保持 `false`；小到足以判定的启动残留从不重算。

验证方式：`pnpm compile` 干净通过；`node scripts/verify-session-index.mjs` → `OK (63 checks)`。把 build 输出里的判据强制置假再跑，断言 `a cached "no conversation" is not served when a title says otherwise` 立即失败，确认用例针对的是这个缺陷本身，而不是恰好通过。

## 验证

```sh
pnpm compile
node scripts/verify-session-index.mjs
```

## 与既有工作的关系

本改动与 `#754` 的 `hasPrompt = previous.hasPrompt || digest.hasPrompt` **互补而非替代**：那条修的是「日志还会继续增长」的会话，本条修的是「已经被固化、日志不再增长」的存量条目。两者都合，这个 bug 才算在数据层面闭环。

背景讨论见 #716。
