### PR TITLE
fix(sixel): 修正 Windows Terminal 下 Sixel 图片渲染缺陷与 page inset 浮层偏移

### DIFF
--- a/scripts/verify-sixel-transcript.tsx
+++ b/scripts/verify-sixel-transcript.tsx
@@ -325,7 +325,19 @@ try {
   await delay(100)
   await checkFrame('text-only change')
   assert.equal(draws, beforeText, 'ordinary streaming text must not retransmit thumbnails')
-  for (const offset of [1, 2, 4, 5, 7, 9, 11, 14, 16, 12, 5, 0]) {
+  // One scroll row moves every visible clip, so the raster each node wants is
+  // a crop the worker has not encoded yet. A frame that erases the displayed
+  // rect without drawing a replacement in the same write is the black tile the
+  // user sees while scrolling; the manager holds the old pixels instead.
+  const scrollStart = output.chunks.length
+  scroller!.scrollTo(1)
+  await until(() => scroller!.getScrollTop() === 1, 'scroll position settles')
+  await checkFrame('scroll 1')
+  const managerErases = /^\x1b\[\d+;\d+H\x1b\[\d+X|\x1b\[0m\x1b\[\d+;\d+H\x1b\[\d+X/u
+  const blanked = output.chunks.slice(scrollStart)
+    .filter(chunk => managerErases.test(chunk) && !chunk.includes('\x1bP0;1;q'))
+  assert.deepEqual(blanked, [], 'a scrolled frame must never blank Sixel pixels without redrawing them')
+  for (const offset of [2, 4, 5, 7, 9, 11, 14, 16, 12, 5, 0]) {
     scroller!.scrollTo(offset)
     await until(() => scroller!.getScrollTop() === offset, 'scroll position settles')
     await checkFrame('scroll ' + offset)

--- a/scripts/verify-terminal-images-sixel.tsx
+++ b/scripts/verify-terminal-images-sixel.tsx
@@ -36,6 +36,9 @@ async function until(check: () => boolean, message: string): Promise<void> {
 }
 const { Terminal } = xterm
 if (!await loadSharp()) { console.log('SKIP Sixel images: optional sharp unavailable'); process.exit(0) }
+// Erase output carries the surface background as an SGR sequence, and chalk
+// clamps to level 0 under a non-TTY stdout, which would strip it away.
+chalk.level = 3
 function decodeRaster(data: string) {
   const body = /^\x1bP0;1;q([\s\S]*)\x1b\\$/u.exec(data)?.[1]
   assert.ok(body, 'complete DCS introducer and terminator')
@@ -202,6 +205,68 @@ await delay(20)
 assert.equal(coalesced.length, 1, 'returning to the active request withdraws obsolete pending work')
 latest.dispose()
 
+// A scroll row moves the image's clip, so the raster it needs is a NEW crop
+// (left/top/cropWidth/cropHeight are part of the variant key) and the encoder
+// is asynchronous. Erasing the displayed rect in the frame that has no
+// replacement to draw is what flashed black while scrolling, and the same
+// skip made an image vanish under a tooltip that merely covered part of it.
+const scrollJobs: Array<{ request: SixelEncodeRequest; resolve: (value: SixelRaster) => void }> = []
+let scrollReady = 0
+const scroll = new SixelGraphicsManager(() => scrollReady++, request => new Promise(resolve => scrollJobs.push({ request, resolve })))
+scroll.setCellSize({ width: 10, height: 20 })
+scroll.beginFrame(40, 16)
+scroll.prepare(placement)
+scroll.reconcile(screen(), screen())
+scrollJobs[0].resolve(readyRaster)
+await until(() => scrollReady === 1, 'scroll fixture encodes the visible crop')
+scroll.beginFrame(40, 16)
+assert.equal(scroll.prepare(placement), true)
+assert.equal(scroll.reconcile(screen(), screen()).erase, '', 'the first display of a cached crop needs no erase')
+assert.match(scroll.paint([]), /^\x1b\[4;3H/u)
+const clipped: TerminalImagePlacement = { ...placement, clip: { x: 2, y: 5, columns: 8, rows: 2 } }
+scroll.beginFrame(40, 16)
+assert.equal(scroll.prepare(clipped), false, 'a scrolled crop starts unencoded')
+assert.equal(scroll.reconcile(screen(), screen()).erase, '', 'a pending replacement must not erase the displayed rect')
+assert.equal(scroll.paint([]), '', 'and must not redraw the stale raster')
+assert.equal(scrollJobs.length, 2, 'the scrolled crop is queued')
+scrollJobs[1].resolve(readyRaster)
+await until(() => scrollReady === 2, 'the replacement requests a repaint')
+scroll.beginFrame(40, 16)
+assert.equal(scroll.prepare(clipped), true)
+const swapped = scroll.reconcile(screen(), screen())
+assert.match(swapped.erase, /\x1b\[8X/u, 'the ready replacement erases the old rect')
+assert.ok(scroll.paint([]).includes('\x1b[6;3H'), 'and draws the replacement in the same frame')
+scroll.beginFrame(40, 16)
+scroll.prepare(clipped)
+scroll.reconcile(screen(), screen(), [{ ...clipped, occluded: true }])
+assert.equal(scroll.paint([]), '', 'an occluded rect is neither erased nor redrawn')
+// The cells an overlay covers must give up their pixels: their style does not
+// change, so the frame diff never rewrites them and the raster would show
+// through the overlay (the white block between "100%" and "原像素").
+scroll.beginFrame(40, 16)
+scroll.prepare(clipped)
+const partialCover = scroll.reconcile(screen(), screen(), [{
+  ...clipped,
+  occluded: true,
+  coveredRects: [{ x: 3, y: 5, width: 4, height: 1 }],
+}])
+assert.match(partialCover.erase, /\x1b\[0m\x1b\[48;2;255;255;255m\x1b\[6;4H\x1b\[4X/u,
+  'the covered cells are erased with the placement surface color')
+assert.ok(!/\x1b\[8X/u.test(partialCover.erase), 'only the covered cells are erased, not the whole raster')
+assert.equal(scroll.paint([]), '', 'the uncovered pixels stay on screen')
+scroll.beginFrame(40, 16)
+scroll.prepare(clipped)
+assert.equal(scroll.reconcile(screen(), screen(), [{
+  ...clipped,
+  occluded: true,
+  coveredRects: [{ x: 3, y: 5, width: 4, height: 1 }],
+}]).erase, '', 'an unchanged cover is erased once')
+scroll.beginFrame(40, 16)
+scroll.prepare(clipped)
+assert.equal(scroll.reconcile(screen(), screen(), [clipped]).erase, '', 'uncovering needs no erase of the rect own pixels')
+assert.ok(scroll.paint([]).includes('\x1b[6;3H'), 'an uncovered rect is redrawn after being held')
+scroll.dispose()
+
 class Input extends PassThrough {
   isTTY = true
   isRaw = false
@@ -232,12 +297,15 @@ delete process.env.STY
 delete process.env.DSH_TUI_ACCESSIBILITY
 delete process.env.DSH_TUI_DISABLE_TERMINAL_IMAGES
 delete process.env.DSH_TUI_IMAGE_PROTOCOL
-const imageTree = (show: boolean, counter = 0, preview = true, covered = false) => (
+const imageTree = (show: boolean, counter = 0, preview = true, covered = false, partial = false) => (
   <AlternateScreen>
     <Box width={50} height={17} flexDirection="column">
       <Text>PREVIEW HEADER</Text>
-      <Box height={7}>
+      <Box height={7} backgroundColor="toolCardBackground">
         {show ? <Image source={source} width={8} height={4} alt="test" presentation={preview ? 'preview' : undefined}><Text>FALLBACK</Text></Image> : null}
+        {/* A popup that covers only part of the raster: the same surface color,
+            so the covered cells keep the image's own backing style. */}
+        {partial ? <Box position="absolute" top={2} left={2} width={3} height={2} backgroundColor="toolCardBackground"><Text>{'   \n   '}</Text></Box> : null}
       </Box>
       <Text>AFTER {counter}</Text>
       {covered ? <Box position="absolute" top={1} left={0} width={8} height={4} opaque><Text>{'        \n        \n        \n        '}</Text></Box> : null}
@@ -266,6 +334,21 @@ try {
   const uncoverStart = stdout.data.length
   app.rerender(imageTree(true, 1))
   await until(() => stdout.data.slice(uncoverStart).includes('\x1bP0;1;q'), 'uncovering restores cached pixels')
+  // A popup covering only part of the raster: the cells it covers must be
+  // erased with the surface color (nothing else rewrites them — a
+  // background-only space cell diffs as unchanged), while the rest of the
+  // image stays on screen.
+  const partialStart = stdout.data.length
+  app.rerender(imageTree(true, 1, true, false, true))
+  await until(() => {
+    const covered = stdout.data.slice(partialStart)
+    return /\x1b\[0m\x1b\[48;2;\d+;\d+;\d+m(?:\x1b\[\d+;\d+H\x1b\[\d+X)+/u.test(covered)
+  }, 'a partial overlay erases its covered cells with the surface color')
+  assert.ok(!/\x1b\[8X/u.test(stdout.data.slice(partialStart)), 'a partial overlay must not erase the whole raster')
+  assert.ok(!stdout.data.slice(partialStart).includes('\x1bP0;1;q'), 'a covered raster is not redrawn over the overlay')
+  const partialUncover = stdout.data.length
+  app.rerender(imageTree(true, 1))
+  await until(() => stdout.data.slice(partialUncover).includes('\x1bP0;1;q'), 'the raster returns once the overlay closes')
   const closeStart = stdout.data.length
   app.rerender(imageTree(false))
   await until(() => stdout.data.slice(closeStart).includes('\x1b[8X'), 'closing a preview must erase actual pixels')
@@ -341,6 +424,25 @@ try {
     const right = Array.from({ length: 50 }, (_, x) => x).find(x => titleLine.getCell(x)?.getChars() === '╮')
     assert.ok(left !== undefined && right !== undefined && right > left)
     for (let x = left; x <= right; x++) assert.equal(titleLine.getCell(x)?.getBgColor(), 0xffffff, 'title background is white, not blue')
+    // The card owns its whole rect: the border ring and the image's own cells
+    // belong to the surface as well. Leaving any of them at the terminal
+    // default is the black frame around the card and the black strip beside
+    // the raster on Windows Terminal.
+    let cardX = 0
+    let cardY = 0
+    for (let ancestor: DOMElement | undefined = card; ancestor; ancestor = ancestor.parentNode) {
+      cardX += ancestor.yogaNode?.getComputedLeft() ?? 0
+      cardY += ancestor.yogaNode?.getComputedTop() ?? 0
+    }
+    const cardWidth = Math.floor(card!.yogaNode?.getComputedWidth() ?? 0)
+    const cardHeight = Math.floor(card!.yogaNode?.getComputedHeight() ?? 0)
+    assert.ok(cardWidth > 0 && cardHeight > 0, 'card rect is measurable')
+    for (let y = Math.floor(cardY); y < Math.floor(cardY) + cardHeight; y++) {
+      const line = cardTerminal.buffer.active.getLine(y)
+      for (let x = Math.floor(cardX); x < Math.floor(cardX) + cardWidth; x++) {
+        assert.equal(line?.getCell(x)?.getBgColor(), 0xffffff, `card cell ${x},${y} keeps the surface background`)
+      }
+    }
   } finally { cardTerminal.dispose() }
   const start = overlayOutput.data.length
   overlayApp.rerender(overlayTree(false))

--- a/scripts/verify-tooltip.tsx
+++ b/scripts/verify-tooltip.tsx
@@ -31,13 +31,15 @@ const dataDir = mkdtempSync(join(tmpdir(), 'verify-tooltip-data-'))
 process.env.HOME = dataDir
 process.env.USERPROFILE = dataDir
 
-const [{ PassThrough, Writable }, React, { Terminal: XTerm }, ui, tooltip, termTest] = await Promise.all([
+const [{ PassThrough, Writable }, React, { Terminal: XTerm }, ui, tooltip, termTest, { PageMargin }, displayPrefs] = await Promise.all([
   import('node:stream'),
   import('react'),
   import('@xterm/headless'),
   import('../src/ui.js'),
   import('../src/components/Tooltip.js'),
   import('./lib/term-test.mjs'),
+  import('../src/components/PageMargin.js'),
+  import('../src/tuiDisplayPrefs.js'),
 ])
 
 const { sleep, settle, settled, screenHas, findText, viewportLines } = termTest
@@ -273,6 +275,38 @@ try {
       !viewportLines(rig3.term).some(line => /\[(?:31|0)m/u.test(line)),
     JSON.stringify(tinyLines))
   await instance3.unmount()
+
+  // 11. Page margin: the pointer anchor is screen geometry while the absolute
+  // card lives in the inset content area (useTerminalSize() already reports the
+  // content size). Adding the inset instead of subtracting it pushed the card
+  // one row low and two columns right on the default margin, so its bottom
+  // border landed ON the hovered row and that row's glyphs showed beside it.
+  displayPrefs.applyPageMargin('normal')
+  const MARGIN_COLS = 60
+  const MARGIN_ROWS = 20
+  const rig4 = makeRig(MARGIN_COLS, MARGIN_ROWS)
+  const instance4 = await render(
+    <AlternateScreen>
+      <PageMargin><Probe /></PageMargin>
+    </AlternateScreen>,
+    { stdout: rig4.stdout, stdin: rig4.stdin, stderr: new (class extends Writable {
+      isTTY = true
+      _write(_c: unknown, _e: BufferEncoding, cb: () => void) { cb() }
+    })(), exitOnCtrlC: false, patchConsole: false },
+  )
+  await sleep(600) // 固定窗:pacing 等首帧上屏，无单一可轮询锚点
+  const anchorRow = findText(rig4.term, 'ROW-TWO')?.row ?? -1
+  hover(rig4.stdin, 5, anchorRow + 1)
+  const marginShown = await settled(() => screenHas(rig4.term, 'multi-first-line'))
+  check('page margin: tooltip appears', marginShown)
+  const markerRow = findText(rig4.term, 'multi-first-line')?.row ?? -1
+  const bottomRow = Array.from({ length: MARGIN_ROWS }, (_, y) => y).find(y =>
+    y > markerRow && (rig4.term.buffer.active.getLine(y)?.translateToString(true) ?? '').includes('╰')) ?? -1
+  const bottomLine = rig4.term.buffer.active.getLine(bottomRow)?.translateToString(true) ?? ''
+  check('page margin: card rests directly above the hovered row',
+    marginShown && bottomRow === anchorRow - 1 && bottomLine.includes('╰'),
+    `anchor=${anchorRow} marker=${markerRow} bottom=${bottomRow} line=${JSON.stringify(bottomLine.trim())}`)
+  await instance4.unmount()
 } finally {
   rmSync(dataDir, { recursive: true, force: true })
 }

--- a/scripts/verify-tooltip.tsx
+++ b/scripts/verify-tooltip.tsx
@@ -156,6 +156,28 @@ try {
   check('top-of-screen anchor drops the tooltip below', tipTopRow > topRow,
     `anchor=${topRow} tip=${tipTopRow}`)
 
+  // The card's border ring belongs to the same surface as its interior. A ring
+  // left at the terminal default is the black frame around the popup — and on
+  // Windows Terminal it is what showed through the old Sixel preview card.
+  {
+    const borderRow = term.buffer.active.getLine(tipTopRow - 1)
+    const contentRow = term.buffer.active.getLine(tipTopRow)
+    const contentX = findText(term, 'TIP-TOP-MARKER')?.col ?? -1
+    const borderLeft = Array.from({ length: COLS }, (_, x) => x)
+      .find(x => borderRow?.getCell(x)?.getChars() === '╭')
+    const borderRight = Array.from({ length: COLS }, (_, x) => x)
+      .find(x => borderRow?.getCell(x)?.getChars() === '╮')
+    const surface = contentRow?.getCell(contentX)?.getBgColor()
+    check('tooltip interior paints a surface color', surface !== undefined && surface !== 0,
+      `bg=${surface?.toString(16)}`)
+    let ringOk = borderLeft !== undefined && borderRight !== undefined
+    for (let x = borderLeft ?? 0; ringOk && x <= (borderRight ?? -1); x++) {
+      if (borderRow?.getCell(x)?.getBgColor() !== surface) ringOk = false
+    }
+    check('tooltip border ring keeps the surface background', ringOk,
+      `border=${borderLeft}..${borderRight} surface=${surface?.toString(16)}`)
+  }
+
   // 3. Leaving hides it.
   hover(stdin, COLS - 1, ROWS - 1)
   check('leaving the target hides the tooltip', await settled(() => !screenHas(term, 'TIP-TOP-MARKER')))

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -220,22 +220,27 @@ export function TooltipLayer({
   const height = lines.length + 2
   // Prefer resting on the row ABOVE the anchor; when there is no room
   // (anchor at the top of the screen), drop below it, clamped on-screen.
-  // The anchor coordinates are SCREEN coordinates (pointer events) while
-  // the absolute box is placed relative to the content-area origin — under
-  // PageMargin (root page inset) the offset must be added back, and the
-  // clamp bounds run over the inset content area.
+  // The anchor is SCREEN geometry (pointer events) while the absolute box is
+  // placed relative to the inset content-area origin, and useTerminalSize()
+  // already reports the content size: convert the anchor into content
+  // coordinates first, then clamp inside the content area. Adding the inset
+  // (the earlier bug) moved the whole card by the page margin — with the
+  // default margin one row low and two columns right, so its bottom border
+  // landed ON the hovered row and that row's glyphs showed beside the card.
   const inset = React.useContext(PageInsetContext)
-  const topAbove = tooltip.anchorRow - height
+  const anchorRow = tooltip.anchorRow - inset.y
+  const anchorCol = tooltip.anchorCol - inset.x
+  const topAbove = anchorRow - height
   const top = Math.max(
-    inset.y,
+    0,
     Math.min(
-      topAbove >= 0 ? topAbove : tooltip.anchorRow + 1,
-      inset.y + Math.max(0, rows - height),
+      topAbove >= 0 ? topAbove : anchorRow + 1,
+      Math.max(0, rows - height),
     ),
   )
   const left = Math.max(
-    inset.x,
-    Math.min(tooltip.anchorCol, inset.x + Math.max(0, columns - width)),
+    0,
+    Math.min(anchorCol, Math.max(0, columns - width)),
   )
   return (
     <Box

--- a/src/ink/colorize.ts
+++ b/src/ink/colorize.ts
@@ -244,3 +244,25 @@ export function applyColor(text: string, color: Color | undefined): string {
   }
   return colorize(text, color, 'foreground')
 }
+
+/**
+ * Marker used to split chalk's open/close pair. No SGR sequence contains a NUL,
+ * so everything before it is the opening code.
+ */
+const SGR_OPEN_MARKER = '\u0000'
+
+/**
+ * The opening SGR sequence for a raw background color — no text, no reset.
+ *
+ * SixelGraphicsManager needs it to give Erase-Character the placement's surface
+ * color as its fill: the erased cells keep a "background-only" style in the cell
+ * model, so filling them with the terminal default would leave a black patch.
+ * @param color - the raw background color value; undefined or empty yields ''.
+ * @returns the opening SGR sequence, or '' when no color applies.
+ */
+export function backgroundOpenCode(color: Color | undefined): string {
+  if (!color) return ''
+  const styled = colorize(SGR_OPEN_MARKER, color, 'background')
+  const end = styled.indexOf(SGR_OPEN_MARKER)
+  return end <= 0 ? '' : styled.slice(0, end)
+}

--- a/src/ink/ink.tsx
+++ b/src/ink/ink.tsx
@@ -706,6 +706,9 @@ export default class Ink {
       altScreen: this.altScreenActive,
       terminalImages: this.altScreenActive && (this.kittyGraphicsSupported || this.sixelGraphicsSupported),
       imageReady: sixelActive ? this.sixelGraphicsManager.prepare : undefined,
+      // Sixel paints rasters over the cells: an image's own cells must then
+      // carry the surface background instead of terminal-default blanks.
+      opaqueImageBacking: sixelActive,
       prevFrameContaminated: this.prevFrameContaminated
     });
     const rendererMs = performance.now() - renderStart;

--- a/src/ink/output.ts
+++ b/src/ink/output.ts
@@ -186,6 +186,14 @@ type Options = {
   /** Paint image fallbacks as blank backing cells and collect placements. */
   terminalImages?: boolean
   imageReady?: (placement: TerminalImagePlacement) => boolean
+  /**
+   * True when the active protocol paints rasters OVER the cell grid (Sixel)
+   * instead of behind it (Kitty). Image-owned cells must then carry the
+   * surface background: the raster covers them anyway, and terminal-default
+   * blanks would show as black holes wherever a raster fails to cover a cell
+   * (aspect rounding, suppressed/occluded placements).
+   */
+  opaqueImageBacking?: boolean
   /** Image requests from the diff baseline, reused by clean subtree blits. */
   previousImages?: readonly TerminalImagePlacement[]
 }
@@ -482,6 +490,49 @@ function buildClusteredChars(
 }
 
 /**
+ * The screen rect a paint operation covers, when it can occlude a raster
+ * painted earlier in the same frame. `clip`/`unclip`/`noSelect` paint nothing.
+ */
+function imageOcclusionRect(op: Operation, width: number): Rectangle | undefined {
+  if (op.type === 'write') {
+    return { x: op.x, y: op.y, width: widestLine(op.text), height: op.text.split('\n').length }
+  }
+  if (op.type === 'blit') return op
+  if (op.type === 'clear' || op.type === 'shade') return op.region
+  if (op.type === 'shift') return { x: 0, y: op.top, width, height: op.bottom - op.top + 1 }
+  return undefined
+}
+
+/**
+ * Fold overlapping occluder rects into disjoint ones, so an image protocol that
+ * has to erase them (Sixel) does not repeat the same cells. One overlay usually
+ * contributes several rects for the same area (interior fill, border row, text
+ * row), and an overlay that covers several placements would otherwise erase the
+ * shared cells once per placement.
+ */
+function mergeOcclusionRects(rects: readonly Rectangle[]): Rectangle[] {
+  const merged: Rectangle[] = []
+  for (const rect of rects) {
+    let current = rect
+    let joined = true
+    while (joined) {
+      joined = false
+      for (let index = merged.length - 1; index >= 0; index--) {
+        const other = merged[index]!
+        const overlapsX = current.x < other.x + other.width && current.x + current.width > other.x
+        const overlapsY = current.y < other.y + other.height && current.y + current.height > other.y
+        if (!overlapsX || !overlapsY) continue
+        current = unionRect(current, other)
+        merged.splice(index, 1)
+        joined = true
+      }
+    }
+    merged.push(current)
+  }
+  return merged
+}
+
+/**
  * Collects write/blit/clear/clip operations from the render tree, then
  * applies them to a Screen buffer in get(). The Screen is what gets
  * diffed against the previous frame to produce terminal updates.
@@ -494,6 +545,7 @@ export default class Output {
   private readonly stylePool: StylePool
   private screen: Screen
   terminalImagesEnabled: boolean
+  opaqueImageBacking: boolean
   private imageReady: ((placement: TerminalImagePlacement) => boolean) | undefined
 
   private readonly operations: Operation[] = []
@@ -560,6 +612,7 @@ export default class Output {
     this.stylePool = stylePool
     this.screen = screen
     this.terminalImagesEnabled = options.terminalImages ?? false
+    this.opaqueImageBacking = options.opaqueImageBacking ?? false
     this.imageReady = options.imageReady
     this.previousImages = options.previousImages ?? []
 
@@ -583,11 +636,13 @@ export default class Output {
     terminalImages = false,
     previousImages: readonly TerminalImagePlacement[] = [],
     imageReady?: (placement: TerminalImagePlacement) => boolean,
+    opaqueImageBacking = false,
   ): void {
     this.width = width
     this.height = height
     this.screen = screen
     this.terminalImagesEnabled = terminalImages
+    this.opaqueImageBacking = opaqueImageBacking
     this.imageReady = imageReady
     this.previousImages = previousImages
     this.operations.length = 0
@@ -794,18 +849,34 @@ export default class Output {
       const end = this.imageBackingEnds.get(placement.node)
       if (end === undefined) return placement
       const visible = placement.clip ?? placement
-      const overlaps = (rect: Rectangle): boolean => rect.x < visible.x + visible.columns &&
-        rect.x + rect.width > visible.x && rect.y < visible.y + visible.rows &&
-        rect.y + rect.height > visible.y
-      const occluded = this.operations.slice(end).some(op => {
-        if (op.type === 'write') return overlaps({ x: op.x, y: op.y,
-          width: widestLine(op.text), height: op.text.split('\n').length })
-        if (op.type === 'blit') return overlaps(op)
-        if (op.type === 'clear' || op.type === 'shade') return overlaps(op.region)
-        if (op.type === 'shift') return overlaps({ x: 0, y: op.top, width: this.width, height: op.bottom - op.top + 1 })
-        return false
-      })
-      return { ...placement, occluded }
+      const right = visible.x + visible.columns
+      const bottom = visible.y + visible.rows
+      const overlaps = (rect: Rectangle): boolean => rect.x < right &&
+        rect.x + rect.width > visible.x && rect.y < bottom && rect.y + rect.height > visible.y
+      // A later paint that covers the whole visible rect makes the raster
+      // unreachable and erasing is the only correct outcome (a blank `opaque`
+      // overlay would otherwise be pierced by the pixels beneath it). A paint
+      // that covers only part of it must not take the rest of the raster down
+      // with it — SixelGraphicsManager keeps those pixels instead.
+      const covers = (rect: Rectangle): boolean =>
+        rect.x <= visible.x && rect.y <= visible.y &&
+        rect.x + rect.width >= right && rect.y + rect.height >= bottom
+      let occluded = false
+      let covered = false
+      const occluders: Rectangle[] = []
+      for (const op of this.operations.slice(end)) {
+        const rect = imageOcclusionRect(op, this.width)
+        if (rect === undefined || !overlaps(rect)) continue
+        occluded = true
+        if (covers(rect)) {
+          covered = true
+          break
+        }
+        occluders.push(rect)
+      }
+      if (!occluded) return placement
+      if (covered) return { ...placement, occluded, occludedFully: true }
+      return { ...placement, occluded, coveredRects: mergeOcclusionRects(occluders) }
     })
   }
 

--- a/src/ink/render-border.ts
+++ b/src/ink/render-border.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk'
 import cliBoxes, { type Boxes, type BoxStyle } from 'cli-boxes'
-import { applyColor } from './colorize.js'
+import { applyColor, applyTextStyles } from './colorize.js'
 import type { DOMNode } from './dom.js'
 import type Output from './output.js'
 import { stringWidth } from './stringWidth.js'
@@ -74,10 +74,19 @@ function styleBorderLine(
   line: string,
   color: Color | undefined,
   dim: boolean | undefined,
+  background: Color | undefined,
 ): string {
   let styled = applyColor(line, color)
   if (dim) {
     styled = chalk.dim(styled)
+  }
+  // The cells a border occupies belong to the surface it frames. Without an
+  // explicit background they diff back to the terminal default, which reads
+  // as a black frame around any bordered surface sitting on a colored one (a
+  // tooltip over the preview card, that card over a tool card) and as a black
+  // hole wherever a Sixel raster is exposed by a border row or column.
+  if (background !== undefined) {
+    styled = applyTextStyles(styled, { backgroundColor: background })
   }
   return styled
 }
@@ -89,12 +98,17 @@ function styleBorderLine(
  * @param y - the border's top row.
  * @param node - the node whose border style to render.
  * @param output - the output buffer receiving the border writes.
+ * @param background - the surface color the border's cells belong to, when the
+ *   node paints its own rect (own background, `opaque`, or an occlusion color
+ *   while a terminal image sits behind it). Transparent bordered overlays pass
+ *   undefined and keep terminal-transparent border cells.
  */
 const renderBorder = (
   x: number,
   y: number,
   node: DOMNode,
   output: Output,
+  background?: Color,
 ): void => {
   if (node.style.borderStyle) {
     const width = Math.floor(node.yogaNode!.getComputedWidth())
@@ -152,14 +166,15 @@ const renderBorder = (
         box.top,
       )
       topBorder =
-        styleBorderLine(before, topBorderColor, dimTopBorderColor) +
+        styleBorderLine(before, topBorderColor, dimTopBorderColor, background) +
         text +
-        styleBorderLine(after, topBorderColor, dimTopBorderColor)
+        styleBorderLine(after, topBorderColor, dimTopBorderColor, background)
     } else if (showTopBorder) {
       topBorder = styleBorderLine(
         topBorderLine,
         topBorderColor,
         dimTopBorderColor,
+        background,
       )
     }
 
@@ -191,6 +206,11 @@ const renderBorder = (
       rightBorder = chalk.dim(rightBorder)
     }
 
+    if (background !== undefined) {
+      leftBorder = applyTextStyles(leftBorder, { backgroundColor: background })
+      rightBorder = applyTextStyles(rightBorder, { backgroundColor: background })
+    }
+
     const bottomBorderLine = showBottomBorder
       ? (showLeftBorder ? box.bottomLeft : '') +
         box.bottom.repeat(contentWidth) +
@@ -208,14 +228,15 @@ const renderBorder = (
         box.bottom,
       )
       bottomBorder =
-        styleBorderLine(before, bottomBorderColor, dimBottomBorderColor) +
+        styleBorderLine(before, bottomBorderColor, dimBottomBorderColor, background) +
         text +
-        styleBorderLine(after, bottomBorderColor, dimBottomBorderColor)
+        styleBorderLine(after, bottomBorderColor, dimBottomBorderColor, background)
     } else if (showBottomBorder) {
       bottomBorder = styleBorderLine(
         bottomBorderLine,
         bottomBorderColor,
         dimBottomBorderColor,
+        background,
       )
     }
 

--- a/src/ink/render-node-to-output.ts
+++ b/src/ink/render-node-to-output.ts
@@ -1032,13 +1032,26 @@ function renderNodeToOutput(
       // rect, though, and those non-default-background cells would also hide
       // the image itself. Replace only the image-owned cells with default-
       // background spaces; layout and surrounding inherited color stay intact.
+      //
+      // Sixel paints the raster OVER the cells instead, so its backing may
+      // (and must) carry the surface background: the raster covers those
+      // cells anyway, and terminal-default blanks would show as black holes
+      // wherever the raster misses a cell — aspect rounding at the right
+      // edge, or a suppressed placement whose cells the frame no longer
+      // repaints.
       const imageWidth = Math.floor(width)
       const imageHeight = Math.floor(height)
+      const backingColor = output.opaqueImageBacking
+        ? node.style.backgroundColor ?? inheritedBackgroundColor
+        : undefined
       const imageLine = ' '.repeat(imageWidth)
+      const fillLine = backingColor === undefined
+        ? imageLine
+        : applyTextStyles(imageLine, { backgroundColor: backingColor })
       output.write(
         Math.floor(x),
         Math.floor(y),
-        Array(imageHeight).fill(imageLine).join('\n'),
+        Array(imageHeight).fill(fillLine).join('\n'),
       )
       output.imageBacking(node)
       for (const child of node.childNodes) {
@@ -1778,7 +1791,18 @@ function renderNodeToOutput(
         }
         const ownBackgroundColor =
           node.style.backgroundColor ?? occlusionBackground
-        if (ownBackgroundColor || node.style.opaque) {
+        // A Sixel image node owns cells the raster normally paints over. When
+        // no placement is admitted — the modal suppressed graphics, the decode
+        // is still pending, or it failed — those cells must still read as the
+        // enclosing surface: the admitted branch above painted them with the
+        // same inherited color, so leaving them unwritten would diff them back
+        // to terminal-default blanks and punch black holes in the card.
+        const imageSurfaceColor =
+          output.opaqueImageBacking && node.nodeName === 'ink-image'
+            ? ownBackgroundColor ?? inheritedBackgroundColor
+            : undefined
+        const fillColor = ownBackgroundColor ?? imageSurfaceColor
+        if (fillColor || node.style.opaque) {
           const borderLeft = yogaNode.getComputedBorder(LayoutEdge.Left)
           const borderRight = yogaNode.getComputedBorder(LayoutEdge.Right)
           const borderTop = yogaNode.getComputedBorder(LayoutEdge.Top)
@@ -1787,8 +1811,8 @@ function renderNodeToOutput(
           const innerHeight = Math.floor(height) - borderTop - borderBottom
           if (innerWidth > 0 && innerHeight > 0) {
             const spaces = ' '.repeat(innerWidth)
-            const fillLine = ownBackgroundColor
-              ? applyTextStyles(spaces, { backgroundColor: ownBackgroundColor })
+            const fillLine = fillColor
+              ? applyTextStyles(spaces, { backgroundColor: fillColor })
               : spaces
             const fill = Array(innerHeight).fill(fillLine).join('\n')
             output.write(x + borderLeft, y + borderTop, fill)
@@ -1826,7 +1850,17 @@ function renderNodeToOutput(
       // Render border AFTER children to ensure it's not overwritten by child
       // clearing operations. When a child shrinks, it clears its old area,
       // which may overlap with where the parent's border now is.
-      renderBorder(x, y, node, output)
+      // A border's cells belong to the surface it frames: pass the node's
+      // effective background so they never fall back to the terminal default
+      // (a black frame around a colored surface, and a black hole where a
+      // Sixel raster is otherwise exposed by a border row or column).
+      renderBorder(
+        x,
+        y,
+        node,
+        output,
+        node.style.backgroundColor ?? occlusionBackground ?? inheritedBackgroundColor,
+      )
     } else if (node.nodeName === 'ink-root') {
       renderChildren(
         node,

--- a/src/ink/renderer.ts
+++ b/src/ink/renderer.ts
@@ -27,6 +27,12 @@ export type RenderOptions = {
   /** Whether terminal graphics are active for this paint pass. */
   terminalImages?: boolean
   imageReady?: (placement: TerminalImagePlacement) => boolean
+  /**
+   * True when rasters paint over the cell grid (Sixel): image-owned cells
+   * carry the surface background instead of terminal-default blanks. See
+   * Output's `opaqueImageBacking`.
+   */
+  opaqueImageBacking?: boolean
   // True when the previous frame's screen buffer was mutated post-render
   // (selection overlay), reset to blank (alt-screen enter/resize/SIGCONT),
   // or reset to 0×0 (forceRedraw). Blitting from such a prevScreen would
@@ -135,6 +141,7 @@ export default function createRenderer(
         options.terminalImages,
         frontFrame.images,
         options.imageReady,
+        options.opaqueImageBacking ?? false,
       )
     } else {
       output = new Output({
@@ -145,6 +152,7 @@ export default function createRenderer(
         terminalImages: options.terminalImages,
         previousImages: frontFrame.images,
         imageReady: options.imageReady,
+        opaqueImageBacking: options.opaqueImageBacking ?? false,
       })
     }
 

--- a/src/ink/sixel-graphics.ts
+++ b/src/ink/sixel-graphics.ts
@@ -10,6 +10,8 @@ import {
 import { cellAt, clearRegion, type Screen } from './screen.js'
 import type { Diff } from './frame.js'
 import { stringWidth } from './stringWidth.js'
+import { backgroundOpenCode } from './colorize.js'
+import type { Color } from './styles.js'
 
 type Rect = { x: number; y: number; columns: number; rows: number }
 type Variant = {
@@ -20,12 +22,31 @@ type Variant = {
   placement: TerminalImagePlacement
   ready: boolean
 }
-type Displayed = Rect & { key: string; raster: SixelRaster }
+type Displayed = Rect & {
+  key: string
+  raster: SixelRaster
+  /** Surface color these pixels sit on; restored when the rect is erased. */
+  background?: string
+  /** Kept on screen because its replacement is pending or it is covered. */
+  held?: boolean
+  /** Key of the covered rects already erased for this rect. */
+  covered?: string
+}
 type Encoder = (request: SixelEncodeRequest) => Promise<SixelRaster>
 
 function overlaps(a: Rect, b: Rect): boolean {
   return a.x < b.x + b.columns && a.x + a.columns > b.x &&
     a.y < b.y + b.rows && a.y + a.rows > b.y
+}
+
+/** Intersection of two cell rects, or undefined when they do not overlap. */
+function intersectRects(a: Rect, b: Rect): Rect | undefined {
+  const x = Math.max(a.x, b.x)
+  const y = Math.max(a.y, b.y)
+  const right = Math.min(a.x + a.columns, b.x + b.columns)
+  const bottom = Math.min(a.y + a.rows, b.y + b.rows)
+  if (right <= x || bottom <= y) return undefined
+  return { x, y, columns: right - x, rows: bottom - y }
 }
 
 /** Viewport-owned pixels. Encoding is shared; placement/erasure is per DOM node. */
@@ -42,6 +63,8 @@ export class SixelGraphicsManager {
   private desired = new Set<string>()
   private displayed = new Map<DOMElement, Displayed>()
   private nextDisplay = new Map<DOMElement, Displayed>()
+  /** Rects kept on screen this frame (replacement pending or covered). */
+  private readonly held = new Map<DOMElement, Displayed>()
   private readonly repaint = new Set<DOMElement>()
   private worker: Worker | undefined
   private workerKeys = new Set<string>()
@@ -140,21 +163,52 @@ export class SixelGraphicsManager {
     }
   }
 
-  /** Reconcile ALL old rectangles before diffing, with only one baseline copy. */
+  /**
+   * Reconcile ALL old rectangles before diffing, with only one baseline copy.
+   *
+   * A rect is erased only when this frame replaces it (a ready raster at a new
+   * key/geometry, erased and drawn in the same write) or drops it entirely.
+   * Rects whose replacement is still being encoded, or which a later paint
+   * covers, are held: erasing them without drawing a replacement in the same
+   * frame is exactly the black flash seen while scrolling and the vanishing
+   * image under an overlay. {@link paint} folds the held rects back into
+   * `displayed`, and the frame that finally replaces one forces a repaint
+   * through the `held` marker.
+   *
+   * A held rect that an overlay PARTLY covers still has to give up the covered
+   * cells: its pixels outlive cell writes (a background-only space cell diffs
+   * as unchanged, so the frame never rewrites it) and would show through the
+   * overlay. Those sub-rects are erased with the placement's surface color.
+   */
   reconcile(screen: Screen, previous: Screen, placements?: readonly TerminalImagePlacement[]): { erase: string; baseline: Screen } {
     const actual = placements ? new Map(placements.map(p => [p.node, p])) : undefined
     const visible: Variant[] = []
     this.desired = new Set()
     this.nextDisplay.clear()
+    this.held.clear()
     this.repaint.clear()
+    // Nodes whose raster this frame drops (the paint no longer registers an
+    // image, or a later paint covers every visible cell): their pixels must be
+    // erased, unlike the ones merely held below.
+    const dropped = new Set<DOMElement>()
     for (const [node, variant] of this.frame) {
       const placement = actual?.get(node)
-      if ((actual && !placement) || placement?.occluded) continue
+      if (actual && !placement) { dropped.add(node); continue }
+      if (placement?.occludedFully) { dropped.add(node); continue }
       visible.push(variant)
       this.desired.add(variant.key)
+      // Partially covered: drawing would pierce the overlay that covers it, so
+      // keep the pixels already on screen and wait for the cover to clear.
+      if (placement?.occluded) continue
       const raster = this.cache.get(variant.key)
       if (variant.ready && raster && placement?.graphicsReady !== false && this.isUncovered(variant.rect, screen)) {
-        this.nextDisplay.set(node, { ...variant.rect, key: variant.key, raster })
+        const background = variant.placement.background
+        this.nextDisplay.set(node, {
+          ...variant.rect,
+          key: variant.key,
+          raster,
+          ...(background === undefined ? {} : { background }),
+        })
       }
     }
     const unique = new Map<string, Variant>()
@@ -166,24 +220,62 @@ export class SixelGraphicsManager {
     this.drain()
 
     const erased: Displayed[] = []
+    let coverErase = ''
     for (const [node, old] of this.displayed) {
       const next = this.nextDisplay.get(node)
-      if (!next || this.dirty || old.key !== next.key || old.x !== next.x || old.y !== next.y) erased.push(old)
+      if (next !== undefined) {
+        if (this.dirty || old.key !== next.key || old.x !== next.x || old.y !== next.y) erased.push(old)
+        continue
+      }
+      // Still requested this frame, but its replacement raster is not ready
+      // (scrolling re-crops per row and the encoder is async) or a later paint
+      // covers it. Erasing here would leave a hole with no draw in the same
+      // frame — the black flash while scrolling and the vanishing image under
+      // a tooltip. Keep the pixels already on screen until a replacement can
+      // be drawn in the same write.
+      if (!this.dirty && this.frame.has(node) && !dropped.has(node)) {
+        const placement = actual?.get(node)
+        const coveredRects = placement?.coveredRects
+        const coveredKey = coveredRects === undefined || coveredRects.length === 0
+          ? undefined
+          : coveredRects.map(rect => `${rect.x},${rect.y},${rect.width},${rect.height}`).join(';')
+        if (coveredKey !== undefined && coveredKey !== old.covered) {
+          // The overlay paints these cells, but only the ones whose style
+          // changes get a write: an unchanged background-only space keeps the
+          // raster's pixels. Erase the covered cells (with the surface color,
+          // so they match the cell model) and leave the rest held.
+          const visibleRect: Rect = { x: old.x, y: old.y, columns: old.columns, rows: old.rows }
+          for (const rect of coveredRects!) {
+            const clipped = intersectRects(visibleRect, { x: rect.x, y: rect.y, columns: rect.width, rows: rect.height })
+            if (clipped !== undefined) coverErase += this.erase(clipped, old.background)
+          }
+        }
+        this.held.set(node, coveredKey === undefined
+          ? { ...old, held: true }
+          : { ...old, held: true, covered: coveredKey })
+        continue
+      }
+      erased.push(old)
     }
     for (const [node, next] of this.nextDisplay) {
       const old = this.displayed.get(node)
-      if (!old || this.dirty || old.key !== next.key || old.x !== next.x || old.y !== next.y ||
+      if (!old || this.dirty || old.held === true ||
+          old.key !== next.key || old.x !== next.x || old.y !== next.y ||
           erased.some(rect => overlaps(rect, next))) this.repaint.add(node)
     }
-    if (erased.length === 0) return { erase: '', baseline: previous }
+    if (erased.length === 0) {
+      return coverErase === ''
+        ? { erase: '', baseline: previous }
+        : { erase: coverErase + '\x1b[H', baseline: previous }
+    }
     const cells = previous.cells.slice()
     const baseline: Screen = { ...previous, cells, cells64: new BigInt64Array(cells.buffer), noSelect: previous.noSelect.slice() }
     let erase = ''
     for (const rect of erased) {
       clearRegion(baseline, rect.x, rect.y, rect.columns, rect.rows)
-      erase += this.erase(rect)
+      erase += this.erase(rect, rect.background)
     }
-    return { erase: erase + '\x1b[H', baseline }
+    return { erase: coverErase + erase + '\x1b[H', baseline }
   }
 
   /** Unchanged images have zero transport cost, including unrelated text ticks. */
@@ -198,6 +290,9 @@ export class SixelGraphicsManager {
       draw += `\x1b[${next.y + 1};${next.x + 1}H${next.raster.data}`
     }
     this.displayed = new Map(this.nextDisplay)
+    // Rects held this frame stay on screen: they were neither erased nor
+    // redrawn, so the terminal still shows them.
+    for (const [node, entry] of this.held) this.displayed.set(node, entry)
     this.dirty = false
     if (draw === '') return ''
     return this.displayModeSet ? `\x1b[?80l${draw}\x1b[?80h` : draw
@@ -209,6 +304,7 @@ export class SixelGraphicsManager {
     const output = [...this.displayed.values()].map(rect => this.erase(rect)).join('')
     this.displayed.clear()
     this.nextDisplay.clear()
+    this.held.clear()
     this.frame.clear()
     this.desired.clear()
     this.pending = []
@@ -228,20 +324,34 @@ export class SixelGraphicsManager {
     return output
   }
 
-  private erase(rect: Rect): string {
+  private erase(rect: Rect, background?: string): string {
     const columns = Math.min(rect.columns, this.columns - rect.x)
     const rows = Math.min(rect.rows, this.rows - rect.y)
     if (columns <= 0 || rows <= 0) return ''
-    let data = '\x1b[0m'
+    // Erase-Character fills with the cell's current background and is the only
+    // way to drop pixels a frame never rewrites. A rect the frame does rewrite
+    // (a placement whose replacement raster was drawn, or the image node's own
+    // opaque backing) would be repainted with the surface color anyway; a rect
+    // it leaves alone (the cells an overlay covers without changing their
+    // style) keeps whatever the erase filled in, so that has to be the
+    // placement's surface color rather than the terminal default.
+    // The placement carries the raw color string; Color is its renderer form.
+    const open = background === undefined ? '' : backgroundOpenCode(background as Color)
+    let data = `\x1b[0m${open}`
     for (let y = rect.y; y < rect.y + rows; y++) data += `\x1b[${y + 1};${rect.x + 1}H\x1b[${columns}X`
+    if (open !== '') data += '\x1b[0m'
     return data
   }
 
   private isUncovered(rect: Rect, screen: Screen): boolean {
+    // Any visible glyph under the raster blocks it; background-only cells do
+    // not. Image-owned cells carry the surface background in Sixel mode (an
+    // opaque backing is required there), and comparing against the empty
+    // style would reject the raster's own backing.
     for (let y = rect.y; y < rect.y + rect.rows; y++) {
       for (let x = rect.x; x < rect.x + rect.columns; x++) {
         const cell = cellAt(screen, x, y)
-        if (cell && (cell.char !== ' ' || cell.styleId !== screen.emptyStyleId)) return false
+        if (cell && cell.char !== ' ' && cell.char !== '') return false
       }
     }
     return true

--- a/src/ink/terminal-image.ts
+++ b/src/ink/terminal-image.ts
@@ -1,4 +1,5 @@
 import type { DOMElement } from './dom.js'
+import type { Rectangle } from './layout/geometry.js'
 
 /** Hard bounds for one decoded image admitted to the terminal renderer. */
 export const TERMINAL_IMAGE_MAX_EDGE = 1024
@@ -63,8 +64,24 @@ export interface TerminalImagePlacement {
   readonly background?: string
   /** False while a protocol-specific raster is pending or unavailable. */
   readonly graphicsReady?: boolean
-  /** Later paint operations cover this backing, including blank overlays. */
+  /** Later paint operations cover part of this raster's visible cells. */
   readonly occluded?: boolean
+  /**
+   * Later paint operations cover every visible cell of this raster, so it is
+   * unreachable and must be erased rather than kept (a blank `opaque` overlay
+   * would otherwise be pierced by the pixels beneath it). Partial coverage
+   * sets {@link occluded} only.
+   */
+  readonly occludedFully?: boolean
+  /**
+   * The later paint operations that cover PART of this raster, in absolute
+   * screen cells. A protocol whose pixels outlive cell writes must erase these
+   * rects itself: with Sixel, a background-only space cell over the raster has
+   * the same style as the image's own backing cell, so the frame diff emits no
+   * write for it and the old pixels keep showing through the overlay (the white
+   * block between "100%" and "原像素" in a preview tooltip).
+   */
+  readonly coveredRects?: readonly Rectangle[]
 }
 
 /**

--- a/src/screens/SessionBrowser.tsx
+++ b/src/screens/SessionBrowser.tsx
@@ -1131,13 +1131,14 @@ export function SessionBrowser({
           the pointer, clamped so it never clips off the terminal. Its own
           clicks hit-test first (absolute hit list), and the root Box's
           onClick dismisses it on any outside click. 指针坐标是屏幕坐标，
-          而 absolute 盒相对内容区原点——有 PageMargin 页边距时需补回
-          inset（同 TooltipLayer 的补偿规则）。 */}
+          而 absolute 盒相对内容区原点、useTerminalSize() 报的已是内容区
+          尺寸——先把锚点换算到内容坐标（减去 inset）再夹取，否则有
+          PageMargin 时整块菜单会偏移一个页边距（同 TooltipLayer 的规则）。 */}
       {menu !== undefined && menuTarget !== undefined && (
         <Box
           position="absolute"
-          left={Math.max(inset.x, Math.min(menu.col + 1, inset.x + Math.max(0, columns - MENU_WIDTH)))}
-          top={Math.max(inset.y, Math.min(menu.row + 1, inset.y + Math.max(0, rows - MENU_HEIGHT)))}
+          left={Math.max(0, Math.min(menu.col + 1 - inset.x, Math.max(0, columns - MENU_WIDTH)))}
+          top={Math.max(0, Math.min(menu.row + 1 - inset.y, Math.max(0, rows - MENU_HEIGHT)))}
           width={MENU_WIDTH}
           height={MENU_HEIGHT}
           flexDirection="column"


### PR DESCRIPTION
## 变更摘要 / Summary

Windows Terminal 不支持 Kitty 图形协议，图片走 **Sixel** 路径。该路径下图像像素位于单元格底色**之上**，而帧 diff 只写「样式有变化」的格子，于是 0.10.1 在 WT 上暴露出 5 处可见缺陷（详见 #876）：滚动闪黑、预览背景黑块与卡片黑框、悬停 tooltip 时图片整幅消失、弹窗黑框、图片右侧黑条，以及一处更隐蔽的「tooltip 里 `100% 原像素` 中间那个空格格一直显示旧图片像素（白块）」。

本 PR 含**两笔提交（两个逻辑改动，可按需拆分）**：

1. `fix(sixel): 修正 Windows Terminal 下图片预览的黑闪、黑框、黑条与 tooltip 白块`（Closes #876）
   - `reconcile` 改为 hold：替代 raster 未就绪、或仅被部分遮挡时保留已显示像素，等替代就绪后同帧「擦 + 画」，不再出现「只擦不画」的黑帧；
   - 新增 `Output.opaqueImageBacking`（由 `ink.tsx` 按 `sixelActive` 传入）：Sixel 下图片骨架格与边框格携带**表面底色**，不再回落到终端默认底色；`isUncovered` 相应放宽为「无可见字形」；
   - `renderBorder` 把节点的有效底色应用到边框格（仅当节点确有底色或遮挡生效，透明浮层不受影响）；
   - `getImages()` 区分 `occludedFully`（整幅被盖 → 擦）与 `coveredRects`（部分被盖 → 只擦被盖的子矩形，并填该图的表面底色）：被盖的「空格 + 底色」格子与图片 backing 样式相同，diff 不会重写它，只能由管理器擦除。
2. `fix(overlay): page inset 下绝对定位浮层偏移一个页边距`（Closes #877）
   - `TooltipLayer` 与 SessionBrowser 右键菜单把指针（屏幕坐标）换算成 absolute 盒坐标时误**加**了 `PageInsetContext` 的 inset；正确做法是减去 inset 再按内容区夹取（`PageMargin` 的文档注释描述的正是后者）。

## 关联 / Related

Closes #876
Closes #877

## 变更类型 / Type

- [x] fix — 修复缺陷

## 验证 / Verification

- [x] `pnpm build`（compile + 全部构建门禁）
- [x] 按改动面选的聚焦回归脚本（本改动面为 `src/ink/` core + 浮层组件）
- [ ] 终端可见改动：inline 与 fullscreen 两种模式、窄终端宽度手动演练 —— **仅完成 fullscreen**（Windows Terminal 1.24，图片预览走 alt-screen）；inline 与窄终端未实测，如实标注

```text
pnpm compile                  ✅ exit 0
pnpm verify:build             ✅ exit 0（整条构建门禁链）
pnpm verify:package           ✅ package surface OK (1880 files, 27 entry targets)
repro-askpanel / verify-askpanel-layout / repro-toolcards            ✅ ALL PASS
verify-terminal-images-sixel / verify-sixel-transcript / verify-overlay-occlusion /
verify-backdrop-dim / verify-terminal-images / verify-transcript-images /
verify-image-inspection / verify-image-preview / verify-tooltip /
verify-session-browser / verify-session-browser-layout                ✅ 全绿
真机（Windows Terminal 1.24.11911.0 + Sixel）：上述现象与 tooltip 白块均消失
```

新增断言（都在既有脚本内扩展，未新增 CI 分组）：

- `scripts/verify-terminal-images-sixel.tsx`：未就绪/遮挡时保留像素、就绪后同帧擦+画、整卡矩形逐格底色、部分覆盖只擦被盖子矩形（含表面底色 SGR）、同一遮挡只擦一次；
- `scripts/verify-sixel-transcript.tsx`：滚动的帧**不得**只擦不画；
- `scripts/verify-tooltip.tsx`：弹窗边框环保留表面底色；页边距下卡片紧贴悬停行上方。

## 自查 / Checklist

- [x] 只改了 `src/`，没有手改或提交 `lib/` 下的生成产物
- [x] 官方 `@deepseek-ai/*` 的 import 仍只出现在 `src/dsh-adapter/` 内（本 PR 只动 `src/ink/`、`src/components/Tooltip.tsx`、`src/screens/SessionBrowser.tsx`）
- [x] 行为、配置、快捷键与限制的改动已在 `README.md` 与 `README_EN.md` 双语同步 —— 本 PR 无用户可见的配置/快捷键变化，未改文档
- [x] 未改 `cordis.patch.yml`，无需同步 `patch-surface.snapshot.json`
- [x] 只暂存了显式路径，没有用 `git add .` / `git add -A`

补充说明：作者不在 `.github/APPROVED_CONTRIBUTORS`，按仓库门禁本 PR 会被 `pr-gate` 关闭，属预期行为；若维护者认可这份实现，reopen 即可。
